### PR TITLE
Apply EXIF orientation at decode, so every image path agrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **Rotated photos are no longer processed sideways.** A JPEG carrying an EXIF
+  orientation tag — the ordinary output of a phone camera, which stores the
+  sensor frame plus "rotate me" rather than rotating pixels — reached the
+  embedder, OCR, face detection and every crop path 90/180/270 degrees from the
+  way the browser (and every other photo viewer) displays it. Nothing errored;
+  the picture was simply the wrong way up in a space nobody looks at directly,
+  so a sideways photo embedded as a sideways photo and landed in the wrong part
+  of the vector space. Orientation is now applied once, in the image decode
+  layer, so every consumer sees the same upright pixels; a media's stored
+  `width`/`height` are the displayed dimensions to match, and cropping, lazy
+  clip resolution and cross-dataset origin resolution decode upright so a box
+  drawn on screen cuts the region the user drew. The `image_exif_orient`
+  cleaner still exists for anyone who wants the rotation baked into the *stored
+  bytes* (for tools outside VTSearch that ignore EXIF), but it is now off by
+  default: it costs a lossy re-encode and no longer changes anything VTSearch
+  itself sees. Images already imported keep the dimensions and embeddings they
+  were ingested with; re-import a rotated corpus to pick up the fix. (#3172)
+
 - **A detector's labelset no longer stores the same media twice.** After one
   pass over a 300-image dataset a detector reported `num_training: 356` — 300
   distinct images, 56 of them held as a duplicate pair. The two halves of the

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -199,6 +199,18 @@ changes to `vtscore/media/__init__.py` are needed.
 | `load_media_data(file_path, media_bytes=None)`| `(Path, bytes \| None) -> dict` | Must include `"duration"` key. The optional `media_bytes` lets callers (e.g. the folder loader) pass already-read bytes to avoid a second disk read. |
 | `media_response(media)`     | `(dict) -> MediaResponse`      | HTTP response for a media item           |
 
+> **Pixel-media types: report *displayed* dimensions.** A media's stored
+> `width`/`height` are the coordinate space every box in the system is expressed
+> against — clip boxes, extractor and localizer output, the region a user drags
+> on the canvas. For images that space is the picture *as displayed*, i.e. after
+> EXIF orientation: a phone photo shot sideways stores a landscape bitmap plus a
+> "rotate me" tag, and browsers honour the tag, so the user is looking at a
+> portrait image. `vtscore.media.image.decode` applies the tag on every decode
+> (`decode_bounded`, `decode_bounded_rgb`, `open_upright`) and exposes
+> `upright_size()` for the header-only read `load_media_data` wants. Reach for
+> `open_image()` only when you genuinely want the untransposed original — it is
+> the lazy, metadata-only escape hatch, not the default.
+
 **Optional overridable properties (with defaults):**
 
 | Property             | Returns     | Default            | Purpose                                   |
@@ -795,7 +807,7 @@ otherwise hide it. Do not add a cleaner affordance outside that block.
 
 | Cleaner | Name | Media Type | Default | Description |
 |---------|------|------------|---------|-------------|
-| `ImageExifOrientCleaner` | `image_exif_orient` | `image` | **on** | Bake a photo's EXIF display orientation into its pixels so the embedder sees it upright |
+| `ImageExifOrientCleaner` | `image_exif_orient` | `image` | off | Bake a photo's EXIF display orientation into its stored bytes (VTSearch already *reads* every image upright; this is for tools that ignore EXIF) |
 | `ImageEdgeTrimCleaner` | `image_edge_trim` | `image` | off | Crop near-solid white/black margins (letterbox, pillarbox, whitespace around a logo) |
 | `AudioSilenceTrimCleaner` | `audio_silence_trim` | `audio` | off | Drop the silence at the head and tail of a clip, keeping internal pauses |
 | `TextMarkupStripCleaner` | `text_markup_strip` | `text` | off | Remove HTML tags and Markdown syntax, keeping the text inside |

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -116,7 +116,7 @@ GET /api/cleaners
 **Query:** `?media_type=image` (optional): filter by `type_id` or
 `folder_import_name`.
 
-→ `{"cleaners": [{"name": "image_exif_orient", "media_type": "image", "display_name": "EXIF Orientation", "default_enabled": true, "description": "Rotate photos to their EXIF display orientation…"}]}`
+→ `{"cleaners": [{"name": "image_exif_orient", "media_type": "image", "display_name": "EXIF Orientation", "default_enabled": false, "description": "Rewrite photos upright in their stored bytes…"}]}`
 
 *Cleaners* are the optional 1-to-1 cleanup gates every imported item of a media
 type can pass through before it is embedded (see

--- a/scripts/scan_exif_orientation.py
+++ b/scripts/scan_exif_orientation.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""How many images in a corpus actually carry a non-trivial EXIF orientation?
+
+VTSearch applies EXIF display orientation at decode
+(:mod:`vtscore.media.image.decode`), so a phone photo shot sideways is embedded,
+thumbnailed, OCR'd and cropped the way the user sees it.  That is a correctness
+fix for ordinary uploads — but whether it *moves a number* on any corpus we
+benchmark against is a separate, empirical question, and the two should not be
+conflated in a report.
+
+This is the measurement.  Point it at a folder of images, a dataset pickle, or
+both, and it prints the histogram of orientation tags:
+
+    python scripts/scan_exif_orientation.py /data/photos
+    python scripts/scan_exif_orientation.py data/datasets/*.pkl
+    python scripts/scan_exif_orientation.py --json /exp/scale26/images
+
+Orientation ``1`` (and a missing tag) means upright; ``2``-``4`` are flips and
+half-turns, which change the picture without changing its shape; ``5``-``8`` are
+the quarter turns, which also transpose the stored ``width``/``height``.  Only
+the last group can move a bounding box, so it is reported separately.
+
+Reading the tag costs a header parse per file — no pixels are decoded — so a
+large corpus scans at disk speed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pickle
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+#: Orientations whose upright form transposes the stored dimensions.
+QUARTER_TURNS = (5, 6, 7, 8)
+
+#: What Pillow will open without a plugin install.
+IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".bmp", ".gif", ".heic", ".heif"}
+
+
+def _orientation_of_bytes(blob: bytes) -> int | None:
+    """Return the orientation tag, or ``None`` when the payload won't open."""
+    import io
+
+    from vtscore.media.image.decode import exif_orientation, open_image
+
+    try:
+        with open_image(io.BytesIO(blob)) as img:
+            return exif_orientation(img)
+    except Exception:
+        return None
+
+
+def _orientation_of_path(path: Path) -> int | None:
+    from vtscore.media.image.decode import exif_orientation, open_image
+
+    try:
+        with open_image(path) as img:
+            return exif_orientation(img)
+    except Exception:
+        return None
+
+
+def _scan_folder(root: Path) -> Iterator[tuple[str, int | None]]:
+    for path in sorted(root.rglob("*")):
+        if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES:
+            yield str(path.relative_to(root)), _orientation_of_path(path)
+
+
+def _scan_pickle(path: Path) -> Iterator[tuple[str, int | None]]:
+    """Scan a dataset pickle's medias, preferring stored bytes over the origin path."""
+    with open(path, "rb") as fh:
+        payload: Any = pickle.load(fh)  # noqa: S301 - a dataset the operator chose
+    medias = payload.get("medias", payload) if isinstance(payload, dict) else payload
+    items = medias.values() if isinstance(medias, dict) else medias
+    for media in items:
+        if not isinstance(media, dict) or media.get("media_type") != "image":
+            continue
+        name = str(media.get("filename") or media.get("id") or "?")
+        blob = media.get("media_bytes")
+        if isinstance(blob, (bytes, bytearray)) and blob:
+            yield name, _orientation_of_bytes(bytes(blob))
+            continue
+        media_path = media.get("media_path")
+        yield name, (_orientation_of_path(Path(media_path)) if media_path else None)
+
+
+def scan(target: Path) -> list[tuple[str, int | None]]:
+    if target.is_dir():
+        return list(_scan_folder(target))
+    if target.suffix.lower() in {".pkl", ".pickle"}:
+        return list(_scan_pickle(target))
+    return [(target.name, _orientation_of_path(target))]
+
+
+def summarise(rows: list[tuple[str, int | None]]) -> dict[str, Any]:
+    counts = Counter(orientation for _name, orientation in rows)
+    readable = sum(n for orientation, n in counts.items() if orientation is not None)
+    rotated = sum(n for orientation, n in counts.items() if orientation not in (None, 1))
+    transposed = sum(counts.get(o, 0) for o in QUARTER_TURNS)
+    return {
+        "images": len(rows),
+        "unreadable": counts.get(None, 0),
+        "readable": readable,
+        "rotated": rotated,
+        "transposed": transposed,
+        "histogram": {str(k): v for k, v in sorted(counts.items(), key=lambda kv: (kv[0] is None, kv[0]))},
+        "examples": [name for name, o in rows if o not in (None, 1)][:10],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("targets", nargs="+", type=Path, help="image folders, dataset pickles, or single files")
+    parser.add_argument("--json", action="store_true", help="emit one JSON object per target instead of a table")
+    args = parser.parse_args()
+
+    exit_code = 0
+    for target in args.targets:
+        if not target.exists():
+            print(f"skip {target}: does not exist", file=sys.stderr)
+            exit_code = 1
+            continue
+        report = summarise(scan(target))
+        if args.json:
+            print(json.dumps({"target": str(target), **report}))
+            continue
+        print(f"\n{target}")
+        print(f"  images        {report['images']}")
+        print(f"  unreadable    {report['unreadable']}")
+        print(f"  rotated       {report['rotated']}  (orientation tag other than 1)")
+        print(f"  transposed    {report['transposed']}  (quarter turns; these also swap width/height)")
+        print(f"  histogram     {report['histogram']}")
+        if report["examples"]:
+            print(f"  e.g.          {', '.join(report['examples'])}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_cleaner_routes.py
+++ b/tests/api/test_cleaner_routes.py
@@ -135,10 +135,17 @@ class TestCleanersApiEndpoint:
         assert all(c["media_type"] == "video" for c in cleaners)
         assert all(c["default_enabled"] is False for c in cleaners)
 
-    def test_exif_cleaner_defaults_on(self, client):
+    def test_every_shipped_cleaner_is_opt_in(self, client):
+        """No gate rewrites a user's payload unless they asked for it.
+
+        ``image_exif_orient`` was the one exception until orientation moved into
+        the decode layer; now that every image is *read* upright, baking the
+        rotation into the stored bytes is a preference, not a correction.
+        """
         resp = client.get("/api/cleaners?media_type=image")
-        exif = next(c for c in resp.get_json()["cleaners"] if c["name"] == "image_exif_orient")
-        assert exif["default_enabled"] is True
+        cleaners = resp.get_json()["cleaners"]
+        assert all(c["default_enabled"] is False for c in cleaners)
+        exif = next(c for c in cleaners if c["name"] == "image_exif_orient")
         assert exif["description"]
 
     def test_cleaners_are_absent_from_the_clipper_listing(self, client):

--- a/tests_lib/core/test_image_decode.py
+++ b/tests_lib/core/test_image_decode.py
@@ -5,27 +5,56 @@ Pillow refuses to open an image past twice ``Image.MAX_IMAGE_PIXELS``, raising
 header alone.  VTSearch lifts that ceiling — a user's gigapixel panorama is
 large, not hostile — and replaces it with a bounded *decode* so peak memory
 stays capped instead.  These tests pin both halves of that trade.
+
+They also pin the module's second job: **applying EXIF display orientation**.
+A phone photo is stored in sensor order with a tag saying how to rotate it, and
+browsers honour that tag — so the picture a user sees is the upright one.  Every
+decode here returns those upright pixels, and :func:`upright_size` reports the
+matching dimensions from the header alone, so the embedder, the thumbnailer, the
+extractors' boxes and a media's stored ``width``/``height`` all describe the
+same image.
 """
 
 from __future__ import annotations
 
 import io
+from pathlib import Path
 
 import pytest
 from PIL import Image
 
 from vtscore.media.image import decode as decode_mod
 from vtscore.media.image.decode import (
+    apply_exif_orientation,
     configure_pil_limits,
     decode_bounded,
     decode_bounded_rgb,
+    exif_orientation,
+    exif_upright_size,
     open_image,
+    open_upright,
+    upright_size,
 )
 
 
 def _encode(img: Image.Image, fmt: str = "PNG") -> bytes:
     buf = io.BytesIO()
     img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _oriented(orientation: int, size: tuple[int, int] = (40, 20)) -> bytes:
+    """A JPEG whose stored bitmap is *size*, tagged with *orientation*.
+
+    Orientation 6 is the ubiquitous one: a phone held upright writes a landscape
+    sensor frame plus "rotate me", which is exactly the file that used to reach
+    the embedder sideways.
+    """
+    exif = Image.Exif()
+    exif[274] = orientation
+    img = Image.new("RGB", size, color=(120, 60, 30))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", exif=exif)
     return buf.getvalue()
 
 
@@ -176,7 +205,7 @@ class TestOversizedImagesSurviveIngest:
 
         configure_pil_limits()
         data = ImageMediaType().load_media_data(tmp_path / "huge.jpg", media_bytes=blob)
-        # Native dimensions, not the bounded decode's: the stored bytes are the
+        # Full dimensions, not the bounded decode's: the stored bytes are the
         # untouched original and crop boxes are expressed against them.
         assert (data["width"], data["height"]) == (900, 600)
         assert data["thumbnail_bytes"]
@@ -192,3 +221,146 @@ class TestOversizedImagesSurviveIngest:
         img = _load_pil(blob)
         assert img is not None
         assert img.mode == "RGB"
+
+
+class TestExifOrientationHelpers:
+    def test_reports_the_tag_without_decoding(self):
+        with open_image(_oriented(6)) as img:
+            assert exif_orientation(img) == 6
+            # Still lazy: reading the tag must not have pulled in the pixels.
+            # ``_im`` is Pillow's backing buffer; the public ``im`` asserts on it.
+            assert img._im is None
+
+    def test_a_missing_or_unreadable_tag_reads_as_upright(self):
+        with open_image(_encode(Image.new("RGB", (8, 8)))) as img:
+            assert exif_orientation(img) == 1
+
+        class _Hostile:
+            format = None
+            size = (8, 8)
+
+            def getexif(self):
+                raise ValueError("corrupt EXIF block")
+
+        assert exif_orientation(_Hostile()) == 1  # type: ignore[arg-type]
+
+    def test_upright_size_swaps_the_axes_for_a_quarter_turn(self):
+        # 5-8 transpose; 1-4 are identity/flips that keep the axes as stored.
+        for orientation in (5, 6, 7, 8):
+            assert upright_size(_oriented(orientation, (40, 20))) == (20, 40)
+        for orientation in (1, 2, 3, 4):
+            assert upright_size(_oriented(orientation, (40, 20))) == (40, 20)
+
+    def test_upright_size_matches_what_the_decode_actually_returns(self):
+        """The invariant the stored ``width``/``height`` rest on."""
+        for orientation in range(1, 9):
+            blob = _oriented(orientation, (40, 20))
+            img, _scale = decode_bounded(blob, max_pixels=0)
+            with img:
+                assert img.size == upright_size(blob) == exif_upright_size(open_image(blob))
+
+    def test_apply_returns_the_same_object_when_there_is_nothing_to_do(self):
+        """No unconditional full-bitmap copy on the overwhelmingly common path."""
+        with open_image(_encode(Image.new("RGB", (16, 16)))) as img:
+            assert apply_exif_orientation(img) is img
+
+    def test_a_rotated_copy_keeps_its_format_and_drops_the_tag(self):
+        with open_image(_oriented(6)) as img:
+            upright = apply_exif_orientation(img)
+            assert upright is not img
+            # Format survives so a caller re-encoding a crop keeps the container
+            # instead of silently switching to PNG.
+            assert upright.format == "JPEG"
+            # Tag stripped, so re-applying is a no-op rather than a second turn.
+            assert exif_orientation(upright) == 1
+            assert apply_exif_orientation(upright) is upright
+
+
+class TestDecodeBoundedAppliesOrientation:
+    def test_a_sideways_photo_decodes_upright(self):
+        img, _scale = decode_bounded(_oriented(6, (40, 20)), max_pixels=0)
+        with img:
+            assert img.size == (20, 40)
+
+    def test_the_rgb_variant_too(self):
+        img, _scale = decode_bounded_rgb(_oriented(6, (40, 20)), max_pixels=0)
+        with img:
+            assert img.mode == "RGB"
+            assert img.size == (20, 40)
+
+    def test_scale_survives_the_transpose(self):
+        """``scale`` is a linear ratio, so a quarter turn must not disturb it.
+
+        Extractors divide reported coordinates by it to land in the media's
+        stored (upright) space; if the transpose leaked into the ratio, every
+        box on a rotated photo would be off by the aspect ratio.
+        """
+        img, scale = decode_bounded(_oriented(6, (400, 200)), max_pixels=5_000)
+        with img:
+            assert img.size[0] < img.size[1]  # upright: portrait
+            assert img.width * img.height <= 5_000
+            # Upright original is 200x400; the decoded box maps back onto it.
+            assert img.width / scale == pytest.approx(200, abs=2)
+            assert img.height / scale == pytest.approx(400, abs=2)
+
+    def test_an_untagged_image_is_unaffected(self):
+        img, scale = decode_bounded(_encode(Image.new("RGB", (40, 20))), max_pixels=0)
+        with img:
+            assert img.size == (40, 20)
+            assert scale == 1.0
+
+
+class TestOpenUpright:
+    def test_decodes_at_native_size_rotated(self):
+        with open_upright(_oriented(6, (400, 200))) as img:
+            assert img.size == (200, 400)
+            assert img.format == "JPEG"
+
+    def test_accepts_a_filesystem_path(self, tmp_path):
+        path = tmp_path / "sideways.jpg"
+        path.write_bytes(_oriented(6, (40, 20)))
+        with open_upright(path) as img:
+            assert img.size == (20, 40)
+
+    def test_open_image_stays_lazy_and_untransposed(self):
+        """The deliberate exception: header reads must not force a decode."""
+        with open_image(_oriented(6, (40, 20))) as img:
+            assert img.size == (40, 20)
+            assert img._im is None
+
+
+class TestOrientationIsConsistentAcrossThePipeline:
+    """The whole point of fixing this at decode: one coordinate space.
+
+    A fix that transposed only in the embedder path would leave the thumbnail,
+    the stored dimensions and the crop boxes disagreeing with it — worse than
+    the original bug, because the disagreement is silent.
+    """
+
+    def test_stored_dimensions_match_the_thumbnail_and_the_embed_decode(self):
+        from vtscore.media.image._image_bulk import _load_pil  # noqa: PLC0415
+        from vtscore.media.image.media_type import ImageMediaType  # noqa: PLC0415
+
+        blob = _oriented(6, (400, 200))
+        data = ImageMediaType().load_media_data(Path("sideways.jpg"), media_bytes=blob)
+        assert (data["width"], data["height"]) == (200, 400)
+
+        embedded = _load_pil(blob)
+        assert embedded is not None
+        assert embedded.height > embedded.width
+
+        with Image.open(io.BytesIO(data["thumbnail_bytes"])) as thumb:
+            assert thumb.height > thumb.width
+
+    def test_a_crop_box_in_stored_space_cuts_the_region_the_user_drew(self):
+        from vtscore.media.image.clipper import ImageBboxClipper  # noqa: PLC0415
+
+        blob = _oriented(6, (400, 200))  # upright: 200 wide x 400 tall
+        clip = ImageBboxClipper((0, 0, 100, 400)).clip(
+            {"id": 0, "media_type": "image", "media_bytes": blob, "width": 200, "height": 400}
+        )[0]
+        # The box is legal in upright space and would have been clamped to
+        # nonsense (or cut the wrong half) against the 400x200 sensor bitmap.
+        assert (clip["width"], clip["height"]) == (100, 400)
+        with Image.open(io.BytesIO(clip["media_bytes"])) as cropped:
+            assert cropped.size == (100, 400)

--- a/tests_lib/detectors/test_cleaner_roster.py
+++ b/tests_lib/detectors/test_cleaner_roster.py
@@ -198,13 +198,19 @@ class TestImageEdgeTrimCleaner:
         media = _image_media(_padded(400, 400, (4, 4, 396, 396), (255, 255, 255), (30, 30, 200)))
         assert get_cleaner("image_edge_trim").clean(media) is media
 
-    def test_crop_preserves_an_unbaked_exif_orientation(self):
-        """Trimming must not silently un-rotate a photo.
+    def test_trims_the_margins_the_viewer_sees_not_the_sensor_ones(self):
+        """A rotated photo is trimmed in *display* space.
 
-        ``image_edge_trim`` can run with ``image_exif_orient`` switched off, in
-        which case the payload still carries an orientation tag that viewers
-        honour.  Dropping it during the re-encode would leave the trimmed copy
-        displayed sideways.
+        The stored bitmap here has a black letterbox above and below a red band,
+        but its EXIF orientation says to rotate 90 degrees — so what anyone
+        actually sees is a *pillarbox*, black to the left and right.  Trimming
+        the sensor bitmap would shave the wrong two edges and leave the visible
+        bars untouched, and would also report dimensions transposed from the
+        media's stored ``width``/``height``.
+
+        The re-encoded copy must not carry the orientation tag onward either:
+        the pixels are upright now, so a viewer honouring the tag would rotate
+        an already-rotated image a second time.
         """
         img = _padded(400, 400, (0, 100, 400, 300), (0, 0, 0), (200, 30, 30))
         exif = Image.Exif()
@@ -215,8 +221,14 @@ class TestImageEdgeTrimCleaner:
 
         out = get_cleaner("image_edge_trim").clean(media)
         assert out is not media
+        # Upright, the 400x200 content band stands on end: the *horizontal*
+        # axis is the one that loses its bars.  (JPEG ringing smears the
+        # boundary a few pixels, so the width is checked as a band.)
+        assert out["height"] == 400
+        assert 190 <= out["width"] <= 215
         with Image.open(io.BytesIO(out["media_bytes"])) as trimmed:
-            assert trimmed.getexif().get(274) == 6
+            assert trimmed.size == (out["width"], out["height"])
+            assert trimmed.getexif().get(274) is None
 
 
 class TestEdgeTrimIsSharedWithThumbnails:

--- a/tests_lib/detectors/test_media_cleaners.py
+++ b/tests_lib/detectors/test_media_cleaners.py
@@ -222,8 +222,8 @@ class TestCleanerRegistry:
     def test_to_dict_carries_default_enabled(self, registered_cleaners):
         from vtscore.media import get_cleaner
 
-        assert get_cleaner("image_exif_orient").to_dict()["default_enabled"] is True
-        assert get_cleaner("text_test_upper").to_dict()["default_enabled"] is False
+        assert get_cleaner("image_edge_trim").to_dict()["default_enabled"] is False
+        assert get_cleaner("text_test_suffix").to_dict()["default_enabled"] is True
 
     def test_clip_wraps_clean_as_one_output(self, registered_cleaners):
         from vtscore.media import get_cleaner
@@ -759,10 +759,12 @@ class TestOriginalPayloadPersistence:
 
 
 class TestImageExifOrientCleaner:
-    def test_defaults_on(self):
+    def test_defaults_off(self):
+        """Opt-in: every decode already applies the tag, so baking it into the
+        stored bytes buys nothing inside VTSearch and costs a lossy re-encode."""
         from vtscore.media import get_cleaner
 
-        assert get_cleaner("image_exif_orient").default_enabled is True
+        assert get_cleaner("image_exif_orient").default_enabled is False
 
     def test_rotates_and_clears_the_tag(self):
         from PIL import Image

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -478,13 +478,14 @@ def _clip_image_to_bytes(file_path: Path, clip_box: str) -> tuple[bytes, str]:
     """Crop an image to the comma-separated ``clip_box``.  Returns ``(bytes, suffix)``."""
     import io as _io
 
-    from PIL import Image
+    from vtscore.media.image.decode import open_upright
 
     parts = [int(float(v)) for v in clip_box.split(",")]
     if len(parts) != 4:
         raise ValueError(f"clip_box must have 4 values, got {len(parts)}")
     box: tuple[int, int, int, int] = (parts[0], parts[1], parts[2], parts[3])
-    with Image.open(file_path) as img:
+    # Upright decode, matching the clipper the box was recorded by.
+    with open_upright(file_path) as img:
         cropped = img.crop(box)
         buf = _io.BytesIO()
         cropped.save(buf, format=img.format or "PNG")

--- a/vtscore/media/cropping.py
+++ b/vtscore/media/cropping.py
@@ -8,7 +8,6 @@ side.
 
 from __future__ import annotations
 
-import io
 from pathlib import Path
 from typing import Any
 
@@ -23,7 +22,8 @@ def crop_file_bytes(
     *params* must be a dict matching the clipper's bounds:
 
     * Audio: ``{"start": float, "end": float}`` - seconds.
-    * Image: ``{"box": [x1, y1, x2, y2]}`` - pixel coords in the original image.
+    * Image: ``{"box": [x1, y1, x2, y2]}`` - pixel coords in the original
+      image, as displayed (i.e. after EXIF orientation).
 
     Raises :class:`ValueError` for unsupported media types or invalid params.
     Raises :class:`FileNotFoundError` if *file_path* does not exist.
@@ -45,16 +45,17 @@ def crop_file_bytes(
         return clipped[0].get("media_bytes", media_bytes)
 
     if media_type == "image":
-        from PIL import Image  # noqa: PLC0415
-
         from vtscore.media.image.clipper import ImageBboxClipper
+        from vtscore.media.image.decode import upright_size  # noqa: PLC0415
 
         box = params.get("box")
         if box is None or len(box) != 4:
             raise ValueError("box must be a 4-tuple [x1, y1, x2, y2]")
         clipper = ImageBboxClipper(box)
-        with Image.open(io.BytesIO(media_bytes)) as img:
-            width, height = img.size
+        # Displayed dimensions, matching how the box was drawn: the browser
+        # applies EXIF orientation, so a box over a rotated photo is in upright
+        # space and the clipper decodes upright to match.
+        width, height = upright_size(media_bytes)
         media = {
             "id": 0,
             "media_type": "image",

--- a/vtscore/media/face/media_type.py
+++ b/vtscore/media/face/media_type.py
@@ -127,18 +127,16 @@ class FaceMediaType(MediaType):
         # Faces are not imported from files in the normal flow, but implement
         # this defensively (image-like) so a face crop loaded from disk still
         # gets its dimensions + thumbnail populated.
-        import io  # noqa: PLC0415
-
-        from PIL import Image  # noqa: PLC0415
-
+        from vtscore.media.image.decode import upright_size  # noqa: PLC0415
         from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
         if media_bytes is None:
             with open(file_path, "rb") as f:
                 media_bytes = f.read()
         try:
-            with Image.open(io.BytesIO(media_bytes)) as img:
-                width, height = img.width, img.height
+            # Upright, matching the thumbnail below: face crops carry no EXIF of
+            # their own, but a crop loaded straight off disk might.
+            width, height = upright_size(media_bytes)
         except Exception:
             width, height = None, None
         thumb = make_image_thumbnail(media_bytes)

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -1088,7 +1088,7 @@ def _load_synthetic_toponymy(clips, embedder, on_progress, demo_origin) -> None:
 def _embed_file_images(selected, clips, embedder, on_progress, demo_origin, skip_embedding=False) -> None:
     """Embed a list of (img_path, category) tuples into ``clips``."""
 
-    from PIL import Image  # noqa: PLC0415
+    from vtscore.media.image.decode import upright_size  # noqa: PLC0415
 
     if not skip_embedding:
         _ensure_image_embedder_loaded(embedder, on_progress)
@@ -1113,8 +1113,7 @@ def _embed_file_images(selected, clips, embedder, on_progress, demo_origin, skip
         with open(img_path, "rb") as f:
             image_bytes = f.read()
         try:
-            with Image.open(img_path) as img:
-                width, height = img.width, img.height
+            width, height = upright_size(img_path)
         except Exception:
             width, height = None, None
         clips[clip_id] = {
@@ -1260,9 +1259,8 @@ def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin, skip_e
     a store-only ``regions`` list of normalized ground-truth boxes.
     """
 
-    from PIL import Image  # noqa: PLC0415
-
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
+    from vtscore.media.image.decode import upright_size  # noqa: PLC0415
 
     if not skip_embedding:
         _ensure_image_embedder_loaded(embedder, on_progress)
@@ -1286,8 +1284,7 @@ def _embed_vg_images(selected, clips, embedder, on_progress, demo_origin, skip_e
         with open(img_path, "rb") as f:
             image_bytes = f.read()
         try:
-            with Image.open(img_path) as img:
-                width, height = img.width, img.height
+            width, height = upright_size(img_path)
         except Exception:
             width, height = None, None
         clips[clip_id] = {
@@ -1323,9 +1320,8 @@ def _embed_openlogo_images(selected, clips, embedder, on_progress, demo_origin, 
     Evaluation flow score against ground truth).
     """
 
-    from PIL import Image  # noqa: PLC0415
-
     from vtscore.media.embedder import media_from_path  # noqa: PLC0415
+    from vtscore.media.image.decode import upright_size  # noqa: PLC0415
 
     if not skip_embedding:
         _ensure_image_embedder_loaded(embedder, on_progress)
@@ -1349,8 +1345,7 @@ def _embed_openlogo_images(selected, clips, embedder, on_progress, demo_origin, 
         with open(img_path, "rb") as f:
             image_bytes = f.read()
         try:
-            with Image.open(img_path) as img:
-                width, height = img.width, img.height
+            width, height = upright_size(img_path)
         except Exception:
             width, height = None, None
         clips[clip_id] = {

--- a/vtscore/media/image/cleaner.py
+++ b/vtscore/media/image/cleaner.py
@@ -24,18 +24,19 @@ class ImageExifOrientCleaner(MediaCleaner):
     """Bake a photo's EXIF display orientation into its pixels.
 
     Phone and camera JPEGs are stored in sensor order with an EXIF
-    ``Orientation`` tag telling the viewer how to rotate them.  Browsers and
-    :func:`~vtscore.media.image.thumbnail.make_image_thumbnail` honour that tag,
-    but the **embed path does not**: it hands the stored bytes straight to the
-    embedder, so a portrait phone photo is embedded sideways while its thumbnail
-    shows upright.  Every rotated photo therefore lands in the wrong part of the
-    vector space, which no amount of training fixes.
+    ``Orientation`` tag telling the viewer how to rotate them.  This gate
+    rewrites the payload as the upright image with the tag cleared, so the
+    *stored bytes* are upright too.
 
-    This gate rewrites the payload as the upright image with the tag cleared, so
-    the bytes the embedder sees match the bytes the user sees.  Because it
-    corrects an outright representation bug rather than making a judgment call
-    about what counts as wasted content, it is the one cleaner that defaults
-    **on**.
+    It is **off by default**, and does not affect what VTSearch sees.  Every
+    decode in :mod:`vtscore.media.image.decode` applies the orientation tag
+    already, so the embedder, thumbnailer, OCR, face detection and the crop
+    paths all work on upright pixels whether or not this cleaner ran.  What it
+    buys is bytes that are upright *outside* VTSearch — for a consumer of an
+    exported dataset that reads the payload without honouring EXIF.  What it
+    costs is a re-encode of every rotated photo (lossy, for JPEG), which is why
+    the default is off: paying it to fix a bug that no longer exists would be a
+    poor trade.
     """
 
     @property
@@ -53,13 +54,13 @@ class ImageExifOrientCleaner(MediaCleaner):
     @property
     def description(self) -> str:
         return (
-            "Rotate photos to their EXIF display orientation so the embedder sees them "
-            "upright, the way thumbnails already show them."
+            "Rewrite photos upright in their stored bytes. VTSearch already reads them "
+            "upright either way; this only matters for tools that ignore EXIF."
         )
 
     @property
     def default_enabled(self) -> bool:
-        return True
+        return False
 
     def clean(self, media: dict[str, Any]) -> dict[str, Any]:
         """Return *media* with the rotation baked in, or unchanged.
@@ -104,9 +105,10 @@ class ImageExifOrientCleaner(MediaCleaner):
 
 
 #: Formats whose Pillow encoder accepts an ``exif=`` keyword.  A cropped copy
-#: keeps the source's EXIF block for these so a photo that still carries an
-#: unbaked orientation tag (i.e. ``image_exif_orient`` is switched off) is not
-#: silently un-rotated by the crop.
+#: keeps the source's EXIF block for these so the camera/GPS metadata survives
+#: the trim.  The block is taken from the *upright* image, where Pillow has
+#: already dropped the orientation tag, so a rotated photo is not re-rotated on
+#: top of pixels that are already upright.
 _EXIF_WRITABLE_FORMATS = frozenset({"JPEG", "PNG", "TIFF", "WEBP", "MPO"})
 
 
@@ -233,10 +235,13 @@ class ImageEdgeTrimCleaner(MediaCleaner):
         if not isinstance(media_bytes, (bytes, bytearray)) or not media_bytes:
             return media
 
-        from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image.decode import open_upright  # noqa: PLC0415
 
         try:
-            with Image.open(io.BytesIO(media_bytes)) as src:
+            # Upright decode: the trimmed copy's dimensions become the media's
+            # stored ``width``/``height``, which are the displayed ones, and the
+            # grid thumbnail runs the same detector over the same upright pixels.
+            with open_upright(io.BytesIO(media_bytes)) as src:
                 box = solid_edge_box(
                     src,
                     edge_tol=self._edge_tol,

--- a/vtscore/media/image/clipper.py
+++ b/vtscore/media/image/clipper.py
@@ -58,7 +58,7 @@ class ImageTilingClipper(MediaClipper):
         return "Tile each image into equidistant square crops along the longer axis."
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
-        from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image.decode import open_upright  # noqa: PLC0415
 
         width = media.get("width")
         height = media.get("height")
@@ -73,7 +73,10 @@ class ImageTilingClipper(MediaClipper):
         if width == tile_size and height == tile_size:
             return [media]
 
-        img = Image.open(io.BytesIO(media_bytes))
+        # Upright decode: ``width``/``height`` above are the displayed
+        # dimensions, so tiling a sideways phone photo against the raw sensor
+        # bitmap would slice along the wrong axis.
+        img = open_upright(io.BytesIO(media_bytes))
 
         if width >= height:
             # Landscape: tile along the x-axis.
@@ -154,13 +157,15 @@ class ImageBboxClipper(MediaClipper):
         return self._box
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
-        from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image.decode import open_upright  # noqa: PLC0415
 
         media_bytes = media.get("media_bytes")
         if media_bytes is None:
             return [media]
 
-        img = Image.open(io.BytesIO(media_bytes))
+        # Upright decode: the box is in the media's displayed coordinate space
+        # (its stored ``width``/``height``), not the raw sensor bitmap's.
+        img = open_upright(io.BytesIO(media_bytes))
         img_w, img_h = img.size
 
         x1 = max(0, min(self._box[0], img_w))
@@ -339,14 +344,17 @@ class ImageObjectClipper(MediaClipper):
         return (ix1, iy1, ix2, iy2)
 
     def clip(self, media: dict[str, Any]) -> list[dict[str, Any]]:
-        from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image.decode import open_upright  # noqa: PLC0415
 
         media_bytes = media.get("media_bytes")
         if media_bytes is None:
             return [media]
 
-        img = Image.open(io.BytesIO(media_bytes)).convert("RGB")
-        fmt = Image.open(io.BytesIO(media_bytes)).format or "PNG"
+        # Upright decode so detected boxes — and the ``clip_box`` recorded from
+        # them — live in the same space as the media's stored dimensions.
+        with open_upright(io.BytesIO(media_bytes)) as src:
+            fmt = src.format or "PNG"
+            img = src.convert("RGB")
         img_w, img_h = img.size
 
         self._load_model()

--- a/vtscore/media/image/decode.py
+++ b/vtscore/media/image/decode.py
@@ -37,6 +37,23 @@ reasons in pixel coordinates:
 which the media registry imports eagerly while auto-discovering media types,
 so the ceiling is lifted process-wide before any image work begins —
 including in code that calls ``PIL.Image.open`` directly.
+
+**EXIF orientation is applied here, once, for everybody.**  Phone and camera
+JPEGs are stored in sensor order with an EXIF ``Orientation`` tag telling the
+viewer how to rotate them; browsers honour it, so the picture the user sees is
+the *upright* one.  Every decode in this module therefore returns upright
+pixels (:func:`decode_bounded`, :func:`decode_bounded_rgb`,
+:func:`open_upright`), and :func:`upright_size` reports the matching
+dimensions from the header alone.  That makes "the original image's space" mean
+one thing everywhere: what the user sees.  Embeddings, thumbnails, OCR boxes,
+face boxes, crop boxes and the media's stored ``width``/``height`` all agree,
+and a call site that divides a bounded-decode coordinate by ``scale`` lands in
+the same space the stored dimensions describe.
+
+:func:`open_image` is the deliberate exception — it stays lazy and untransposed
+because it exists for header-only reads, where forcing a decode to rotate
+pixels nobody asked for would defeat the point.  Ask it for metadata, not for
+pixels.
 """
 
 from __future__ import annotations
@@ -53,6 +70,14 @@ if TYPE_CHECKING:
 
 #: Anything :func:`PIL.Image.open` accepts, plus a raw in-memory blob.
 ImageSource = Union[str, Path, bytes, bytearray, memoryview, IO[bytes]]
+
+#: EXIF tag holding the display orientation.  ``1`` (and a missing tag) mean
+#: "already upright"; ``5``-``8`` additionally swap the two axes.
+EXIF_ORIENTATION_TAG = 274
+
+#: Orientations that transpose the image, i.e. whose upright form has the
+#: source's width and height exchanged.
+_AXIS_SWAPPING_ORIENTATIONS = frozenset({5, 6, 7, 8})
 
 _limits_configured = False
 
@@ -101,17 +126,110 @@ def open_image(source: ImageSource) -> "Image.Image":
     return Image.open(_as_openable(source))
 
 
+def exif_orientation(img: "Image.Image") -> int:
+    """Return *img*'s EXIF display orientation, or ``1`` when it has none.
+
+    Reads the header only — safe to call on a lazy :func:`open_image` result
+    without forcing a decode.  A payload whose EXIF block is missing or
+    unparseable reports ``1`` rather than raising: an unreadable tag and an
+    absent one both mean "no rotation is known to be needed".
+    """
+    try:
+        exif = img.getexif()
+    except Exception:
+        return 1
+    if not exif:
+        return 1
+    value = exif.get(EXIF_ORIENTATION_TAG)
+    return value if isinstance(value, int) and 1 <= value <= 8 else 1
+
+
+def apply_exif_orientation(img: "Image.Image") -> "Image.Image":
+    """Return *img* rotated to its EXIF display orientation.
+
+    Returns *img* **itself** when there is nothing to do (no tag, or a tag that
+    already says upright) — the overwhelmingly common case, and the reason this
+    exists instead of a bare ``ImageOps.exif_transpose`` call, which copies the
+    full bitmap unconditionally.  When a rotation *is* applied the result is a
+    new image with the orientation tag stripped, so re-applying is a no-op; the
+    source's ``format`` is carried across so a caller re-encoding a crop keeps
+    the original container instead of silently falling back to PNG.
+
+    Callers that own *img* should close it when a different object comes back.
+    """
+    if exif_orientation(img) == 1:
+        return img
+
+    from PIL import ImageOps  # noqa: PLC0415
+
+    upright = ImageOps.exif_transpose(img)
+    if upright is None or upright is img:
+        return img
+    upright.format = img.format
+    return upright
+
+
+def _upright(img: "Image.Image") -> "Image.Image":
+    """:func:`apply_exif_orientation`, closing *img* when it is superseded."""
+    upright = apply_exif_orientation(img)
+    if upright is not img:
+        img.close()
+    return upright
+
+
+def exif_upright_size(img: "Image.Image") -> tuple[int, int]:
+    """Return *img*'s ``(width, height)`` **as displayed**, from the header.
+
+    Costs one EXIF parse and no decode: a 90°/270° orientation just exchanges
+    the two numbers.  This is what a media item's stored ``width``/``height``
+    must be, so that boxes expressed against them address the same pixels the
+    user is looking at.
+    """
+    width, height = img.size
+    if exif_orientation(img) in _AXIS_SWAPPING_ORIENTATIONS:
+        return height, width
+    return width, height
+
+
+def upright_size(source: ImageSource) -> tuple[int, int]:
+    """:func:`exif_upright_size` for a source that is not open yet."""
+    with open_image(source) as img:
+        return exif_upright_size(img)
+
+
+def open_upright(source: ImageSource) -> "Image.Image":
+    """Open *source* at native resolution, rotated to its display orientation.
+
+    The full-resolution counterpart to :func:`decode_bounded`, for the paths
+    that reason in pixel coordinates against a media's stored
+    ``width``/``height`` — cropping, clipping, origin resolution.  Unlike
+    :func:`open_image` the result is *not* lazy when a rotation is needed
+    (rotating requires the pixels), which is exactly the trade those call sites
+    want: they are about to decode anyway, and a crop box that disagreed with
+    the stored dimensions by 90° would cut out the wrong region.
+    """
+    return _upright(open_image(source))
+
+
 def decode_bounded(
     source: ImageSource,
     max_pixels: int | None = None,
 ) -> tuple["Image.Image", float]:
-    """Open *source*, downsampled to at most *max_pixels* total pixels.
+    """Open *source* upright, downsampled to at most *max_pixels* total pixels.
 
     Returns ``(img, scale)`` where ``scale`` is the ratio of the returned
-    image's width to the original's — ``1.0`` when the source already fit
-    inside the budget, and ``< 1.0`` when it was reduced.  Call sites that
-    report pixel coordinates (bounding boxes) divide by ``scale`` to map
-    them back into the original image's coordinate space.
+    image's longest-side length to the original's — ``1.0`` when the source
+    already fit inside the budget, and ``< 1.0`` when it was reduced.  Call
+    sites that report pixel coordinates (bounding boxes) divide by ``scale``
+    to map them back into the original image's coordinate space.
+
+    EXIF display orientation is applied (see the module docstring), so "the
+    original image's space" means the *upright* image — the same space the
+    media's stored ``width``/``height`` describe and the same one the user
+    sees in the browser.  The downsample happens first and the rotation
+    second, so a rotated gigapixel photo is still never materialised at full
+    resolution, and ``scale`` is unaffected either way: a transpose exchanges
+    the axes without changing the linear reduction ratio.
 
     Aspect ratio is preserved.  Small images are never upscaled.  For JPEGs
     the reduction goes through Pillow's DCT-scaled ``draft`` path, so a huge
@@ -132,8 +250,10 @@ def decode_bounded(
         # 1/8 size) and only then resamples, so the full-resolution bitmap
         # never has to fit in memory for the formats that support it.
         img.thumbnail(target, Image.Resampling.LANCZOS, reducing_gap=2.0)
+    # Measured before the transpose, while both sides are still in source
+    # axis order; the rotation below preserves the ratio but may swap w/h.
     scale = (img.width / orig_w) if orig_w > 0 else 1.0
-    return img, scale
+    return _upright(img), scale
 
 
 def decode_bounded_rgb(

--- a/vtscore/media/image/media_type.py
+++ b/vtscore/media/image/media_type.py
@@ -135,7 +135,7 @@ class ImageMediaType(MediaType):
     # ------------------------------------------------------------------
 
     def load_media_data(self, file_path: Path, media_bytes: bytes | None = None) -> dict:
-        from vtscore.media.image.decode import open_image  # noqa: PLC0415
+        from vtscore.media.image.decode import upright_size  # noqa: PLC0415
         from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
         if media_bytes is None:
@@ -144,10 +144,11 @@ class ImageMediaType(MediaType):
         try:
             # Header-only read, and the bomb ceiling is lifted, so an enormous
             # source reports its true dimensions instead of being refused.
-            # These stay *native* size: the stored bytes are the untouched
-            # original, and crop/clip boxes are expressed against them.
-            with open_image(media_bytes) as img:
-                width, height = img.width, img.height
+            # These are the *displayed* dimensions: the stored bytes are the
+            # untouched original, but every decode applies EXIF orientation, so
+            # a portrait photo shot sideways must report portrait here or the
+            # crop/clip boxes expressed against these numbers land rotated.
+            width, height = upright_size(media_bytes)
         except Exception:
             width, height = None, None
         # Precompute the grid/list thumbnail at ingest so the request path
@@ -175,7 +176,7 @@ class ImageMediaType(MediaType):
         thumb = media.get("thumbnail_bytes")
         if thumb:
             return thumb
-        from vtscore.media.image.decode import open_image  # noqa: PLC0415
+        from vtscore.media.image.decode import upright_size  # noqa: PLC0415
         from vtscore.media.image.thumbnail import make_image_thumbnail  # noqa: PLC0415
 
         data = self._resolve_media_bytes(media)
@@ -184,9 +185,8 @@ class ImageMediaType(MediaType):
         if media.get("width") is None or media.get("height") is None:
             try:
                 # Header-only read with the bomb ceiling lifted, mirroring
-                # load_media_data: dimensions stay native size.
-                with open_image(data) as img:
-                    media["width"], media["height"] = img.width, img.height
+                # load_media_data: dimensions are EXIF-upright.
+                media["width"], media["height"] = upright_size(data)
             except Exception:
                 pass
         result = make_image_thumbnail(data)

--- a/vtscore/media/image/thumbnail.py
+++ b/vtscore/media/image/thumbnail.py
@@ -83,18 +83,20 @@ def make_image_thumbnail(
     Returns ``None`` when the bytes can't be decoded as an image (e.g. SVG or
     a corrupt file), letting the caller fall back to the original bytes.
     """
-    from PIL import Image, ImageOps  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
 
     from vtscore.media.image.decode import decode_bounded  # noqa: PLC0415
 
     try:
         # Bounded decode: the result is at most ``max_dim`` px on its longest
         # side, so a gigapixel source has nothing to gain from being decoded at
-        # full resolution first.  Both the crop and the edge-trim below work in
-        # *fractional* coordinates, so they are unaffected by the downsample.
+        # full resolution first.  It also comes back already rotated to its EXIF
+        # display orientation, so the crop below — like the media's stored
+        # ``width``/``height`` — addresses upright pixels.  Both the crop and the
+        # edge-trim work in *fractional* coordinates, so they are unaffected by
+        # the downsample.
         decoded, _scale = decode_bounded(media_bytes)
-        with decoded as src:
-            img = ImageOps.exif_transpose(src) or src
+        with decoded as img:
             if crop is not None:
                 img = _crop_to_region(img, crop)
             else:

--- a/vtscore/media/lazy_clip.py
+++ b/vtscore/media/lazy_clip.py
@@ -240,10 +240,13 @@ def _apply_recipe(source_bytes: bytes, recipe: tuple, media: dict[str, Any]) -> 
 
         return _wav_slice(source_bytes, recipe[1], recipe[2])
     if kind == "image":
-        from PIL import Image  # noqa: PLC0415
+        from vtscore.media.image.decode import open_upright  # noqa: PLC0415
 
         box = recipe[1]
-        with Image.open(io.BytesIO(source_bytes)) as img:
+        # Upright decode, matching the clipper that produced the recorded box:
+        # re-cropping the raw sensor bitmap would rebuild a rotated photo's clip
+        # from the wrong region.
+        with open_upright(io.BytesIO(source_bytes)) as img:
             fmt = img.format or "PNG"
             cropped = img.crop(box)
             buf = io.BytesIO()


### PR DESCRIPTION
Closes #3172

## What was wrong

A JPEG carrying an EXIF orientation tag — what a phone camera writes, storing the sensor frame plus "rotate me" rather than rotating the pixels — reached the embedder, the thumbnailer, OCR and face detection rotated 90°/180°/270° from how the browser (and every other photo viewer) displays it. Nothing errored; the picture was simply the wrong way up in a space nobody looks at directly, so a sideways photo embedded as a sideways photo.

## What changed

Orientation now belongs to `vtscore/media/image/decode.py`, applied once for everybody:

- `decode_bounded` / `decode_bounded_rgb` return upright pixels. The downsample happens first and the rotation second, so a rotated gigapixel source is still never materialised at full resolution; `scale` is measured before the transpose and is unaffected by it (a quarter turn exchanges the axes without changing the linear ratio), so the extractors' `coord / scale` contract keeps holding — it just lands in upright space now.
- `open_upright` is the full-resolution counterpart, for the paths that reason in pixel coordinates.
- `upright_size` reports the *displayed* dimensions from the header alone, with no decode: a quarter turn just exchanges the two numbers.
- `open_image` deliberately stays lazy and untransposed — it exists for header-only reads, and forcing a decode there would defeat the point.
- `apply_exif_orientation` returns the same object when there is nothing to do, so the common (untagged) path does not pay `ImageOps.exif_transpose`'s unconditional full-bitmap copy. When it does rotate, it carries `format` across so a caller re-encoding a crop keeps the container instead of silently falling back to PNG.

As the issue notes, transposing only the embedder path would have been worse than the bug, so the whole coordinate space moves together:

- **Stored dimensions.** A media's `width`/`height` are now the displayed ones — in `ImageMediaType.load_media_data` / `ensure_thumbnail_bytes`, in `FaceMediaType.load_media_data`, and in the three demo-source loaders in `_demo_sources.py`.
- **Crop / clip paths.** `ImageBboxClipper`, `ImageTilingClipper`, `ImageObjectClipper`, `vtscore/media/cropping.py`, `vtscore/media/lazy_clip.py` and `vtscore/detectors/resolver.py` all decode upright, so a box drawn on screen cuts the region the user drew, and a lazily re-derived clip reproduces the one the clipper originally made.
- **`image_edge_trim`.** Now trims the bars the *viewer* sees rather than the sensor bitmap's, and reports dimensions consistent with the stored ones. The EXIF block it carries onto the trimmed copy is taken from the upright image, where Pillow has already dropped the orientation tag — so the crop is not re-rotated on top of pixels that are already upright.
- **`make_image_thumbnail`.** Drops its own `exif_transpose`; the decode layer does it now.
- **Region votes.** Nothing to change — `pool_box_from_media` matches a normalised UI box against `patch_grid`, which comes off the embedder's decode. Those two used to disagree for a rotated photo and now agree by construction.

## `image_exif_orient` becomes opt-in

The repo already shipped a default-on cleaner that baked the rotation into the stored bytes, which is presumably why the bug survived: rotated photos imported through the picker UI *were* handled, while everything else (CLI imports, programmatic loads, experiment pile builds, anything imported before the cleaner landed) was not. The issue's premise is right about the decode layer; it just didn't account for that partial cover.

Its whole stated rationale was "the embed path does not honour the tag". That is no longer true, so paying a lossy re-encode of every rotated photo by default buys nothing VTSearch itself can see. The cleaner stays available — upright *stored bytes* still matter to a consumer of an exported dataset that ignores EXIF — but `default_enabled` is now `False`, and its docstring/description say what it is actually for.

## Scope check

I could not run the measurement the issue asks for: neither the demo corpora nor `/exp/scale26` are reachable from this container (no `data/`, no `/exp`), so **this PR does not establish whether any published number moves.** What it does ship is the instrument, so the question can be answered in one command wherever the corpora live:

```
python scripts/scan_exif_orientation.py /exp/scale26/images data/datasets/*.pkl
```

It prints the orientation histogram for a folder, a dataset pickle or a single file, separating the quarter turns (5–8, which also transpose `width`/`height`) from the flips (2–4, which don't). Header parses only — no pixels are decoded — so a large corpus scans at disk speed.

My expectation, stated as an expectation rather than a result: the benchmark corpora are curated ML datasets that have been through a re-encode somewhere, so this is most likely a correctness fix for ordinary user uploads rather than something that moves a published number. Worth confirming before anyone cites it either way.

## Compatibility

Breaking, deliberately, and worth being explicit about: images already imported keep the dimensions and embeddings they were ingested with. A rotated corpus needs a re-import to pick up the fix — the same cached-embedding invalidation the issue flagged against #3160.

## Testing

`./run-tests.sh` — full suite green on the current base (8820 passed, 6 skipped; pyright, pip-audit, npm audit, Vitest all OK).

New coverage in `tests_lib/core/test_image_decode.py`: the header-only tag read stays lazy; an unreadable EXIF block reads as upright; `upright_size` swaps the axes for 5–8 and not for 1–4, and matches what the decode actually returns for all eight orientations; `scale` survives the transpose; `open_image` stays untransposed; and a pipeline-consistency class pinning that the stored dimensions, the thumbnail, the embed decode and a bbox crop all describe the same image.

`tests_lib/detectors/test_cleaner_roster.py`'s EXIF-preserving trim test is rewritten: it now pins that a rotated photo's *visible* pillarbox is what gets trimmed (a case where the old and new behaviour differ by 90°), and that the tag does not survive onto pixels that are already upright.

## Rebase note

The branch was rebuilt on top of the current `dev` (through #3177) to clear the conflict. The only genuine conflict was `CHANGELOG.md`, where this entry and #3174's were both inserted at the head of `### Fixed`; both are kept, newest first.

Worth flagging: an earlier automated rebase of this branch reported success but had silently reverted the #3174 and #3173 CHANGELOG entries along with parts of their code. That result was discarded rather than pushed — this branch was rebuilt by replaying only this change's own diff onto `dev`, and its net diff against `dev` is now exactly the 18 files listed above.