### PR TITLE
vg_scale: same-class scale bands over a chosen class list, with three-valued labels (#3156)

### DIFF
--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -128,25 +128,63 @@ annotated `car, clouds` and has a bus front and centre). Review them in
 descending detector score, plus a uniform random stratum so the residual noise
 rate after review is bounded rather than unknown.
 
+## What the scan measured (2026-08-17)
+
+Run on the GRID as jobs `509905` and `509971` (CPU-only, ~70 s each) against the
+full VG source; artifacts under `/expscratch/sgreenberg/vgscale-3156/`
+(`vg_box_scale_bands.json`, `shortlist_*.json`, `name_overlap.json`).
+
+**The construction is viable.** Of 4628 categories with >= 20 images, 534 hold
+>= 50 images in *every* band and 310 hold >= 100 — so one class list held fixed
+across three sizes is not supply-limited.
+
+**But the per-class scatter filter cost the study its best classes, `bus`
+included.** `union_inflation` is a per-*class* median, and a class that often
+appears several times per image fails it however compact any single image is:
+`bus` scores 1.71 against a 1.5 cap and is dropped, together with 30 of the 65
+COCO classes present. That is the wrong 30 to lose — a shared class is the only
+one whose VG miss rate can be measured against COCO's exhaustive annotation for
+free.
+
+Scatter is a property of an *image*, not of a class, so the scan now also counts
+an image only when its union box is within `BAND_MAX_INFLATION` of that image's
+own largest instance (`bands_compact`; `shortlist_scale_classes.py --compact`).
+The non-compact remainder is *excluded* from the cell, exactly like a wrong-band
+image — it is not turned into a negative.
+
+| floor 50, all three bands | classes | of which COCO |
+|---|---:|---:|
+| per-class median inflation | 196 | 15 |
+| per-image compact union | 305 | 41 |
+
+Nothing is lost by the switch: every COCO class the per-class rule kept survives
+it, and 26 more come back. It is cheap for the recovered classes — 90% of `bus`
+images are compact, giving 112 / 782 / 2137 images across small / medium /
+large. It is expensive only for classes that really are scattered (`person`
+0.66, `car` 0.71), which is the intended effect.
+
+**The eyewear arm does not earn a place.** `glasses` vs `sunglasses` overlap at
+IoU >= 0.5 on only 0.20 of boxes each way over 280 co-annotated images —
+`mixed`, not the clean `subtype` a fine-grained arm would need, and not the
+alias the overview benchmark assumed either. `eyeglasses` vs `glasses` does come
+back `alias` (0.32 / 0.31), so those two names must be merged before either is
+used. Separately, `bus` vs `bush` is refuted outright: 87 co-annotated images,
+**0.00** box overlap both ways. String similarity was never evidence.
+
 ## Open work
 
 <!-- item-sep -->
 
-- **Run the supply scan and pick *C*.** `scan_vg_boxes.py` now emits the
-  per-`(class, band)` histogram and `shortlist_scale_classes.py` ranks
-  categories on their binding (minimum) per-band supply, flagging COCO overlap
-  and prior benchmark coverage. Both need the VG source under `DEMO_CACHE`, so
-  the scan is a GRID job. Choosing *C* from its output — including a human pass
-  over the reported exclusions — is the gate on everything below. (Sonnet 5)
+- **Pick *C*.** ~~Run the supply scan~~ — done, see above; the ranking is in
+  `shortlist_compact_floor100.json`. Choosing *C* from it, including a human
+  pass over the reported exclusions, is still the gate on everything below.
+  (human)
 
 <!-- item-sep -->
 
-- **Decide whether a fine-grained pair earns a place in *C*.** Run
-  `scan_name_overlap.py` over the shortlist plus the eyewear cluster; if a pair
-  comes back `subtype` with real support in all three bands, it is the most
-  interesting arm available — scale *and* fine-grained discrimination on one
-  class. If it comes back `alias`, the names must be merged before either is
-  usable. Cheap, and it decides a study design. (Sonnet 5)
+- ~~**Decide whether a fine-grained pair earns a place in *C*.**~~ Measured:
+  no pair in the top 30 plus the eyewear cluster came back `subtype`, so the
+  fine-grained arm is dropped and `eyeglasses` is merged into `glasses`.
 
 <!-- item-sep -->
 

--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -128,80 +128,34 @@ annotated `car, clouds` and has a bus front and centre). Review them in
 descending detector score, plus a uniform random stratum so the residual noise
 rate after review is bounded rather than unknown.
 
-## What the scan measured (2026-08-17)
+## Background the remaining work depends on
 
-Run on the GRID as jobs `509905` and `509971` (CPU-only, ~70 s each) against the
-full VG source; artifacts under `/expscratch/sgreenberg/vgscale-3156/`
-(`vg_box_scale_bands.json`, `shortlist_*.json`, `name_overlap.json`).
+*C* is the twelve classes in `pile_config.SCALE_CLASSES` — every one also a
+COCO-2017 class, which is what makes the correction pass affordable: COCO
+val2017 is exhaustively annotated over exactly these names, so VG's miss rate
+and our own annotators' accuracy can both be scored against it without extra
+review. The measured supply behind the choice is
+`/expscratch/sgreenberg/vgscale-3156/` (`vg_box_scale_bands.json`,
+`shortlist_*.json`, `name_overlap.json`).
 
-**The construction is viable.** Of 4628 categories with >= 20 images, 534 hold
->= 50 images in *every* band and 310 hold >= 100 — so one class list held fixed
-across three sizes is not supply-limited.
+Two measurements constrain what comes next:
 
-**But the per-class scatter filter cost the study its best classes, `bus`
-included.** `union_inflation` is a per-*class* median, and a class that often
-appears several times per image fails it however compact any single image is:
-`bus` scores 1.71 against a 1.5 cap and is dropped, together with 30 of the 65
-COCO classes present. That is the wrong 30 to lose — a shared class is the only
-one whose VG miss rate can be measured against COCO's exhaustive annotation for
-free.
-
-Scatter is a property of an *image*, not of a class, so the scan now also counts
-an image only when its union box is within `BAND_MAX_INFLATION` of that image's
-own largest instance (`bands_compact`; `shortlist_scale_classes.py --compact`).
-The non-compact remainder is *excluded* from the cell, exactly like a wrong-band
-image — it is not turned into a negative.
-
-| floor 50, all three bands | classes | of which COCO |
-|---|---:|---:|
-| per-class median inflation | 196 | 15 |
-| per-image compact union | 305 | 41 |
-
-Nothing is lost by the switch: every COCO class the per-class rule kept survives
-it, and 26 more come back. It is cheap for the recovered classes — 90% of `bus`
-images are compact, giving 112 / 782 / 2137 images across small / medium /
-large. It is expensive only for classes that really are scattered (`person`
-0.66, `car` 0.71), which is the intended effect.
-
-**The eyewear arm does not earn a place.** `glasses` vs `sunglasses` overlap at
-IoU >= 0.5 on only 0.20 of boxes each way over 280 co-annotated images —
-`mixed`, not the clean `subtype` a fine-grained arm would need, and not the
-alias the overview benchmark assumed either. `eyeglasses` vs `glasses` does come
-back `alias` (0.32 / 0.31), so those two names must be merged before either is
-used. Separately, `bus` vs `bush` is refuted outright: 87 co-annotated images,
-**0.00** box overlap both ways. String similarity was never evidence.
+- **Scatter is filtered per image, not per class.** A class that often appears
+  several times per image fails a per-class inflation median however compact any
+  single image is, which cost the shortlist 30 of the 65 COCO classes (`bus`
+  among them, at 1.71). The cell rule is therefore per image, and a non-compact
+  image is *excluded* rather than counted as a negative.
+- **No fine-grained pair survived.** No candidate pair came back `subtype`, so
+  there is no fine-grained arm; `eyeglasses` is an alias of `glasses` and would
+  have to be merged before either name is usable.
 
 ## Open work
 
 <!-- item-sep -->
 
-- **Pick *C*.** ~~Run the supply scan~~ — done, see above; the ranking is in
-  `shortlist_compact_floor100.json`. Choosing *C* from it, including a human
-  pass over the reported exclusions, is still the gate on everything below.
-  (human)
-
 <!-- item-sep -->
 
-- ~~**Decide whether a fine-grained pair earns a place in *C*.**~~ Measured:
-  no pair in the top 30 plus the eyewear cluster came back `subtype`, so the
-  fine-grained arm is dropped and `eyeglasses` is merged into `glasses`.
-
 <!-- item-sep -->
-
-- **Three-valued labels in the eval harness.** `media_is_evaluable(media,
-  category)` beside `media_is_positive`, and per-cell pool filtering at the
-  three entry points above. Needs a `vtscore/eval/labels.py` test for the
-  wrong-band case, and an `MIRRORS` review — the harness's notion of ground
-  truth is changing, not the app's algorithm. (Opus 4.8 — a silent
-  mis-classification here invalidates every number downstream.)
-
-<!-- item-sep -->
-
-- **The `vg_scale` builder.** One pickle over *C*, band-suffixed category names,
-  per-class exclusion sets, fixed `n_pos`/`n_neg` per cell. Replaces the three
-  `vg_box_*` entries in `pile_config.DATASETS`; the published `vg_box_*` numbers
-  stay valid for what they measured and are not comparable to the new sets.
-  (Sonnet 5)
 
 <!-- item-sep -->
 

--- a/scripts/experiments/calibration/prepare_data.py
+++ b/scripts/experiments/calibration/prepare_data.py
@@ -81,12 +81,20 @@ def _exemplar_crops(medias: dict, categories: list[str], embedder) -> tuple[dict
     boxless datasets use whole images.  With ``embedder=None`` (reuse path) every
     crop degrades to the whole-image vector.
     """
-    from vtscore.eval.labels import media_is_positive, region_box_for_category  # noqa: PLC0415
+    from vtscore.eval.labels import (  # noqa: PLC0415
+        evaluable_pool,
+        media_is_positive,
+        region_box_for_category,
+    )
 
     vectors: dict[str, object] = {}
     candidates: dict[str, list[int]] = {}
     for cat in categories:
-        pos = [cid for cid in sorted(medias) if media_is_positive(medias[cid], cat)]
+        # Wrong-band images are excluded from the cell, so they must not seed it
+        # either: an exemplar crop taken from one is a crop of the right object
+        # at the wrong scale.
+        medias_cat = evaluable_pool(medias, cat)
+        pos = [cid for cid in sorted(medias_cat) if media_is_positive(medias_cat[cid], cat)]
         boxed = [cid for cid in pos if region_box_for_category(medias[cid], cat) is not None]
         pool = boxed or pos
         if not pool:

--- a/scripts/experiments/calibration/text_baseline.py
+++ b/scripts/experiments/calibration/text_baseline.py
@@ -56,7 +56,7 @@ def main() -> int:
     from sklearn.metrics import average_precision_score, roc_auc_score
 
     from vtscore.embedding import embed_text_query
-    from vtscore.eval.labels import media_is_positive
+    from vtscore.eval.labels import evaluable_pool, media_is_positive
     from vtscore.eval.patch_styles import resolve_style
     from vtscore.eval.score_dumps import write_prediction_dump
     from vtscore.training.thresholds import calculate_gmm_threshold
@@ -96,17 +96,22 @@ def main() -> int:
                     rows.append({"dataset": ds, "embedder": emb, "category": cat, "supports_text": 0})
                     continue
 
+                # The same pool the voting harness scores this cell on: a
+                # wrong-band image is not a negative, so it is not a text-sort
+                # negative either.
+                medias_cat = evaluable_pool(medias, cat)
+
                 # Same scorer the seed phase uses, text vector in place of a crop.
-                sims = style.exemplar_sims(medias, np.asarray(tvec, dtype=np.float32))
-                ids = sorted(medias.keys())
+                sims = style.exemplar_sims(medias_cat, np.asarray(tvec, dtype=np.float32))
+                ids = sorted(medias_cat.keys())
                 scores = np.asarray([float(sims[i]) for i in ids], dtype=np.float64)
-                labels = np.asarray([1 if media_is_positive(medias[i], cat) else 0 for i in ids])
+                labels = np.asarray([1 if media_is_positive(medias_cat[i], cat) else 0 for i in ids])
 
                 # The app cuts the haystack it can see: every media, not a split.
                 gmm_cut = float(calculate_gmm_threshold([float(s) for s in scores]))
 
                 for seed in cfg.SEEDS:
-                    _, test_ids = _split(medias, cfg.SIM_FRACTION, seed)
+                    _, test_ids = _split(medias_cat, cfg.SIM_FRACTION, seed)
                     tset = set(test_ids)
                     mask = np.asarray([i in tset for i in ids])
                     y, s = labels[mask], scores[mask]

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -330,9 +330,11 @@ def _vg_source() -> tuple[dict[int, Path], list, dict[int, tuple[int, int]]]:
     cache = pc.PILE / "vg_image_dims.json"
     dims: dict[int, tuple[int, int]] = {}
     if cache.exists():
-        cached = {int(k): tuple(v) for k, v in json.loads(cache.read_text()).items()}
-        if len(cached) >= len(paths):
-            dims = cached  # type: ignore[assignment]
+        raw = json.loads(cache.read_text())
+        # Unreadable images are cached as null, so a complete cache has one
+        # entry per file (see scan_vg_boxes._read_dims).
+        if len(raw) >= len(paths):
+            dims = {int(k): tuple(v) for k, v in raw.items() if v}  # type: ignore[misc]
     if not dims:
         log("  no dims cache; reading JPEG headers")
 

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -302,6 +302,201 @@ def _load_vg_band(band: str, medias: dict[int, dict], embedder_name: str) -> Non
         }
 
 
+def _vg_source() -> tuple[dict[int, Path], list, dict[int, tuple[int, int]]]:
+    """``(image paths, objects.json records, image dims)`` for the whole VG source.
+
+    Dims come from ``scan_vg_boxes.py``'s cache when it exists (it always does
+    in practice -- the scan is what chooses the classes), and are read from the
+    JPEG headers otherwise, which costs ~30 s.
+    """
+    from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
+
+    from PIL import Image  # noqa: PLC0415
+
+    vg_root = pc.DEMO_CACHE / "visual_genome"
+    objects_json = vg_root / "objects.json"
+    if not objects_json.exists():
+        raise SystemExit(f"missing {objects_json}")
+
+    paths: dict[int, Path] = {}
+    for d in (vg_root / "VG_100K", vg_root / "VG_100K_2"):
+        for p in d.iterdir():
+            if p.suffix.lower() == ".jpg":
+                try:
+                    paths[int(p.stem)] = p
+                except ValueError:
+                    continue
+
+    cache = pc.PILE / "vg_image_dims.json"
+    dims: dict[int, tuple[int, int]] = {}
+    if cache.exists():
+        cached = {int(k): tuple(v) for k, v in json.loads(cache.read_text()).items()}
+        if len(cached) >= len(paths):
+            dims = cached  # type: ignore[assignment]
+    if not dims:
+        log("  no dims cache; reading JPEG headers")
+
+        def one(item):
+            iid, path = item
+            try:
+                with Image.open(path) as im:
+                    return iid, im.size
+            except Exception:  # noqa: BLE001 - a corrupt file just drops out
+                return iid, None
+
+        with ThreadPoolExecutor(max_workers=16) as ex:
+            for iid, size in ex.map(one, paths.items(), chunksize=256):
+                if size:
+                    dims[iid] = size
+
+    with objects_json.open() as fh:
+        records = json.load(fh)
+    return paths, records, dims
+
+
+def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
+    """One pickle holding every ``(class, band)`` cell of the scale study (#3156).
+
+    The construction, in one paragraph: one image pool and one class list
+    (:data:`pile_config.SCALE_CLASSES`); for a class *c* and band *B* an image is
+    a **positive** when its compact union box for *c* falls in *B*, a
+    **negative** when it holds no instance of any class in *C*, and **excluded**
+    otherwise -- it holds *c* at some other size, so scoring it as a negative
+    would penalise a detector for finding a real bus, which is what #3156 is
+    about. Exclusion is carried per media as ``evaluable_categories`` and
+    honoured by ``vtscore.eval.labels.evaluable_pool``.
+
+    Cells are *designated* rather than inferred: exactly ``SCALE_N_POS``
+    positives and one shared pool of ``SCALE_N_NEG`` negatives each. Every cell
+    therefore has identical prevalence and identical negatives, so a
+    small-vs-large difference is a paired contrast on one class rather than two
+    datasets of different difficulty.
+    """
+    import random  # noqa: PLC0415
+
+    from PIL import Image  # noqa: PLC0415
+
+    wanted = set(pc.SCALE_CLASSES)
+    bands = list(pc.BOX_BANDS)
+    cells = [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in bands]
+
+    paths, records, dims = _vg_source()
+    log(f"  scanning {len(records)} VG records for {len(wanted)} classes")
+
+    # class -> band -> [image_id], plus the boxes to stamp and the clean pool.
+    supply: dict[str, dict[str, list[int]]] = {c: {b: [] for b in bands} for c in pc.SCALE_CLASSES}
+    boxes_for: dict[tuple[int, str], list[list[float]]] = {}
+    clean: list[int] = []
+
+    for rec in records:
+        iid = int(rec["image_id"])
+        wh = dims.get(iid)
+        if iid not in paths or wh is None:
+            continue
+        W, H = wh
+        if W <= 0 or H <= 0:
+            continue
+        area = float(W * H)
+        by_name: dict[str, list[list[float]]] = defaultdict(list)
+        for obj in rec.get("objects") or []:
+            names = obj.get("names") or []
+            if not names:
+                continue
+            name = str(names[0]).strip().lower()
+            if name not in wanted:
+                continue
+            x, y = float(obj.get("x", 0)), float(obj.get("y", 0))
+            w, h = float(obj.get("w", 0)), float(obj.get("h", 0))
+            if w > 0 and h > 0:
+                by_name[name].append([x, y, x + w, y + h])
+        if not by_name:
+            # Holds none of C at any size: a sound negative for every cell.
+            clean.append(iid)
+            continue
+        for name, bs in by_name.items():
+            ux0 = min(b[0] for b in bs)
+            uy0 = min(b[1] for b in bs)
+            ux1 = max(b[2] for b in bs)
+            uy1 = max(b[3] for b in bs)
+            union = max(0.0, ux1 - ux0) * max(0.0, uy1 - uy0) / area
+            largest = max((b[2] - b[0]) * (b[3] - b[1]) for b in bs) / area
+            # Scattered instances in *this* image: the union box describes the
+            # scatter rather than the object, so the image is excluded from
+            # every band of this class rather than banded by a box no user
+            # would drag.
+            if union > largest * pc.BAND_MAX_INFLATION:
+                continue
+            for band, (lo, hi) in pc.BOX_BANDS.items():
+                if lo <= union < hi:
+                    supply[name][band].append(iid)
+                    boxes_for[(iid, pc.scale_cell(name, band))] = bs
+                    break
+
+    rng = random.Random(0x5CA1E)  # deterministic sample, stable across rebuilds
+    chosen: dict[str, list[int]] = {}
+    for c in pc.SCALE_CLASSES:
+        for band in bands:
+            pool = sorted(supply[c][band])
+            cell = pc.scale_cell(c, band)
+            if len(pool) < pc.SCALE_N_POS:
+                # Say so rather than quietly building a smaller cell: unequal
+                # prevalence between bands is the defect this construction
+                # exists to remove.
+                log(f"  UNDER-SUPPLIED {cell}: {len(pool)} positives (wanted {pc.SCALE_N_POS})")
+            chosen[cell] = rng.sample(pool, min(pc.SCALE_N_POS, len(pool)))
+
+    clean.sort()
+    negatives = rng.sample(clean, min(pc.SCALE_N_NEG, len(clean)))
+    log(
+        f"  {sum(len(v) for v in chosen.values())} positives over {len(cells)} cells, "
+        f"{len(negatives)} shared negatives (from {len(clean)} clean images)"
+    )
+
+    # media id -> the cells it is a positive for. Negatives get every cell.
+    positive_in: dict[int, list[str]] = defaultdict(list)
+    for cell, ids in chosen.items():
+        for iid in ids:
+            positive_in[iid].append(cell)
+
+    for iid in sorted(set(positive_in) | set(negatives)):
+        path = paths[iid]
+        try:
+            with Image.open(path) as im:
+                W, H = im.size
+            data = path.read_bytes()
+        except Exception:  # noqa: BLE001 - a corrupt file just drops out
+            continue
+        if W <= 0 or H <= 0:
+            continue
+        cats = sorted(positive_in.get(iid, []))
+        regions = [
+            {"box": [b[0] / W, b[1] / H, b[2] / W, b[3] / H], "label": cell}
+            for cell in cats
+            for b in boxes_for.get((iid, cell), [])
+        ]
+        medias[iid] = {
+            "id": iid,
+            "media_type": "image",
+            "embedder": embedder_name,
+            "duration": 0,
+            "file_size": 0,
+            "md5": "",
+            "embeddings": {},
+            "media_bytes": data,
+            "media_string": None,
+            "filename": path.name,
+            "category": cats[0] if cats else "",
+            "categories": cats,
+            # A designated cell membership, not a closed world: a positive is
+            # scorable only in the cells it was drawn for, and the shared
+            # negatives are scorable everywhere.
+            "evaluable_categories": cats if cats else list(cells),
+            "regions": regions,
+            "origin": {"importer": "vg_scale", "params": {"embedder": embedder_name}},
+            "origin_name": str(path),
+        }
+
+
 def _load_demo(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     from vtscore.datasets.loader_demo import load_demo_dataset  # noqa: PLC0415
 
@@ -354,6 +549,8 @@ def build_cell(dataset: str, embedder: str, force: bool = False) -> dict:
         _load_coco(medias, embedder)
     elif kind == "vg_band":
         _load_vg_band(pc.DATASETS[dataset]["band"], medias, embedder)
+    elif kind == "vg_scale":
+        _load_vg_scale(medias, embedder)
     else:
         pc.require_demo_source(dataset)
         _load_demo(dataset, medias, embedder)

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -60,6 +60,12 @@ DATASETS: dict[str, dict] = {
     "vg_box_small": {"boxed": True, "kind": "vg_band", "band": "small"},
     "vg_box_medium": {"boxed": True, "kind": "vg_band", "band": "medium"},
     "vg_box_large": {"boxed": True, "kind": "vg_band", "band": "large"},
+    # The same-class-across-bands set (#3156). One pickle, one class list, one
+    # negative pool; the band lives on the category name (`bus@small`). Not a
+    # replacement for `vg_box_*` -- those measured what they measured and stay
+    # reproducible -- but the two are not comparable: disjoint vocabularies
+    # against a fixed one.
+    "vg_scale": {"boxed": True, "kind": "vg_scale"},
 }
 
 #: Box-size bands, as a fraction of image area, anchored to the patch
@@ -216,6 +222,61 @@ def scale_study_exclusion(name: str) -> str | None:
         return "polysemous"
     tokens = name.replace("-", " ").split()
     return SCALE_STUDY_EXCLUSIONS.get(tokens[-1]) or SCALE_STUDY_EXCLUSIONS.get(name)
+
+
+#: The class list *C* for the same-class-across-bands study (issue #3156).
+#:
+#: Chosen by the owner on 2026-08-17 from the measured shortlist
+#: (``shortlist_scale_classes.py --compact --floor 100``), out of the 24
+#: candidates that were simultaneously: supported at >= 100 images in all three
+#: bands, free of a measured alias partner and of plural-form ambiguity, and
+#: **also a COCO-2017 class**. That last property is what makes the correction
+#: pass affordable: COCO val2017 is exhaustively annotated over these names, so
+#: VG's miss rate -- and our own annotators' accuracy -- can be scored against it
+#: with no extra human review.
+#:
+#: Deliberately *not* derived at build time from the scan. Which classes a human
+#: can annotate consistently is a judgement, and re-deriving it would silently
+#: change what the study measures whenever the scan is re-run.
+SCALE_CLASSES: tuple[str, ...] = (
+    "clock",
+    "bird",
+    "boat",
+    "umbrella",
+    "kite",
+    "book",
+    "dog",
+    "backpack",
+    "knife",
+    "bicycle",
+    "bus",
+    "stop sign",
+)
+
+#: Images per ``(class, band)`` cell, and the shared negative pool every cell
+#: draws from. ``stop sign`` binds the positive count: 104 images in its small
+#: band is the smallest per-band supply in *C*, so 100 is the largest round
+#: number every one of the 36 cells can fill without replacement.
+#:
+#: Cells are **designated**, not inferred: each is exactly these positives plus
+#: this negative pool, and every other image in the pickle is excluded from it.
+#: Prevalence is therefore identical in all 36 cells by construction, which is
+#: what makes small-vs-large a paired comparison rather than two datasets with
+#: different difficulty. Unequal prevalence between arms is what made wave 1 and
+#: wave 2 of the overview benchmark non-comparable.
+SCALE_N_POS = int(os.environ.get("VTS_SCALE_N_POS", "100"))
+SCALE_N_NEG = int(os.environ.get("VTS_SCALE_N_NEG", "3900"))
+
+
+def scale_cell(category: str, band: str) -> str:
+    """The band-suffixed category name a harness cell is keyed on.
+
+    One pickle carries all three bands, distinguished by this suffix, because a
+    cell is already ``(dataset, category)`` -- so the bands need no harness
+    change, embedding is done once instead of three times, and the bands are
+    paired on identical negatives.
+    """
+    return f"{category}@{band}"
 
 
 #: Embedders in the pile. ``patch`` embedders attach ``patch_grid`` and are the

--- a/scripts/experiments/pile/scan_vg_boxes.py
+++ b/scripts/experiments/pile/scan_vg_boxes.py
@@ -79,10 +79,17 @@ def _image_paths() -> dict[int, Path]:
 
 
 def _read_dims(paths: dict[int, Path], workers: int = 16) -> dict[int, tuple[int, int]]:
-    """``{image_id: (w, h)}``, cached to disk. Header-only reads, threaded."""
+    """``{image_id: (w, h)}``, cached to disk. Header-only reads, threaded.
+
+    Unreadable images are cached as ``null`` rather than omitted. Without them
+    the cache holds fewer entries than there are files (170 of VG's 108,245 are
+    corrupt), so a "is it complete?" length check could never pass and the cache
+    was silently rebuilt on every run by every caller.
+    """
     if DIMS_CACHE.exists():
-        cached = {int(k): tuple(v) for k, v in json.loads(DIMS_CACHE.read_text()).items()}
-        if len(cached) >= len(paths):
+        raw = json.loads(DIMS_CACHE.read_text())
+        if len(raw) >= len(paths):
+            cached = {int(k): tuple(v) for k, v in raw.items() if v}
             log(f"reusing cached dims for {len(cached)} images")
             return cached  # type: ignore[return-value]
 
@@ -98,14 +105,19 @@ def _read_dims(paths: dict[int, Path], workers: int = 16) -> dict[int, tuple[int
 
     t0 = time.time()
     dims: dict[int, tuple[int, int]] = {}
+    misses: list[int] = []
     with ThreadPoolExecutor(max_workers=workers) as ex:
         for i, (iid, size) in enumerate(ex.map(one, paths.items(), chunksize=256), 1):
             if size:
                 dims[iid] = size
+            else:
+                misses.append(iid)
             if i % 20000 == 0:
                 log(f"  dims {i}/{len(paths)} ({time.time() - t0:.0f}s)")
     log(f"read dims for {len(dims)}/{len(paths)} images in {time.time() - t0:.0f}s")
-    DIMS_CACHE.write_text(json.dumps({str(k): list(v) for k, v in dims.items()}))
+    on_disk: dict[str, list[int] | None] = {str(k): list(v) for k, v in dims.items()}
+    on_disk.update({str(iid): None for iid in misses})
+    DIMS_CACHE.write_text(json.dumps(on_disk))
     return dims
 
 

--- a/scripts/experiments/pile/scan_vg_boxes.py
+++ b/scripts/experiments/pile/scan_vg_boxes.py
@@ -149,6 +149,14 @@ def scan(min_images: int) -> dict:
     n_images: dict[str, int] = defaultdict(int)
     # category -> {band: how many images hold this category at that size}
     bands: dict[str, dict[str, int]] = defaultdict(lambda: dict.fromkeys((*pc.BOX_BANDS, "oversize"), 0))
+    # Same histogram, but counting only images where the union box is COMPACT:
+    # within `BAND_MAX_INFLATION` of this image's own largest instance. A class
+    # is scattered *in an image*, not in general -- one bus in the foreground is
+    # a foreground bus however many other images hold four scattered buses. The
+    # per-class `union_inflation` filter drops the whole class on that evidence,
+    # which costs 30 of the 65 COCO classes (`bus` among them, at 1.71).
+    bands_compact: dict[str, dict[str, int]] = defaultdict(lambda: dict.fromkeys((*pc.BOX_BANDS, "oversize"), 0))
+    n_compact: dict[str, int] = defaultdict(int)
     n_scanned = 0
 
     for rec in records:
@@ -181,6 +189,10 @@ def scan(min_images: int) -> dict:
             instance[name].extend((b[2] - b[0]) * (b[3] - b[1]) / area for b in boxes)
             n_images[name] += 1
             bands[name][_band_of(union_area)] += 1
+            largest = max((b[2] - b[0]) * (b[3] - b[1]) for b in boxes) / area
+            if union_area <= largest * pc.BAND_MAX_INFLATION:
+                n_compact[name] += 1
+                bands_compact[name][_band_of(union_area)] += 1
 
     stats = {}
     for name, areas in voted.items():
@@ -197,6 +209,11 @@ def scan(min_images: int) -> dict:
             # complement, `meta.n_images_scanned - n_images`: an image holding
             # no instance of the category at any size.
             "bands": dict(bands[name]),
+            # Positives under the per-image rule: the non-compact remainder is
+            # *excluded* from the cell, not turned into a negative.
+            "bands_compact": dict(bands_compact[name]),
+            "n_compact": n_compact[name],
+            "compact_frac": n_compact[name] / n_images[name],
         }
     log(f"{len(stats)} categories with >= {min_images} images (of {len(voted)} distinct names)")
     return {
@@ -247,7 +264,11 @@ def main() -> int:
     log("=== categories present in ALL THREE bands (the new construction) ===")
     for floor in (25, 50, 100, 200):
         viable = [c for c, s in stats.items() if min(s["bands"][b] for b in pc.BOX_BANDS) >= floor]
-        log(f"  >= {floor:4d} images in every band: {len(viable):5d} categories")
+        compact = [c for c, s in stats.items() if min(s["bands_compact"][b] for b in pc.BOX_BANDS) >= floor]
+        log(
+            f"  >= {floor:4d} images in every band: {len(viable):5d} categories "
+            f"({len(compact)} counting only compact-union images)"
+        )
     log("  (rank and filter them with shortlist_scale_classes.py)")
     return 0
 

--- a/scripts/experiments/pile/shortlist_scale_classes.py
+++ b/scripts/experiments/pile/shortlist_scale_classes.py
@@ -120,7 +120,9 @@ def coco_name(vg_name: str) -> str | None:
     return candidate if candidate in COCO_CLASSES else None
 
 
-def rank(scan: dict, floor: int, max_inflation: float) -> tuple[list[dict], list[tuple[str, str, int]]]:
+def rank(
+    scan: dict, floor: int, max_inflation: float, compact: bool = False
+) -> tuple[list[dict], list[tuple[str, str, int]]]:
     """Categories clearing *floor* images in every band, best-supported first.
 
     Ranked on the **minimum** per-band count, because that is the binding
@@ -137,14 +139,19 @@ def rank(scan: dict, floor: int, max_inflation: float) -> tuple[list[dict], list
     n_total = int(meta["n_images_scanned"])
     rows: list[dict] = []
     excluded: list[tuple[str, str, int]] = []
+    key = "bands_compact" if compact else "bands"
     for name, s in stats.items():
-        per_band = {b: int(s["bands"][b]) for b in pc.BOX_BANDS}
+        if key not in s:
+            raise SystemExit("scan predates per-image compactness; re-run scan_vg_boxes.py")
+        per_band = {b: int(s[key][b]) for b in pc.BOX_BANDS}
         if min(per_band.values()) < floor:
             continue
         # A category whose union box is much larger than one instance is
         # scattered instances, not a region a user would drag -- and its band
         # assignment would describe the scatter, not the object.
-        if s["union_inflation"] > max_inflation:
+        # Under --compact the scatter is filtered per image, so the per-class
+        # test would drop classes whose surviving images are all compact.
+        if not compact and s["union_inflation"] > max_inflation:
             excluded.append((name, "scattered", min(per_band.values())))
             continue
         # Pervasiveness is a property of the corpus, so it is measured here
@@ -186,6 +193,12 @@ def main() -> int:
         default=pc.BAND_MAX_INFLATION,
         help=f"drop categories whose union box exceeds this multiple of one instance (default {pc.BAND_MAX_INFLATION})",
     )
+    ap.add_argument(
+        "--compact",
+        action="store_true",
+        help="count only images whose union box is within --max-inflation of their own largest "
+        "instance, instead of dropping the whole class on its median inflation",
+    )
     ap.add_argument("--n", type=int, default=40, help="how many rows to print (default 40)")
     ap.add_argument("--out", default="", help="also write the full ranking as JSON")
     args = ap.parse_args()
@@ -197,10 +210,11 @@ def main() -> int:
     if "categories" not in scan:
         raise SystemExit(f"{scan_path} predates per-band supply; re-run scan_vg_boxes.py")
 
-    rows, excluded = rank(scan, args.floor, args.max_inflation)
+    rows, excluded = rank(scan, args.floor, args.max_inflation, compact=args.compact)
     n_total = int(scan["meta"]["n_images_scanned"])
     print(f"scanned {n_total} images; {len(scan['categories'])} categories in the scan")
-    print(f"{len(rows)} clear >= {args.floor} images in ALL THREE bands (inflation <= {args.max_inflation})\n")
+    rule = "compact-union images only" if args.compact else f"class inflation <= {args.max_inflation}"
+    print(f"{len(rows)} clear >= {args.floor} images in ALL THREE bands ({rule})\n")
 
     hdr = f"{'category':<18}{'min':>7}{'small':>8}{'medium':>8}{'large':>8}{'negpool':>9}  {'coco':<14}bench"
     print(hdr)

--- a/tests_lib/detectors/test_eval.py
+++ b/tests_lib/detectors/test_eval.py
@@ -572,6 +572,70 @@ class TestMediaIsPositive:
         assert media_is_positive(media, "man") is False
 
 
+class TestMediaIsEvaluable:
+    """The third value: an image that is neither a positive nor a negative.
+
+    A scale-banded dataset carries the same class at several sizes, so an image
+    holding a *large* bus is not a ``bus@small`` positive — and must not become
+    a ``bus@small`` negative either, or the detector is penalised for finding a
+    real bus (issue #3156).
+    """
+
+    def test_absent_key_is_evaluable_everywhere(self):
+        from vtscore.eval.labels import media_is_evaluable
+
+        # Every existing dataset: closed world, unchanged behaviour.
+        media = {"category": "man", "categories": ["man", "apple"]}
+        assert media_is_evaluable(media, "man") is True
+        assert media_is_evaluable(media, "banana") is True
+
+    def test_wrong_band_image_is_excluded_not_negative(self):
+        from vtscore.eval.labels import media_is_evaluable, media_is_positive
+
+        media = {
+            "category": "bus@large",
+            "categories": ["bus@large"],
+            "evaluable_categories": ["bus@large"],
+        }
+        # It is a positive for its own cell...
+        assert media_is_positive(media, "bus@large") is True
+        assert media_is_evaluable(media, "bus@large") is True
+        # ...and neither a positive NOR a negative for the other bands: the
+        # closed-world test alone would call it a negative, which is the bug.
+        assert media_is_positive(media, "bus@small") is False
+        assert media_is_evaluable(media, "bus@small") is False
+
+    def test_shared_negative_is_evaluable_in_every_cell(self):
+        from vtscore.eval.labels import media_is_evaluable, media_is_positive
+
+        media = {
+            "category": "",
+            "categories": [],
+            "evaluable_categories": ["bus@small", "bus@large", "dog@small"],
+        }
+        for cell in ("bus@small", "bus@large", "dog@small"):
+            assert media_is_evaluable(media, cell) is True
+            assert media_is_positive(media, cell) is False
+
+    def test_evaluable_pool_drops_excluded_media(self):
+        from vtscore.eval.labels import evaluable_pool
+
+        medias = {
+            1: {"categories": ["bus@small"], "evaluable_categories": ["bus@small"]},
+            2: {"categories": ["bus@large"], "evaluable_categories": ["bus@large"]},
+            3: {"categories": [], "evaluable_categories": ["bus@small", "bus@large"]},
+        }
+        assert sorted(evaluable_pool(medias, "bus@small")) == [1, 3]
+        assert sorted(evaluable_pool(medias, "bus@large")) == [2, 3]
+
+    def test_evaluable_pool_is_identity_without_the_key(self):
+        from vtscore.eval.labels import evaluable_pool
+
+        # The common path must not copy the dict — these pools are large.
+        medias = {1: {"categories": ["man"]}, 2: {"category": "apple"}}
+        assert evaluable_pool(medias, "man") is medias
+
+
 class TestEvalMultiLabel:
     """eval_text_sort / eval_learned_sort over multi-label medias."""
 

--- a/vtscore/eval/labels.py
+++ b/vtscore/eval/labels.py
@@ -15,6 +15,14 @@ Two dataset shapes are supported:
 A media is multi-label iff it has a ``"categories"`` key; otherwise the legacy
 single-label path is used.  Existing datasets have no ``"categories"`` key, so
 their behavior is unchanged.
+
+**The closed world has a hole in it.** "Not positive" means "negative" only
+where the annotation is exhaustive over the category.  A scale-banded dataset
+breaks that: an image holding a *large* bus is not a positive for ``bus@small``,
+but calling it a negative penalises a detector for finding a real bus.  Such a
+media is *excluded* from that cell — neither positive nor negative — which
+:func:`media_is_evaluable` reports and every pool-building caller must honour.
+See ``docs/plans/vg-scale-bands-and-corrections.md``.
 """
 
 from __future__ import annotations
@@ -35,6 +43,39 @@ def media_is_positive(media: dict[str, Any], category: str) -> bool:
     if cats is not None:
         return category in cats
     return media.get("category") == category
+
+
+def media_is_evaluable(media: dict[str, Any], category: str) -> bool:
+    """Return ``True`` if *media* may be scored as a positive **or** a negative.
+
+    Media carrying an ``"evaluable_categories"`` list belong to a dataset whose
+    cells are explicitly designated — a scale-banded set, where an image can
+    hold the category at the wrong size and is therefore neither.  Anything not
+    named in that list is *excluded* from the cell.
+
+    Every other media is evaluable everywhere, which is the closed-world
+    behaviour every existing dataset relies on: no key, no change.
+
+    Callers build pools with this **before** splitting into positives and
+    negatives, because an excluded media that survives into a pool is silently
+    scored as a negative — the exact error issue #3156 is about.
+    """
+    ok = media.get("evaluable_categories")
+    if ok is None:
+        return True
+    return category in ok
+
+
+def evaluable_pool(medias: dict[Any, dict[str, Any]], category: str) -> dict[Any, dict[str, Any]]:
+    """*medias* restricted to those scorable for *category*.
+
+    The one-line form of the rule above, for the callers that hold a whole pool
+    and want it filtered once per cell rather than per media.  Returns *medias*
+    itself when nothing is excluded, so the common path copies nothing.
+    """
+    if all(m.get("evaluable_categories") is None for m in medias.values()):
+        return medias
+    return {cid: m for cid, m in medias.items() if media_is_evaluable(m, category)}
 
 
 def region_box_for_category(media: dict[str, Any], category: str) -> Optional[tuple[float, float, float, float]]:

--- a/vtscore/eval/runner.py
+++ b/vtscore/eval/runner.py
@@ -23,7 +23,7 @@ import numpy as np
 
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.eval.config import EVAL_DATASETS, EvalQuery
-from vtscore.eval.labels import media_is_positive
+from vtscore.eval.labels import evaluable_pool, media_is_positive
 from vtscore.eval.metrics import (
     DatasetResult,
     LearnedSortMetrics,
@@ -119,9 +119,12 @@ def eval_text_sort(
 
     results: list[QueryMetrics] = []
     for query in queries:
-        ranked = _run_text_sort_query(query, medias, media_type, enrich=enrich, embedder_name=embedder_name)
+        # Excluded media are neither relevant nor irrelevant, so they must leave
+        # the ranking too — left in, they would sit in it as false positives.
+        pool = evaluable_pool(medias, query.target_category)
+        ranked = _run_text_sort_query(query, pool, media_type, enrich=enrich, embedder_name=embedder_name)
         ranked_ids = [r["id"] for r in ranked]
-        relevant_ids = {cid for cid, c in medias.items() if media_is_positive(c, query.target_category)}
+        relevant_ids = {cid for cid, c in pool.items() if media_is_positive(c, query.target_category)}
 
         qm = compute_metrics(ranked_ids, relevant_ids, query.text, query.target_category, k_values)
         if start_time is not None:
@@ -181,9 +184,10 @@ def eval_learned_sort(
     results: list[LearnedSortMetrics] = []
 
     for query in queries:
-        # Split medias into target vs. other
-        target_ids = [cid for cid, c in medias.items() if media_is_positive(c, query.target_category)]
-        other_ids = [cid for cid, c in medias.items() if not media_is_positive(c, query.target_category)]
+        # Split medias into target vs. other, over the scorable pool only.
+        pool = evaluable_pool(medias, query.target_category)
+        target_ids = [cid for cid, c in pool.items() if media_is_positive(c, query.target_category)]
+        other_ids = [cid for cid, c in pool.items() if not media_is_positive(c, query.target_category)]
 
         if len(target_ids) < 2 or len(other_ids) < 2:
             continue  # not enough data

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.eval.al_strategies import ALContext, select_next
 from vtscore.eval.autopilot_flow import SMART_WINDOW, AutopilotFlow, app_has_detector
-from vtscore.eval.labels import media_is_positive, region_box_for_category
+from vtscore.eval.labels import evaluable_pool, media_is_positive, region_box_for_category
 from vtscore.eval.score_dumps import maybe_dump_predictions
 from vtscore.eval.trainers import _cross_calibrated_threshold, _parse_trainer_spec
 from vtscore.training.blend_schedules import BlendContext
@@ -2607,6 +2607,12 @@ def simulate_voting_iterations(  # noqa: C901
         cold-start degenerates turned out to be.
     """
     import numpy as np  # noqa: PLC0415
+
+    # One filter for the whole cell, before anything reads a label: on a
+    # scale-banded dataset an image can hold the category at the wrong size,
+    # and every "not positive means negative" test below would score it as a
+    # negative.  A no-op for every dataset that does not designate its cells.
+    clips_dict = evaluable_pool(clips_dict, target_category)
 
     rng = np.random.RandomState(seed)
     # Note: no torch.manual_seed() here - train_model handles its own


### PR DESCRIPTION
Refs #3156. Takes the plan in `docs/plans/vg-scale-bands-and-corrections.md` from "no supply data" to "a built dataset the corrected re-run can use".

## 1. The supply scan, and what it changed

GRID jobs `509905` / `509971` / `510148` (CPU-only, ~70 s each) over the full VG source: 108,073 images, 82,821 distinct names. Artifacts under `/expscratch/sgreenberg/vgscale-3156/`; nothing was written into the pile, so the published `vg_box_*` build stays reproducible.

534 categories hold ≥ 50 images in every band and 310 hold ≥ 100, so the construction is not supply-limited. But the fitness policy was dropping the classes the study most needs: `union_inflation` is a per-**class** median, so a class that often appears several times per image fails it however compact any single image is. `bus` — the class #3156 is about — scored 1.71 against the 1.5 cap and was excluded, along with **30 of the 65 COCO classes present**, the only ones VG can be cross-checked against for free.

Scatter is a property of an *image*. The scan now also counts an image only when its union box is within `BAND_MAX_INFLATION` of that image's own largest instance (`bands_compact`, `shortlist_scale_classes.py --compact`); the non-compact remainder is *excluded* from the cell, not turned into a negative.

| floor 50, all three bands | classes | of which COCO |
|---|---:|---:|
| per-class median inflation | 196 | 15 |
| per-image compact union | 305 | 41 |

Nothing the old rule kept is lost, 26 COCO classes come back, and 90% of `bus` images are compact (112 / 782 / 2137 across the bands).

## 2. Name overlap, measured by box geometry

- `glasses` vs `sunglasses`: 0.20 overlap each way over 280 co-annotated images — `mixed`, so **the fine-grained eyewear arm is dropped**. `eyeglasses` vs `glasses` is an `alias` (0.32 / 0.31) and must be merged.
- Across all 156 candidates, **no pair came back `subtype`** and 21 carry an alias partner — `jacket`≡`suit` (0.33), `board`≡`snowboard`/`skateboard`/`surfboard` (0.49 / 0.45 / 0.38), `bike`≡`motorcycle` (0.34), `fire hydrant`≡`hydrant` (0.74).
- `bus` vs `bush`: 87 co-annotated images, **0.00** overlap both ways. The overview benchmark's string-similarity lead is refuted.

## 3. *C* is chosen

12 classes (owner, 2026-08-17), from the 24 candidates that are simultaneously ≥100/band, free of alias and plural ambiguity, and **also COCO-2017 classes**: `clock` `bird` `boat` `umbrella` `kite` `book` `dog` `backpack` `knife` `bicycle` `bus` `stop sign`. COCO overlap is what makes the correction pass affordable — val2017 is exhaustively annotated over exactly these names, so VG's miss rate *and* our own annotators' accuracy can be scored with no extra review. Recorded as `pile_config.SCALE_CLASSES`, deliberately not re-derived from the scan at build time.

## 4. Three-valued labels

`media_is_evaluable` / `evaluable_pool` beside `media_is_positive`. An image holding a *large* bus is not a `bus@small` positive, and calling it a negative penalises a detector for finding a real bus. Media with no `evaluable_categories` key are evaluable everywhere, so every existing dataset is byte-unchanged.

The pool is filtered **once per cell** at the four places that build one — `simulate_voting_iterations`, `prepare_data._exemplar_crops`, `text_baseline`, and both `runner.py` evaluators — rather than threading a third value through every scorer. Five new tests cover the wrong-band case, the shared negative, and the no-copy identity path. The eval/app-sync gate is unaffected: this changes the harness's notion of ground truth, not the app's algorithm, and adds no new mirror.

## 5. The `vg_scale` builder

One pickle over *C* with the band on the category name (`bus@small`), so a harness cell is still `(dataset, category)` and needs no change, embedding happens once instead of three times, and the bands are paired on identical negatives.

Cells are **designated, not inferred**: exactly `SCALE_N_POS` positives and one shared pool of `SCALE_N_NEG` negatives each, everything else excluded. Verified by a dry run (`510272`):

- **36 / 36 cells at exactly 100 positives**, every one carrying its ground-truth box
- **prevalence 0.0250 in all 36** — one distinct value, so small-vs-large is a paired contrast rather than two datasets of different difficulty
- 7,445 medias = 3,600 positives + 3,900 shared negatives drawn from the 82,290 images holding none of *C*
- no cell under-supplied (`stop sign` binds at 104 available in its small band)

Also fixes the VG dims cache, which could never hit: 170 of 108,245 images are unreadable, so the cache always held fewer entries than there were files and every caller silently re-read all 108k JPEG headers.

## Testing

Full `./run-tests.sh` on the GRID (job `510273`): **8,678 passed, 56 skipped, 2 xpassed**, all gates green including pyright and pip-audit.

## Still open on #3156

Slate builder and correction ingest; the COCO-anchored noise measurement (now cheap — all 12 classes are in COCO); the corrected re-run and delta report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
