### PR TITLE
vgscan: per-band supply, so a class can span all three size bands

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -50,6 +50,7 @@ to go stale. Keep the grouping in sync when you add or delete a plan — one lin
 - [`max-patch-experiment.md`](max-patch-experiment.md)
 - [`set-scorer-experiment.md`](set-scorer-experiment.md)
 - [`coverage-atlas.md`](coverage-atlas.md)
+- [`vg-scale-bands-and-corrections.md`](vg-scale-bands-and-corrections.md)
 
 ## Platform / CLI
 

--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -50,6 +50,60 @@ makes small-vs-large paired on *identical* negatives. Sample a fixed
 `n_pos`/`n_neg` per cell so prevalence cannot drift between bands — unequal
 prevalence is what already made wave 1 and wave 2 non-comparable.
 
+## Which classes are fit to be in *C*
+
+Supply is necessary and nowhere near sufficient. A scale study asks two things
+of a class that mere objecthood does not, and `pile_config.is_object_category`
+— which defines the published `vg_box_*` sets — tests neither:
+
+- **Its size must be its own.** A part's box is set by its host, so a "small
+  nose" is just a distant face. Banding it measures the host's distance and the
+  arm quietly becomes a different experiment.
+- **Its absence must be checkable.** Negatives are ~95% of *I* and rest on "no
+  instance here". For a part that is unverifiable at any scale — every image
+  with a person has a nose whether or not VG annotated one — so the negatives
+  are poisoned by construction and no amount of review repairs them. That is
+  the worst case for the correction pass, not a candidate for it.
+
+`pile_config.scale_study_exclusion` layers the stricter policy on top, keeping
+`is_object_category` intact so the published sets stay reproducible. It rejects
+**parts** (`nose`, `tip`, `hair`, `collar`, `roof`, `tree trunk`), **places**
+(`court`, `station`, `intersection` — a location has no principled box extent),
+**polysemous** bare names (`trunk`, `bat` — one string, several objects, so the
+class cannot be scored as one; matched whole-name, since a modifier is what
+resolves the ambiguity), and **pervasive** classes, measured against
+`PERVASIVE_PREVALENCE` rather than listed. `sky` needs no rule: it is already a
+mass noun and never entered `vg_box_*` in the first place.
+
+The shortlist **reports** these with reasons instead of dropping them silently.
+The list is curated, so a wrong exclusion shrinks the study and a wrong
+inclusion changes what it measures — both need a human to look.
+
+## Near-synonyms: measure the vocabulary, don't trust it
+
+`glasses` / `sunglasses` / `reading glasses` would be a genuinely interesting
+fine-grained target, but only if the labels can be trusted, and free text gives
+no guarantee that they can: the names might be nested, disjoint, or overlapping
+per annotator, and those want three different experiments.
+
+`scan_name_overlap.py` decides it from geometry rather than from strings. On
+images where both names appear, it asks how often an `a` box lands on the same
+pixels as a `b` box (IoU ≥ 0.5) — same pixels under two names means one object
+annotated twice:
+
+| overlap | verdict | consequence |
+|---|---|---|
+| high both ways | **alias** | one label split arbitrarily; each name's negatives are poisoned by the other until merged |
+| high one way only | **subtype** | a real fine-grained pair; the broad name's negatives are sound |
+| near zero | **distinct** | different objects that merely co-occur |
+| never co-annotated | **untestable** | genuinely unrelated and systematically split-by-annotator are indistinguishable here |
+
+This is the principled version of the heuristic the overview benchmark tripped
+over — flagging false positives whose annotations *contain* the target name,
+which for `bus` matched 80 images annotated `bush`. String similarity is not
+evidence about objects; box geometry is. (`--names bus,bush` refutes that lead
+directly.)
+
 ## How corrections get recorded
 
 Record them in **VG's own shape** — `(image_id, class, box)` — and merge over
@@ -82,8 +136,17 @@ rate after review is bounded rather than unknown.
   per-`(class, band)` histogram and `shortlist_scale_classes.py` ranks
   categories on their binding (minimum) per-band supply, flagging COCO overlap
   and prior benchmark coverage. Both need the VG source under `DEMO_CACHE`, so
-  the scan is a GRID job. Choosing *C* from its output is the gate on
-  everything below. (Sonnet 5)
+  the scan is a GRID job. Choosing *C* from its output — including a human pass
+  over the reported exclusions — is the gate on everything below. (Sonnet 5)
+
+<!-- item-sep -->
+
+- **Decide whether a fine-grained pair earns a place in *C*.** Run
+  `scan_name_overlap.py` over the shortlist plus the eyewear cluster; if a pair
+  comes back `subtype` with real support in all three bands, it is the most
+  interesting arm available — scale *and* fine-grained discrimination on one
+  class. If it comes back `alias`, the names must be merged before either is
+  usable. Cheap, and it decides a study design. (Sonnet 5)
 
 <!-- item-sep -->
 

--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -1,0 +1,126 @@
+# Same-class scale bands for VG, and the label corrections they need
+
+Refs [#3156](https://github.com/samggreenberg/VTSearch/issues/3156).
+
+## Why the current `vg_box_*` sets can't answer the scale question
+
+`scan_vg_boxes.py` measures each VG category's **median** voted-box area, and
+`build_pile.py::_band_categories` assigns the category to whichever band that
+median lands in. A category therefore lives in exactly one band, and the three
+sets carry disjoint vocabularies — the overview benchmark ran `nose`, `glasses`,
+`watch` against `fence`, `hill`, `lady`
+([`docs/experiments/overview-bench/REPORT.md`](../experiments/overview-bench/REPORT.md)).
+
+So the published small-vs-large gap confounds **box size** with **class
+identity**: it cannot distinguish "small regions are hard" from "noses are
+harder than fences". The question worth asking is *how well can we find buses in
+the middleground*, which needs one class list held fixed while only size varies.
+
+## The construction that does answer it
+
+One image pool *I* and one class list *C*. For each class `c` and band `B`,
+every image in *I* is one of three things:
+
+| | condition | eval role |
+|---|---|---|
+| **positive** | the voted box for `c` falls in band `B` | positive |
+| **negative** | no instance of `c` at any size | negative |
+| **excluded** | `c` present, but at some *other* size | dropped from the cell |
+
+The excluded state is the part that does not exist today.
+`vtscore.eval.labels.media_is_positive` is closed-world two-valued, so a
+wrong-band image would silently become a negative and the detector would be
+penalised for finding a real bus — the exact failure #3156 is about. The cheap
+implementation is to filter the media pool **once per cell** rather than thread
+a third value through every scorer: `calibration/prepare_data.py`,
+`voting_iterations.py`, `text_baseline.py`.
+
+**Size means the union box.** `region_box_for_category` already returns the
+union over a category's instances, because that is what one Good vote drags.
+An image holding one foreground bus and three background buses is therefore a
+foreground-bus image — which is the honest reading of "find buses in the
+middleground".
+
+**One pickle, not three.** Since *C* and the negative pool are shared, the bands
+differ only in which images are positive vs excluded. Build a single pickle and
+carry the band on the category name (`bus@small` / `bus@medium` / `bus@large`):
+a harness cell is already `(dataset, category)`, so this needs no harness
+change, cuts embedding ~3× (the `dinov3_patch` cells run ~1400 s each), and
+makes small-vs-large paired on *identical* negatives. Sample a fixed
+`n_pos`/`n_neg` per cell so prevalence cannot drift between bands — unequal
+prevalence is what already made wave 1 and wave 2 non-comparable.
+
+## How corrections get recorded
+
+Record them in **VG's own shape** — `(image_id, class, box)` — and merge over
+`objects.json` *before* banding. A correction must be able to move an image
+between bands, so an eval-time label overlay cannot do the job; a build-time
+merge makes the scan, the bands, prevalence and region voting all pick it up.
+
+Record **verdicts, not corrections**: every reviewed `(image, class)` pair gets
+a row, whether or not it disagrees with VG. Corrections are then derived, and
+review coverage falls out for free — without it, "no bus annotated" is
+indistinguishable from "nobody looked", and every corrected metric is biased by
+an unknown amount.
+
+VTSearch supplies the loop with no new plugin code: a Good vote already carries
+`region_box` through `LabeledElement` and the label export, so a `server_folder`
+import → vote → `server_json_file` export round-trip emits exactly the required
+record. The box fixes presence *and* band membership in one gesture.
+
+**The negatives are the expensive half.** They are ~95% of *I* and rest on an
+absence claim, which is precisely what VG cannot support (`498326.jpg` is
+annotated `car, clouds` and has a bus front and centre). Review them in
+descending detector score, plus a uniform random stratum so the residual noise
+rate after review is bounded rather than unknown.
+
+## Open work
+
+<!-- item-sep -->
+
+- **Run the supply scan and pick *C*.** `scan_vg_boxes.py` now emits the
+  per-`(class, band)` histogram and `shortlist_scale_classes.py` ranks
+  categories on their binding (minimum) per-band supply, flagging COCO overlap
+  and prior benchmark coverage. Both need the VG source under `DEMO_CACHE`, so
+  the scan is a GRID job. Choosing *C* from its output is the gate on
+  everything below. (Sonnet 5)
+
+<!-- item-sep -->
+
+- **Three-valued labels in the eval harness.** `media_is_evaluable(media,
+  category)` beside `media_is_positive`, and per-cell pool filtering at the
+  three entry points above. Needs a `vtscore/eval/labels.py` test for the
+  wrong-band case, and an `MIRRORS` review — the harness's notion of ground
+  truth is changing, not the app's algorithm. (Opus 4.8 — a silent
+  mis-classification here invalidates every number downstream.)
+
+<!-- item-sep -->
+
+- **The `vg_scale` builder.** One pickle over *C*, band-suffixed category names,
+  per-class exclusion sets, fixed `n_pos`/`n_neg` per cell. Replaces the three
+  `vg_box_*` entries in `pile_config.DATASETS`; the published `vg_box_*` numbers
+  stay valid for what they measured and are not comparable to the new sets.
+  (Sonnet 5)
+
+<!-- item-sep -->
+
+- **Slate builder and correction ingest.** Per-class review slates from the
+  score dumps (`vtscore/eval/score_dumps.py`) in three recorded strata —
+  `boundary`, `extreme`, `random` — written as a folder plus manifest for
+  `server_folder` import; and the reverse script turning an exported LabelSet
+  JSON back into verdict rows keyed `(image_id, class)`. (Sonnet 5)
+
+<!-- item-sep -->
+
+- **COCO-anchored noise measurement.** For classes in both vocabularies, VG's
+  miss rate can be measured against COCO val2017's exhaustive annotation with no
+  human review at all — and the same comparison scores our own annotators. Worth
+  running *before* the manual pass, to size it. (Sonnet 5)
+
+<!-- item-sep -->
+
+- **Corrected re-run and delta report.** Re-run the affected overview-bench
+  cells against corrected labels and publish the before/after, so the size of
+  the label-noise effect is on the record rather than assumed. (Sonnet 5)
+
+<!-- item-sep -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -419,5 +419,6 @@ skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,s
 # camelCase TS mirror of the projection's rep_id field),
 # and stylistic spellings the project uses consistently (re-use,
 # pre-select, unparseable, invokable). usera = the "userA" persona in
-# design docs; teh = Yee Whye Teh in references.
-ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,ans,repid,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod,usera,teh,provence"
+# design docs; teh = Yee Whye Teh in references. mane/tread are object
+# parts in the VG scale-study exclusion vocabulary (pile_config).
+ignore-words-list = "clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,ans,repid,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,ser,lod,usera,teh,provence,mane,tread"

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -76,7 +76,16 @@ sets carry disjoint vocabularies and a small-vs-large difference confounds box
 size with class identity. The scan therefore also emits each category's full
 per-band histogram, and `shortlist_scale_classes.py` ranks the categories with
 real support at *every* size — the input to a construction that holds the class
-list fixed and varies only scale. See
+list fixed and varies only scale.
+
+Supply alone does not qualify a class: `pile_config.scale_study_exclusion`
+additionally rejects **parts** (a "small nose" is a distant face, and "no nose
+here" is unverifiable wherever a person is), **places** (no principled box
+extent), bare **polysemous** names, and **pervasive** classes. The shortlist
+prints those with reasons rather than dropping them quietly. And
+`scan_name_overlap.py` settles whether two names denote one object by box IoU
+rather than by string similarity — the trap that made the benchmark's error
+report match `bush` for `bus`. See
 [`docs/plans/vg-scale-bands-and-corrections.md`](../../../docs/plans/vg-scale-bands-and-corrections.md).
 
 Verified separation, measured with `--bands`: 38/40 of `vg_box_small`'s

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -71,6 +71,14 @@ Rebuild the scan behind them with `python scan_vg_boxes.py` (writes
 `vg_box_scale.json`; caches image dims, since `objects.json` stores boxes in
 pixels and carries no image dimensions).
 
+**Banding by median puts each category in exactly one band**, so these three
+sets carry disjoint vocabularies and a small-vs-large difference confounds box
+size with class identity. The scan therefore also emits each category's full
+per-band histogram, and `shortlist_scale_classes.py` ranks the categories with
+real support at *every* size — the input to a construction that holds the class
+list fixed and varies only scale. See
+[`docs/plans/vg-scale-bands-and-corrections.md`](../../../docs/plans/vg-scale-bands-and-corrections.md).
+
 Verified separation, measured with `--bands`: 38/40 of `vg_box_small`'s
 categories fall in `sub_patch`, 40/40 of `vg_box_medium` in `patch_to_leaf`,
 33/40 of `vg_box_large` in `leaf_to_4x`. The handful of strays are a

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -184,7 +184,7 @@ def _band_categories(band: str) -> list[str]:
     scan_path = pc.PILE / "vg_box_scale.json"
     if not scan_path.exists():
         raise SystemExit(f"missing {scan_path}; run scan_vg_boxes.py first")
-    stats = json.loads(scan_path.read_text())
+    stats = json.loads(scan_path.read_text())["categories"]
     lo, hi = pc.BOX_BANDS[band]
 
     pool = [

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -134,6 +134,90 @@ def is_object_category(name: str) -> bool:
     return tokens[-1] not in NON_OBJECT_CATEGORIES and name not in NON_OBJECT_CATEGORIES
 
 
+#: Extra exclusions for a **same-class-across-scale-bands** study, keyed by head
+#: noun and carrying the reason. Deliberately separate from
+#: :func:`is_object_category`, which defines the published ``vg_box_*`` sets and
+#: must keep defining them; this is a stricter policy layered on top for the new
+#: construction, so the old numbers stay reproducible.
+#:
+#: The extra bar exists because a scale study asks two things of a class that
+#: mere objecthood does not:
+#:
+#: * **Its size must be its own.** A part's box is set by its host, so a "small
+#:   nose" is just a distant face -- banding it measures the host's distance,
+#:   not the object's scale, and the arm silently becomes a different experiment.
+#: * **Its absence must be checkable.** The negative pool is ~95% of the images
+#:   and rests on "no instance here". For a part that is unverifiable at any
+#:   scale: every image with a person has a nose whether or not VG annotated
+#:   one, so the negatives are poisoned by construction and no amount of review
+#:   fixes it. That is the worst case for the correction pass, not a candidate
+#:   for it.
+#:
+#: Curated, not inferred -- and reported rather than applied silently, because
+#: silent automated judgements about VG's vocabulary are what #3156 is about.
+SCALE_STUDY_EXCLUSIONS: dict[str, str] = {
+    # Individuated only by a host object. Size tracks the host; absence is
+    # unverifiable wherever the host appears.
+    **dict.fromkeys(
+        """nose ear ears eye eyes face head hair mouth lip lips chin cheek forehead eyebrow
+        eyebrows neck chest shoulder shoulders arm arms hand hands finger fingers thumb leg legs
+        foot feet knee elbow wrist ankle waist hip tail paw paws hoof hooves horn horns tusk tusks
+        beak snout mane fur skin tooth teeth tongue mustache moustache beard sideburns""".split(),
+        "part",
+    ),
+    # Parts of artefacts: same two failures, non-anatomical.
+    **dict.fromkeys(
+        """collar sleeve sleeves cuff pocket zipper hem waistband strap straps buckle handle knob
+        spout lid rim brim blade tread stem tip base""".split(),
+        "part",
+    ),
+    # A location rather than a thing: the box has no principled extent (where
+    # does an intersection begin?), so its area is an annotator choice and the
+    # band it lands in is noise.
+    **dict.fromkeys(
+        """court courtyard intersection station runway walkway crossing crosswalk driveway alley
+        parking lot yard park playground platform entrance exit doorway hallway corridor stairway
+        staircase kitchen bathroom bedroom room office restaurant store shop market""".split(),
+        "place",
+    ),
+    # Parts of a plant or structure: same failure as anatomy.
+    **dict.fromkeys("""trunk branch twig root roof chimney railing banister step steps""".split(), "part"),
+}
+
+#: One string, several objects: "find the trunk in the middleground" is not one
+#: question, so the class cannot be scored as one. Matched on the **whole name**
+#: rather than the head noun, because a modifier is precisely what resolves the
+#: ambiguity -- bare ``bat`` is unusable, ``baseball bat`` is a perfectly good
+#: class. (Head-noun matching would reject both, and misreport the reason for
+#: ``tree trunk``, which is unfit for being a *part*, not for being ambiguous.)
+POLYSEMOUS_NAMES: frozenset[str] = frozenset(
+    """trunk bat mouse pitcher crane tie nail bow plate glass iron seal pen""".split()
+)
+
+#: A class annotated on more than this share of all images is treated as
+#: pervasive: its negative pool is both thin and least trustworthy, since a
+#: ubiquitous thing is exactly what an annotator stops bothering to mark. `sky`
+#: is the worked example -- 18.8% prevalent as annotated, plainly higher in
+#: truth (`docs/experiments/overview-bench/REPORT.md`). Measured, not listed,
+#: because which names are pervasive is a property of the corpus.
+PERVASIVE_PREVALENCE = float(os.environ.get("VTS_PERVASIVE_PREVALENCE", "0.10"))
+
+
+def scale_study_exclusion(name: str) -> str | None:
+    """Why *name* is unfit for a scale-band study, or ``None`` if it is fit.
+
+    Head-noun matched, like :func:`is_object_category`, so ``left eye`` and
+    ``bus station`` are caught while ``eyeglasses`` and ``gas station wall``
+    are judged on their own heads.
+    """
+    if not is_object_category(name):
+        return "non_object"
+    if name in POLYSEMOUS_NAMES:
+        return "polysemous"
+    tokens = name.replace("-", " ").split()
+    return SCALE_STUDY_EXCLUSIONS.get(tokens[-1]) or SCALE_STUDY_EXCLUSIONS.get(name)
+
+
 #: Embedders in the pile. ``patch`` embedders attach ``patch_grid`` and are the
 #: only ones that can carry a region-voting arm. ``batch`` is the GPU forward
 #: batch size (``VTSEARCH_EMBED_BATCH_SIZE``); the app's default of 32 is sized

--- a/scripts/experiments/pile/scan_name_overlap.py
+++ b/scripts/experiments/pile/scan_name_overlap.py
@@ -198,10 +198,7 @@ def main() -> int:
     for p in result["pairs"]:
         if p["verdict"] in ("distinct", "untestable") and p["co_images"] < MIN_CO_IMAGES:
             continue
-        log(
-            f"  {p['a']:<20}{p['b']:<20}{p['co_images']:>9}"
-            f"{p['a_on_b']:>9.3f}{p['b_on_a']:>9.3f}  {p['verdict']}"
-        )
+        log(f"  {p['a']:<20}{p['b']:<20}{p['co_images']:>9}{p['a_on_b']:>9.3f}{p['b_on_a']:>9.3f}  {p['verdict']}")
 
     counts: dict[str, int] = defaultdict(int)
     for p in result["pairs"]:

--- a/scripts/experiments/pile/scan_name_overlap.py
+++ b/scripts/experiments/pile/scan_name_overlap.py
@@ -1,0 +1,222 @@
+"""Do two VG names denote the same object? Measure it, don't guess.
+
+VG's vocabulary is free text, so one physical object arrives under several
+names. `glasses` / `sunglasses` / `reading glasses` would be a genuinely
+interesting fine-grained target -- *if* the labels could be trusted. They can't
+be assumed to: `glasses` might be a superset of `sunglasses`, disjoint from it,
+or overlapping at each annotator's whim, and the three cases want three
+different experiments.
+
+The overview benchmark already got burned reaching for a cheap proxy: its error
+report flagged false positives carrying a name that *contains* the target,
+which for `bus` matched 80 images annotated **`bush`**
+(`docs/experiments/overview-bench/REPORT.md`). String similarity is not evidence
+about objects. Box geometry is.
+
+**The test.** On images where both names appear, ask how often an `a` box
+lands on the same pixels as a `b` box (IoU >= `--iou`). Same pixels, two names
+means one object annotated twice:
+
+* **high both ways** -- an *alias*. The names are one label split arbitrarily,
+  so each one's negative pool is poisoned by the other and neither can be used
+  until they are merged.
+* **high one way only** -- a *subtype* (`sunglasses` boxes sit on `glasses`
+  boxes, but most `glasses` are not `sunglasses`). This is the interesting
+  case: a real fine-grained pair, where the broad name's negatives are sound.
+* **near zero** -- *distinct* objects that merely co-occur.
+
+**What it cannot resolve.** A pair that never co-occurs on any image is
+reported as `untestable`, not as distinct. Two names systematically split
+across annotators -- one says `glasses`, another says `spectacles`, neither
+ever labels the same image -- produce exactly the same emptiness as two genuinely
+unrelated words. Distinguishing those needs the human pass, and this script's
+job is to say which pairs are worth spending it on.
+
+Usage::
+
+    python scan_name_overlap.py --names glasses,sunglasses,eyeglasses,spectacles
+    python scan_name_overlap.py --from-shortlist shortlist.json --top 30
+    python scan_name_overlap.py --names bus,bush --iou 0.5   # the false lead, refuted
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from collections import defaultdict
+from itertools import combinations
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+VG_ROOT = pc.DEMO_CACHE / "visual_genome"
+OBJECTS_JSON = VG_ROOT / "objects.json"
+
+Box = tuple[float, float, float, float]
+
+
+def log(msg: str) -> None:
+    print(f"[overlap] {msg}", flush=True)
+
+
+def iou(a: Box, b: Box) -> float:
+    """Intersection over union of two ``(x0, y0, x1, y1)`` boxes."""
+    ix0, iy0 = max(a[0], b[0]), max(a[1], b[1])
+    ix1, iy1 = min(a[2], b[2]), min(a[3], b[3])
+    inter = max(0.0, ix1 - ix0) * max(0.0, iy1 - iy0)
+    if inter <= 0:
+        return 0.0
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def scan(wanted: set[str], thresh: float) -> dict:
+    """Per-name counts and per-pair box-overlap rates over the whole of VG.
+
+    Pixel boxes are compared directly: IoU is scale-free, so unlike the area
+    banding this needs no image dimensions and no dims cache.
+    """
+    log(f"loading {OBJECTS_JSON.name} ({OBJECTS_JSON.stat().st_size / 1e6:.0f} MB)...")
+    t0 = time.time()
+    with OBJECTS_JSON.open() as fh:
+        records = json.load(fh)
+    log(f"  parsed {len(records)} image records in {time.time() - t0:.0f}s")
+
+    n_images: dict[str, int] = defaultdict(int)
+    n_boxes: dict[str, int] = defaultdict(int)
+    co_images: dict[tuple[str, str], int] = defaultdict(int)
+    # (a, b) -> how many a-boxes have an on-target b-box, on co-annotated images
+    hits: dict[tuple[str, str], int] = defaultdict(int)
+    considered: dict[tuple[str, str], int] = defaultdict(int)
+
+    for rec in records:
+        by_name: dict[str, list[Box]] = defaultdict(list)
+        for obj in rec.get("objects") or []:
+            names = obj.get("names") or []
+            if not names:
+                continue
+            name = str(names[0]).strip().lower()
+            if name not in wanted:
+                continue
+            x, y = float(obj.get("x", 0)), float(obj.get("y", 0))
+            w, h = float(obj.get("w", 0)), float(obj.get("h", 0))
+            if w > 0 and h > 0:
+                by_name[name].append((x, y, x + w, y + h))
+        for name, boxes in by_name.items():
+            n_images[name] += 1
+            n_boxes[name] += len(boxes)
+        for a, b in combinations(sorted(by_name), 2):
+            co_images[(a, b)] += 1
+            # Directional: what fraction of a's boxes are covered by some b box,
+            # and vice versa. Asymmetry is what separates a subtype from an alias.
+            for first, second in ((a, b), (b, a)):
+                considered[(first, second)] += len(by_name[first])
+                hits[(first, second)] += sum(
+                    1 for box in by_name[first] if any(iou(box, other) >= thresh for other in by_name[second])
+                )
+
+    pairs = []
+    for a, b in sorted(co_images):
+        fwd = hits[(a, b)] / considered[(a, b)] if considered[(a, b)] else 0.0
+        rev = hits[(b, a)] / considered[(b, a)] if considered[(b, a)] else 0.0
+        pairs.append(
+            {
+                "a": a,
+                "b": b,
+                "co_images": co_images[(a, b)],
+                "a_on_b": round(fwd, 4),
+                "b_on_a": round(rev, 4),
+                "verdict": classify(co_images[(a, b)], fwd, rev),
+            }
+        )
+    # Pairs that never co-occur are untestable rather than absent - say so, so a
+    # missing row is never read as "measured, and they are distinct".
+    for a, b in combinations(sorted(wanted), 2):
+        if (a, b) not in co_images:
+            pairs.append({"a": a, "b": b, "co_images": 0, "a_on_b": 0.0, "b_on_a": 0.0, "verdict": "untestable"})
+
+    return {
+        "meta": {"iou_threshold": thresh, "names": sorted(wanted)},
+        "names": {n: {"n_images": n_images[n], "n_boxes": n_boxes[n]} for n in sorted(wanted)},
+        "pairs": sorted(pairs, key=lambda p: (-max(p["a_on_b"], p["b_on_a"]), p["a"], p["b"])),
+    }
+
+
+#: Below this many co-annotated images a rate is noise, not a measurement.
+MIN_CO_IMAGES = 10
+#: Rates above/below these separate "the same object" from "different objects".
+HIGH, LOW = 0.30, 0.05
+
+
+def classify(co: int, fwd: float, rev: float) -> str:
+    if co == 0:
+        return "untestable"
+    if co < MIN_CO_IMAGES:
+        return "thin"
+    if fwd >= HIGH and rev >= HIGH:
+        return "alias"
+    if max(fwd, rev) >= HIGH and min(fwd, rev) < LOW:
+        return "subtype"
+    if max(fwd, rev) < LOW:
+        return "distinct"
+    return "mixed"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--names", default="", help="comma-separated VG names to compare")
+    ap.add_argument("--from-shortlist", default="", help="shortlist_scale_classes.py --out JSON")
+    ap.add_argument("--top", type=int, default=30, help="with --from-shortlist, how many classes to take")
+    ap.add_argument("--iou", type=float, default=0.5, help="IoU above which two boxes are the same object")
+    ap.add_argument("--out", default="", help="also write the full result as JSON")
+    args = ap.parse_args()
+
+    wanted = {n.strip().lower() for n in args.names.split(",") if n.strip()}
+    if args.from_shortlist:
+        rows = json.loads(Path(args.from_shortlist).read_text())
+        wanted |= {r["category"] for r in rows[: args.top]}
+    if len(wanted) < 2:
+        raise SystemExit("need at least two names; pass --names or --from-shortlist")
+    if not OBJECTS_JSON.exists():
+        raise SystemExit(f"missing {OBJECTS_JSON}")
+
+    result = scan(wanted, args.iou)
+
+    log("")
+    log(f"=== per-name support ({len(result['names'])} names) ===")
+    for name, s in sorted(result["names"].items(), key=lambda kv: -kv[1]["n_images"]):
+        log(f"  {name:<24}{s['n_images']:>8} images{s['n_boxes']:>9} boxes")
+
+    log("")
+    log(f"=== box overlap at IoU >= {args.iou} ===")
+    log(f"  {'a':<20}{'b':<20}{'co-imgs':>9}{'a on b':>9}{'b on a':>9}  verdict")
+    for p in result["pairs"]:
+        if p["verdict"] in ("distinct", "untestable") and p["co_images"] < MIN_CO_IMAGES:
+            continue
+        log(
+            f"  {p['a']:<20}{p['b']:<20}{p['co_images']:>9}"
+            f"{p['a_on_b']:>9.3f}{p['b_on_a']:>9.3f}  {p['verdict']}"
+        )
+
+    counts: dict[str, int] = defaultdict(int)
+    for p in result["pairs"]:
+        counts[p["verdict"]] += 1
+    log("")
+    log(f"  verdicts: {dict(sorted(counts.items()))}")
+    log("  alias    -> merge the names, or neither one's negatives are sound")
+    log("  subtype  -> a real fine-grained pair; the broad name's negatives are sound")
+    log("  untestable -> never co-annotated; distinct and split-by-annotator look identical here")
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(result, indent=2) + "\n")
+        log(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/scan_vg_boxes.py
+++ b/scripts/experiments/pile/scan_vg_boxes.py
@@ -12,6 +12,22 @@ VG_100K_2, with the full free-text object vocabulary from ``objects.json`` --
 and reports the per-category voted-box scale so banded datasets can be built
 from the whole pool.
 
+**Per-band supply, not just a median.** The scan reports each category's *whole
+distribution* over the size bands, not only its median. Banding a category by
+its median puts it in exactly one band, which is what made the three
+``vg_box_*`` sets carry disjoint vocabularies -- so a small-vs-large difference
+confounded box size with class identity (noses vs fences). The question worth
+asking is "how well can we find buses in the middleground", which needs the
+*same* class present at every size, and that needs the histogram: how many
+images hold a background bus, a middleground bus, a foreground bus. See
+``shortlist_scale_classes.py``, which reads this scan and ranks the classes that
+have real support in all three bands.
+
+Areas are the **union** over a category's instances in an image -- the box one
+Good vote actually drags (``vtscore.eval.labels.region_box_for_category``) -- so
+an image holding one foreground bus and three background buses is a
+foreground-bus image, which is the honest reading of what the user would draw.
+
 ``objects.json`` stores boxes in **pixels** and carries no image dimensions, so
 areas are normalised against dims read from each JPEG header (PIL reads the
 header without decoding the image, which is what makes 108k files tractable).
@@ -102,6 +118,19 @@ def _union(boxes: list[tuple[float, float, float, float]]) -> tuple[float, float
     return x0, y0, x1, y1
 
 
+def _band_of(area: float) -> str:
+    """Which size band a voted-box *area* falls in.
+
+    ``oversize`` is above ``MAX_VOTED_AREA``: a box covering >80% of the image
+    is not a region, it is the image, so those instances are counted and
+    reported but are not usable as band positives.
+    """
+    for name, (lo, hi) in pc.BOX_BANDS.items():
+        if lo <= area < hi:
+            return name
+    return "oversize"
+
+
 def scan(min_images: int) -> dict:
     """Per-category voted-box scale over the whole of VG."""
     paths = _image_paths()
@@ -118,6 +147,9 @@ def scan(min_images: int) -> dict:
     voted: dict[str, list[float]] = defaultdict(list)
     instance: dict[str, list[float]] = defaultdict(list)
     n_images: dict[str, int] = defaultdict(int)
+    # category -> {band: how many images hold this category at that size}
+    bands: dict[str, dict[str, int]] = defaultdict(lambda: dict.fromkeys((*pc.BOX_BANDS, "oversize"), 0))
+    n_scanned = 0
 
     for rec in records:
         iid = int(rec["image_id"])
@@ -127,6 +159,7 @@ def scan(min_images: int) -> dict:
         W, H = wh
         if W <= 0 or H <= 0:
             continue
+        n_scanned += 1
         area = float(W * H)
         by_name: dict[str, list[tuple[float, float, float, float]]] = defaultdict(list)
         for obj in rec.get("objects") or []:
@@ -143,9 +176,11 @@ def scan(min_images: int) -> dict:
             by_name[name].append((x, y, x + w, y + h))
         for name, boxes in by_name.items():
             ux0, uy0, ux1, uy1 = _union(boxes)
-            voted[name].append(max(0.0, (ux1 - ux0)) * max(0.0, (uy1 - uy0)) / area)
+            union_area = max(0.0, (ux1 - ux0)) * max(0.0, (uy1 - uy0)) / area
+            voted[name].append(union_area)
             instance[name].extend((b[2] - b[0]) * (b[3] - b[1]) / area for b in boxes)
             n_images[name] += 1
+            bands[name][_band_of(union_area)] += 1
 
     stats = {}
     for name, areas in voted.items():
@@ -158,9 +193,21 @@ def scan(min_images: int) -> dict:
             "instance_area": i,
             "union_inflation": (v / i) if i > 0 else float("inf"),
             "n_images": n_images[name],
+            # Positive supply per band. The clean-negative supply is the
+            # complement, `meta.n_images_scanned - n_images`: an image holding
+            # no instance of the category at any size.
+            "bands": dict(bands[name]),
         }
     log(f"{len(stats)} categories with >= {min_images} images (of {len(voted)} distinct names)")
-    return stats
+    return {
+        "meta": {
+            "n_images_scanned": n_scanned,
+            "min_images": min_images,
+            "bands": {name: list(edges) for name, edges in pc.BOX_BANDS.items()},
+            "max_voted_area": pc.MAX_VOTED_AREA,
+        },
+        "categories": stats,
+    }
 
 
 def main() -> int:
@@ -169,21 +216,22 @@ def main() -> int:
     ap.add_argument("--out", default=str(pc.PILE / "vg_box_scale.json"), help="where to write the scan")
     args = ap.parse_args()
 
-    stats = scan(args.min_images)
-    Path(args.out).write_text(json.dumps(stats, indent=2, sort_keys=True) + "\n")
+    out = scan(args.min_images)
+    stats = out["categories"]
+    Path(args.out).write_text(json.dumps(out, indent=2, sort_keys=True) + "\n")
     log(f"wrote {args.out}")
 
     # Report against the geometry-anchored bands the calibration harness uses.
     PATCH, LEAF = 1 / 196, 1 / 12
-    bands = [
+    median_bands = [
         ("sub_patch", 0.0, PATCH),
         ("patch_to_leaf", PATCH, LEAF),
         ("leaf_to_4x", LEAF, 4 * LEAF),
         ("above_4x", 4 * LEAF, 1.01),
     ]
     log("")
-    log("=== full-VG category counts per geometry band ===")
-    for name, lo, hi in bands:
+    log("=== categories BANDED BY MEDIAN (one band each -- the old construction) ===")
+    for name, lo, hi in median_bands:
         pool = [c for c, s in stats.items() if lo <= s["voted_area"] < hi]
         clean = [c for c in pool if stats[c]["union_inflation"] <= 1.5]
         log(
@@ -192,6 +240,15 @@ def main() -> int:
         )
         example = sorted(pool, key=lambda c: -stats[c]["n_images"])[:8]
         log(f"      most-supported: {example}")
+
+    # The number that actually decides whether a same-class-across-bands study
+    # is possible: how many categories are present at EVERY size.
+    log("")
+    log("=== categories present in ALL THREE bands (the new construction) ===")
+    for floor in (25, 50, 100, 200):
+        viable = [c for c, s in stats.items() if min(s["bands"][b] for b in pc.BOX_BANDS) >= floor]
+        log(f"  >= {floor:4d} images in every band: {len(viable):5d} categories")
+    log("  (rank and filter them with shortlist_scale_classes.py)")
     return 0
 
 

--- a/scripts/experiments/pile/shortlist_scale_classes.py
+++ b/scripts/experiments/pile/shortlist_scale_classes.py
@@ -120,26 +120,40 @@ def coco_name(vg_name: str) -> str | None:
     return candidate if candidate in COCO_CLASSES else None
 
 
-def rank(scan: dict, floor: int, max_inflation: float) -> list[dict]:
+def rank(scan: dict, floor: int, max_inflation: float) -> tuple[list[dict], list[tuple[str, str, int]]]:
     """Categories clearing *floor* images in every band, best-supported first.
 
     Ranked on the **minimum** per-band count, because that is the binding
     constraint: a class with 8,000 large images and 6 small ones cannot carry a
     three-band contrast however abundant it looks overall.
+
+    Returns the survivors *and* the classes that had the supply but failed the
+    fitness policy, each with its reason. The rejects are returned rather than
+    dropped because they are the list a human has to sanity-check: a wrong
+    exclusion silently shrinks the study, and a wrong *inclusion* silently
+    changes what it measures.
     """
     meta, stats = scan["meta"], scan["categories"]
     n_total = int(meta["n_images_scanned"])
-    rows = []
+    rows: list[dict] = []
+    excluded: list[tuple[str, str, int]] = []
     for name, s in stats.items():
-        if not pc.is_object_category(name):
+        per_band = {b: int(s["bands"][b]) for b in pc.BOX_BANDS}
+        if min(per_band.values()) < floor:
             continue
         # A category whose union box is much larger than one instance is
         # scattered instances, not a region a user would drag -- and its band
         # assignment would describe the scatter, not the object.
         if s["union_inflation"] > max_inflation:
+            excluded.append((name, "scattered", min(per_band.values())))
             continue
-        per_band = {b: int(s["bands"][b]) for b in pc.BOX_BANDS}
-        if min(per_band.values()) < floor:
+        # Pervasiveness is a property of the corpus, so it is measured here
+        # rather than listed in the config.
+        reason = pc.scale_study_exclusion(name)
+        if reason is None and int(s["n_images"]) / n_total >= pc.PERVASIVE_PREVALENCE:
+            reason = "pervasive"
+        if reason is not None:
+            excluded.append((name, reason, min(per_band.values())))
             continue
         rows.append(
             {
@@ -158,7 +172,8 @@ def rank(scan: dict, floor: int, max_inflation: float) -> list[dict]:
             }
         )
     rows.sort(key=lambda r: (-r["min_band"], r["category"]))
-    return rows
+    excluded.sort(key=lambda e: (e[1], -e[2]))
+    return rows, excluded
 
 
 def main() -> int:
@@ -182,7 +197,7 @@ def main() -> int:
     if "categories" not in scan:
         raise SystemExit(f"{scan_path} predates per-band supply; re-run scan_vg_boxes.py")
 
-    rows = rank(scan, args.floor, args.max_inflation)
+    rows, excluded = rank(scan, args.floor, args.max_inflation)
     n_total = int(scan["meta"]["n_images_scanned"])
     print(f"scanned {n_total} images; {len(scan['categories'])} categories in the scan")
     print(f"{len(rows)} clear >= {args.floor} images in ALL THREE bands (inflation <= {args.max_inflation})\n")
@@ -196,6 +211,25 @@ def main() -> int:
             f"{r['category']:<18}{r['min_band']:>7}{b['small']:>8}{b['medium']:>8}{b['large']:>8}"
             f"{r['neg_pool']:>9}  {(r['coco'] or ''):<14}{'yes' if r['benchmarked'] else ''}"
         )
+
+    if excluded:
+        print(f"\n=== had the supply, failed the fitness policy ({len(excluded)}) -- CHECK THESE ===")
+        by_reason: dict[str, list[str]] = {}
+        for name, reason, _ in excluded:
+            by_reason.setdefault(reason, []).append(name)
+        blurb = {
+            "part": "size is the host's, and 'no nose here' is unverifiable wherever a person is",
+            "place": "a location, not a thing: the box has no principled extent",
+            "polysemous": "one string, several objects, so it cannot be scored as one class",
+            "pervasive": f"annotated on >= {pc.PERVASIVE_PREVALENCE:.0%} of images; thin, untrustworthy negatives",
+            "scattered": "union box far larger than one instance; the band describes the scatter",
+            "non_object": "attribute, frame relation, or mass noun (pile_config.is_object_category)",
+        }
+        for reason in sorted(by_reason):
+            names = sorted(by_reason[reason])
+            print(f"\n  {reason} -- {blurb.get(reason, '')}")
+            for i in range(0, len(names), 6):
+                print(f"    {', '.join(names[i : i + 6])}")
 
     n_coco = sum(1 for r in rows if r["coco"])
     n_bench = sum(1 for r in rows if r["benchmarked"])

--- a/scripts/experiments/pile/shortlist_scale_classes.py
+++ b/scripts/experiments/pile/shortlist_scale_classes.py
@@ -1,0 +1,214 @@
+"""Rank VG categories by how well they support a *same-class-across-bands* study.
+
+The old ``vg_box_{small,medium,large}`` sets banded each category by its
+**median** voted-box area, so a category landed in exactly one band and the
+three sets carried disjoint vocabularies (`nose`/`glasses`/`watch` against
+`fence`/`hill`/`lady`). A small-vs-large cost difference therefore confounded
+box size with class identity, which is not the question anyone wanted asked.
+
+The question worth asking is "how well can we find buses in the middleground?",
+which needs one class list *C* held fixed while only the size varies. For a
+class to serve that, VG has to hold enough images of it at **every** size:
+
+* **positives** for band *B* -- images whose voted box for *c* falls in *B*;
+* **negatives** -- images holding no instance of *c* at any size;
+* and, silently, an **excluded** remainder -- images holding *c* at some *other*
+  size, which are neither (there is a bus, so they are not negatives; it is the
+  wrong size, so they are not positives for this band).
+
+This script reads ``scan_vg_boxes.py``'s output and reports which categories
+clear a per-band floor, so *C* is chosen from measured supply rather than from
+intuition about what "ought" to appear at every distance.
+
+Pure stdlib and importless of ``vtscore``: the scan is a 108k-image job that
+needs the VG source, but ranking its JSON is a laptop operation and should not
+require the cluster.
+
+**What this cannot tell you.** Supply here is counted from VG's own
+annotations, and those are exactly what issue #3156 puts under suspicion --
+`498326.jpg` is annotated `car, clouds` and has a bus front and centre. So a
+per-band count is a lower bound on true positive supply and the negative-pool
+size is an upper bound. Use it to choose *C*, not to characterise the data.
+
+Usage::
+
+    python shortlist_scale_classes.py                     # top 40, floor 50
+    python shortlist_scale_classes.py --floor 100 --n 25
+    python shortlist_scale_classes.py --out shortlist.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pile_config as pc
+
+#: COCO-2017's 80 classes, keyed by the VG free-text name that denotes the same
+#: thing. Overlap is worth flagging because COCO val2017 is **exhaustively**
+#: annotated over these classes: for a class in both vocabularies, VG's miss
+#: rate can be measured against COCO with no human annotation at all, and a
+#: human annotator's own accuracy can be scored the same way. That makes a
+#: shared class the cheapest possible calibration of the whole correction pass.
+COCO_CLASSES: frozenset[str] = frozenset(
+    """person bicycle car motorcycle airplane bus train truck boat bench bird cat dog horse sheep
+    cow elephant bear zebra giraffe backpack umbrella handbag tie suitcase frisbee skis snowboard
+    kite skateboard surfboard bottle cup fork knife spoon bowl banana apple sandwich orange broccoli
+    carrot pizza donut cake chair couch bed toilet tv laptop mouse remote keyboard microwave oven
+    toaster sink refrigerator book clock vase scissors toothbrush""".split()
+    + [
+        "traffic light",
+        "fire hydrant",
+        "stop sign",
+        "parking meter",
+        "sports ball",
+        "baseball bat",
+        "baseball glove",
+        "tennis racket",
+        "wine glass",
+        "hot dog",
+        "potted plant",
+        "dining table",
+        "cell phone",
+        "hair drier",
+        "teddy bear",
+    ]
+)
+
+#: VG's vocabulary is free text, so the same object arrives under several names.
+#: Only aliases that resolve to a COCO class are listed -- this map exists to
+#: make the COCO flag correct, not to normalise VG generally.
+COCO_ALIASES: dict[str, str] = {
+    "plane": "airplane",
+    "aeroplane": "airplane",
+    "jet": "airplane",
+    "motorbike": "motorcycle",
+    "sofa": "couch",
+    "television": "tv",
+    "monitor": "tv",
+    "cellphone": "cell phone",
+    "phone": "cell phone",
+    "fridge": "refrigerator",
+    "bike": "bicycle",
+    "cycle": "bicycle",
+    "hydrant": "fire hydrant",
+    "trafficlight": "traffic light",
+    "computer": "laptop",
+    "purse": "handbag",
+    "glass": "wine glass",
+}
+
+#: Categories the overview benchmark already ran, so a corrected re-run can be
+#: compared against a published number rather than starting from nothing.
+#: Sources: `docs/experiments/overview-bench/REPORT.md`, "Classes used".
+BENCHMARKED: frozenset[str] = frozenset(
+    # wave 1, visual_genome_m
+    """ball bed bus cat laptop nose sink sky""".split()
+    # wave 2 re-run, vg_box_{small,medium,large}
+    + """nose glasses watch camera tip outlet drain mask mustache tusks
+    hair shorts clock lamp truck backpack basket frisbee holder chairs
+    fence hill lady couch court walkway runway station intersection barn""".split()
+    # wave 2 first run
+    + """hands lips chest collar dresser sheet""".split()
+)
+
+
+def coco_name(vg_name: str) -> str | None:
+    """The COCO class *vg_name* denotes, or ``None`` when COCO has no such class."""
+    candidate = COCO_ALIASES.get(vg_name, vg_name)
+    return candidate if candidate in COCO_CLASSES else None
+
+
+def rank(scan: dict, floor: int, max_inflation: float) -> list[dict]:
+    """Categories clearing *floor* images in every band, best-supported first.
+
+    Ranked on the **minimum** per-band count, because that is the binding
+    constraint: a class with 8,000 large images and 6 small ones cannot carry a
+    three-band contrast however abundant it looks overall.
+    """
+    meta, stats = scan["meta"], scan["categories"]
+    n_total = int(meta["n_images_scanned"])
+    rows = []
+    for name, s in stats.items():
+        if not pc.is_object_category(name):
+            continue
+        # A category whose union box is much larger than one instance is
+        # scattered instances, not a region a user would drag -- and its band
+        # assignment would describe the scatter, not the object.
+        if s["union_inflation"] > max_inflation:
+            continue
+        per_band = {b: int(s["bands"][b]) for b in pc.BOX_BANDS}
+        if min(per_band.values()) < floor:
+            continue
+        rows.append(
+            {
+                "category": name,
+                "min_band": min(per_band.values()),
+                "bands": per_band,
+                "oversize": int(s["bands"].get("oversize", 0)),
+                "n_images": int(s["n_images"]),
+                # Images holding no instance of this category at any size. The
+                # negative pool a cell draws from -- and the pool whose "no bus
+                # here" claim the annotation pass has to actually verify.
+                "neg_pool": n_total - int(s["n_images"]),
+                "coco": coco_name(name),
+                "benchmarked": name in BENCHMARKED,
+                "union_inflation": round(float(s["union_inflation"]), 3),
+            }
+        )
+    rows.sort(key=lambda r: (-r["min_band"], r["category"]))
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--scan", default=str(pc.PILE / "vg_box_scale.json"), help="scan_vg_boxes.py output")
+    ap.add_argument("--floor", type=int, default=50, help="minimum images per band (default 50)")
+    ap.add_argument(
+        "--max-inflation",
+        type=float,
+        default=pc.BAND_MAX_INFLATION,
+        help=f"drop categories whose union box exceeds this multiple of one instance (default {pc.BAND_MAX_INFLATION})",
+    )
+    ap.add_argument("--n", type=int, default=40, help="how many rows to print (default 40)")
+    ap.add_argument("--out", default="", help="also write the full ranking as JSON")
+    args = ap.parse_args()
+
+    scan_path = Path(args.scan)
+    if not scan_path.exists():
+        raise SystemExit(f"missing {scan_path}; run scan_vg_boxes.py first")
+    scan = json.loads(scan_path.read_text())
+    if "categories" not in scan:
+        raise SystemExit(f"{scan_path} predates per-band supply; re-run scan_vg_boxes.py")
+
+    rows = rank(scan, args.floor, args.max_inflation)
+    n_total = int(scan["meta"]["n_images_scanned"])
+    print(f"scanned {n_total} images; {len(scan['categories'])} categories in the scan")
+    print(f"{len(rows)} clear >= {args.floor} images in ALL THREE bands (inflation <= {args.max_inflation})\n")
+
+    hdr = f"{'category':<18}{'min':>7}{'small':>8}{'medium':>8}{'large':>8}{'negpool':>9}  {'coco':<14}bench"
+    print(hdr)
+    print("-" * len(hdr))
+    for r in rows[: args.n]:
+        b = r["bands"]
+        print(
+            f"{r['category']:<18}{r['min_band']:>7}{b['small']:>8}{b['medium']:>8}{b['large']:>8}"
+            f"{r['neg_pool']:>9}  {(r['coco'] or ''):<14}{'yes' if r['benchmarked'] else ''}"
+        )
+
+    n_coco = sum(1 for r in rows if r["coco"])
+    n_bench = sum(1 for r in rows if r["benchmarked"])
+    print(f"\n{n_coco} of {len(rows)} are also COCO classes (free cross-check against exhaustive annotation)")
+    print(f"{n_bench} of {len(rows)} were already benchmarked (comparable to the published numbers)")
+    print("\nNOTE: these counts come from VG's own annotations, which #3156 disputes.")
+    print("      Treat positive supply as a lower bound and the negative pool as an upper bound.")
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(rows, indent=2) + "\n")
+        print(f"\nwrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Prep pass for #3156: the analysis of why the current `vg_box_*` sets can't answer the scale question, plus the scan that measures whether a construction that can is even possible.

## The finding

`build_pile.py::_band_categories` bands each VG category by its **median** voted-box area, so a category lands in exactly one band and the three sets carry disjoint vocabularies — the overview benchmark ran `nose`/`glasses`/`watch` against `fence`/`hill`/`lady`. The published small-vs-large gap therefore confounds **box size** with **class identity**: it cannot separate "small regions are hard" from "noses are harder than fences".

The question worth asking — *how well can we find buses in the middleground?* — needs one class list held fixed while only size varies. That needs per-`(class, band)` supply, not a median.

## What's in this PR

- **`scan_vg_boxes.py`** now emits each category's full histogram over the size bands alongside the median it already reported. Areas are the **union** over a category's instances (what one Good vote actually drags, per `region_box_for_category`), so an image with one foreground bus and three background buses counts as a foreground-bus image.
- **`shortlist_scale_classes.py`** (new) ranks categories on their binding — minimum — per-band count, and flags two things that make a class cheap to work with: COCO-vocabulary overlap, where val2017's exhaustive annotation measures VG's miss rate with no human review at all, and prior benchmark coverage, where a corrected re-run has a published number to compare against. Pure stdlib and importless of `vtscore`, so ranking runs on a laptop even though the scan needs the cluster.
- **Scan file format** gains a `meta`/`categories` split instead of staying a flat map, so the image total the negative pool is derived from travels with the scan. `build_pile.py` reads the new shape; the existing `vg_box_scale.json` needs a re-scan.
- **`docs/plans/vg-scale-bands-and-corrections.md`** records the construction and the work still owed.

## The construction it's prep for

One image pool and one class list, with every `(image, class)` pair in one of three states rather than two:

| | condition | eval role |
|---|---|---|
| positive | voted box for `c` falls in band `B` | positive |
| negative | no instance of `c` at any size | negative |
| **excluded** | `c` present, at some *other* size | dropped from the cell |

The excluded state doesn't exist today — `media_is_positive` is closed-world two-valued, so a wrong-band image would silently become a negative and the detector would be penalised for finding a real bus, which is the failure #3156 opens with.

## Verification

Full `./run-tests.sh`: `RUN PASSED`, 8691 passed / 6 skipped. The shortlist script was exercised end-to-end against a synthetic scan; the real scan needs the VG source under `DEMO_CACHE` and runs on the GRID.

Refs #3156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Yrbm88iLRytiTSLEniesx

---
_Generated by [Claude Code](https://claude.ai/code/session_013Yrbm88iLRytiTSLEniesx)_