### PR TITLE
Make a finished import distinguishable from a wedged one, and cancel honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A finished dataset import no longer looks like a wedged one.** An import
+  that had already succeeded — pickle written, dataset registered — kept the
+  progress channel parked on its last message ("Loading SigLIP processor…")
+  indefinitely, with no loader thread left in the process. Three things fed
+  that: a model load taken through the app-wide progress sink narrated itself
+  on the dataset channel and never said it had finished, the load task's
+  success path wrote no terminal state (only its failure paths did), and
+  `POST /api/dataset/cancel` answered `{"ok": true}` while doing nothing,
+  because cancellation is cooperative and there was no worker left to observe
+  the flag. Model loads now terminate whatever channel they borrowed
+  (background warm-ups are silent, and an import's model load reports on the
+  import's own row); a load parks its tracker when the work ends, whichever
+  way it ended; and cancel reports what it actually reached — `409` with
+  `ok: false` when it reached nothing, clearing the stale progress on the way
+  out. The dataset registry also re-reads its manifest when the file on disk
+  changes, so a dataset registered by another process (a CLI `--autodetect`
+  run against the same data dir) is listed without a restart. (#3167)
+
 - **Detector load can no longer hang forever at "Preparing".** Loading a
   detector while the selected dataset was not yet (re)loaded — typical right
   after an app restart, while the dataset was still being read from its

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -635,6 +635,16 @@ dataset loads share one embedder without their trackers crossing — a mis-route
 callback would not merely mis-draw a bar, since trackers call `check_cancelled()`
 and would abort the wrong load.
 
+That process-wide default is the app's *dataset* progress channel, which nothing
+else terminates: a sink cannot see when the work it is narrating ends.  So
+`load_models()` terminates it itself — an unscoped load reports as usual and
+then sends one `idle` tick on the way out (`MediaEmbedder._orphan_progress`).
+Background warm-ups that should not appear on any channel say so explicitly with
+`with emb.silent_progress():` (the smart-preload threads, the post-import
+embedder warm-up).  Skipping either is how a *finished* import came to look
+identical to a wedged one, with the dataset channel parked on "Loading SigLIP
+processor…" and no loader thread anywhere in the process (#3167).
+
 ### The plugin systems
 
 **Pattern:** Each `PluginRegistry`-backed plugin family uses the same

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -554,7 +554,7 @@ loaded via `spec_from_file_location` so discovery still works.
 
 | Attribute       | Type               | Description                         |
 |-----------------|--------------------|-------------------------------------|
-| `_on_progress`  | `ProgressCallback` | Progress callback (default: no-op). Process-wide default set via `set_progress_callback()`; **reads and writes are per-thread**, so wrap a temporary redirect in `with emb.progress_scope(cb):` rather than saving/restoring by hand. Embedders are singletons — a process-wide swap would cross concurrent loads' progress bars and cancellations. |
+| `_on_progress`  | `ProgressCallback` | Progress callback (default: no-op). Process-wide default set via `set_progress_callback()`; **reads and writes are per-thread**, so wrap a temporary redirect in `with emb.progress_scope(cb):` rather than saving/restoring by hand. Embedders are singletons — a process-wide swap would cross concurrent loads' progress bars and cancellations. A background warm-up with no progress surface should use `with emb.silent_progress():`; an unscoped `load_models()` reports on the process-wide default and parks it `idle` when it returns. |
 
 ### Built-in embedders
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -193,17 +193,36 @@ is the current snapshot; no separate bootstrap call is needed.
 POST /api/dataset/cancel
 ```
 
-Cancels all active loading tasks.
+Cancels all active loading tasks and the legacy global tracker, then waits
+briefly (~2 s) for one of them to act on the flag.
 
-→ `{"ok": true}`
+Cancellation is **cooperative**: the endpoint sets an event that a running
+worker has to observe. `ok` therefore reports whether the cancel actually
+reached something, not merely that the flag was set — a flag set with no
+worker left to see it stops nothing.
+
+→ `200 {"ok": true, "message": "...", "targets": [...], "acknowledged": [...], "pending": [...], "unresponsive": [...]}`
+
+| Field | Meaning |
+|---|---|
+| `targets` | Everything that claimed to be working when the cancel arrived (loading-task ids, plus `"dataset_progress"` for the global tracker). |
+| `acknowledged` | Targets that reached a terminal state within the grace period. |
+| `pending` | Targets still running, whose live worker will observe the flag. |
+| `unresponsive` | Targets whose progress claimed work no live thread was doing — stale trackers, now cleared. Not operations that were stopped. |
+
+`ok` is `true` when at least one target acknowledged or is pending. When the
+cancel reached nothing — no operation was running, or every target's progress
+was stale — the response is `409` with `ok: false`, and the stale progress it
+found is cleared on the way out.
 
 ```
 POST /api/dataset/cancel/{task_id}
 ```
 
-Cancels a specific loading task.
+Cancels a specific loading task, with the same response shape and the same
+`409` contract when the task was not running or its worker is gone.
 
-→ `{"ok": true}` or `{"error": "Task not found"}` (404)
+→ `200 {"ok": true, ...}`, `409 {"ok": false, ...}`, or `{"error": "Task not found"}` (404)
 
 ---
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -845,12 +845,44 @@
       "CancelDatasetLoadResponse": {
         "additionalProperties": false,
         "properties": {
+          "acknowledged": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "message": {
+            "type": "string"
+          },
           "ok": {
             "type": "boolean"
+          },
+          "pending": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "targets": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "unresponsive": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           }
         },
         "required": [
-          "ok"
+          "acknowledged",
+          "message",
+          "ok",
+          "pending",
+          "targets",
+          "unresponsive"
         ],
         "type": "object"
       },
@@ -9428,7 +9460,7 @@
     },
     "/api/dataset/cancel": {
       "post": {
-        "description": "Cancels all active loading tasks and the legacy global tracker.",
+        "description": "Cancels all active loading tasks and the legacy global tracker, then waits\nbriefly for one of them to act on the flag.  Cancellation is cooperative,\nso a flag set with no worker left to observe it stops nothing; answering\n``ok`` in that case is what let a *finished* import keep looking like a\nwedged one (#3167).  A cancel that reached nothing answers ``409``, and any\nstale progress it found is cleared on the way out.",
         "operationId": "cancel_dataset_load",
         "responses": {
           "200": {
@@ -9440,6 +9472,16 @@
               }
             },
             "description": "OK"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelDatasetLoadResponse"
+                }
+              }
+            },
+            "description": "The cancel reached nothing: no operation was running, or the progress it claimed was stale."
           },
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"
@@ -9464,6 +9506,7 @@
         }
       ],
       "post": {
+        "description": "Same honesty contract as ``POST /api/dataset/cancel``, narrowed to one\ntask.",
         "operationId": "cancel_dataset_load_task",
         "responses": {
           "200": {
@@ -9477,7 +9520,17 @@
             "description": "OK"
           },
           "404": {
-            "description": "No active task with the supplied id."
+            "description": "No task with the supplied id."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CancelDatasetLoadResponse"
+                }
+              }
+            },
+            "description": "The task was not running, or its progress was stale (no live worker)."
           },
           "default": {
             "$ref": "#/components/responses/DEFAULT_ERROR"

--- a/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { of, Subject } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import { DashboardLoadingTasksService } from './dashboard-loading-tasks.service';
 import { AchievementsService } from './achievements.service';
@@ -24,6 +24,7 @@ describe('DashboardLoadingTasksService', () => {
   let loadingTasks$: Subject<LoadingTask[]>;
   let detectorLoadingTasks$: Subject<LoadingTask[]>;
   let serverReset$: Subject<void>;
+  let datasetsRegistryApiStub: { cancelTask: ReturnType<typeof vi.fn> };
 
   function task(overrides: Partial<LoadingTask>): LoadingTask {
     return {
@@ -54,16 +55,24 @@ describe('DashboardLoadingTasksService', () => {
       setLoading: vi.fn(),
     };
     const achievementsStub = { refresh: vi.fn() };
-    const datasetsRegistryApiStub = { cancelTask: vi.fn(() => of(null)) };
-    const detectorsRegistryApiStub = { cancelDetectorLoadingTask: vi.fn(() => of(null)) };
+    datasetsRegistryApiStub = { cancelTask: vi.fn(() => of(null)) };
+    const detectorsRegistryApiStub = {
+      cancelDetectorLoadingTask: vi.fn(() => of(null)),
+    };
 
     configureZoneless({
       providers: [
         { provide: ProgressEventsService, useValue: progressEventsStub },
         { provide: DatasetStateService, useValue: datasetStateStub },
         { provide: AchievementsService, useValue: achievementsStub },
-        { provide: DatasetsRegistryApiService, useValue: datasetsRegistryApiStub },
-        { provide: DetectorsRegistryApiService, useValue: detectorsRegistryApiStub },
+        {
+          provide: DatasetsRegistryApiService,
+          useValue: datasetsRegistryApiStub,
+        },
+        {
+          provide: DetectorsRegistryApiService,
+          useValue: detectorsRegistryApiStub,
+        },
       ],
     });
 
@@ -88,7 +97,10 @@ describe('DashboardLoadingTasksService', () => {
     ]);
     expect(onComplete).not.toHaveBeenCalled();
 
-    loadingTasks$.next([task({ task_id: 'import-1' }), task({ task_id: 'load-1' })]);
+    loadingTasks$.next([
+      task({ task_id: 'import-1' }),
+      task({ task_id: 'load-1' }),
+    ]);
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
@@ -114,7 +126,10 @@ describe('DashboardLoadingTasksService', () => {
     ]);
     // The unrelated import fails; the dataset load succeeds. Promotion of
     // the successfully loaded dataset must not be held hostage.
-    loadingTasks$.next([task({ task_id: 'import-1', error: 'disk full' }), task({ task_id: 'load-1' })]);
+    loadingTasks$.next([
+      task({ task_id: 'import-1', error: 'disk full' }),
+      task({ task_id: 'load-1' }),
+    ]);
 
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
@@ -129,7 +144,10 @@ describe('DashboardLoadingTasksService', () => {
       task({ task_id: 'load-1', status: 'running' }),
       task({ task_id: 'load-2', status: 'running' }),
     ]);
-    loadingTasks$.next([task({ task_id: 'load-1' }), task({ task_id: 'load-2' })]);
+    loadingTasks$.next([
+      task({ task_id: 'load-1' }),
+      task({ task_id: 'load-2' }),
+    ]);
 
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
@@ -143,7 +161,9 @@ describe('DashboardLoadingTasksService', () => {
 
   it('fires detector onComplete registered while detector polling is already active (regression)', () => {
     // A detector load is in flight → constructor auto-starts the loop.
-    detectorLoadingTasks$.next([task({ task_id: 'det-other', status: 'running' })]);
+    detectorLoadingTasks$.next([
+      task({ task_id: 'det-other', status: 'running' }),
+    ]);
 
     const onComplete = vi.fn();
     service.startDetectorProgressPolling(onComplete);
@@ -170,6 +190,22 @@ describe('DashboardLoadingTasksService', () => {
     expect(service.isCancelling('load-1')).toBe(false);
   });
 
+  it('clears the cancelling flag when the backend refuses the cancel', () => {
+    // POST /api/dataset/cancel/<id> answers 409 when the cancel reached
+    // nothing — the task had already finished, or its progress was stale with
+    // no worker behind it. The row is not cancelling, so it must not be left
+    // sitting on "Cancelling…".
+    datasetsRegistryApiStub.cancelTask.mockReturnValueOnce(
+      throwError(() => ({ status: 409 })),
+    );
+    service.startProgressPolling();
+    loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
+
+    service.cancelLoadingTask('load-1');
+
+    expect(service.isCancelling('load-1')).toBe(false);
+  });
+
   it('flags a detector task as cancelling and clears it when it settles', () => {
     service.startDetectorProgressPolling();
     detectorLoadingTasks$.next([task({ task_id: 'det-1', status: 'running' })]);
@@ -177,7 +213,9 @@ describe('DashboardLoadingTasksService', () => {
     service.cancelDetectorLoadingTask('det-1');
     expect(service.isCancelling('det-1')).toBe(true);
 
-    detectorLoadingTasks$.next([task({ task_id: 'det-1', error: 'Cancelled' })]);
+    detectorLoadingTasks$.next([
+      task({ task_id: 'det-1', error: 'Cancelled' }),
+    ]);
     expect(service.isCancelling('det-1')).toBe(false);
   });
 

--- a/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.spec.ts
@@ -56,23 +56,15 @@ describe('DashboardLoadingTasksService', () => {
     };
     const achievementsStub = { refresh: vi.fn() };
     datasetsRegistryApiStub = { cancelTask: vi.fn(() => of(null)) };
-    const detectorsRegistryApiStub = {
-      cancelDetectorLoadingTask: vi.fn(() => of(null)),
-    };
+    const detectorsRegistryApiStub = { cancelDetectorLoadingTask: vi.fn(() => of(null)) };
 
     configureZoneless({
       providers: [
         { provide: ProgressEventsService, useValue: progressEventsStub },
         { provide: DatasetStateService, useValue: datasetStateStub },
         { provide: AchievementsService, useValue: achievementsStub },
-        {
-          provide: DatasetsRegistryApiService,
-          useValue: datasetsRegistryApiStub,
-        },
-        {
-          provide: DetectorsRegistryApiService,
-          useValue: detectorsRegistryApiStub,
-        },
+        { provide: DatasetsRegistryApiService, useValue: datasetsRegistryApiStub },
+        { provide: DetectorsRegistryApiService, useValue: detectorsRegistryApiStub },
       ],
     });
 
@@ -97,10 +89,7 @@ describe('DashboardLoadingTasksService', () => {
     ]);
     expect(onComplete).not.toHaveBeenCalled();
 
-    loadingTasks$.next([
-      task({ task_id: 'import-1' }),
-      task({ task_id: 'load-1' }),
-    ]);
+    loadingTasks$.next([task({ task_id: 'import-1' }), task({ task_id: 'load-1' })]);
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
@@ -126,10 +115,7 @@ describe('DashboardLoadingTasksService', () => {
     ]);
     // The unrelated import fails; the dataset load succeeds. Promotion of
     // the successfully loaded dataset must not be held hostage.
-    loadingTasks$.next([
-      task({ task_id: 'import-1', error: 'disk full' }),
-      task({ task_id: 'load-1' }),
-    ]);
+    loadingTasks$.next([task({ task_id: 'import-1', error: 'disk full' }), task({ task_id: 'load-1' })]);
 
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
@@ -144,10 +130,7 @@ describe('DashboardLoadingTasksService', () => {
       task({ task_id: 'load-1', status: 'running' }),
       task({ task_id: 'load-2', status: 'running' }),
     ]);
-    loadingTasks$.next([
-      task({ task_id: 'load-1' }),
-      task({ task_id: 'load-2' }),
-    ]);
+    loadingTasks$.next([task({ task_id: 'load-1' }), task({ task_id: 'load-2' })]);
 
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
@@ -161,9 +144,7 @@ describe('DashboardLoadingTasksService', () => {
 
   it('fires detector onComplete registered while detector polling is already active (regression)', () => {
     // A detector load is in flight → constructor auto-starts the loop.
-    detectorLoadingTasks$.next([
-      task({ task_id: 'det-other', status: 'running' }),
-    ]);
+    detectorLoadingTasks$.next([task({ task_id: 'det-other', status: 'running' })]);
 
     const onComplete = vi.fn();
     service.startDetectorProgressPolling(onComplete);
@@ -195,9 +176,7 @@ describe('DashboardLoadingTasksService', () => {
     // nothing — the task had already finished, or its progress was stale with
     // no worker behind it. The row is not cancelling, so it must not be left
     // sitting on "Cancelling…".
-    datasetsRegistryApiStub.cancelTask.mockReturnValueOnce(
-      throwError(() => ({ status: 409 })),
-    );
+    datasetsRegistryApiStub.cancelTask.mockReturnValueOnce(throwError(() => ({ status: 409 })));
     service.startProgressPolling();
     loadingTasks$.next([task({ task_id: 'load-1', status: 'running' })]);
 
@@ -213,9 +192,7 @@ describe('DashboardLoadingTasksService', () => {
     service.cancelDetectorLoadingTask('det-1');
     expect(service.isCancelling('det-1')).toBe(true);
 
-    detectorLoadingTasks$.next([
-      task({ task_id: 'det-1', error: 'Cancelled' }),
-    ]);
+    detectorLoadingTasks$.next([task({ task_id: 'det-1', error: 'Cancelled' })]);
     expect(service.isCancelling('det-1')).toBe(false);
   });
 

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -75,7 +75,10 @@ export class DashboardLoadingTasksService {
    * completed task's association fields (e.g. its ``dataset_id``) without a
    * second poll — used by the combine-datasets summary toast.
    */
-  private datasetPollCallbacks: Array<{ taskId: string; cb: (completedTasks: LoadingTask[]) => void }> = [];
+  private datasetPollCallbacks: Array<{
+    taskId: string;
+    cb: (completedTasks: LoadingTask[]) => void;
+  }> = [];
   private detectorPollCallbacks: Array<() => void> = [];
 
   constructor() {
@@ -94,7 +97,9 @@ export class DashboardLoadingTasksService {
     // drop the per-task sets, and clear inline error rows that
     // reference vanished tasks. The next non-idle SSE snapshot will
     // re-engage polling cleanly via the constructor subscriptions above.
-    this.progressEvents.serverReset$.subscribe(() => this.resetOnBackendRestart());
+    this.progressEvents.serverReset$.subscribe(() =>
+      this.resetOnBackendRestart(),
+    );
   }
 
   private resetOnBackendRestart(): void {
@@ -123,6 +128,14 @@ export class DashboardLoadingTasksService {
     if (this._cancellingTaskIds().has(taskId)) return;
     const next = new Set(this._cancellingTaskIds());
     next.add(taskId);
+    this._cancellingTaskIds.set(next);
+  }
+
+  private unmarkCancelling(taskId: string): void {
+    const current = this._cancellingTaskIds();
+    if (!current.has(taskId)) return;
+    const next = new Set(current);
+    next.delete(taskId);
     this._cancellingTaskIds.set(next);
   }
 
@@ -161,7 +174,9 @@ export class DashboardLoadingTasksService {
   /** Loading tasks that have no matching dataset row (new imports, etc.). */
   get orphanLoadingTasks(): LoadingTask[] {
     const datasetIds = new Set(this.datasetState.datasets.map((d) => d.id));
-    return this.loadingTasks.filter((t) => !t.dataset_id || !datasetIds.has(t.dataset_id));
+    return this.loadingTasks.filter(
+      (t) => !t.dataset_id || !datasetIds.has(t.dataset_id),
+    );
   }
 
   getInlineTask(datasetId: string): LoadingTask | undefined {
@@ -172,7 +187,10 @@ export class DashboardLoadingTasksService {
     return this.detectorLoadingTasks.find((t) => t.detector_id === modelId);
   }
 
-  startProgressPolling(awaitTaskId?: string, onComplete?: (completedTasks: LoadingTask[]) => void): void {
+  startProgressPolling(
+    awaitTaskId?: string,
+    onComplete?: (completedTasks: LoadingTask[]) => void,
+  ): void {
     // Register any task we've been told to expect.  See the field
     // comment on `awaitedTaskIds` for why this is needed.
     if (awaitTaskId) {
@@ -181,7 +199,10 @@ export class DashboardLoadingTasksService {
     // Registered on the service (not captured by the loop) so it fires
     // even when the early-return below is taken - see the field comment.
     if (onComplete) {
-      this.datasetPollCallbacks.push({ taskId: awaitTaskId ?? '', cb: onComplete });
+      this.datasetPollCallbacks.push({
+        taskId: awaitTaskId ?? '',
+        cb: onComplete,
+      });
     }
     // If polling is already active, don't restart; the existing loop
     // already covers all tasks.  This avoids clearing completedTaskIds
@@ -192,67 +213,70 @@ export class DashboardLoadingTasksService {
     this.datasetPollingActive = true;
     this.completedTaskIds.clear();
 
-    this.progressEvents.loadingTasks$
-      .pipe(takeUntil(this.polling$))
-      .subscribe({
-        next: (tasks: LoadingTask[]) => {
-          // Any task we were waiting for has now shown up in the SSE
-          // stream; drop it from the awaited set so the bail-out check
-          // below can fire as soon as the stream goes quiet.
-          for (const t of tasks) {
-            this.awaitedTaskIds.delete(t.task_id);
-          }
+    this.progressEvents.loadingTasks$.pipe(takeUntil(this.polling$)).subscribe({
+      next: (tasks: LoadingTask[]) => {
+        // Any task we were waiting for has now shown up in the SSE
+        // stream; drop it from the awaited set so the bail-out check
+        // below can fire as soon as the stream goes quiet.
+        for (const t of tasks) {
+          this.awaitedTaskIds.delete(t.task_id);
+        }
 
-          // Separate active from finished. Failed tasks are surfaced
-          // globally by SseErrorRouterService → ToastService; we just
-          // keep them in the inline list so the row still shows the
-          // dashed loading bar with the error text.
-          const active = tasks.filter((t) => t.status !== 'idle');
-          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
-          const failed = errored.filter((t) => t.error !== 'Cancelled');
+        // Separate active from finished. Failed tasks are surfaced
+        // globally by SseErrorRouterService → ToastService; we just
+        // keep them in the inline list so the row still shows the
+        // dashed loading bar with the error text.
+        const active = tasks.filter((t) => t.status !== 'idle');
+        const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
+        const failed = errored.filter((t) => t.error !== 'Cancelled');
 
-          this._loadingTasks.set([...active, ...failed]);
-          this.pruneCancelling(new Set(active.map((t) => t.task_id)));
+        this._loadingTasks.set([...active, ...failed]);
+        this.pruneCancelling(new Set(active.map((t) => t.task_id)));
 
-          // Detect tasks that just completed successfully so we can
-          // refresh the registry immediately (not only when ALL finish).
-          const justFinished = tasks.filter(
-            (t) => t.status === 'idle' && !t.error && !this.completedTaskIds.has(t.task_id),
-          );
-          for (const t of justFinished) {
-            this.completedTaskIds.add(t.task_id);
-          }
-          if (justFinished.length > 0) {
+        // Detect tasks that just completed successfully so we can
+        // refresh the registry immediately (not only when ALL finish).
+        const justFinished = tasks.filter(
+          (t) =>
+            t.status === 'idle' &&
+            !t.error &&
+            !this.completedTaskIds.has(t.task_id),
+        );
+        for (const t of justFinished) {
+          this.completedTaskIds.add(t.task_id);
+        }
+        if (justFinished.length > 0) {
+          this.datasetState.refresh();
+          this.achievements.refresh();
+        }
+
+        this.datasetState.setLoading(active.length > 0);
+
+        if (active.length === 0 && this.awaitedTaskIds.size === 0) {
+          // No more active tasks and no awaited task pending; stop
+          // polling.
+          this.polling$.next();
+          this.datasetPollingActive = false;
+          // Refresh unless we just did (justFinished already triggered it)
+          if (justFinished.length === 0) {
             this.datasetState.refresh();
-            this.achievements.refresh();
           }
-
-          this.datasetState.setLoading(active.length > 0);
-
-          if (active.length === 0 && this.awaitedTaskIds.size === 0) {
-            // No more active tasks and no awaited task pending; stop
-            // polling.
-            this.polling$.next();
-            this.datasetPollingActive = false;
-            // Refresh unless we just did (justFinished already triggered it)
-            if (justFinished.length === 0) {
-              this.datasetState.refresh();
-            }
-            // Fire every registered completion callback whose own task
-            // didn't fail.  Callbacks without a task id (legacy callers)
-            // keep the old "any failure suppresses" gate.
-            const callbacks = this.datasetPollCallbacks;
-            this.datasetPollCallbacks = [];
-            const failedIds = new Set(failed.map((t) => t.task_id));
-            for (const entry of callbacks) {
-              const suppressed = entry.taskId ? failedIds.has(entry.taskId) : failed.length > 0;
-              if (!suppressed) {
-                entry.cb(tasks);
-              }
+          // Fire every registered completion callback whose own task
+          // didn't fail.  Callbacks without a task id (legacy callers)
+          // keep the old "any failure suppresses" gate.
+          const callbacks = this.datasetPollCallbacks;
+          this.datasetPollCallbacks = [];
+          const failedIds = new Set(failed.map((t) => t.task_id));
+          for (const entry of callbacks) {
+            const suppressed = entry.taskId
+              ? failedIds.has(entry.taskId)
+              : failed.length > 0;
+            if (!suppressed) {
+              entry.cb(tasks);
             }
           }
-        },
-      });
+        }
+      },
+    });
   }
 
   startDetectorProgressPolling(onComplete?: () => void): void {
@@ -280,7 +304,10 @@ export class DashboardLoadingTasksService {
 
           // Detect tasks that just completed successfully
           const justFinished = tasks.filter(
-            (t) => t.status === 'idle' && !t.error && !this.completedModelTaskIds.has(t.task_id),
+            (t) =>
+              t.status === 'idle' &&
+              !t.error &&
+              !this.completedModelTaskIds.has(t.task_id),
           );
           for (const t of justFinished) {
             this.completedModelTaskIds.add(t.task_id);
@@ -310,11 +337,21 @@ export class DashboardLoadingTasksService {
 
   cancelLoadingTask(taskId: string): void {
     this.markCancelling(taskId);
-    this.datasetsRegistryApi.cancelTask(taskId).subscribe();
+    // A cancel that reached nothing answers 409 (the task had already
+    // finished, or its progress was stale with no worker behind it — see
+    // POST /api/dataset/cancel). The row is not cancelling in that case, so
+    // drop the flag rather than leaving it stuck on "Cancelling…"; the
+    // backend clears the stale progress itself, so the row leaves on the next
+    // SSE snapshot.
+    this.datasetsRegistryApi.cancelTask(taskId).subscribe({
+      error: () => this.unmarkCancelling(taskId),
+    });
   }
 
   dismissLoadingTask(taskId: string): void {
-    this._loadingTasks.set(this.loadingTasks.filter((t) => t.task_id !== taskId));
+    this._loadingTasks.set(
+      this.loadingTasks.filter((t) => t.task_id !== taskId),
+    );
   }
 
   cancelDetectorLoadingTask(taskId: string): void {

--- a/frontend/src/app/services/dashboard-loading-tasks.service.ts
+++ b/frontend/src/app/services/dashboard-loading-tasks.service.ts
@@ -75,10 +75,7 @@ export class DashboardLoadingTasksService {
    * completed task's association fields (e.g. its ``dataset_id``) without a
    * second poll — used by the combine-datasets summary toast.
    */
-  private datasetPollCallbacks: Array<{
-    taskId: string;
-    cb: (completedTasks: LoadingTask[]) => void;
-  }> = [];
+  private datasetPollCallbacks: Array<{ taskId: string; cb: (completedTasks: LoadingTask[]) => void }> = [];
   private detectorPollCallbacks: Array<() => void> = [];
 
   constructor() {
@@ -97,9 +94,7 @@ export class DashboardLoadingTasksService {
     // drop the per-task sets, and clear inline error rows that
     // reference vanished tasks. The next non-idle SSE snapshot will
     // re-engage polling cleanly via the constructor subscriptions above.
-    this.progressEvents.serverReset$.subscribe(() =>
-      this.resetOnBackendRestart(),
-    );
+    this.progressEvents.serverReset$.subscribe(() => this.resetOnBackendRestart());
   }
 
   private resetOnBackendRestart(): void {
@@ -174,9 +169,7 @@ export class DashboardLoadingTasksService {
   /** Loading tasks that have no matching dataset row (new imports, etc.). */
   get orphanLoadingTasks(): LoadingTask[] {
     const datasetIds = new Set(this.datasetState.datasets.map((d) => d.id));
-    return this.loadingTasks.filter(
-      (t) => !t.dataset_id || !datasetIds.has(t.dataset_id),
-    );
+    return this.loadingTasks.filter((t) => !t.dataset_id || !datasetIds.has(t.dataset_id));
   }
 
   getInlineTask(datasetId: string): LoadingTask | undefined {
@@ -187,10 +180,7 @@ export class DashboardLoadingTasksService {
     return this.detectorLoadingTasks.find((t) => t.detector_id === modelId);
   }
 
-  startProgressPolling(
-    awaitTaskId?: string,
-    onComplete?: (completedTasks: LoadingTask[]) => void,
-  ): void {
+  startProgressPolling(awaitTaskId?: string, onComplete?: (completedTasks: LoadingTask[]) => void): void {
     // Register any task we've been told to expect.  See the field
     // comment on `awaitedTaskIds` for why this is needed.
     if (awaitTaskId) {
@@ -199,10 +189,7 @@ export class DashboardLoadingTasksService {
     // Registered on the service (not captured by the loop) so it fires
     // even when the early-return below is taken - see the field comment.
     if (onComplete) {
-      this.datasetPollCallbacks.push({
-        taskId: awaitTaskId ?? '',
-        cb: onComplete,
-      });
+      this.datasetPollCallbacks.push({ taskId: awaitTaskId ?? '', cb: onComplete });
     }
     // If polling is already active, don't restart; the existing loop
     // already covers all tasks.  This avoids clearing completedTaskIds
@@ -213,70 +200,67 @@ export class DashboardLoadingTasksService {
     this.datasetPollingActive = true;
     this.completedTaskIds.clear();
 
-    this.progressEvents.loadingTasks$.pipe(takeUntil(this.polling$)).subscribe({
-      next: (tasks: LoadingTask[]) => {
-        // Any task we were waiting for has now shown up in the SSE
-        // stream; drop it from the awaited set so the bail-out check
-        // below can fire as soon as the stream goes quiet.
-        for (const t of tasks) {
-          this.awaitedTaskIds.delete(t.task_id);
-        }
-
-        // Separate active from finished. Failed tasks are surfaced
-        // globally by SseErrorRouterService → ToastService; we just
-        // keep them in the inline list so the row still shows the
-        // dashed loading bar with the error text.
-        const active = tasks.filter((t) => t.status !== 'idle');
-        const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
-        const failed = errored.filter((t) => t.error !== 'Cancelled');
-
-        this._loadingTasks.set([...active, ...failed]);
-        this.pruneCancelling(new Set(active.map((t) => t.task_id)));
-
-        // Detect tasks that just completed successfully so we can
-        // refresh the registry immediately (not only when ALL finish).
-        const justFinished = tasks.filter(
-          (t) =>
-            t.status === 'idle' &&
-            !t.error &&
-            !this.completedTaskIds.has(t.task_id),
-        );
-        for (const t of justFinished) {
-          this.completedTaskIds.add(t.task_id);
-        }
-        if (justFinished.length > 0) {
-          this.datasetState.refresh();
-          this.achievements.refresh();
-        }
-
-        this.datasetState.setLoading(active.length > 0);
-
-        if (active.length === 0 && this.awaitedTaskIds.size === 0) {
-          // No more active tasks and no awaited task pending; stop
-          // polling.
-          this.polling$.next();
-          this.datasetPollingActive = false;
-          // Refresh unless we just did (justFinished already triggered it)
-          if (justFinished.length === 0) {
-            this.datasetState.refresh();
+    this.progressEvents.loadingTasks$
+      .pipe(takeUntil(this.polling$))
+      .subscribe({
+        next: (tasks: LoadingTask[]) => {
+          // Any task we were waiting for has now shown up in the SSE
+          // stream; drop it from the awaited set so the bail-out check
+          // below can fire as soon as the stream goes quiet.
+          for (const t of tasks) {
+            this.awaitedTaskIds.delete(t.task_id);
           }
-          // Fire every registered completion callback whose own task
-          // didn't fail.  Callbacks without a task id (legacy callers)
-          // keep the old "any failure suppresses" gate.
-          const callbacks = this.datasetPollCallbacks;
-          this.datasetPollCallbacks = [];
-          const failedIds = new Set(failed.map((t) => t.task_id));
-          for (const entry of callbacks) {
-            const suppressed = entry.taskId
-              ? failedIds.has(entry.taskId)
-              : failed.length > 0;
-            if (!suppressed) {
-              entry.cb(tasks);
+
+          // Separate active from finished. Failed tasks are surfaced
+          // globally by SseErrorRouterService → ToastService; we just
+          // keep them in the inline list so the row still shows the
+          // dashed loading bar with the error text.
+          const active = tasks.filter((t) => t.status !== 'idle');
+          const errored = tasks.filter((t) => t.status === 'idle' && !!t.error);
+          const failed = errored.filter((t) => t.error !== 'Cancelled');
+
+          this._loadingTasks.set([...active, ...failed]);
+          this.pruneCancelling(new Set(active.map((t) => t.task_id)));
+
+          // Detect tasks that just completed successfully so we can
+          // refresh the registry immediately (not only when ALL finish).
+          const justFinished = tasks.filter(
+            (t) => t.status === 'idle' && !t.error && !this.completedTaskIds.has(t.task_id),
+          );
+          for (const t of justFinished) {
+            this.completedTaskIds.add(t.task_id);
+          }
+          if (justFinished.length > 0) {
+            this.datasetState.refresh();
+            this.achievements.refresh();
+          }
+
+          this.datasetState.setLoading(active.length > 0);
+
+          if (active.length === 0 && this.awaitedTaskIds.size === 0) {
+            // No more active tasks and no awaited task pending; stop
+            // polling.
+            this.polling$.next();
+            this.datasetPollingActive = false;
+            // Refresh unless we just did (justFinished already triggered it)
+            if (justFinished.length === 0) {
+              this.datasetState.refresh();
+            }
+            // Fire every registered completion callback whose own task
+            // didn't fail.  Callbacks without a task id (legacy callers)
+            // keep the old "any failure suppresses" gate.
+            const callbacks = this.datasetPollCallbacks;
+            this.datasetPollCallbacks = [];
+            const failedIds = new Set(failed.map((t) => t.task_id));
+            for (const entry of callbacks) {
+              const suppressed = entry.taskId ? failedIds.has(entry.taskId) : failed.length > 0;
+              if (!suppressed) {
+                entry.cb(tasks);
+              }
             }
           }
-        }
-      },
-    });
+        },
+      });
   }
 
   startDetectorProgressPolling(onComplete?: () => void): void {
@@ -304,10 +288,7 @@ export class DashboardLoadingTasksService {
 
           // Detect tasks that just completed successfully
           const justFinished = tasks.filter(
-            (t) =>
-              t.status === 'idle' &&
-              !t.error &&
-              !this.completedModelTaskIds.has(t.task_id),
+            (t) => t.status === 'idle' && !t.error && !this.completedModelTaskIds.has(t.task_id),
           );
           for (const t of justFinished) {
             this.completedModelTaskIds.add(t.task_id);
@@ -340,18 +321,16 @@ export class DashboardLoadingTasksService {
     // A cancel that reached nothing answers 409 (the task had already
     // finished, or its progress was stale with no worker behind it — see
     // POST /api/dataset/cancel). The row is not cancelling in that case, so
-    // drop the flag rather than leaving it stuck on "Cancelling…"; the
-    // backend clears the stale progress itself, so the row leaves on the next
-    // SSE snapshot.
+    // drop the flag rather than leaving it stuck on "Cancelling…"; the backend
+    // clears the stale progress itself, so the row leaves on the next SSE
+    // snapshot.
     this.datasetsRegistryApi.cancelTask(taskId).subscribe({
       error: () => this.unmarkCancelling(taskId),
     });
   }
 
   dismissLoadingTask(taskId: string): void {
-    this._loadingTasks.set(
-      this.loadingTasks.filter((t) => t.task_id !== taskId),
-    );
+    this._loadingTasks.set(this.loadingTasks.filter((t) => t.task_id !== taskId));
   }
 
   cancelDetectorLoadingTask(taskId: string): void {

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1984,9 +1984,7 @@ class TestCancelIngest:
         let a *finished* import look exactly like a wedged one (#3167).
         """
         resp = client.post("/api/dataset/cancel")
-        assert resp.status_code == 409, (
-            f"nothing was running; the cancel delivered nothing, got {resp.status_code}"
-        )
+        assert resp.status_code == 409, f"nothing was running; the cancel delivered nothing, got {resp.status_code}"
         data = resp.get_json()
         assert data["ok"] is False
         assert data["targets"] == []

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1976,12 +1976,21 @@ class TestEmptyLoadBackstop:
 class TestCancelIngest:
     """Tests for the POST /api/dataset/cancel endpoint."""
 
-    def test_cancel_endpoint_returns_ok(self, client):
-        """POST /api/dataset/cancel should return ok."""
+    def test_cancel_with_nothing_running_refuses(self, client):
+        """A cancel that reaches nothing must say so, not report success.
+
+        Cancellation is cooperative, so the flag only means anything if a
+        worker is around to observe it.  Answering ``ok`` regardless is what
+        let a *finished* import look exactly like a wedged one (#3167).
+        """
         resp = client.post("/api/dataset/cancel")
-        assert resp.status_code == 200
+        assert resp.status_code == 409, (
+            f"nothing was running; the cancel delivered nothing, got {resp.status_code}"
+        )
         data = resp.get_json()
-        assert data["ok"] is True
+        assert data["ok"] is False
+        assert data["targets"] == []
+        assert "nothing to cancel" in data["message"].lower()
 
     def test_cancel_sets_event(self, client):
         """POST /api/dataset/cancel should set the cancellation event."""

--- a/tests/datasets/test_load_terminal_state.py
+++ b/tests/datasets/test_load_terminal_state.py
@@ -1,0 +1,115 @@
+"""A finished import must be distinguishable from a wedged one (#3167).
+
+An import that had *succeeded* left every external signal saying "still
+loading": its loading task sat on the last message the pipeline happened to
+emit, and the global ``dataset_progress`` tracker — the SSE ``dataset``
+channel — kept whatever an unscoped model load had written into it.  Nothing
+cleared either, because only the failure paths wrote a terminal state.  The
+only way to learn the truth was to attach a profiler to the process.
+
+These drive a real load through ``_run_origin_load_in_background`` on the
+calling thread and assert both channels come to rest.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import numpy as np
+
+from vtscore.concurrency.progress import dataset_progress, loading_tasks
+
+
+def _sync_thread_factory():
+    """Run the load body inline so the assertions see a finished load."""
+
+    def fake_thread(target, daemon=True, name=None):
+        t = mock.MagicMock()
+        t.start = lambda: target()
+        return t
+
+    return fake_thread
+
+
+def _fake_load(target_medias):
+    """Minimal importer: one already-embedded media, so no model is needed."""
+    target_medias[1] = {
+        "id": 1,
+        "media_type": "audio",
+        "duration": 1.0,
+        "file_size": 100,
+        "md5": "terminal-state-md5",
+        "embedder": "",
+        "embedding": np.zeros(8, dtype=np.float32),
+        "filename": "fake.wav",
+        "category": "unknown",
+        "origin": None,
+        "origin_name": "fake.wav",
+        "media_bytes": None,
+        "media_string": None,
+        "media_path": None,
+    }
+
+
+def _run_load(tmp_path) -> str:
+    """Run one full load synchronously and return its task id."""
+    from vtsearch import settings as settings_mod
+    from vtscore.datasets.load_pipeline import _run_origin_load_in_background
+    from vtscore.datasets.registry import list_datasets, unregister_dataset
+
+    settings_mod.set_saved_datasets_dir(str(tmp_path / "saved"))
+    with mock.patch(
+        "vtscore.datasets.load_pipeline.threading.Thread",
+        side_effect=_sync_thread_factory(),
+    ):
+        task_id = _run_origin_load_in_background(
+            _fake_load,
+            {"importer": "test_terminal", "params": {}},
+            media_type="audio",
+            embedder="clap",
+        )
+    for entry in list_datasets():
+        unregister_dataset(entry["id"])
+    return task_id
+
+
+class TestSuccessfulLoadParksItsChannels:
+    def test_task_tracker_leaves_loading(self, isolated_settings, tmp_path):
+        task_id = _run_load(tmp_path)
+        try:
+            snapshot = loading_tasks.get_tracker(task_id).get()
+            assert snapshot["status"] == "idle", (
+                "a load that finished must say so; parking on the last 'loading' "
+                f"message is what made a success look like a hang, got {snapshot!r}"
+            )
+            assert snapshot["error"] is None, f"the load succeeded, got {snapshot!r}"
+        finally:
+            loading_tasks.remove_task(task_id)
+
+    def test_has_active_tasks_goes_false(self, isolated_settings, tmp_path):
+        """The success path must not leave the tracker claiming to be busy."""
+        task_id = _run_load(tmp_path)
+        try:
+            assert not loading_tasks.has_active_tasks(), (
+                "nothing is running; a stale 'active' task also blocks the next load's cancel-flag reset"
+            )
+        finally:
+            loading_tasks.remove_task(task_id)
+
+    def test_global_dataset_channel_is_left_idle(self, isolated_settings, tmp_path):
+        """The SSE ``dataset`` channel must not keep narrating a finished import.
+
+        Anything that reports progress without a per-thread callback lands on
+        this singleton — the observed symptom was it stuck on "Loading SigLIP
+        processor…" for forty minutes with no loader thread in the process.
+        """
+        dataset_progress.update("loading", "Loading SigLIP processor…", 0, 0)
+
+        task_id = _run_load(tmp_path)
+        try:
+            snapshot = dataset_progress.get()
+            assert snapshot["status"] == "idle", (
+                f"the last load out of the door parks an orphaned dataset channel; got {snapshot!r}"
+            )
+        finally:
+            loading_tasks.remove_task(task_id)

--- a/tests/datasets/test_load_terminal_state.py
+++ b/tests/datasets/test_load_terminal_state.py
@@ -77,7 +77,9 @@ class TestSuccessfulLoadParksItsChannels:
     def test_task_tracker_leaves_loading(self, isolated_settings, tmp_path):
         task_id = _run_load(tmp_path)
         try:
-            snapshot = loading_tasks.get_tracker(task_id).get()
+            tracker = loading_tasks.get_tracker(task_id)
+            assert tracker is not None, "the finished task should still be listed"
+            snapshot = tracker.get()
             assert snapshot["status"] == "idle", (
                 "a load that finished must say so; parking on the last 'loading' "
                 f"message is what made a success look like a hang, got {snapshot!r}"

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -300,17 +300,62 @@ class TestLoadingTasksMediaType:
 
 
 class TestCancelTaskEndpoint:
-    """Test the /api/dataset/cancel/<task_id> endpoint."""
+    """Test the /api/dataset/cancel/<task_id> endpoint.
 
-    def test_cancel_existing_task(self, client):
+    Cancellation is cooperative: the endpoint sets a flag, and something has
+    to be *running* to observe it.  So the response distinguishes a cancel
+    that reached a live worker from one that reached nothing at all — the
+    ambiguity that made a finished import look wedged (#3167).
+    """
+
+    def test_cancel_running_task_reports_it_was_delivered(self, client):
         pt = loading_tasks.create_task("cancel_test", "CancelDS")
+        pt.update("loading", "Working…", 10, 100)
+        stop = threading.Event()
+        worker = threading.Thread(target=stop.wait, daemon=True)
+        loading_tasks.set_worker("cancel_test", worker)
+        worker.start()
         try:
             resp = client.post("/api/dataset/cancel/cancel_test")
             assert resp.status_code == 200
-            assert resp.get_json()["ok"] is True
+            data = resp.get_json()
+            assert data["ok"] is True
+            assert data["pending"] == ["cancel_test"], f"the worker is alive and will observe the flag, got {data!r}"
             assert pt.is_cancelled
         finally:
+            stop.set()
+            worker.join(timeout=5)
             loading_tasks.remove_task("cancel_test")
+
+    def test_cancel_task_whose_worker_is_gone_refuses(self, client):
+        """A tracker claiming work with no live worker is stale, not running."""
+        pt = loading_tasks.create_task("stale_test", "StaleDS")
+        pt.update("loading", "Loading SigLIP processor…", 0, 0)
+        dead = threading.Thread(target=lambda: None, daemon=True)
+        loading_tasks.set_worker("stale_test", dead)
+        dead.start()
+        dead.join(timeout=5)
+        try:
+            resp = client.post("/api/dataset/cancel/stale_test")
+            assert resp.status_code == 409, f"no thread remained to act on the flag, got {resp.status_code}"
+            data = resp.get_json()
+            assert data["ok"] is False
+            assert data["unresponsive"] == ["stale_test"]
+            assert pt.get()["status"] == "idle", (
+                f"the phantom that forced the refusal should be cleared, not left on screen, got {pt.get()!r}"
+            )
+        finally:
+            loading_tasks.remove_task("stale_test")
+
+    def test_cancel_idle_task_refuses(self, client):
+        """An already-finished task has nothing left to cancel."""
+        loading_tasks.create_task("idle_test", "IdleDS")
+        try:
+            resp = client.post("/api/dataset/cancel/idle_test")
+            assert resp.status_code == 409
+            assert resp.get_json()["ok"] is False
+        finally:
+            loading_tasks.remove_task("idle_test")
 
     def test_cancel_nonexistent_returns_404(self, client):
         resp = client.post("/api/dataset/cancel/nonexistent_task")

--- a/tests_lib/datasets/test_progress_termination.py
+++ b/tests_lib/datasets/test_progress_termination.py
@@ -1,0 +1,188 @@
+"""Progress channels must reach a terminal state when the work ends (#3167).
+
+A ``server_folder`` import that had *succeeded* was indistinguishable from a
+wedged one: the SSE ``dataset`` channel sat on ``"Loading SigLIP processor…"``
+indefinitely, with no loader thread anywhere in the process.  Two mechanisms
+produced that, and both are covered here.
+
+* **An unscoped model load narrates itself on a channel nobody terminates.**
+  A thread that installs no ``progress_scope`` reports through the embedder's
+  process-wide default sink, which the app wires to the global
+  ``dataset_progress`` tracker.  The sink cannot see when the work it is
+  narrating ends, so ``load_models`` says so itself.
+* **The load task's success path wrote no terminal state.**  Only the failure
+  paths parked the tracker; a clean finish left it on its last "loading …"
+  message until the finished entry aged out.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from vtscore.datasets.load_pipeline import _park_load_terminal
+from vtscore.datasets.stages.embedding import _ensure_model_loaded
+from vtscore.media.embedder import MediaEmbedder
+
+
+class _RecordingSink:
+    """A progress callback that keeps every tick it was handed."""
+
+    def __init__(self) -> None:
+        self.ticks: list[tuple[str, str]] = []
+
+    def __call__(self, status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+        self.ticks.append((status, message))
+
+    @property
+    def statuses(self) -> list[str]:
+        return [status for status, _msg in self.ticks]
+
+
+class _NoisyEmbedder(MediaEmbedder):
+    """Embedder whose model load announces itself, as the real ones do."""
+
+    @property
+    def name(self) -> str:
+        return "noisy_test_embedder"
+
+    @property
+    def media_type_id(self) -> str:
+        return "audio"
+
+    def __init__(self) -> None:
+        self._model = None
+
+    def _load_models_impl(self) -> None:
+        self._on_progress("loading", "Loading Noisy processor…", 0, 0)
+        self._model = True
+
+    def _embed_media_impl(self, media: dict) -> np.ndarray:
+        return np.ones(3, dtype=np.float32)
+
+
+def _fresh_embedder(default_sink) -> _NoisyEmbedder:
+    emb = _NoisyEmbedder()
+    emb.set_default_progress_callback(default_sink)
+    return emb
+
+
+class TestUnscopedModelLoad:
+    """``load_models`` terminates the sink it borrowed."""
+
+    def test_unscoped_load_ends_on_idle(self):
+        sink = _RecordingSink()
+        emb = _fresh_embedder(sink)
+
+        emb.load_models()
+
+        assert sink.ticks[0] == ("loading", "Loading Noisy processor…"), (
+            f"the load should still narrate itself on the default sink, got {sink.ticks!r}"
+        )
+        assert sink.statuses[-1] == "idle", (
+            "an unscoped model load must park the sink it borrowed; leaving it on "
+            f"'loading' is the #3167 phantom, got {sink.ticks!r}"
+        )
+
+    def test_terminal_tick_fires_even_when_the_load_raises(self):
+        sink = _RecordingSink()
+        emb = _fresh_embedder(sink)
+
+        def _boom() -> None:
+            emb._on_progress("loading", "Loading Noisy processor…", 0, 0)
+            raise RuntimeError("model download failed")
+
+        emb._load_models_impl = _boom  # type: ignore[method-assign]
+
+        try:
+            emb.load_models()
+        except RuntimeError:
+            pass
+        else:  # pragma: no cover - the stub always raises
+            raise AssertionError("the failing load should have propagated")
+
+        assert sink.statuses[-1] == "idle", (
+            f"a failed load leaves the same phantom as a successful one, got {sink.ticks!r}"
+        )
+
+    def test_scoped_load_leaves_the_default_sink_alone(self):
+        default = _RecordingSink()
+        scoped = _RecordingSink()
+        emb = _fresh_embedder(default)
+
+        with emb.progress_scope(scoped):
+            emb.load_models()
+
+        assert default.ticks == [], (
+            f"a caller with its own channel must not touch the default sink, got {default.ticks!r}"
+        )
+        assert scoped.statuses == ["loading"], (
+            f"the caller owns termination of its own channel; load_models must not park it, got {scoped.ticks!r}"
+        )
+
+    def test_silent_progress_suppresses_the_load_entirely(self):
+        sink = _RecordingSink()
+        emb = _fresh_embedder(sink)
+
+        with emb.silent_progress():
+            emb.load_models()
+
+        assert sink.ticks == [], f"a silenced warm-up must publish nothing, got {sink.ticks!r}"
+
+    def test_already_loaded_model_publishes_nothing(self):
+        sink = _RecordingSink()
+        emb = _fresh_embedder(sink)
+        emb._model = True
+
+        emb.load_models()
+
+        assert sink.ticks == [], f"a no-op load should not tick at all, got {sink.ticks!r}"
+
+
+class TestImportModelLoadRouting:
+    """The import's model load belongs on the import's own tracker."""
+
+    def test_ensure_model_loaded_uses_the_supplied_callback(self):
+        default = _RecordingSink()
+        supplied = _RecordingSink()
+        emb = _fresh_embedder(default)
+
+        _ensure_model_loaded(emb, supplied)
+
+        assert default.ticks == [], (
+            "the import has a tracker of its own; routing its model load through "
+            f"the global default is what made it a phantom, got {default.ticks!r}"
+        )
+        assert ("loading", "Loading Noisy processor…") in supplied.ticks, (
+            f"the model's own progress should reach the load's tracker, got {supplied.ticks!r}"
+        )
+
+
+class TestLoadTaskTerminalState:
+    """A finished load parks its tracker, success or failure."""
+
+    def test_success_parks_the_tracker_idle(self):
+        from vtscore.concurrency.progress import ProgressTracker
+
+        tracker = ProgressTracker(extra_fields={"error": None, "step": None, "total_steps": None})
+        tracker.update("loading", "Loading Noisy processor…", 0, 0)
+
+        _park_load_terminal(tracker, 300)
+
+        snapshot = tracker.get()
+        assert snapshot["status"] == "idle", f"a completed load must leave 'loading', got {snapshot['status']!r}"
+        assert snapshot["error"] is None
+        assert "300" in snapshot["message"], f"the terminal message should say what landed, got {snapshot['message']!r}"
+
+    def test_failure_keeps_its_error(self):
+        from vtscore.concurrency.progress import ProgressTracker
+
+        tracker = ProgressTracker(extra_fields={"error": None, "step": None, "total_steps": None})
+        tracker.update("idle", "", 0, 0, error="Cancelled")
+
+        _park_load_terminal(tracker, 0)
+
+        snapshot = tracker.get()
+        assert snapshot["error"] == "Cancelled", (
+            "the failure path already parked this tracker; its error is the "
+            f"terminal state and must survive, got {snapshot!r}"
+        )

--- a/tests_lib/datasets/test_registry_multiprocess_safety.py
+++ b/tests_lib/datasets/test_registry_multiprocess_safety.py
@@ -121,3 +121,63 @@ class TestRegistryMultiprocessSafety:
             t.join()
 
         assert len(_read_disk_ids()) == n
+
+
+class TestRegistryReadsSeeDiskWrites:
+    """Reads must reflect the manifest on disk, not a cache frozen at startup (#3167).
+
+    Writes have merged correctly since the fix above, but *reads* filled the
+    in-memory cache once and thereafter refreshed it only from this process's
+    own mutations.  A dataset registered by anyone else — a CLI autodetect run
+    against the same data dir, a second server — was therefore invisible until
+    the process restarted: the API flatly denied the existence of a dataset
+    sitting fully registered on disk, which is the same "every signal says
+    nothing happened" ambiguity as a progress channel that never terminates.
+    """
+
+    def test_list_datasets_picks_up_a_sibling_write(self):
+        registry.reset_for_tests()
+        a = registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+        assert {e["id"] for e in registry.list_datasets()} == {a["id"]}
+
+        _commit_sibling_entry("sibling-b")
+
+        assert {e["id"] for e in registry.list_datasets()} == {a["id"], "sibling-b"}, (
+            "a registration committed by another process must be visible without a restart"
+        )
+
+    def test_get_dataset_picks_up_a_sibling_write(self):
+        registry.reset_for_tests()
+        registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+        assert registry.get_dataset("sibling-b") is None
+
+        _commit_sibling_entry("sibling-b")
+
+        entry = registry.get_dataset("sibling-b")
+        assert entry is not None and entry["name"] == "sibling", (
+            f"the entry is on disk; the API must not deny it exists, got {entry!r}"
+        )
+
+    def test_list_datasets_picks_up_a_sibling_deletion(self):
+        registry.reset_for_tests()
+        a = registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+        registry.register_dataset(name="B", media_type="audio", num_items=1, pkl_path="b.pkl")
+
+        remaining = [e for e in json.loads(registry.REGISTRY_PATH.read_text(encoding="utf-8")) if e["id"] == a["id"]]
+        registry.REGISTRY_PATH.write_text(json.dumps(remaining), encoding="utf-8")
+
+        assert {e["id"] for e in registry.list_datasets()} == {a["id"]}
+
+    def test_unchanged_manifest_is_not_re_read(self, monkeypatch):
+        """The freshness check is a stat, not a re-parse on every read."""
+        registry.reset_for_tests()
+        registry.register_dataset(name="A", media_type="audio", num_items=1, pkl_path="a.pkl")
+
+        reads = []
+        real_load = registry._load
+        monkeypatch.setattr(registry, "_load", lambda: (reads.append(1), real_load())[1])
+
+        registry.list_datasets()
+        registry.list_datasets()
+
+        assert reads == [], f"an unchanged manifest should not be parsed again, got {len(reads)} reads"

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -610,6 +610,8 @@ class LoadingTasksTracker:
                 "name": name,
                 "created_at": time.time(),
                 "finished_at": None,
+                # Filled in by :meth:`set_worker` once the caller has its thread.
+                "worker": None,
                 "dataset_id": dataset_id,
                 "media_type": media_type,
                 "detector_id": detector_id,
@@ -664,6 +666,47 @@ class LoadingTasksTracker:
             tasks = list(self._tasks.values())
         for entry in tasks:
             entry["tracker"].cancel()
+
+    def set_worker(self, task_id: str, thread: threading.Thread) -> None:
+        """Record the thread running *task_id*, so cancellation can be honest.
+
+        Cancellation is cooperative: :meth:`ProgressTracker.cancel` only sets a
+        flag, and *something has to be running* to observe it.  Knowing whether
+        a worker is still alive is what lets a cancel distinguish "it will stop
+        shortly" from "there is nobody here to stop" instead of answering both
+        with the same cheerful ``ok`` (#3167).
+
+        Register the thread *before* starting it; a task with no registered
+        worker reads as not running.
+        """
+        with self._lock:
+            entry = self._tasks.get(task_id)
+            if entry:
+                entry["worker"] = thread
+
+    def worker_alive(self, task_id: str) -> bool:
+        """Return ``True`` if *task_id* has a registered worker still running."""
+        with self._lock:
+            entry = self._tasks.get(task_id)
+        worker = entry.get("worker") if entry else None
+        return bool(worker is not None and worker.is_alive())
+
+    def any_worker_alive(self) -> bool:
+        """Return ``True`` if any registered worker thread is still running."""
+        with self._lock:
+            entries = list(self._tasks.values())
+        return any(e.get("worker") is not None and e["worker"].is_alive() for e in entries)
+
+    def active_task_ids(self) -> list[str]:
+        """Return the ids of tasks whose tracker still claims to be working.
+
+        "Claims" is deliberate: a stale tracker looks exactly like a running
+        one from here, which is why :func:`cancel_dataset_progress` cross-checks
+        each id against :meth:`worker_alive` before reporting what it did.
+        """
+        with self._lock:
+            entries = list(self._tasks.items())
+        return [tid for tid, e in entries if e["tracker"].get()["status"] != "idle"]
 
     def set_dataset_id(self, task_id: str, dataset_id: str) -> None:
         """Associate a loading task with its final registry dataset ID."""
@@ -832,14 +875,164 @@ def get_progress() -> dict[str, Any]:
     return dataset_progress.get()
 
 
-def cancel_dataset_progress() -> None:
-    """Signal the current dataset operation(s) to cancel.
+#: Name used for the legacy global :data:`dataset_progress` singleton in a
+#: cancellation report, where every other entry is a loading-task id.
+LEGACY_PROGRESS_TARGET = "dataset_progress"
 
-    Cancels all active per-task loading trackers as well as the legacy
-    global singleton (used by staging operations).
+#: How long :func:`cancel_dataset_progress` waits for a worker to act on the
+#: flag before reporting what it saw. Cooperative cancellation normally lands
+#: within one progress tick (well under a second); a worker that has not
+#: finished by then is classified by whether its thread is still alive, not by
+#: the clock, so this only has to be long enough to avoid calling a prompt
+#: cancel "pending".
+CANCEL_ACK_GRACE_SECONDS = 2.0
+
+#: Poll interval while waiting for acknowledgement.
+_CANCEL_POLL_SECONDS = 0.02
+
+
+def _cancel_acknowledged(target: str) -> bool:
+    """Return ``True`` once *target* has reached a terminal state."""
+    if target == LEGACY_PROGRESS_TARGET:
+        return dataset_progress.get()["status"] == "idle"
+    if loading_tasks.is_finished(target):
+        return True
+    tracker = loading_tasks.get_tracker(target)
+    # A task that has been pruned out of the tracker is as stopped as it gets.
+    return tracker is None or tracker.get()["status"] == "idle"
+
+
+def _park_unresponsive(target: str) -> None:
+    """Clear a progress entry that claims work no living thread is doing.
+
+    Refusing to lie about the cancel is only half the fix: the phantom that
+    made the refusal necessary is still on screen, and it will still be there
+    tomorrow. Nothing is going to clear it — that is what "no worker" means —
+    so the request that proved it stale clears it.
     """
+    if target == LEGACY_PROGRESS_TARGET:
+        dataset_progress.update("idle", "", 0, 0)
+        return
+    tracker = loading_tasks.get_tracker(target)
+    if tracker is not None:
+        tracker.update(
+            "idle",
+            "",
+            0,
+            0,
+            error="Abandoned: no worker was running this operation.",
+        )
+    loading_tasks.mark_finished(target)
+
+
+def _cancel_report(targets: list[str], grace_seconds: float) -> dict[str, Any]:
+    """Wait out the grace period and classify every target in *targets*."""
+    report: dict[str, Any] = {
+        "ok": False,
+        "targets": list(targets),
+        "acknowledged": [],
+        "pending": [],
+        "unresponsive": [],
+        "message": "",
+    }
+    if not targets:
+        report["message"] = "Nothing to cancel: no dataset operation is running."
+        return report
+
+    deadline = time.monotonic() + max(0.0, grace_seconds)
+    outstanding = list(targets)
+    while True:
+        outstanding = [t for t in outstanding if not _cancel_acknowledged(t)]
+        if not outstanding or time.monotonic() >= deadline:
+            break
+        time.sleep(_CANCEL_POLL_SECONDS)
+
+    still = set(outstanding)
+    report["acknowledged"] = [t for t in targets if t not in still]
+    any_alive = loading_tasks.any_worker_alive()
+    for target in outstanding:
+        alive = any_alive if target == LEGACY_PROGRESS_TARGET else loading_tasks.worker_alive(target)
+        report["pending" if alive else "unresponsive"].append(target)
+    for target in report["unresponsive"]:
+        _park_unresponsive(target)
+
+    report["ok"] = bool(report["acknowledged"] or report["pending"])
+    stopped = len(report["acknowledged"])
+    stopping = len(report["pending"])
+    stale = len(report["unresponsive"])
+    if report["ok"]:
+        parts = []
+        if stopped:
+            parts.append(f"{stopped} stopped")
+        if stopping:
+            parts.append(f"{stopping} still stopping")
+        if stale:
+            parts.append(f"{stale} stale entr{'y' if stale == 1 else 'ies'} cleared")
+        report["message"] = "Cancelled: " + ", ".join(parts) + "."
+    else:
+        report["message"] = (
+            f"Nothing acknowledged the cancel: {stale} progress "
+            f"entr{'y' if stale == 1 else 'ies'} claimed work with no worker running it. "
+            "The operation had already finished or died; the stale progress has been cleared."
+        )
+    return report
+
+
+def cancel_dataset_progress(grace_seconds: float = CANCEL_ACK_GRACE_SECONDS) -> dict[str, Any]:
+    """Signal the current dataset operation(s) to cancel, and report the outcome.
+
+    Cancels all active per-task loading trackers as well as the legacy global
+    singleton (used by staging operations), then waits up to *grace_seconds*
+    for someone to act on the flag.
+
+    Cancellation is cooperative — :meth:`ProgressTracker.cancel` sets an event
+    and :meth:`ProgressTracker.check_cancelled` has to be *reached* by a
+    running thread — so setting the flag says nothing about whether anything
+    will happen.  Reporting success unconditionally therefore answered the one
+    question a stuck-looking import raises ("is anything actually running?")
+    with the same word either way (#3167).
+
+    Returns a report with:
+
+    ``targets``
+        every id that claimed to be working when the cancel arrived, using
+        :data:`LEGACY_PROGRESS_TARGET` for the global singleton.
+    ``acknowledged``
+        targets that reached a terminal state within the grace period.
+    ``pending``
+        targets still running, with a live worker thread that will observe the
+        flag; the cancel was delivered, it just has not landed yet.
+    ``unresponsive``
+        targets whose progress claimed work no live thread was doing.  These
+        are stale trackers, not running jobs; they are parked at ``idle`` so
+        the phantom does not outlive the request that exposed it.
+    ``ok``
+        ``True`` when at least one target acknowledged or is pending — i.e.
+        when the cancel actually reached something.
+    """
+    targets = loading_tasks.active_task_ids()
+    if dataset_progress.get()["status"] != "idle":
+        targets.append(LEGACY_PROGRESS_TARGET)
+
     loading_tasks.cancel_all()
     dataset_progress.cancel()
+
+    return _cancel_report(targets, grace_seconds)
+
+
+def cancel_dataset_task(task_id: str, grace_seconds: float = CANCEL_ACK_GRACE_SECONDS) -> dict[str, Any] | None:
+    """Cancel one loading task and report the outcome, or ``None`` if unknown.
+
+    Same contract as :func:`cancel_dataset_progress`, narrowed to a single
+    task: a task whose tracker still claims work but whose worker thread has
+    exited is reported as ``unresponsive`` rather than cancelled.
+    """
+    tracker = loading_tasks.get_tracker(task_id)
+    if tracker is None:
+        return None
+    targets = [task_id] if tracker.get()["status"] != "idle" else []
+    tracker.cancel()
+    return _cancel_report(targets, grace_seconds)
 
 
 def check_dataset_cancelled() -> None:

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -319,8 +319,13 @@ def _warmup_embedder_async(media_dict: dict) -> None:
         if emb is None:
             return
         try:
-            emb.load_models()
-            emb.embed_text("warmup")
+            # Explicitly silent: this thread has no progress surface (see the
+            # docstring), and an unscoped load would narrate itself on the
+            # global dataset channel instead — a phantom import, right as the
+            # real one finished (#3167).
+            with emb.silent_progress():
+                emb.load_models()
+                emb.embed_text("warmup")
         except Exception:
             pass
 
@@ -361,6 +366,52 @@ def _handle_load_failure(
             traceback.print_exc()
     gc.collect()
     tracker.update("idle", "", 0, 0, error=error, step=None, total_steps=None)
+
+
+def _park_load_terminal(tracker, n_items: int) -> None:
+    """Park *tracker* at a terminal state once the load thread has unwound.
+
+    The failure paths already do this — :func:`_handle_load_failure` writes
+    ``idle`` plus an ``error`` — but the success path historically wrote
+    nothing, so a load that finished cleanly left its tracker on whatever
+    "loading …" message happened to fire last.  Nothing ever cleared it:
+    :meth:`~vtscore.concurrency.progress.LoadingTasksTracker.has_active_tasks`
+    stayed true until the finished entry aged out, the dashboard's
+    just-finished test (``status == "idle" && !error``) never fired so the
+    registry refresh waited on the prune instead, and every external signal
+    kept saying "still importing" about a thread that had exited (#3167).
+
+    Terminal states belong in a ``finally``.  A tracker that already carries an
+    error is left alone: that failure *is* its terminal state.
+    """
+    if tracker.get().get("error"):
+        return
+    tracker.update(
+        "idle",
+        f"Loaded {n_items} item(s)",
+        n_items,
+        n_items,
+        step=_TOTAL_LOAD_STEPS,
+        total_steps=_TOTAL_LOAD_STEPS,
+    )
+
+
+def _park_global_progress_if_orphaned() -> None:
+    """Park the legacy global tracker when nothing is left to keep it moving.
+
+    ``dataset_progress`` is the SSE ``dataset`` channel and is written by any
+    library path that reports progress without a per-thread callback.  Those
+    callers each terminate their own work now, but the channel is the one
+    surface a user reads as "is this server busy?", so the last load out of the
+    door also checks it: a non-idle channel with no loading task behind it is a
+    phantom by definition, and leaving it up is what made a finished import
+    indistinguishable from a wedged one (#3167).
+    """
+    if loading_tasks.has_active_tasks():
+        return
+    if dataset_progress.get().get("status") == "idle":
+        return
+    dataset_progress.update("idle", "", 0, 0)
 
 
 def _run_origin_load_in_background(
@@ -601,9 +652,16 @@ def _run_origin_load_in_background(
             if size_mb is None:
                 size_mb = resolve_download_size_mb(dataset_id)
             timing_recorder.finish(n=len(ctx.medias), size_mb=size_mb, ok=not tracker.get().get("error"))
+            _park_load_terminal(tracker, len(ctx.medias))
             loading_tasks.mark_finished(task_id)
+            _park_global_progress_if_orphaned()
 
-    threading.Thread(target=task, daemon=True).start()
+    # Registered before the thread starts so a cancel arriving in the same
+    # instant can tell "not started yet" from "nothing here"; see
+    # ``LoadingTasksTracker.set_worker``.
+    worker = threading.Thread(target=task, daemon=True)
+    loading_tasks.set_worker(task_id, worker)
+    worker.start()
     return task_id
 
 
@@ -903,5 +961,6 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
                 loading_tasks.mark_finished(task_id)
 
     thread = threading.Thread(target=stage_task, daemon=True)
+    loading_tasks.set_worker(task_id, thread)
     thread.start()
     return task_id

--- a/vtscore/datasets/registry.py
+++ b/vtscore/datasets/registry.py
@@ -50,9 +50,15 @@ _T = TypeVar("_T")
 # ``file_lock``; this lock only serialises threads within one process.
 _lock = threading.RLock()
 
-# In-memory cache - loaded once from disk, refreshed from disk on every
-# mutation (see :func:`_read_modify_write`).
+# In-memory cache - refreshed from disk on every mutation (see
+# :func:`_read_modify_write`) and whenever the manifest on disk no longer
+# matches the stamp the cache was built from (see :func:`_ensure_loaded`).
 _entries: list[dict[str, Any]] | None = None
+
+# ``(mtime_ns, size)`` of the manifest the cache was built from, or ``None``
+# when the file did not exist.  Compared on every read so a write by another
+# process is picked up immediately.
+_entries_stamp: tuple[int, int] | None = None
 
 # The set of dataset IDs that are currently loaded in memory.
 _loaded_ids: set[str] = set()
@@ -87,11 +93,35 @@ def _save(entries: list[dict[str, Any]]) -> None:
     atomic_write_json(REGISTRY_PATH, entries)
 
 
+def _manifest_stamp() -> tuple[int, int] | None:
+    """Return ``(mtime_ns, size)`` for the manifest, or ``None`` if absent."""
+    try:
+        stat = REGISTRY_PATH.stat()
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
 def _ensure_loaded() -> list[dict[str, Any]]:
-    """Return the in-memory cache, loading from disk on first call."""
-    global _entries
-    if _entries is None:
+    """Return the in-memory cache, re-reading it whenever disk has moved on.
+
+    The cache used to be filled once and thereafter refreshed only by this
+    process's own mutations, which made every *read* blind to a write by
+    anyone else — a CLI autodetect run against the same data dir (the very
+    case :func:`_read_modify_write` takes a cross-process lock for), a second
+    server, a hand-edited manifest.  A dataset could then sit on disk, fully
+    registered, while ``GET /api/datasets/registry`` reported it did not exist
+    until the process was restarted: the same "every signal says nothing
+    happened" ambiguity as a progress channel that never terminates (#3167).
+
+    A stat per read is cheap next to the JSON parse it usually skips, and the
+    stamp makes the re-read happen exactly when the file has actually changed.
+    """
+    global _entries, _entries_stamp
+    stamp = _manifest_stamp()
+    if _entries is None or stamp != _entries_stamp:
         _entries = _load()
+        _entries_stamp = stamp
     return _entries
 
 
@@ -109,13 +139,14 @@ def _read_modify_write(mutator: Callable[[list[dict[str, Any]]], _T]) -> _T:
     call's result.  The list is always persisted and swapped into the in-memory
     cache, so the cache converges to disk truth on every mutation.
     """
-    global _entries
+    global _entries, _entries_stamp
     with file_lock(REGISTRY_PATH):
         entries = _load()
         result = mutator(entries)
         _save(entries)
         with _lock:
             _entries = entries
+            _entries_stamp = _manifest_stamp()
     return result
 
 
@@ -407,8 +438,9 @@ def set_readers(dataset_id: str, readers: list[str], requesting_user: str) -> tu
 
 def reset_for_tests() -> None:
     """Reset the in-memory cache (for test isolation)."""
-    global _entries
+    global _entries, _entries_stamp
     with _lock:
         _entries = None
+        _entries_stamp = None
         _loaded_ids.clear()
         _loading_ids.clear()

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -148,10 +148,19 @@ def _noop_progress(status: str, message: str = "", current: int = 0, total: int 
 
 
 def _ensure_model_loaded(emb, on_progress: Callable[[str, str, int, int], None]) -> None:
-    """Load the embedder's models if not already loaded, announcing progress."""
+    """Load the embedder's models if not already loaded, announcing progress.
+
+    The load runs inside :meth:`~vtscore.media.embedder.MediaEmbedder.progress_scope`
+    so the model's own "Loading … processor…" ticks land on *this* load's
+    tracker, next to every other phase of the import.  Unscoped they fall
+    through to the embedder's process-wide default sink — the global
+    ``dataset_progress`` singleton — which belongs to no particular import and
+    so shows the right message on the wrong channel (#3167).
+    """
     if getattr(emb, "_model", None) is None:
         on_progress("loading", "Loading embedding model…", 0, 0)
-        emb.load_models()
+        with emb.progress_scope(on_progress):
+            emb.load_models()
 
 
 def _missing_for_embedder(

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -547,7 +547,12 @@ def smart_preload_in_background() -> None:
                 emb = get_embedder(emb_name)
                 if getattr(emb, "_model", None) is not None:
                     continue
-                emb.load_models()
+                # A speculative warm-up is not an operation the user started,
+                # so it gets no progress surface: unscoped it would narrate
+                # itself on the app's global dataset channel and read as an
+                # import that never ends (#3167).
+                with emb.silent_progress():
+                    emb.load_models()
             except Exception:
                 pass
 
@@ -604,7 +609,10 @@ def preload_embedder_for_dataset(dataset_id: str) -> str:
             emb = get_embedder(emb_name)
             if getattr(emb, "_model", None) is not None:
                 return
-            emb.load_models()
+            # Silent for the same reason as smart_preload_in_background: the
+            # user selected a row, they did not start an import.
+            with emb.silent_progress():
+                emb.load_models()
         except Exception:
             pass
 

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -873,8 +873,11 @@ class _ThreadLocalProgress:
     thread*, which is exactly what every save-and-restore call site wants.  A
     thread that never assigned anything reads the process-wide default
     (:meth:`MediaEmbedder.set_default_progress_callback`), so background work
-    with no explicit callback — the smart-preload thread, say — still reports
-    into the host application's progress sink.
+    with no explicit callback still reports into the host application's
+    progress sink.  That fallback narrates work the sink cannot see the end of,
+    so a model load taken through it is terminated explicitly by
+    :meth:`MediaEmbedder._orphan_progress`; background warm-ups that want no
+    progress surface at all should say so with :meth:`MediaEmbedder.silent_progress`.
     """
 
     def __get__(self, obj: "MediaEmbedder | None", objtype: type | None = None) -> Any:
@@ -950,6 +953,49 @@ class MediaEmbedder(ABC):
             yield
         finally:
             slot.local.cb = prev
+
+    def silent_progress(self):
+        """Suppress this embedder's progress for the calling thread.
+
+        Sugar over :meth:`progress_scope` for background warm-ups that have no
+        progress surface of their own (the smart-preload threads, the
+        post-import embedder warm-up).  Without it those calls fall through to
+        the process-wide default sink, which in the app is the dataset-import
+        channel — see :meth:`_orphan_progress`.
+        """
+        return self.progress_scope(_noop_progress)
+
+    @contextlib.contextmanager
+    def _orphan_progress(self):
+        """Publish a terminal ``idle`` for a model load nobody is watching.
+
+        A thread that installed no :meth:`progress_scope` still reports through
+        the process-wide default sink, which the app wires to the global
+        ``dataset_progress`` tracker — the SSE ``dataset`` channel.  That sink
+        has no idea when the work it is narrating ends, so an unscoped
+        ``load_models`` left the channel parked on its last "Loading … processor…"
+        message forever: an import that had *succeeded* looked exactly like a
+        wedged one, and only a profiler could tell them apart (#3167).
+
+        The load itself is the boundary that knows when the work ends, so it is
+        where the terminal state belongs.  For the duration of an unscoped load
+        this pins the default sink as the thread's own callback (so a nested
+        ``load_models`` doesn't re-arm the same wrapper) and, in a ``finally``,
+        sends one ``idle`` tick to say the phase is over.
+
+        A caller that installed a scope owns its own channel and is left alone;
+        so is a sink that is already the no-op default.
+        """
+        slot = _progress_slot(self)
+        if getattr(slot.local, "cb", None) is not None or slot.default is _noop_progress:
+            yield
+            return
+        sink = slot.default
+        with self.progress_scope(sink):
+            try:
+                yield
+            finally:
+                sink("idle", "", 0, 0)
 
     # ------------------------------------------------------------------
     # Identity
@@ -1102,10 +1148,14 @@ class MediaEmbedder(ABC):
         thread performs the actual load; others wait and then return
         immediately (the subclass ``_load_models_impl`` checks
         ``self._model is not None``).
+
+        A load whose caller installed no :meth:`progress_scope` reports through
+        the process-wide default sink and is terminated there on the way out;
+        see :meth:`_orphan_progress`.
         """
         if getattr(self, "_model", None) is not None:
             return
-        with self._model_load_lock:
+        with self._orphan_progress(), self._model_load_lock:
             try:
                 self._load_models_impl()
             except ImportError as exc:

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -367,7 +367,7 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
 
     from vtsearch.threading import spawn
 
-    spawn(load_task, name=f"ds-load-{dataset_id[:8]}")
+    _loading_tasks.set_worker(task_id, spawn(load_task, name=f"ds-load-{dataset_id[:8]}"))
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
 
 
@@ -453,7 +453,7 @@ def build_dataset_coverage_atlas(dataset_id: str):
 
     from vtsearch.threading import spawn
 
-    spawn(build_task, name=f"atlas-{dataset_id[:8]}")
+    _loading_tasks.set_worker(task_id, spawn(build_task, name=f"atlas-{dataset_id[:8]}"))
     return {"ok": True, "message": "Coverage atlas build started", "task_id": str(task_id)}
 
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -373,7 +373,9 @@ def _promote_in_background(
             gc.collect()
             loading_tasks.mark_finished(task_id)
 
-    threading.Thread(target=task, daemon=True).start()
+    worker = threading.Thread(target=task, daemon=True)
+    loading_tasks.set_worker(task_id, worker)
+    worker.start()
     return task_id
 
 

--- a/vtsearch/routes/datasets/status.py
+++ b/vtsearch/routes/datasets/status.py
@@ -13,7 +13,7 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.concurrency.progress import (
     cancel_dataset_progress,
-    loading_tasks as _loading_tasks,
+    cancel_dataset_task,
 )
 from vtsearch.schemas.datasets import (
     CancelDatasetLoadResponseSchema,
@@ -54,22 +54,40 @@ def dataset_status():
 
 @datasets_status_bp.route("/api/dataset/cancel", methods=["POST"])
 @datasets_status_bp.response(200, CancelDatasetLoadResponseSchema)
+@datasets_status_bp.alt_response(
+    409,
+    schema=CancelDatasetLoadResponseSchema,
+    description="The cancel reached nothing: no operation was running, or the progress it claimed was stale.",
+)
 def cancel_dataset_load():
     """Cancel dataset load/import operations.
 
-    Cancels all active loading tasks and the legacy global tracker.
+    Cancels all active loading tasks and the legacy global tracker, then waits
+    briefly for one of them to act on the flag.  Cancellation is cooperative,
+    so a flag set with no worker left to observe it stops nothing; answering
+    ``ok`` in that case is what let a *finished* import keep looking like a
+    wedged one (#3167).  A cancel that reached nothing answers ``409``, and any
+    stale progress it found is cleared on the way out.
     """
-    _loading_tasks.cancel_all()
-    cancel_dataset_progress()
-    return {"ok": True}
+    report = cancel_dataset_progress()
+    return (report, 409) if not report["ok"] else report
 
 
 @datasets_status_bp.route("/api/dataset/cancel/<task_id>", methods=["POST"])
 @datasets_status_bp.response(200, CancelDatasetLoadResponseSchema)
-@datasets_status_bp.alt_response(404, description="No active task with the supplied id.")
+@datasets_status_bp.alt_response(404, description="No task with the supplied id.")
+@datasets_status_bp.alt_response(
+    409,
+    schema=CancelDatasetLoadResponseSchema,
+    description="The task was not running, or its progress was stale (no live worker).",
+)
 def cancel_dataset_load_task(task_id: str):
-    """Cancel a specific dataset loading task."""
-    ok = _loading_tasks.cancel_task(task_id)
-    if not ok:
+    """Cancel a specific dataset loading task.
+
+    Same honesty contract as ``POST /api/dataset/cancel``, narrowed to one
+    task.
+    """
+    report = cancel_dataset_task(task_id)
+    if report is None:
         abort(404, message="Task not found")
-    return {"ok": True}
+    return (report, 409) if not report["ok"] else report

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -552,9 +552,26 @@ class DatasetStatusResponseSchema(Schema):
 
 
 class CancelDatasetLoadResponseSchema(Schema):
-    """Response for ``POST /api/dataset/cancel`` and ``/cancel/<task_id>``."""
+    """Response for ``POST /api/dataset/cancel`` and ``/cancel/<task_id>``.
+
+    Cancellation is cooperative, so ``ok`` reports whether the flag actually
+    reached something that can act on it — not merely that it was set.  The
+    lists say which operations did what; see
+    :func:`vtscore.concurrency.progress.cancel_dataset_progress`.  A request
+    that reached nothing answers ``409`` with ``ok: false``.
+    """
 
     ok = fields.Boolean(required=True)
+    message = fields.String(required=True)
+    #: Everything that claimed to be working when the cancel arrived.
+    targets = fields.List(fields.String(), required=True)
+    #: Targets that reached a terminal state within the grace period.
+    acknowledged = fields.List(fields.String(), required=True)
+    #: Targets still running, whose live worker will observe the flag.
+    pending = fields.List(fields.String(), required=True)
+    #: Targets whose progress claimed work no live thread was doing. Stale
+    #: trackers, now cleared — not operations that were stopped.
+    unresponsive = fields.List(fields.String(), required=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3167.

A `server_folder` import that had **succeeded** was indistinguishable from a wedged one from outside the process, and `POST /api/dataset/cancel` reported success while doing nothing. Three separate mechanisms produced that; all three are fixed.

## 1. A model load narrating a channel nobody terminates

Root cause of the observed symptom (`"Loading SigLIP processor…"` forever, with no loader thread in the process).

A thread that installs no `progress_scope` still reports through the embedder's **process-wide default sink**, which `app.py` wires to the global `dataset_progress` tracker — i.e. the SSE `dataset` channel. That sink cannot see when the work it is narrating ends, so an unscoped `load_models()` left the channel parked on its last message forever.

Several call sites did exactly that, including two that fire *at the end of every successful import*: `smart_preload_in_background()` (kicked from `register_dataset`) and `_warmup_embedder_async()`. `preload_embedder_for_dataset()` (fired when the user clicks a dashboard row) is a third, which is why the phantom came back after a restart.

- `MediaEmbedder.load_models()` now terminates whatever channel it borrowed: an unscoped load reports as usual and sends one `idle` tick from a `finally` (`_orphan_progress`). Scoped callers own their own channel and are untouched.
- New `MediaEmbedder.silent_progress()` for background warm-ups that should appear on no channel at all — used by both preload threads and the post-import warm-up.
- `_ensure_model_loaded` (the import's own model load) now wraps in `progress_scope(on_progress)`, so `"Loading … processor…"` shows on the importing dataset's row instead of a global channel that belongs to no import.

## 2. Terminal state on the success path, not only on failure

`_handle_load_failure` parked the tracker; the success path wrote nothing, so a clean finish left the task on its last `"loading …"` message until the entry aged out. Consequences beyond the stuck message: `has_active_tasks()` stayed true (blocking the next load's cancel-flag reset), and the dashboard's just-finished test (`status === 'idle' && !error`) never fired, so the registry refresh waited on the 5 s prune instead of happening immediately.

`_run_origin_load_in_background` now parks its tracker in the outermost `finally` (leaving an already-recorded error alone), and the last load out of the door also parks the legacy global channel when no loading task is left behind it.

## 3. Cancel that reports what it actually reached

Cancellation is cooperative — `cancel()` sets an event that a *running* thread has to reach — so `{"ok": true}` said the same thing whether a worker stopped or nothing was there at all.

Loading tasks now register their worker thread, and `cancel_dataset_progress` / `cancel_dataset_task` return a report:

| Field | Meaning |
|---|---|
| `targets` | Everything claiming work when the cancel arrived |
| `acknowledged` | Reached a terminal state within a ~2 s grace period |
| `pending` | Still running, with a live worker that will observe the flag |
| `unresponsive` | Claimed work with no live thread — a stale tracker, now cleared |

`ok` is true only when the cancel reached something; otherwise both endpoints answer **409** with the same body. Refusing is only half of it, so the stale progress that forced the refusal is parked on the way out rather than left on screen forever.

## 4. Registry reads that see disk

`GET /api/datasets/registry` returning `{"datasets": []}` for a dataset sitting registered on disk was a third channel of the same ambiguity. Writes have merged across processes since the `_read_modify_write` fix, but *reads* filled the in-memory cache once and refreshed it only from this process's own mutations — so a registration by a CLI `--autodetect` run against the same data dir (the very case that lock exists for) was invisible until restart. `_ensure_loaded` now re-reads when the manifest's `(mtime_ns, size)` changes; unchanged manifests still skip the parse.

## Frontend

`cancelLoadingTask` handles the 409 by dropping the row's "Cancelling…" flag — the task is not cancelling, and the backend has already cleared the phantom.

## Tests

- `tests_lib/datasets/test_progress_termination.py` — unscoped/scoped/silent model loads, the terminal tick on the failure path too, import model-load routing, terminal state on success vs. failure.
- `tests/datasets/test_load_terminal_state.py` — a real load through `_run_origin_load_in_background` leaves both the task tracker and the global `dataset` channel idle, and `has_active_tasks()` false.
- `tests/datasets/test_parallel_loading.py` — per-task cancel: delivered to a live worker (200/`pending`), refused for a dead worker (409/`unresponsive`, phantom cleared), refused for an idle task.
- `tests/datasets/test_datasets.py` — whole-server cancel with nothing running now refuses instead of claiming success.
- `tests_lib/datasets/test_registry_multiprocess_safety.py` — reads pick up a sibling process's write and deletion; an unchanged manifest is not re-parsed.

Full `./run-tests.sh`: 8745 passed, 6 skipped; all gates green (pyright, pip-audit, npm audit, Vitest 2086 passed).

## Breaking change

`POST /api/dataset/cancel` and `/api/dataset/cancel/{task_id}` gained fields and can now answer 409; `cancel_dataset_progress()` returns a report dict instead of `None`. OpenAPI snapshot and `docs/api/datasets.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXSexxQzeqkjgyENgk9yTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXSexxQzeqkjgyENgk9yTR)_