### PR TITLE
Canonicalise the realized fold-anchored cut inside empty intervals

### DIFF
--- a/docs/experiments/overview-bench/RESULT-horizon-250.md
+++ b/docs/experiments/overview-bench/RESULT-horizon-250.md
@@ -94,6 +94,18 @@ difference between machines flips it. Filed as #3166; it is why
 `caltech101_m` is excluded from the whole-image numbers above, and one more
 reason to retire that haystack from this sweep.
 
+**Resolved in #3166**, and the fit turned out not to be the culprit: the
+threshold is realized as `np.quantile` of the final haystack at the combined
+fold quantile, and that interpolates *linearly* between adjacent order
+statistics. Across the empty interval of a saturated distribution the
+interpolation has gain `(n - 1) * gap` — at `n` ~ 9k and a near-unit gap, a
+quantile difference of 2.9e-6 lands exactly on the 0.026 observed here. The cut
+is now snapped to the midpoint of the empty interval it falls in, which is
+decision-exact (no item changes side) and removes the gain, so the threshold
+cannot move until the admitted set really does. Runs before and after the fix
+are therefore not threshold-comparable on saturated cells; every other column
+is unaffected.
+
 Grids: `/expscratch/sgreenberg/bench-h250/{wave1,vgbox,binary}/results`, arrays
 `507700` (cancelled at 143 / 270), `507713` (189 / 189), `507722` (45 / 45), zero
 task failures. Reproduce with `analyze_horizon.py <short_results> <long_results>`.

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -220,7 +220,10 @@ MIRRORS: list[Mirror] = [
             "long as this function has nothing BETWEEN the fit and the cut. If a stage is added "
             "there - a clamp, a smoothing pass, a provenance-dependent substitution - the sweep "
             "silently stops measuring the shipped estimator, and its rows would still look "
-            "perfectly reasonable. Re-check that the composition is still fit-then-cut."
+            "perfectly reasonable. Re-check that the composition is still fit-then-cut. "
+            "Checked at #3166: the empty-interval snap that fixed the saturated-distribution "
+            "threshold went INSIDE threshold_at, not between the fit and the cut, precisely so "
+            "the sweep picks it up for free and this composition stayed untouched."
         ),
         divergence=(
             "INTENTIONAL: the harness does NOT reproduce this function's terminal fallbacks (the "

--- a/tests_lib/sorting/test_gmm_saturated_determinism.py
+++ b/tests_lib/sorting/test_gmm_saturated_determinism.py
@@ -1,0 +1,173 @@
+"""The GMM cut must be reproducible on a **saturated** score distribution (#3166).
+
+`caltech101_m` / `siglip` / `airplanes` is saturated: positives score near 1.0,
+negatives near 0, and nothing sits between them.  Re-running that benchmark cell
+on a different node reproduced every other column bit-for-bit (`n_good`,
+`n_bad`, `average_precision`, `auroc` all differed by exactly 0) while the
+`threshold` moved by 0.0264.
+
+The cause is amplification, not a wandering fit.  `FoldAnchoredCut.threshold_at`
+realises its combined fold quantile with ``np.quantile``, which interpolates
+*linearly* between adjacent order statistics.  Across the empty interval of a
+saturated distribution that interpolation has gain ``(n - 1) * gap``: at
+``n = 9000`` and a unit-wide gap, ``dt = 8999 * dq``, so a quantile difference of
+2.9e-6 - well inside what differing BLAS kernels or thread counts produce
+between two machines - lands exactly on the observed 0.026.
+
+The fix (:func:`snap_cut_to_sample`) canonicalises a cut that falls strictly
+inside an empty interval to that interval's midpoint, which removes the gain
+entirely while leaving the admitted set untouched.  These tests pin both halves:
+the cut is decision-exact, and it does not move under perturbations - of the
+fit, of the quantile, or of the BLAS thread count - that leave the admitted set
+alone.
+"""
+
+import numpy as np
+import pytest
+
+from vtscore.training.thresholds import (
+    FoldAnchoredCut,
+    GmmFit1D,
+    calculate_gmm_threshold,
+    fit_score_gmm,
+    fold_anchored_gmm_threshold,
+    gmm_fit_array,
+    snap_cut_to_sample,
+)
+
+
+def saturated_scores(n=9000, frac_pos=0.09, seed=0, sigma=1e-5):
+    """Two clusters pinned at 0 and 1 with no interior mass - the #3166 shape."""
+    rng = np.random.default_rng(seed)
+    n_pos = int(n * frac_pos)
+    neg = np.abs(rng.normal(0.0, sigma, n - n_pos))
+    pos = 1.0 - np.abs(rng.normal(0.0, sigma, n_pos))
+    return np.clip(np.concatenate([neg, pos]), 0.0, 1.0)
+
+
+def admitted(scores, threshold):
+    """The Good set a threshold selects - what must not change when a cut moves."""
+    return frozenset(np.flatnonzero(np.asarray(scores) >= threshold).tolist())
+
+
+class TestSnapCutToSample:
+    """Invariants of the canonicalisation itself."""
+
+    def test_interior_cut_snaps_to_gap_midpoint(self):
+        src = np.array([0.0, 0.1, 0.9, 1.0])
+        assert snap_cut_to_sample(0.2, src) == pytest.approx(0.5)
+        assert snap_cut_to_sample(0.8, src) == pytest.approx(0.5)
+
+    def test_snap_is_decision_exact(self):
+        """No element of the sample changes side, for any cut, anywhere."""
+        src = np.sort(saturated_scores(n=400, seed=3))
+        for cut in np.linspace(-0.2, 1.2, 401):
+            assert admitted(src, snap_cut_to_sample(float(cut), src)) == admitted(src, float(cut))
+
+    def test_cut_on_an_observed_score_is_left_alone(self):
+        """That value *is* identifiable - it decides its own score's verdict."""
+        src = np.array([0.0, 0.25, 0.75, 1.0])
+        for v in src:
+            assert snap_cut_to_sample(float(v), src) == float(v)
+
+    def test_out_of_support_and_empty_pass_through(self):
+        src = np.array([0.2, 0.8])
+        assert snap_cut_to_sample(-1.0, src) == -1.0
+        assert snap_cut_to_sample(2.0, src) == 2.0
+        assert snap_cut_to_sample(0.5, np.array([])) == 0.5
+        assert np.isnan(snap_cut_to_sample(float("nan"), src))
+
+    def test_snap_is_idempotent_and_monotone(self):
+        src = np.sort(saturated_scores(n=200, seed=4))
+        cuts = np.linspace(0.0, 1.0, 257)
+        snapped = [snap_cut_to_sample(float(c), src) for c in cuts]
+        assert snapped == [snap_cut_to_sample(v, src) for v in snapped]
+        assert all(a <= b for a, b in zip(snapped, snapped[1:], strict=False))
+
+
+class TestSaturatedThresholdIsStable:
+    """The amplifier is gone: sub-order-statistic wobble cannot move the cut."""
+
+    def _cut(self, mu_lo, haystack):
+        fit = GmmFit1D(w_lo=0.91, mu_lo=mu_lo, var_lo=1e-6, w_hi=0.09, mu_hi=1.0, var_hi=1e-6)
+        return FoldAnchoredCut(
+            fits=(fit,), fold_haystacks=(haystack,), final_haystack=haystack, n_anchored=1
+        )
+
+    def test_float_level_fit_wobble_leaves_the_threshold_bit_identical(self):
+        """The regression: pre-#3166 this slid smoothly across the empty gap."""
+        haystack = np.sort(saturated_scores())
+        base = self._cut(0.0, haystack).threshold_at(0)
+        for delta in (1e-15, 1e-12, 1e-9, 1e-6, 1e-3):
+            assert self._cut(delta, haystack).threshold_at(0) == base
+
+    def test_threshold_lands_in_the_empty_interval(self):
+        """Sanity: the cut separates the two modes, it is not merely constant."""
+        haystack = np.sort(saturated_scores())
+        threshold = self._cut(0.0, haystack).threshold_at(0)
+        assert float(haystack[haystack < 0.5].max()) < threshold < float(haystack[haystack > 0.5].min())
+
+    def test_quantile_wobble_that_crosses_no_order_statistic_is_invisible(self):
+        """``dt = dq * (n - 1) * gap`` was the whole bug; the gain is now zero."""
+        haystack = np.sort(saturated_scores())
+        snapped = {
+            snap_cut_to_sample(float(np.quantile(haystack, 0.91 + dq)), haystack)
+            for dq in (0.0, 1e-7, 1e-6, 3e-6, 1e-5)
+        }
+        assert len(snapped) == 1
+        raw = {float(np.quantile(haystack, 0.91 + dq)) for dq in (0.0, 1e-7, 1e-6, 3e-6, 1e-5)}
+        # Guard the guard: those same wobbles really did move the raw quantile
+        # by ~0.09, three orders of magnitude more than the wobble itself.
+        assert max(raw) - min(raw) > 0.05
+
+
+class TestSaturatedFitUnderThreadCounts:
+    """The issue's own reproduction: refit under different BLAS thread counts.
+
+    Cross-*machine* BLAS differences cannot be staged in-process, but the thread
+    count is the same knob and is the one the issue names.  The assertion is
+    one-directional - the shipped threshold must not depend on it.
+    """
+
+    @pytest.mark.parametrize("frac_pos", [0.02, 0.09, 0.5])
+    def test_threshold_is_independent_of_thread_count(self, frac_pos):
+        threadpool_limits = pytest.importorskip("threadpoolctl").threadpool_limits
+        scores = saturated_scores(frac_pos=frac_pos, seed=11)
+        folds = [saturated_scores(frac_pos=frac_pos, seed=20 + k) for k in range(3)]
+        rng = np.random.default_rng(5)
+        anchors = []
+        for fold in folds:
+            idx = rng.choice(fold.size, 24, replace=False)
+            picked = fold[idx]
+            anchors.append((picked.tolist(), (picked > 0.5).astype(float).tolist()))
+
+        anchored, plain = set(), set()
+        for limit in (1, 2, 4):
+            with threadpool_limits(limits=limit):
+                anchored.add(fold_anchored_gmm_threshold(folds, anchors, scores, 0)[0])
+                plain.add(calculate_gmm_threshold(scores.tolist()))
+        assert len(anchored) == 1, anchored
+        assert len(plain) == 1, plain
+
+
+class TestSnappedCutPreservesTheAdmittedSet:
+    """Canonicalising must not change what a detector calls Good."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_gmm_threshold_admits_exactly_the_unsnapped_set(self, seed):
+        scores = saturated_scores(seed=seed)
+        arr = gmm_fit_array(scores.tolist())
+        fit = fit_score_gmm(arr)
+        assert fit is not None
+        assert admitted(arr, calculate_gmm_threshold(scores.tolist())) == admitted(arr, fit.midpoint())
+
+    def test_non_saturated_distribution_is_barely_moved(self):
+        """On a distribution with interior mass the gaps are ~1/n, so is the snap."""
+        rng = np.random.default_rng(7)
+        scores = np.clip(
+            np.concatenate([rng.normal(0.3, 0.1, 5000), rng.normal(0.7, 0.1, 5000)]), 0.0, 1.0
+        )
+        arr = gmm_fit_array(scores.tolist())
+        fit = fit_score_gmm(arr)
+        assert fit is not None
+        assert calculate_gmm_threshold(scores.tolist()) == pytest.approx(fit.midpoint(), abs=1e-3)

--- a/tests_lib/sorting/test_gmm_saturated_determinism.py
+++ b/tests_lib/sorting/test_gmm_saturated_determinism.py
@@ -90,9 +90,7 @@ class TestSaturatedThresholdIsStable:
 
     def _cut(self, mu_lo, haystack):
         fit = GmmFit1D(w_lo=0.91, mu_lo=mu_lo, var_lo=1e-6, w_hi=0.09, mu_hi=1.0, var_hi=1e-6)
-        return FoldAnchoredCut(
-            fits=(fit,), fold_haystacks=(haystack,), final_haystack=haystack, n_anchored=1
-        )
+        return FoldAnchoredCut(fits=(fit,), fold_haystacks=(haystack,), final_haystack=haystack, n_anchored=1)
 
     def test_float_level_fit_wobble_leaves_the_threshold_bit_identical(self):
         """The regression: pre-#3166 this slid smoothly across the empty gap."""
@@ -154,20 +152,23 @@ class TestSnappedCutPreservesTheAdmittedSet:
     """Canonicalising must not change what a detector calls Good."""
 
     @pytest.mark.parametrize("seed", [0, 1, 2])
-    def test_gmm_threshold_admits_exactly_the_unsnapped_set(self, seed):
-        scores = saturated_scores(seed=seed)
-        arr = gmm_fit_array(scores.tolist())
-        fit = fit_score_gmm(arr)
-        assert fit is not None
-        assert admitted(arr, calculate_gmm_threshold(scores.tolist())) == admitted(arr, fit.midpoint())
+    def test_fold_anchored_threshold_admits_the_same_items_as_the_raw_quantile(self, seed):
+        haystack = np.sort(saturated_scores(seed=seed))
+        fit = GmmFit1D(w_lo=0.91, mu_lo=0.0, var_lo=1e-6, w_hi=0.09, mu_hi=1.0, var_hi=1e-6)
+        cut = FoldAnchoredCut(fits=(fit,), fold_haystacks=(haystack,), final_haystack=haystack, n_anchored=1)
+        for k in range(-3, 4):
+            raw = float(np.quantile(haystack, min(1.0, max(0.0, cut.quantile_at(k)))))
+            assert admitted(haystack, cut.threshold_at(k)) == admitted(haystack, raw)
 
-    def test_non_saturated_distribution_is_barely_moved(self):
-        """On a distribution with interior mass the gaps are ~1/n, so is the snap."""
-        rng = np.random.default_rng(7)
-        scores = np.clip(
-            np.concatenate([rng.normal(0.3, 0.1, 5000), rng.normal(0.7, 0.1, 5000)]), 0.0, 1.0
-        )
-        arr = gmm_fit_array(scores.tolist())
-        fit = fit_score_gmm(arr)
+    def test_the_plain_gmm_cut_is_left_unsnapped(self):
+        """``calculate_gmm_threshold`` is ``fit.midpoint()``: unit gain, nothing to fix.
+
+        Snapping it would break the recomposition identity the eval harness leans
+        on (re-cut one fit, reproduce the app) and, above ``_GMM_MAX_SAMPLES``,
+        would snap against a subsample whose empty intervals are not empty in the
+        full population.  The amplifier is ``np.quantile``, and only that.
+        """
+        scores = saturated_scores(seed=9)
+        fit = fit_score_gmm(gmm_fit_array(scores.tolist()))
         assert fit is not None
-        assert calculate_gmm_threshold(scores.tolist()) == pytest.approx(fit.midpoint(), abs=1e-3)
+        assert calculate_gmm_threshold(scores.tolist()) == fit.midpoint()

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -487,6 +487,62 @@ def gmm_fit_array(scores: "list[float] | np.ndarray") -> np.ndarray:
     return arr
 
 
+def snap_cut_to_sample(cut: float, sorted_scores: np.ndarray) -> float:
+    """Canonicalise *cut* to the empty interval of *sorted_scores* it falls in.
+
+    A threshold that lands strictly between two adjacent observed scores is
+    **unidentifiable**: every value in that open interval admits exactly the
+    same items, so which one a fit happens to produce carries no information -
+    only float noise.  This maps the whole interval to its midpoint, so the
+    returned cut is a function of the two bracketing *data* values rather than
+    of the last bits of an EM fit.
+
+    That is the fix for issue #3166.  On a **saturated** score distribution -
+    positives near 1.0, negatives near 0, nothing in between - the interval is
+    enormous, and the un-canonicalised cut slides freely across it: the
+    fold-anchored estimator realises its combined quantile with
+    ``np.quantile``, which interpolates *linearly* between adjacent order
+    statistics, so a difference of ``dq`` in the quantile moves the threshold by
+    ``dq * (n - 1) * gap``.  With ``n`` ~ 9k and a unit-wide gap that is a gain
+    of ~9000x: a sub-part-per-million wobble in the quantile - well within what
+    differing BLAS kernels or thread counts produce between two machines -
+    became the 0.026 threshold difference issue #3166 measured between two runs
+    that agreed bit-for-bit on every other column.  Snapping removes the gain
+    entirely: the threshold cannot move until the quantile crosses a whole
+    order statistic, at which point the admitted set really has changed.
+
+    **Decision-exact by construction.**  The snap only ever moves a cut inside
+    an interval containing no observed score, so ``score >= threshold`` gives
+    the identical verdict on every element of *sorted_scores*.  A cut that
+    coincides with an observed score is already canonical and is returned
+    unchanged - moving it would flip that score's (and its duplicates') verdict,
+    which is the one case where the exact value does carry information.
+
+    Args:
+        cut: The candidate threshold.
+        sorted_scores: The sample the threshold will be applied to, **sorted
+            ascending**.  Empty or non-finite inputs are passed through.
+
+    Returns:
+        The canonical representative of *cut*'s admitted set.  Out-of-support
+        cuts (below every score, or above every score) have no bracketing pair
+        to snap to and are returned unchanged.
+    """
+    if sorted_scores.size == 0 or not math.isfinite(cut):
+        return float(cut)
+    i = int(np.searchsorted(sorted_scores, cut, side="left"))
+    # ``i == 0`` / ``i == size``: the cut sits off the end of the support, so
+    # there is no empty *interval* bracketing it - only an unbounded ray, which
+    # has no midpoint.  ``sorted_scores[i] == cut``: the cut is exactly on an
+    # observed score, where the value is identifiable (it decides that score's
+    # own verdict) and must be left alone.
+    if i == 0 or i == sorted_scores.size:
+        return float(cut)
+    if float(sorted_scores[i]) == cut:
+        return float(cut)
+    return (float(sorted_scores[i - 1]) + float(sorted_scores[i])) / 2.0
+
+
 def fit_score_gmm(arr: np.ndarray) -> GmmFit1D | None:
     """Fit a deterministic 2-component GMM to a 1-D score array.
 
@@ -572,7 +628,8 @@ def _anchored_em(
 
     *x* is the free (unlabelled) sample, *a_lo* / *a_hi* the anchor scores
     clamped to the low / high component.  Pure numpy, log-domain E-step, fixed
-    iteration order - deterministic for fixed inputs by construction.  Only
+    iteration order, and no BLAS calls (see the M-step comment) - deterministic
+    for fixed inputs, and reproducible across machines with it.  Only
     numerical failure (non-finite parameters) returns ``None`` here; semantic
     degeneracy (inverted means, collapsed component) is judged by the caller so
     it can name the reason.
@@ -609,16 +666,21 @@ def _anchored_em(
         m_hi = float(r[:, 1].sum()) + lam * n_hi
         if not (m_lo > 0.0 and m_hi > 0.0):
             return None
+        # ``np.sum`` rather than ``@``: a dot product is dispatched to BLAS,
+        # whose accumulation order depends on the kernel the CPU selects and on
+        # the thread count, so the same input can differ in its last bits
+        # between two machines.  numpy's own pairwise reduction does not
+        # (issue #3166).  The extra temporaries are one ``x``-sized array each.
         mu_new = np.array(
             [
-                (float(r[:, 0] @ x) + lam * sum_a_lo) / m_lo,
-                (float(r[:, 1] @ x) + lam * sum_a_hi) / m_hi,
+                (float(np.sum(r[:, 0] * x)) + lam * sum_a_lo) / m_lo,
+                (float(np.sum(r[:, 1] * x)) + lam * sum_a_hi) / m_hi,
             ]
         )
         var_new = np.array(
             [
-                (float(r[:, 0] @ (x - mu_new[0]) ** 2) + lam * float(((a_lo - mu_new[0]) ** 2).sum())) / m_lo,
-                (float(r[:, 1] @ (x - mu_new[1]) ** 2) + lam * float(((a_hi - mu_new[1]) ** 2).sum())) / m_hi,
+                (float(np.sum(r[:, 0] * (x - mu_new[0]) ** 2)) + lam * float(((a_lo - mu_new[0]) ** 2).sum())) / m_lo,
+                (float(np.sum(r[:, 1] * (x - mu_new[1]) ** 2)) + lam * float(((a_hi - mu_new[1]) ** 2).sum())) / m_hi,
             ]
         )
         var_new = np.maximum(var_new, var_floor)
@@ -973,6 +1035,19 @@ class FoldAnchoredCut:
         tilts the crossing itself; plain ``"mid"`` ignores the weights and is
         constant in inclusion.
 
+        The realized value is finally canonicalised by
+        :func:`snap_cut_to_sample`, so a cut landing between two adjacent
+        haystack scores reports the midpoint of that empty interval rather than
+        wherever ``np.quantile``'s linear interpolation put it.  That is
+        decision-exact - the admitted set is identical either way - and it is
+        what makes the threshold **reproducible**: without it, interpolating
+        across an empty interval multiplies any wobble in *q* by
+        ``(n - 1) * gap``, which on a saturated distribution turned a
+        sub-part-per-million cross-machine difference into a visible threshold
+        move (issue #3166).  The cost is that the threshold now steps rather
+        than slides *within* one order-statistic band, which is honest: the
+        admitted set was constant across that band all along.
+
         **Monotone by construction**, so the included sets stay nested
         (everything included at ``k`` stays included at ``k + 1``) - the
         contract that makes "cut off at Inclusion 1, verify up to Inclusion 4"
@@ -982,10 +1057,12 @@ class FoldAnchoredCut:
         the exits stay monotone *and strictly moving* - issue #2896), the
         empirical quantile of that cut in its fold's haystack, the mean/median
         across folds, the ``mid_tilt`` composition (a constant plus a
-        monotone-in-inclusion shift), and realizing a quantile on the final
-        haystack.  The only plateau in the chain is the honest boundary where
-        a cut runs off its haystack's support and the quantile pins at 0 or 1
-        - crucially, the acquisition offset
+        monotone-in-inclusion shift), realizing a quantile on the final
+        haystack, and the snap (which maps each order-statistic band to its own
+        midpoint, so it is non-decreasing).  The plateaus in the chain are the
+        honest ones - a band of the knob over which the *admitted set* does not
+        change, including the boundary where a cut runs off its haystack's
+        support and the quantile pins at 0 or 1 - crucially, the acquisition offset
         (:data:`ACQUISITION_INCLUSION_OFFSET`) therefore stays a real gap
         across the slider instead of silently collapsing wherever the tilt
         used to saturate.
@@ -993,7 +1070,8 @@ class FoldAnchoredCut:
         if self.final_haystack.size == 0:
             return 0.5
         q = self._quantile_at(*inclusion_cost_weights(inclusion_value))
-        return float(np.quantile(self.final_haystack, min(1.0, max(0.0, q))))
+        realized = float(np.quantile(self.final_haystack, min(1.0, max(0.0, q))))
+        return snap_cut_to_sample(realized, self.final_haystack)
 
 
 def fit_fold_anchored_cut(
@@ -1112,7 +1190,8 @@ def fold_anchored_gmm_threshold(
     final_arr = gmm_fit_array(final_scores)
     fallback_fit = fit_score_gmm(final_arr) if final_arr.size >= 2 else None
     if fallback_fit is not None:
-        return fallback_fit.midpoint(), "fold_fallback_final_unanchored"
+        cut = snap_cut_to_sample(fallback_fit.midpoint(), np.sort(final_arr))
+        return cut, "fold_fallback_final_unanchored"
     if final_arr.size:
         return float(np.median(final_arr)), "fold_fallback_final_median"
     return 0.5, "fold_fallback_final_median"
@@ -1137,6 +1216,11 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
     (seed-42) random subsample - the two-Gaussian fit is unchanged in practice
     but the cost no longer grows with the dataset size.
 
+    The midpoint is canonicalised by :func:`snap_cut_to_sample` against the same
+    sample, so a cut landing between two adjacent scores reports the midpoint of
+    that empty interval instead of a value only the EM fit's last bits decide
+    (issue #3166).  The verdict on every score in the sample is unchanged.
+
     Args:
         scores: List of model confidence scores, expected to follow a bimodal distribution.
 
@@ -1154,7 +1238,7 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         # If GMM fails, return median (of the subsample when one was taken -
         # representative of the full distribution and keeps this path bounded).
         return float(np.median(arr))
-    return fit.midpoint()
+    return snap_cut_to_sample(fit.midpoint(), np.sort(arr))
 
 
 def _score_rows_digest(score_rows_by_group: dict | None) -> bytes | None:
@@ -1988,6 +2072,10 @@ def fit_gmm_threshold(scores: list[float]) -> tuple[float, GmmFit1D | None]:
     (issue #2841) need the component means, so this returns both from one EM
     fit.  ``None`` accompanies the 0.5 / median fallbacks, where there is no
     fit to speak of and a schedule must degrade to the plain blend.
+
+    The cut is :func:`snap_cut_to_sample`-canonicalised exactly as
+    :func:`calculate_gmm_threshold`'s is, so the two agree; the *fit* is
+    returned unsnapped, since the schedules read its component geometry.
     """
     if len(scores) < 2:
         return 0.5, None
@@ -1995,7 +2083,7 @@ def fit_gmm_threshold(scores: list[float]) -> tuple[float, GmmFit1D | None]:
     fit = fit_score_gmm(arr)
     if fit is None:
         return float(np.median(arr)), None
-    return fit.midpoint(), fit
+    return snap_cut_to_sample(fit.midpoint(), np.sort(arr)), fit
 
 
 def calculate_safe_threshold(

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -518,6 +518,20 @@ def snap_cut_to_sample(cut: float, sorted_scores: np.ndarray) -> float:
     unchanged - moving it would flip that score's (and its duplicates') verdict,
     which is the one case where the exact value does carry information.
 
+    **Applied only where the chain has gain**, i.e. at
+    :meth:`FoldAnchoredCut.threshold_at`, whose ``np.quantile`` interpolation is
+    the amplifier.  :func:`calculate_gmm_threshold` and :func:`fit_gmm_threshold`
+    deliberately do *not* snap: their cut is ``fit.midpoint()``, a smooth
+    function of the fitted means, so an ulp of wobble in the fit buys an ulp of
+    wobble in the cut and there is nothing to amplify.  Snapping them would also
+    cost more than it bought - it would break the ``calculate_gmm_threshold(s) ==
+    fit_score_gmm(gmm_fit_array(s)).midpoint()`` recomposition identity the eval
+    harness relies on to re-cut one fit and reproduce the app, and above
+    :data:`_GMM_MAX_SAMPLES` it would snap against a *subsample*, whose empty
+    intervals are not empty in the full population.  ``threshold_at`` has
+    neither problem: it snaps against exactly the array its own quantile was
+    realised on.
+
     Args:
         cut: The candidate threshold.
         sorted_scores: The sample the threshold will be applied to, **sorted
@@ -1190,8 +1204,7 @@ def fold_anchored_gmm_threshold(
     final_arr = gmm_fit_array(final_scores)
     fallback_fit = fit_score_gmm(final_arr) if final_arr.size >= 2 else None
     if fallback_fit is not None:
-        cut = snap_cut_to_sample(fallback_fit.midpoint(), np.sort(final_arr))
-        return cut, "fold_fallback_final_unanchored"
+        return fallback_fit.midpoint(), "fold_fallback_final_unanchored"
     if final_arr.size:
         return float(np.median(final_arr)), "fold_fallback_final_median"
     return 0.5, "fold_fallback_final_median"
@@ -1216,11 +1229,6 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
     (seed-42) random subsample - the two-Gaussian fit is unchanged in practice
     but the cost no longer grows with the dataset size.
 
-    The midpoint is canonicalised by :func:`snap_cut_to_sample` against the same
-    sample, so a cut landing between two adjacent scores reports the midpoint of
-    that empty interval instead of a value only the EM fit's last bits decide
-    (issue #3166).  The verdict on every score in the sample is unchanged.
-
     Args:
         scores: List of model confidence scores, expected to follow a bimodal distribution.
 
@@ -1238,7 +1246,7 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         # If GMM fails, return median (of the subsample when one was taken -
         # representative of the full distribution and keeps this path bounded).
         return float(np.median(arr))
-    return snap_cut_to_sample(fit.midpoint(), np.sort(arr))
+    return fit.midpoint()
 
 
 def _score_rows_digest(score_rows_by_group: dict | None) -> bytes | None:
@@ -2072,10 +2080,6 @@ def fit_gmm_threshold(scores: list[float]) -> tuple[float, GmmFit1D | None]:
     (issue #2841) need the component means, so this returns both from one EM
     fit.  ``None`` accompanies the 0.5 / median fallbacks, where there is no
     fit to speak of and a schedule must degrade to the plain blend.
-
-    The cut is :func:`snap_cut_to_sample`-canonicalised exactly as
-    :func:`calculate_gmm_threshold`'s is, so the two agree; the *fit* is
-    returned unsnapped, since the schedules read its component geometry.
     """
     if len(scores) < 2:
         return 0.5, None
@@ -2083,7 +2087,7 @@ def fit_gmm_threshold(scores: list[float]) -> tuple[float, GmmFit1D | None]:
     fit = fit_score_gmm(arr)
     if fit is None:
         return float(np.median(arr)), None
-    return snap_cut_to_sample(fit.midpoint(), np.sort(arr)), fit
+    return fit.midpoint(), fit
 
 
 def calculate_safe_threshold(


### PR DESCRIPTION
Closes #3166.

## The culprit is amplification, not a wandering fit

The issue's hypothesis was that the mixture fit lands in a different local optimum on a saturated distribution. It doesn't — and the arithmetic says so precisely.

`FoldAnchoredCut.threshold_at` realizes its combined fold quantile with `np.quantile`, which interpolates **linearly** between adjacent order statistics. Across the empty interval of a saturated distribution that interpolation has gain `(n - 1) * gap`:

```
n = 9000, gap ~ 1.0   =>   dt = 8999 * dq
dq = 2.9e-6          =>   dt = 0.0261
```

which is the 0.0264 measured on `caltech101_m` / `siglip` / `airplanes`. A sub-part-per-million wobble in `q` — comfortably inside what differing BLAS kernels or thread counts produce between two nodes — is enough, with no change of optimum required. That also explains why `n_good`, `n_bad`, `average_precision` and `auroc` all differed by exactly 0: nothing crossed the cut, because there was nothing in the interval to cross.

Attempting to reproduce a wandering fit directly did not: `fit_score_gmm` on saturated synthetics is bit-identical under `threadpoolctl` limits of 1/2/4, and stable to input perturbations up to 1e-10 relative. On a saturated sample sklearn's component variances sit pinned at `reg_covar`, which makes the EM hard-assign and converge to the same partition every time.

## The fix

`snap_cut_to_sample(cut, sorted_scores)` maps a cut that lands **strictly inside an interval containing no observed score** to that interval's midpoint. Applied at `FoldAnchoredCut.threshold_at`, against the very array its own quantile was realized on.

- **Decision-exact by construction.** The snap only moves a cut through a region with no data in it, so `score >= threshold` gives the identical verdict on every element. A cut sitting exactly *on* an observed score is identifiable (it decides that score's own verdict) and is left alone; out-of-support cuts have no bracketing pair and pass through.
- **The gain is now zero.** The threshold cannot move until `q` crosses a whole order statistic — at which point the admitted set really has changed and the difference is real.
- **Monotonicity is preserved.** The snap is non-decreasing (each order-statistic band maps to its own midpoint), so the Inclusion nesting contract still holds. It converts a slide across an empty band into a step, which is honest: the admitted set was constant across that band all along.

Deliberately **not** applied to `calculate_gmm_threshold` / `fit_gmm_threshold`. Their cut is `fit.midpoint()` — a smooth function of the fitted means, unit gain, nothing to amplify. Snapping them would break the `calculate_gmm_threshold(s) == fit_score_gmm(gmm_fit_array(s)).midpoint()` recomposition identity the eval harness leans on, and above `_GMM_MAX_SAMPLES` it would snap against a *subsample* whose empty intervals are not empty in the full population.

## Also: no BLAS in the anchored EM

`_anchored_em`'s M-step used `r[:, 0] @ x`, dispatched to BLAS, whose accumulation order depends on the CPU kernel and the thread count — the exact mechanism the issue names, sitting inside an iterative loop in the shipped path. Swapped for `np.sum(r[:, 0] * x)`; numpy's own pairwise reduction is single-threaded and kernel-stable. Costs one `x`-sized temporary per term.

## Eval/app sync

The snap went **inside** `threshold_at` rather than between the fit and the cut, precisely so the `#2865` sweep (which composes `fit_fold_anchored_cut(...)` then `threshold_at(k)` itself) picks it up for free. `fold_anchored_gmm_threshold` is byte-unchanged and the pins file is unchanged; the mirror's note records that this was checked.

## Tests

`tests_lib/sorting/test_gmm_saturated_determinism.py`, 15 tests:

- the snap's invariants — gap midpoint, decision-exactness over a 401-point sweep, on-a-score passthrough, out-of-support/empty/NaN passthrough, idempotence, monotonicity;
- float-level fit wobble (1e-15 … 1e-3 in `mu_lo`) leaves `threshold_at` **bit-identical**, with a companion assertion that the same wobbles moved the *raw* quantile by >0.05 so the guard cannot silently go vacuous;
- the issue's own reproduction: the shipped threshold under `threadpool_limits` of 1, 2 and 4;
- the admitted set matches the raw quantile's across inclusion −3…3, and the plain GMM cut is confirmed unsnapped.

Full `./run-tests.sh`: 8743 passed, all gates green.

`docs/experiments/overview-bench/RESULT-horizon-250.md` gains a "Resolved" note under its numerical-wrinkle section, including the warning that runs before and after are not threshold-comparable on saturated cells (every other column is unaffected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN4DJQGKy7Cbq9ovT9QEuz)_