### PR TITLE
The 250-vote horizon result: more clicks move the threshold, not the ranking

### DIFF
--- a/docs/experiments/overview-bench/ANALYSIS_HORIZON_boxbands_partial.txt
+++ b/docs/experiments/overview-bench/ANALYSIS_HORIZON_boxbands_partial.txt
@@ -1,0 +1,34 @@
+==============================================================================================================
+HORIZON COMPARISON — 150 votes against 250
+==============================================================================================================
+/expscratch/sgreenberg/bench-vgbox2/results: 270 cells, 265 with data, 5 never found a positive
+/expscratch/sgreenberg/bench-h250/vgbox/results: 143 cells, 142 with data, 1 never found a positive
+
+OVERLAP CHECK: 19930 shared steps, largest absolute difference 0
+  -> the long run reproduces the short one step for step
+
+RUNS THAT ONLY STARTED PAST VOTE 150: 2
+  first positive around vote 175: vg_box_small / siglip / tip / 2
+  first positive around vote 177: vg_box_small / siglip2_l / tip / 2
+  (each of these was reported as a starved run at the shorter horizon)
+
+WHAT VOTES 151-250 BOUGHT — paired per cell, mean +- SE over 140 cells
+negative cost / positive AP = the longer horizon is better; |mean| < 2*SE is not resolvable
+           metric  votes 101-150  votes 201-250         change resolvable
+             cost          0.616          0.593 -0.023 +-0.006        yes
+              fpr          0.380          0.458 +0.078 +-0.017        yes
+              fnr          0.236          0.135 -0.100 +-0.017        yes
+average_precision          0.279          0.291 +0.012 +-0.003        yes
+            auroc          0.776          0.803 +0.026 +-0.004        yes
+           n_good          9.964         13.061 +3.097 +-0.353        yes
+
+BY ARM
+      dataset     embedder  cells  cost_old  cost_new         d_cost d_positives
+vg_box_medium       siglip     30     0.630     0.593 -0.037 +-0.013        +3.4
+vg_box_medium    siglip2_l     30     0.603     0.588 -0.015 +-0.011        +2.7
+ vg_box_small dinov3_patch     22     0.535     0.530 -0.005 +-0.015        +3.1
+ vg_box_small       siglip     29     0.645     0.627 -0.018 +-0.015        +2.8
+ vg_box_small    siglip2_l     29     0.648     0.613 -0.035 +-0.013        +3.5
+
+RUNS STILL NOT WORKING (window cost > 0.9): 23 at the old horizon -> 23 at the new one
+cells improved by >0.01: 75, unchanged: 29, worse by >0.01: 36

--- a/docs/experiments/overview-bench/ANALYSIS_HORIZON_noboxes.txt
+++ b/docs/experiments/overview-bench/ANALYSIS_HORIZON_noboxes.txt
@@ -1,0 +1,30 @@
+==============================================================================================================
+HORIZON COMPARISON — 150 votes against 250
+==============================================================================================================
+/expscratch/sgreenberg/bench-binary/results: 45 cells, 43 with data, 2 never found a positive
+/expscratch/sgreenberg/bench-h250/binary/results: 45 cells, 44 with data, 1 never found a positive
+
+OVERLAP CHECK: 6249 shared steps, largest absolute difference 0
+  -> the long run reproduces the short one step for step
+
+RUNS THAT ONLY STARTED PAST VOTE 150: 1
+  first positive around vote 232: coco_val / dinov3_patch / refrigerator / 0
+  (each of these was reported as a starved run at the shorter horizon)
+
+WHAT VOTES 151-250 BOUGHT — paired per cell, mean +- SE over 43 cells
+negative cost / positive AP = the longer horizon is better; |mean| < 2*SE is not resolvable
+           metric  votes 101-150  votes 201-250         change resolvable
+             cost          0.400          0.381 -0.019 +-0.012         no
+              fpr          0.263          0.271 +0.008 +-0.017         no
+              fnr          0.137          0.109 -0.027 +-0.009        yes
+average_precision          0.508          0.523 +0.015 +-0.008         no
+            auroc          0.892          0.900 +0.009 +-0.003        yes
+           n_good          8.850         10.544 +1.694 +-0.395        yes
+
+BY ARM
+        dataset     embedder  cells  cost_old  cost_new         d_cost d_positives
+       coco_val dinov3_patch     19     0.293     0.261 -0.032 +-0.020        +1.1
+visual_genome_m dinov3_patch     24     0.484     0.475 -0.009 +-0.015        +2.2
+
+RUNS STILL NOT WORKING (window cost > 0.9): 0 at the old horizon -> 0 at the new one
+cells improved by >0.01: 20, unchanged: 8, worse by >0.01: 15

--- a/docs/experiments/overview-bench/ANALYSIS_HORIZON_vg_coco.txt
+++ b/docs/experiments/overview-bench/ANALYSIS_HORIZON_vg_coco.txt
@@ -1,0 +1,38 @@
+==============================================================================================================
+HORIZON COMPARISON — 150 votes against 250
+==============================================================================================================
+/expscratch/sgreenberg/bench-overview/results: 189 cells, 182 with data, 7 never found a positive
+/expscratch/sgreenberg/bench-h250/wave1/results: 189 cells, 184 with data, 5 never found a positive
+
+OVERLAP CHECK: 26538 shared steps, largest absolute difference 0.0264
+  -> ** THE RUNS DIVERGE: the comparison below is between different draws, not horizons **
+
+RUNS THAT ONLY STARTED PAST VOTE 150: 2
+  first positive around vote 159: coco_val / siglip2_l / sports ball / 1
+  first positive around vote 224: visual_genome_m / siglip / ball / 1
+  (each of these was reported as a starved run at the shorter horizon)
+
+WHAT VOTES 151-250 BOUGHT — paired per cell, mean +- SE over 182 cells
+negative cost / positive AP = the longer horizon is better; |mean| < 2*SE is not resolvable
+           metric  votes 101-150  votes 201-250         change resolvable
+             cost          0.201          0.195 -0.007 +-0.003         no
+              fpr          0.124          0.136 +0.011 +-0.005        yes
+              fnr          0.077          0.059 -0.018 +-0.004        yes
+average_precision          0.709          0.708 -0.001 +-0.001         no
+            auroc          0.949          0.954 +0.004 +-0.001        yes
+           n_good          8.756         10.029 +1.273 +-0.198        yes
+
+BY ARM
+        dataset     embedder  cells  cost_old  cost_new         d_cost d_positives
+   caltech101_m dinov3_patch     18     0.005     0.010 +0.005 +-0.002        +0.0
+   caltech101_m       siglip     18     0.004     0.009 +0.005 +-0.001        +0.0
+   caltech101_m    siglip2_l     18     0.001     0.004 +0.003 +-0.001        +0.0
+       coco_val dinov3_patch     19     0.152     0.160 +0.007 +-0.008        +1.2
+       coco_val       siglip     19     0.218     0.199 -0.019 +-0.007        +2.2
+       coco_val    siglip2_l     19     0.202     0.203 +0.001 +-0.010        +1.1
+visual_genome_m dinov3_patch     24     0.324     0.299 -0.025 +-0.013        +2.7
+visual_genome_m       siglip     23     0.392     0.371 -0.021 +-0.018        +1.8
+visual_genome_m    siglip2_l     24     0.367     0.360 -0.006 +-0.008        +1.6
+
+RUNS STILL NOT WORKING (window cost > 0.9): 1 at the old horizon -> 0 at the new one
+cells improved by >0.01: 51, unchanged: 79, worse by >0.01: 52

--- a/docs/experiments/overview-bench/PREREG-horizon-250.md
+++ b/docs/experiments/overview-bench/PREREG-horizon-250.md
@@ -1,5 +1,8 @@
 # Pre-registration — does the loop keep improving past 150 votes?
 
+**Scored in [`RESULT-horizon-250.md`](RESULT-horizon-250.md)** — one expectation
+right, one wrong, one half wrong.
+
 Written before the 250-vote grid drained. The report's curves stop at 150 votes
 because that is where the original grid stopped, not because anything about the
 data or the method ends there. This run extends the horizon to 250.

--- a/docs/experiments/overview-bench/RESULT-horizon-250.md
+++ b/docs/experiments/overview-bench/RESULT-horizon-250.md
@@ -1,0 +1,99 @@
+# Result — 250 votes instead of 150
+
+Scores [`PREREG-horizon-250.md`](PREREG-horizon-250.md). The question was whether a
+user who keeps clicking past 150 votes gets a better detector. **Yes — modestly,
+reliably, and not for the reason the question assumes.**
+
+## What the extra 100 votes bought
+
+Paired per run, votes 101–150 against 201–250 (equal windows on the same cell, so
+between-category variance cancels). Full tables in `ANALYSIS_HORIZON_*.txt`.
+
+| | `visual_genome_m` + `coco_val` (128 runs) | box bands (140 runs, partial grid) |
+|---|---|---|
+| cost | **−0.011 ± 0.005** | **−0.023 ± 0.006** |
+| fnr | **−0.025 ± 0.005** | **−0.100 ± 0.017** |
+| fpr | **+0.014 ± 0.007** | **+0.078 ± 0.017** |
+| AP | −0.002 ± 0.002 (not resolvable) | +0.012 ± 0.003 |
+| positives held | +1.8 ± 0.3 | +3.1 ± 0.4 |
+
+**The gain is a threshold effect, not a learning effect.** The extra clicks find
+1.8–3.1 more positives; ranking barely moves (AP −0.002 on the whole-image
+haystacks, +0.012 on the bands) while the operating point shifts hard toward
+inclusion — recall improves two to four times as much as precision degrades, and
+cost nets out slightly better. What 100 more clicks buy is a cut placed on a less
+thin positive set, not a detector that ranks better.
+
+That has a cheaper implication than "ask users to click more": the same gain
+should be available from a cut rule that accounts for how few positives it is
+calibrating on. Asking for 100 extra clicks to move a threshold is an expensive
+way to buy what a better estimator could give for free — and it is the same
+conclusion the [main report](REPORT.md) reaches from the regret decomposition,
+arriving from the opposite direction.
+
+## Runs that were not starved, only under-clicked
+
+Five runs the 150-vote grid reports as *starved* — never a single positive — find
+their first positive after vote 150:
+
+| run | first positive |
+|---|---|
+| `coco_val` / `sports ball` / seed 1 | vote 159 |
+| `vg_box_small` / `tip` / seed 2 (`siglip`) | vote 175 |
+| `vg_box_small` / `tip` / seed 2 (`siglip2_l`) | vote 177 |
+| `visual_genome_m` / `ball` / seed 1 | vote 224 |
+| `coco_val` / `refrigerator` / seed 0 (no boxes) | vote 232 |
+
+So the report's "14 of 504 runs never found a positive (2.8 %)" is a statement
+about the **horizon**, not about the method: a third of those runs were still
+going to work. What does *not* improve is the runs that are stuck rather than
+starved — cells whose deep-regime cost stays above 0.9 number **23 before and 23
+after** on the box bands. More clicks help runs that already have traction.
+
+## Scoring the pre-registration
+
+| expectation | outcome |
+|---|---|
+| 1. Little on the box bands (under ~0.02 cost) | **Wrong.** −0.023 ± 0.006, resolvable, and the largest effect measured. |
+| 2. Something on `visual_genome_m` / `coco_val` | **Right**, −0.011 ± 0.005, though smaller than the bands'. |
+| 3. Most of the gain on the slow starters | **Half wrong.** Five starved runs did start, but the stuck-run count did not move at all (23 → 23); the gain is spread across runs that were already working. |
+
+The single sizing cell quoted in the pre-registration (`vg_box_small` / `glasses`,
+which gained nothing) was not representative — it was one cell chosen for being
+cheap to time, and a 140-cell paired comparison says otherwise. Sizing cells size;
+they do not measure.
+
+## What this does *not* license
+
+- **The Visual Genome half is provisional.** #3156 is correcting VG's annotations
+  — the `bus` sheet in the main report shows frame-filling buses annotated
+  `door, tire, window` — and `fb4f4ec03` replaces the box-area banding, whose
+  bands currently carry disjoint vocabularies. Every VG number here should be
+  re-measured against the corrected data. The COCO half is unaffected: its
+  annotation is exhaustive over its classes.
+- **The box-band grid is partial.** It was cancelled mid-flight for the reason
+  above, after completing `vg_box_small` (30 / 30 / 22 cells by embedder) and the
+  two whole-image arms of `vg_box_medium`; `vg_box_large` has no coverage. The
+  numbers above are what those 140 runs say, not a full band comparison.
+- **The main report is unchanged for now.** Updating it means re-running on
+  corrected annotations, which is #3156's work.
+
+## Provenance and a numerical wrinkle
+
+The horizon run reuses each source study's `prepare_info.json` and crops, so it is
+the same cells carried further. The overlap check confirms this exactly: 26,538
+shared steps on the whole-image grid, 19,930 on the bands and 6,249 without
+boxes, **all bit-identical** — except one cell.
+
+`caltech101_m` / `siglip` / `airplanes` / seed 1 diverges from vote 37 onward:
+`AP`, `AUROC` and `n_good` are identical, so the votes and the model are
+identical, but the **threshold** differs by up to 0.026 and cost through it by
+0.020. The category is saturated — positives near 1.0, negatives near 0 — which
+leaves the mixture fit that places the cut ill-conditioned, so a float-level
+difference between machines flips it. Filed as its own issue; it is why
+`caltech101_m` is excluded from the whole-image numbers above, and one more
+reason to retire that haystack from this sweep.
+
+Grids: `/expscratch/sgreenberg/bench-h250/{wave1,vgbox,binary}/results`, arrays
+`507700` (cancelled at 143 / 270), `507713` (189 / 189), `507722` (45 / 45), zero
+task failures. Reproduce with `analyze_horizon.py <short_results> <long_results>`.

--- a/docs/experiments/overview-bench/RESULT-horizon-250.md
+++ b/docs/experiments/overview-bench/RESULT-horizon-250.md
@@ -90,7 +90,7 @@ boxes, **all bit-identical** — except one cell.
 identical, but the **threshold** differs by up to 0.026 and cost through it by
 0.020. The category is saturated — positives near 1.0, negatives near 0 — which
 leaves the mixture fit that places the cut ill-conditioned, so a float-level
-difference between machines flips it. Filed as its own issue; it is why
+difference between machines flips it. Filed as #3166; it is why
 `caltech101_m` is excluded from the whole-image numbers above, and one more
 reason to retire that haystack from this sweep.
 


### PR DESCRIPTION
Scores [`PREREG-horizon-250.md`](https://github.com/samggreenberg/VTSearch/blob/dev/docs/experiments/overview-bench/PREREG-horizon-250.md), which merged with #3148 before the grid drained.

**The question:** does a user who keeps clicking past 150 votes get a better detector? **Yes — modestly, reliably, and not for the reason the question assumes.**

Paired per run, votes 101–150 against 201–250 (equal windows on the same cell):

| | VG + COCO (128 runs) | box bands (140 runs, partial) |
|---|---|---|
| cost | **−0.011 ± 0.005** | **−0.023 ± 0.006** |
| fnr | **−0.025 ± 0.005** | **−0.100 ± 0.017** |
| fpr | **+0.014 ± 0.007** | **+0.078 ± 0.017** |
| AP | −0.002 ± 0.002 (n.s.) | +0.012 ± 0.003 |
| positives | +1.8 ± 0.3 | +3.1 ± 0.4 |

**It is a threshold effect, not a learning effect.** The extra clicks find 1.8–3.1 more positives; ranking barely moves while the operating point shifts hard toward inclusion — recall improves two to four times as much as precision degrades. So 100 extra clicks buy *a cut placed on a less thin positive set*, which is a threshold estimator's job. That is the same conclusion the report's regret decomposition reaches from the other direction, and it argues for fixing the estimator rather than asking users for more clicks.

**Five runs the report calls "starved" were only under-clicked** — first positives at votes 159, 175, 177, 224 and 232. "14 of 504 runs never found a positive (2.8 %)" is a statement about the horizon. What does *not* move: stuck runs (deep cost > 0.9) are 23 before and 23 after.

## Pre-registration, scored honestly

| expectation | outcome |
|---|---|
| Little on the box bands (<0.02) | **Wrong** — largest effect measured |
| Something on VG/COCO | **Right**, smaller than the bands' |
| Most of the gain on slow starters | **Half wrong** — starved runs started, stuck runs did not budge |

The sizing cell I quoted as an early signal (`vg_box_small`/`glasses`, gained nothing) was not representative. Sizing cells size; they do not measure.

## Deliberately *not* in the report yet

VG is being re-annotated (#3156) and re-banded (`fb4f4ec03`), so its half is provisional and the box-band grid was cancelled mid-flight at 143/270 cells. COCO's half is unaffected — exhaustive annotation over 80 classes. Updating `REPORT.md` means re-running on corrected data, which is #3156's work.

## One numerical wrinkle, caught by the overlap check

The horizon run must reproduce the original step for step, and it does: 26,538 + 19,930 + 6,249 shared steps, **all bit-identical — except one cell.** `caltech101_m`/`siglip`/`airplanes`/seed 1 has identical votes, identical `AP`/`AUROC`/`n_good`, and a **threshold that differs by up to 0.026**. Saturated category → ill-conditioned mixture fit for the cut → a float-level difference between machines flips it. Filed as #3166; it is why caltech is excluded from the numbers above.

Zero task failures across 567 job steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)