### PR TITLE
One media, one label per detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A detector's labelset no longer stores the same media twice.** After one
+  pass over a 300-image dataset a detector reported `num_training: 356` — 300
+  distinct images, 56 of them held as a duplicate pair. The two halves of the
+  labelset round-trip disagreed on what "the same media" means: loading a
+  detector turned an entry into a vote when it matched a dataset item by
+  origin **or** content hash, while saving decided an entry belonged to the
+  active dataset by comparing origins alone. Anything that matched only on its
+  hash — an exemplar carrying the `example_media` sentinel, a label imported
+  from a plain md5 list, a label saved under another dataset's importer — was
+  restored as a vote, re-emitted as a fresh element, and kept beside its
+  original. Both writers now use the same origin-or-hash resolution, so a
+  re-vote updates the existing element instead of appending, and a labelset
+  that already carries duplicates collapses on the next write. Two related
+  leaks went with it: the Find "add corrections to detector" fold left the
+  stale entry in place beside its correction (one media, two contradicting
+  labels), and a drawn Good region was erased whenever a detector reload
+  resynced the labelset, because the restored vote came back image-level.
+  Duplicated entries were also double-weighted at training time. (#3174)
+
 - **A finished dataset import no longer looks like a wedged one.** An import
   that had already succeeded — pickle written, dataset registered — kept the
   progress channel parked on its last message ("Loading SigLIP processor…")

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -346,6 +346,39 @@ class TestCorrectionsToDetector:
         assert get_active_detector_context().find_eval_stale is False
         assert client.get("/api/find/stats").get_json()["stale"] is False
 
+    def test_correction_supersedes_an_md5_matched_entry(self, client):
+        """A correction replaces the media's prior entry even when that entry
+        names the file by a different origin (issue #3174).
+
+        Matching on ``element_key`` alone left the stale entry in place, so the
+        labelset ended up holding the same media twice with contradicting
+        labels - and training saw both bags.
+        """
+        self._setup_find(client)
+
+        # Replace one media's entry with a stale, md5-only record of the same
+        # bytes: same file, different provenance, so ``element_key`` differs.
+        stale_id = next(iter(app_module.medias))
+        stale_md5 = app_module.medias[stale_id]["md5"]
+        path = _detector_path("corrections-model")
+        data = _read_detector(path)
+        assert data is not None
+        data["labelset"]["labels"] = [el for el in data["labelset"]["labels"] if el.get("md5") != stale_md5] + [
+            {"md5": stale_md5, "label": "good", "origin_name": "elsewhere.wav"}
+        ]
+        _write_detector(path, data)
+
+        # Flip the detector's call on that media so it becomes a correction.
+        ctx = get_active_detector_context()
+        opposite = "bad" if ctx.find_initial_labels.get(stale_id) == "good" else "good"
+        assert client.post(f"/api/medias/{stale_id}/vote", json={"target": opposite}).status_code == 200
+
+        assert client.post("/api/find/corrections-to-detector").status_code == 200
+
+        entries = [el for el in self._labelset_labels("corrections-model") if el.get("md5") == stale_md5]
+        assert len(entries) == 1, f"labelset stored the same media twice: {entries}"
+        assert entries[0]["label"] == opposite
+
 
 class TestReScoreKeepsVerifiedVotes:
     """Re-scoring must not overwrite a human-verified vote (#2928).

--- a/tests/detectors/test_labelset_no_duplicates.py
+++ b/tests/detectors/test_labelset_no_duplicates.py
@@ -1,0 +1,319 @@
+"""One media, one label per detector (issue #3174).
+
+A detector's labelset used to grow a *second* ``LabeledElement`` for a media
+whose existing entry named the same file by a different origin - an exemplar
+carrying the ``example_media`` sentinel, a label imported from a plain md5
+list, a label saved under another dataset's importer.  The write path decided
+"this entry belongs to the active dataset" by comparing
+:func:`~vtscore.datasets.labelset.element_key` (origin-preferred), while the
+*read* path (``restore_labels_from_detector``) turned entries into votes by
+``resolve_media_ids`` (origin **or** md5).  Anything that matched only on md5
+was therefore restored as a vote, re-emitted as a fresh element, and kept
+alongside its original - so ``num_training`` counted 356 for a 300-image pass.
+
+These tests pin the symmetry: an entry that becomes a vote is an entry the
+vote-derived labelset supersedes.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from tests import load_detector_and_wait
+from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+from vtsearch.settings import get_detectors_dir
+
+
+@pytest.fixture(autouse=True)
+def clean_detectors_dir():
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+    yield
+    tm_dir = get_detectors_dir()
+    if tm_dir.is_dir():
+        shutil.rmtree(tm_dir)
+
+
+def _register(client, name: str) -> str:
+    res = client.post(
+        "/api/detectors/registry",
+        json={"name": name, "media_type": "audio", "text_query": "t"},
+    )
+    assert res.status_code in (200, 201), res.get_data(as_text=True)
+    return res.get_json()["detector"]["id"]
+
+
+def _seed_labelset(name: str, labels: list[dict]) -> None:
+    path = _detector_path(name)
+    data = _read_detector(path)
+    assert data is not None
+    data["labelset"] = {"labels": labels}
+    _write_detector(path, data)
+
+
+def _labels(name: str) -> list[dict]:
+    data = _read_detector(_detector_path(name))
+    assert data is not None
+    return data["labelset"]["labels"]
+
+
+class TestVoteSyncCollapsesMd5MatchedEntries:
+    """The post-vote sync path (``sync_labels_to_loaded_detector``)."""
+
+    def test_md5_matched_entry_is_superseded_not_duplicated(self, client):
+        """The reported shape: two ``bad`` elements for one media.
+
+        The pair was indistinguishable in ``labels-detail`` (which does not
+        render ``origin``) - same md5, same label, different element id.
+        """
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        detector_id = _register(client, "DupBad")
+        first_id = next(iter(medias))
+        media = medias[first_id]
+
+        # An entry that names the same bytes but not the same origin: exactly
+        # what a plain md5 label list, or an exemplar's example_media
+        # sentinel, leaves behind.
+        _seed_labelset(
+            "DupBad",
+            [{"md5": media["md5"], "label": "bad", "origin_name": "elsewhere.wav"}],
+        )
+        load_detector_and_wait(client, detector_id)
+
+        assert client.post(f"/api/medias/{first_id}/vote", json={"target": "bad"}).status_code == 200
+
+        labels = _labels("DupBad")
+        assert len(labels) == 1, f"labelset stored the same media twice: {labels}"
+        assert labels[0]["md5"] == media["md5"]
+        assert labels[0]["label"] == "bad"
+        # The surviving entry is the vote-derived one, carrying the active
+        # dataset's provenance rather than the stale name.
+        assert labels[0]["origin_name"] == media.get("origin_name")
+
+    def test_num_training_counts_distinct_media(self, client):
+        """The counter a reviewer reads as progress must not exceed the slate."""
+        from vtscore.detectors.registry import get_detector
+        from vtsearch.state import medias
+
+        ids = list(medias)[:3]
+        if len(ids) < 3:
+            pytest.skip("Need at least 3 medias")
+
+        detector_id = _register(client, "CountTruth")
+        _seed_labelset(
+            "CountTruth",
+            [{"md5": medias[cid]["md5"], "label": "bad", "origin_name": f"stale{cid}.wav"} for cid in ids],
+        )
+        load_detector_and_wait(client, detector_id)
+
+        for cid in ids:
+            client.post(f"/api/medias/{cid}/vote", json={"target": "bad"})
+
+        assert len(_labels("CountTruth")) == 3
+        entry = get_detector(detector_id)
+        assert entry is not None
+        assert entry["num_training"] == 3
+
+    def test_cross_dataset_entry_still_survives(self, client):
+        """The merge must stay non-destructive for entries that resolve nowhere."""
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        detector_id = _register(client, "KeepForeign")
+        _seed_labelset(
+            "KeepForeign",
+            [
+                {
+                    "md5": "ff" * 16,
+                    "label": "good",
+                    "origin": {"importer": "ds_a", "params": {"size": "100"}},
+                    "origin_name": "from_other_dataset.wav",
+                }
+            ],
+        )
+        load_detector_and_wait(client, detector_id)
+
+        first_id = next(iter(medias))
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
+
+        labels = _labels("KeepForeign")
+        assert {lbl["md5"] for lbl in labels} == {"ff" * 16, medias[first_id]["md5"]}
+
+    def test_preexisting_duplicate_pair_heals_on_the_next_vote(self, client):
+        """A labelset that already carries the duplicate collapses on write."""
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        detector_id = _register(client, "HealDupes")
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        _seed_labelset(
+            "HealDupes",
+            [
+                {"md5": media["md5"], "label": "bad", "origin_name": "stale.wav"},
+                {
+                    "md5": media["md5"],
+                    "label": "bad",
+                    "origin": media.get("origin"),
+                    "origin_name": media.get("origin_name"),
+                },
+            ],
+        )
+        load_detector_and_wait(client, detector_id)
+
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "bad"})
+        assert len(_labels("HealDupes")) == 1
+
+
+class TestExplicitSaveCollapsesMd5MatchedEntries:
+    """``POST /api/detectors/<name>/labels`` shares the merge helper."""
+
+    def test_save_supersedes_an_md5_matched_entry(self, client):
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        _register(client, "SaveDedupe")
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        _seed_labelset(
+            "SaveDedupe",
+            [{"md5": media["md5"], "label": "good", "origin_name": "elsewhere.wav"}],
+        )
+
+        client.post(f"/api/medias/{first_id}/vote", json={"target": "good"})
+        res = client.post("/api/detectors/SaveDedupe/labels")
+        assert res.status_code == 200
+        assert res.get_json()["num_labels"] == 1
+        assert len(_labels("SaveDedupe")) == 1
+
+
+class TestRestoredRegionBoxSurvivesResync:
+    """A drawn region must not be erased by the labelset round-trip."""
+
+    def test_region_box_rides_through_restore_and_back(self, client):
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+
+        detector_id = _register(client, "KeepRegion")
+        first_id = next(iter(medias))
+        media = medias[first_id]
+        box = [0.1, 0.2, 0.6, 0.7]
+        _seed_labelset(
+            "KeepRegion",
+            [
+                {
+                    "md5": media["md5"],
+                    "label": "good",
+                    "origin": media.get("origin"),
+                    "origin_name": media.get("origin_name"),
+                    "region_box": box,
+                }
+            ],
+        )
+        load_detector_and_wait(client, detector_id)
+
+        # Voting a *different* media resyncs the whole labelset to disk; the
+        # region-voted element must be re-emitted with its box intact.
+        others = [cid for cid in medias if cid != first_id]
+        if not others:
+            pytest.skip("Need a second media")
+        client.post(f"/api/medias/{others[0]}/vote", json={"target": "bad"})
+
+        labels = _labels("KeepRegion")
+        kept = [lbl for lbl in labels if lbl["md5"] == media["md5"]]
+        assert len(kept) == 1
+        assert kept[0].get("region_box") == box
+
+
+class TestImportMergeKeepsOneElementPerMedia:
+    """``_merge_entries_into_labelset`` - last write wins, no contradicting pair."""
+
+    def test_conflicting_label_replaces_rather_than_appends(self):
+        from vtscore.datasets.labelset import LabelSet
+        from vtsearch.routes.detectors.labels import _merge_entries_into_labelset
+
+        ls = LabelSet.from_dict({"labels": [{"md5": "aa" * 16, "label": "good", "origin_name": "x.wav"}]})
+        applied, skipped, new_entries = _merge_entries_into_labelset(
+            ls, [{"md5": "aa" * 16, "label": "bad", "origin_name": "x.wav"}]
+        )
+
+        assert (applied, skipped) == (1, 0)
+        assert len(ls.elements) == 1
+        assert ls.elements[0].label == "bad"
+        assert len(new_entries) == 1
+
+    def test_restating_the_same_label_is_skipped(self):
+        from vtscore.datasets.labelset import LabelSet
+        from vtsearch.routes.detectors.labels import _merge_entries_into_labelset
+
+        ls = LabelSet.from_dict({"labels": [{"md5": "aa" * 16, "label": "good", "origin_name": "x.wav"}]})
+        applied, skipped, _ = _merge_entries_into_labelset(
+            ls, [{"md5": "aa" * 16, "label": "good", "origin_name": "x.wav"}]
+        )
+
+        assert (applied, skipped) == (0, 1)
+        assert len(ls.elements) == 1
+
+    def test_same_md5_under_a_different_origin_collapses(self):
+        """Origin-keyed and md5-keyed records of one file are one media."""
+        from vtscore.datasets.labelset import LabelSet
+        from vtsearch.routes.detectors.labels import _merge_entries_into_labelset
+
+        ls = LabelSet.from_dict(
+            {
+                "labels": [
+                    {
+                        "md5": "aa" * 16,
+                        "label": "good",
+                        "origin": {"importer": "ds_a", "params": {}},
+                        "origin_name": "x.wav",
+                    }
+                ]
+            }
+        )
+        applied, skipped, _ = _merge_entries_into_labelset(
+            ls,
+            [
+                {
+                    "md5": "aa" * 16,
+                    "label": "bad",
+                    "origin": {"importer": "ds_b", "params": {}},
+                    "origin_name": "copy_of_x.wav",
+                }
+            ],
+        )
+
+        assert (applied, skipped) == (1, 0)
+        assert len(ls.elements) == 1
+        assert ls.elements[0].label == "bad"
+
+    def test_distinct_media_still_accumulate(self):
+        from vtscore.datasets.labelset import LabelSet
+        from vtsearch.routes.detectors.labels import _merge_entries_into_labelset
+
+        ls = LabelSet.from_dict({"labels": [{"md5": "aa" * 16, "label": "good"}]})
+        applied, skipped, _ = _merge_entries_into_labelset(
+            ls,
+            [
+                {"md5": "bb" * 16, "label": "good"},
+                {"label": "not-a-label", "md5": "cc" * 16},
+            ],
+        )
+
+        assert (applied, skipped) == (1, 1)
+        assert len(ls.elements) == 2

--- a/vtscore/datasets/labelset.py
+++ b/vtscore/datasets/labelset.py
@@ -394,6 +394,34 @@ def element_key(el: LabeledElement) -> Any:
     return None
 
 
+def element_identity_keys(el: LabeledElement) -> list[Any]:
+    """Return every hashable key under which *el* denotes the same media.
+
+    :func:`element_key` picks the *preferred* identity (origin when present,
+    else md5), which is what a stable element id is derived from.  But two
+    elements can denote the same media while disagreeing on that preference:
+    an exemplar carrying the ``example_media`` sentinel origin and a vote on
+    the same file inside a folder-imported dataset share only their content
+    hash.  Matching on the preferred key alone lets those two accumulate as a
+    duplicate pair (issue #3174).
+
+    This returns the union - the preferred key plus the ``("md5", ...)`` key
+    when the element has a hash - mirroring
+    :func:`~vtscore.state.media_lookup.resolve_media_ids`, which also matches
+    a label entry to media by origin **or** md5.  Elements with neither an
+    origin nor an md5 have no identity at all and yield an empty list.
+    """
+    keys: list[Any] = []
+    key = element_key(el)
+    if key is not None:
+        keys.append(key)
+    if el.md5:
+        md5_key = ("md5", el.md5)
+        if md5_key not in keys:
+            keys.append(md5_key)
+    return keys
+
+
 def media_element_key(media: dict[str, Any]) -> Any:
     """Return the element-identity key for a media dict (origin-keyed when possible).
 

--- a/vtscore/detectors/label_restoration.py
+++ b/vtscore/detectors/label_restoration.py
@@ -48,7 +48,7 @@ def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> in
             cids = md5_lookup.get(resolved_md5, [])
             if cids:
                 for cid in cids:
-                    apply_label(cid, elem.label, silent=True)
+                    apply_label(cid, elem.label, silent=True, region_box=elem.region_box)
                 restored += 1
             else:
                 _log.debug(
@@ -73,6 +73,11 @@ def restore_labels_from_detector(det_data: dict) -> int:
     trends and span/diversity coverage start fresh from the user's session
     votes.  The good/bad counts still reflect restored labels, so autopilot's
     initial Find Goods / Find Bads gates can skip ahead.
+
+    A Good element's ``region_box`` rides along into ``vote_region_boxes``.
+    Dropping it here used to erase the drawn region the moment the next vote
+    resynced the labelset back to disk - the restored vote was image-level, so
+    the element it re-emitted was too.
 
     Returns the number of labels successfully restored.
     """
@@ -106,7 +111,7 @@ def restore_labels_from_detector(det_data: dict) -> int:
         cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup, name_lookup)
         if cids:
             for cid in cids:
-                apply_label(cid, elem.label, silent=True)
+                apply_label(cid, elem.label, silent=True, region_box=elem.region_box)
             restored += 1
         else:
             unresolved.append(elem)

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -64,37 +64,76 @@ def _get_loaded_detector_state() -> tuple[dict[str, Any], Path, dict[str, Any], 
     return entry, path, data, det_ctx
 
 
+def active_dataset_lookups(medias: dict[str, Any] | dict) -> tuple[dict, dict, dict]:
+    """Return the ``(origin, md5, name)`` lookup triple for *medias*.
+
+    Thin wrapper over :func:`~vtscore.state.media_lookup.build_media_lookup`
+    kept here so the two labelset writers that need it (the post-vote sync and
+    the explicit save) build it the same way, from the same validated snapshot
+    they compose the labels from.
+    """
+    from vtscore.state import build_media_lookup
+
+    return build_media_lookup(medias)
+
+
+def _owned_by_active_dataset(el, lookups: tuple[dict, dict, dict]) -> bool:
+    """Whether *el* denotes a media that is present in the active dataset.
+
+    Uses the *same* resolution
+    (:func:`~vtscore.state.media_lookup.resolve_media_ids`) that
+    :func:`~vtscore.detectors.label_restoration.restore_labels_from_detector`
+    uses to turn labelset elements back into votes.  That symmetry is the
+    whole point: any element that becomes a vote on load is an element the
+    vote-derived labelset will re-emit, so keeping the original alongside it
+    stores the same media twice (issue #3174).
+    """
+    from vtscore.state import resolve_media_ids
+
+    origin_lookup, md5_lookup, name_lookup = lookups
+    return bool(resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup))
+
+
 def _merge_labelsets_across_datasets(
     existing_ls: LabelSet,
     current_ls: LabelSet,
-    current_dataset_keys: set,
+    lookups: tuple[dict, dict, dict],
 ) -> LabelSet:
     """Merge a fresh per-dataset labelset into a cross-dataset existing one.
 
-    Existing entries owned by the active dataset (key in ``current_dataset_keys``)
-    are dropped - they get replaced by ``current_ls``. Other entries are kept
-    verbatim. Duplicate keys across the resulting list are collapsed
-    (first occurrence wins).
+    Existing entries that resolve to a media in the active dataset are dropped
+    - they get replaced by ``current_ls``, which is the authoritative record of
+    what the user has voted there.  Entries that resolve to nothing were
+    accumulated under other datasets and are kept verbatim.  Duplicate
+    identities across the resulting list are collapsed (first occurrence wins),
+    so a labelset that already carried duplicates heals on the next write.
+
+    *lookups* is the ``(origin, md5, name)`` triple from
+    :func:`active_dataset_lookups`, built from the same medias snapshot
+    *current_ls* was composed from.
     """
-    from vtscore.datasets.labelset import element_key
+    from vtscore.datasets.labelset import element_identity_keys
 
     new_elements = []
     seen_keys: set = set()
+
+    def _take(el) -> bool:
+        """Record *el*'s identities, returning False if one was already seen."""
+        keys = element_identity_keys(el)
+        if any(k in seen_keys for k in keys):
+            return False
+        seen_keys.update(keys)
+        return True
+
     for el in existing_ls.elements:
-        key = element_key(el)
-        if key in current_dataset_keys:
+        if _owned_by_active_dataset(el, lookups):
             continue
-        if key is not None:
-            if key in seen_keys:
-                continue
-            seen_keys.add(key)
+        if not _take(el):
+            continue
         new_elements.append(el)
     for el in current_ls.elements:
-        key = element_key(el)
-        if key is not None:
-            if key in seen_keys:
-                continue
-            seen_keys.add(key)
+        if not _take(el):
+            continue
         new_elements.append(el)
     return LabelSet(new_elements)
 
@@ -141,7 +180,6 @@ def _sync_labels_to_loaded_detector_locked() -> None:
         return
     entry, path, data, det_ctx = state
 
-    from vtscore.datasets.labelset import media_element_key
     from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.registry import update_detector
     from vtscore.detectors.store import _write_detector
@@ -165,18 +203,12 @@ def _sync_labels_to_loaded_detector_locked() -> None:
     )
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
 
-    # Origin keys for *every* media in the active dataset (voted or not).
-    # Existing labelset entries that match one of these keys are considered
+    # Lookup tables over *every* media in the active dataset (voted or not).
+    # Existing labelset entries that resolve against them are considered
     # "owned" by the active dataset and will be reconciled against the
-    # current votes; entries that don't match are cross-dataset entries
-    # and are preserved verbatim.
-    current_dataset_keys = set()
-    for media in snap.values():
-        key = media_element_key(media)
-        if key is not None:
-            current_dataset_keys.add(key)
-
-    merged = _merge_labelsets_across_datasets(existing_ls, current_ls, current_dataset_keys)
+    # current votes; entries that resolve to nothing are cross-dataset
+    # entries and are preserved verbatim.
+    merged = _merge_labelsets_across_datasets(existing_ls, current_ls, active_dataset_lookups(snap))
     data["labelset"] = merged.to_dict()
     _write_detector(path, data)
 

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -64,55 +64,40 @@ def _get_loaded_detector_state() -> tuple[dict[str, Any], Path, dict[str, Any], 
     return entry, path, data, det_ctx
 
 
-def active_dataset_lookups(medias: dict[str, Any] | dict) -> tuple[dict, dict, dict]:
-    """Return the ``(origin, md5, name)`` lookup triple for *medias*.
-
-    Thin wrapper over :func:`~vtscore.state.media_lookup.build_media_lookup`
-    kept here so the two labelset writers that need it (the post-vote sync and
-    the explicit save) build it the same way, from the same validated snapshot
-    they compose the labels from.
-    """
-    from vtscore.state import build_media_lookup
-
-    return build_media_lookup(medias)
-
-
-def _owned_by_active_dataset(el, lookups: tuple[dict, dict, dict]) -> bool:
-    """Whether *el* denotes a media that is present in the active dataset.
-
-    Uses the *same* resolution
-    (:func:`~vtscore.state.media_lookup.resolve_media_ids`) that
-    :func:`~vtscore.detectors.label_restoration.restore_labels_from_detector`
-    uses to turn labelset elements back into votes.  That symmetry is the
-    whole point: any element that becomes a vote on load is an element the
-    vote-derived labelset will re-emit, so keeping the original alongside it
-    stores the same media twice (issue #3174).
-    """
-    from vtscore.state import resolve_media_ids
-
-    origin_lookup, md5_lookup, name_lookup = lookups
-    return bool(resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup))
-
-
 def _merge_labelsets_across_datasets(
     existing_ls: LabelSet,
     current_ls: LabelSet,
-    lookups: tuple[dict, dict, dict],
+    current_dataset_medias: dict[int, dict[str, Any]],
 ) -> LabelSet:
     """Merge a fresh per-dataset labelset into a cross-dataset existing one.
 
-    Existing entries that resolve to a media in the active dataset are dropped
-    - they get replaced by ``current_ls``, which is the authoritative record of
-    what the user has voted there.  Entries that resolve to nothing were
-    accumulated under other datasets and are kept verbatim.  Duplicate
-    identities across the resulting list are collapsed (first occurrence wins),
-    so a labelset that already carried duplicates heals on the next write.
+    Existing entries that resolve to a media in *current_dataset_medias* are
+    dropped - they get replaced by ``current_ls``, which is the authoritative
+    record of what the user has voted there.  Entries that resolve to nothing
+    were accumulated under other datasets and are kept verbatim.
 
-    *lookups* is the ``(origin, md5, name)`` triple from
-    :func:`active_dataset_lookups`, built from the same medias snapshot
-    *current_ls* was composed from.
+    Ownership is decided by the *same* resolution
+    (:func:`~vtscore.state.media_lookup.resolve_media_ids`, origin **or** md5)
+    that :func:`~vtscore.detectors.label_restoration.restore_labels_from_detector`
+    uses to turn labelset elements back into votes.  That symmetry is the whole
+    point: an element that becomes a vote on load is an element ``current_ls``
+    re-emits, so keeping the original beside it stores the same media twice.
+    Comparing :func:`~vtscore.datasets.labelset.element_key` instead - which
+    prefers origin and so misses an entry that shares only a content hash - is
+    what made a 300-image pass report ``num_training: 356`` (issue #3174).
+
+    Duplicate identities across the resulting list are collapsed (first
+    occurrence wins), so a labelset that already carried duplicates heals on
+    the next write.
+
+    *current_dataset_medias* must be the same medias snapshot *current_ls* was
+    composed from, so the two halves of the merge can't straddle a concurrent
+    dataset switch.
     """
     from vtscore.datasets.labelset import element_identity_keys
+    from vtscore.state import build_media_lookup, resolve_media_ids
+
+    origin_lookup, md5_lookup, name_lookup = build_media_lookup(current_dataset_medias)
 
     new_elements = []
     seen_keys: set = set()
@@ -126,7 +111,7 @@ def _merge_labelsets_across_datasets(
         return True
 
     for el in existing_ls.elements:
-        if _owned_by_active_dataset(el, lookups):
+        if resolve_media_ids(el.to_dict(), origin_lookup, md5_lookup, name_lookup):
             continue
         if not _take(el):
             continue
@@ -203,12 +188,10 @@ def _sync_labels_to_loaded_detector_locked() -> None:
     )
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
 
-    # Lookup tables over *every* media in the active dataset (voted or not).
-    # Existing labelset entries that resolve against them are considered
-    # "owned" by the active dataset and will be reconciled against the
-    # current votes; entries that resolve to nothing are cross-dataset
-    # entries and are preserved verbatim.
-    merged = _merge_labelsets_across_datasets(existing_ls, current_ls, active_dataset_lookups(snap))
+    # Existing labelset entries that resolve into the active dataset are
+    # "owned" by it and get reconciled against the current votes; entries that
+    # resolve to nothing are cross-dataset and are preserved verbatim.
+    merged = _merge_labelsets_across_datasets(existing_ls, current_ls, snap)
     data["labelset"] = merged.to_dict()
     _write_detector(path, data)
 

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -134,11 +134,7 @@ def save_detector_labels(name: str):
     from vtscore.datasets.labelset import LabelSet
     from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
-    from vtscore.detectors.label_sync import (
-        _label_sync_write_lock,
-        _merge_labelsets_across_datasets,
-        active_dataset_lookups,
-    )
+    from vtscore.detectors.label_sync import _label_sync_write_lock, _merge_labelsets_across_datasets
 
     # The read→compose→write below races the loaded-detector label sync (and
     # the other detector-JSON writers), so it runs under the same lock.
@@ -164,15 +160,12 @@ def save_detector_labels(name: str):
             vote_region_boxes=snap.vote_region_boxes,
         )
 
-        # Lookup tables over *every* media in the active dataset (voted or not).
-        # Existing labelset entries that resolve against them are "owned" by
-        # the active dataset and get reconciled against the current votes;
-        # entries that resolve to nothing were accumulated under other datasets
-        # and are preserved verbatim by the merge.
+        # Existing labelset entries that resolve into the active dataset are
+        # "owned" by it and get reconciled against the current votes; entries
+        # that resolve to nothing were accumulated under other datasets and are
+        # preserved verbatim by the merge.
         existing_ls = LabelSet.from_dict(data.get("labelset") or {})
-        labelset = _merge_labelsets_across_datasets(
-            existing_ls, current_ls, active_dataset_lookups(medias_snap)
-        )
+        labelset = _merge_labelsets_across_datasets(existing_ls, current_ls, medias_snap)
         data["labelset"] = labelset.to_dict()
 
         # Capture the active dataset's clipper into the detector's input_spec

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -131,10 +131,14 @@ def save_detector_labels(name: str):
     active-dataset keys and thus leave the persisted labelset untouched, but
     the ``@require_*_header`` decorators reject it up front regardless.
     """
-    from vtscore.datasets.labelset import LabelSet, media_element_key
+    from vtscore.datasets.labelset import LabelSet
     from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
-    from vtscore.detectors.label_sync import _label_sync_write_lock, _merge_labelsets_across_datasets
+    from vtscore.detectors.label_sync import (
+        _label_sync_write_lock,
+        _merge_labelsets_across_datasets,
+        active_dataset_lookups,
+    )
 
     # The read→compose→write below races the loaded-detector label sync (and
     # the other detector-JSON writers), so it runs under the same lock.
@@ -160,18 +164,15 @@ def save_detector_labels(name: str):
             vote_region_boxes=snap.vote_region_boxes,
         )
 
-        # Origin keys for *every* media in the active dataset (voted or not).
-        # Existing labelset entries matching one of these keys are "owned" by
+        # Lookup tables over *every* media in the active dataset (voted or not).
+        # Existing labelset entries that resolve against them are "owned" by
         # the active dataset and get reconciled against the current votes;
-        # entries that don't match were accumulated under other datasets and
-        # are preserved verbatim by the merge.
+        # entries that resolve to nothing were accumulated under other datasets
+        # and are preserved verbatim by the merge.
         existing_ls = LabelSet.from_dict(data.get("labelset") or {})
-        current_dataset_keys = set()
-        for media in medias_snap.values():
-            key = media_element_key(media)
-            if key is not None:
-                current_dataset_keys.add(key)
-        labelset = _merge_labelsets_across_datasets(existing_ls, current_ls, current_dataset_keys)
+        labelset = _merge_labelsets_across_datasets(
+            existing_ls, current_ls, active_dataset_lookups(medias_snap)
+        )
         data["labelset"] = labelset.to_dict()
 
         # Capture the active dataset's clipper into the detector's input_spec
@@ -217,20 +218,27 @@ def _merge_entries_into_labelset(existing_ls, label_entries: list[dict]) -> tupl
     """Merge imported label entries into ``existing_ls`` in place, deduping.
 
     Iterates ``label_entries``, skipping entries whose label isn't ``good`` or
-    ``bad`` and entries whose ``(md5, label)`` pair already exists in the
-    labelset.  Each accepted entry is appended to ``existing_ls.elements`` and
-    recorded so the caller can resolve/apply it later.
+    ``bad``.  An entry whose media is already in the labelset **replaces** that
+    element (last write wins) rather than being appended beside it, so one
+    media never holds two elements under one detector (issue #3174); a re-import
+    that merely restates the label it already carries is skipped instead.
 
-    Returns ``(applied, skipped, new_entries)`` matching the legacy counts and
-    list that the route built inline.
+    "Already in the labelset" is the union of the element's identities -
+    origin *and* md5, per
+    :func:`~vtscore.datasets.labelset.element_identity_keys` - so an entry
+    naming the same file by a different origin still collapses onto it.
+
+    Returns ``(applied, skipped, new_entries)``: ``new_entries`` are the raw
+    dicts the caller resolves and applies to the loaded detector's votes.
     """
-    from vtscore.datasets.labelset import LabeledElement
+    from vtscore.datasets.labelset import LabeledElement, element_identity_keys
 
-    # Build a set of existing (md5, label) pairs for dedup
-    existing_keys: set[tuple[str, str]] = set()
-    for el in existing_ls.elements:
-        if el.md5:
-            existing_keys.add((el.md5, el.label))
+    # Map every identity an existing element answers to onto its position, so
+    # an incoming entry that matches by *either* origin or md5 finds it.
+    index: dict[tuple, int] = {}
+    for pos, el in enumerate(existing_ls.elements):
+        for key in element_identity_keys(el):
+            index.setdefault(key, pos)
 
     applied = 0
     skipped = 0
@@ -240,15 +248,20 @@ def _merge_entries_into_labelset(existing_ls, label_entries: list[dict]) -> tupl
         if label not in ("good", "bad"):
             skipped += 1
             continue
-        md5 = entry.get("md5", "")
-        if md5 and (md5, label) in existing_keys:
-            skipped += 1
-            continue
         elem = LabeledElement.from_dict(entry)
-        existing_ls.elements.append(elem)
+        keys = element_identity_keys(elem)
+        pos = next((index[k] for k in keys if k in index), None)
+        if pos is not None:
+            if existing_ls.elements[pos].label == label:
+                skipped += 1
+                continue
+            existing_ls.elements[pos] = elem
+        else:
+            pos = len(existing_ls.elements)
+            existing_ls.elements.append(elem)
+        for key in keys:
+            index.setdefault(key, pos)
         new_entries.append(entry)
-        if md5:
-            existing_keys.add((md5, label))
         applied += 1
 
     return applied, skipped, new_entries

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -754,7 +754,7 @@ def find_corrections_to_detector():
     the Stats note can say so; the retrained detector takes effect the next time
     the dataset is scored.
     """
-    from vtscore.datasets.labelset import LabelSet, element_key
+    from vtscore.datasets.labelset import LabelSet, element_identity_keys
     from vtscore.detectors.dataset_sync import _detector_file_mtime, validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
     from vtscore.detectors.label_sync import _label_sync_write_lock
@@ -815,9 +815,17 @@ def find_corrections_to_detector():
 
         # Merge: a correction supersedes any prior entry for the same source media
         # (so a culled false-positive flips its old "good" entry to "bad").
-        corr_keys = {element_key(el) for el in corrections_ls.elements}
-        corr_keys.discard(None)
-        merged_elements = [el for el in existing_ls.elements if element_key(el) not in corr_keys]
+        # "Same source media" is the union of identities the element could carry
+        # - origin *and* md5 - because a prior entry may name the file by a
+        # different origin than the active dataset does (issue #3174); matching
+        # on the preferred key alone would leave the stale entry in place and
+        # store the media twice, with contradicting labels.
+        corr_keys: set = set()
+        for el in corrections_ls.elements:
+            corr_keys.update(element_identity_keys(el))
+        merged_elements = [
+            el for el in existing_ls.elements if not any(k in corr_keys for k in element_identity_keys(el))
+        ]
         merged_elements.extend(corrections_ls.elements)
         merged = LabelSet(merged_elements)
 


### PR DESCRIPTION
Closes #3174

## Root cause

The two halves of the labelset round-trip disagreed on what "the same media" means.

- **Reading** — `restore_labels_from_detector` turns a labelset element into a vote when `resolve_media_ids` matches it to a dataset item **by origin *or* by md5**.
- **Writing** — `_merge_labelsets_across_datasets` decided an existing entry was "owned by the active dataset" (and therefore superseded by the vote-derived labelset) by comparing `element_key`, which *prefers* origin and falls back to md5 only when there is no origin.

So any entry that matched a dataset media **only on its content hash** was restored as a vote, re-emitted by the sync as a fresh element carrying the dataset's origin, and kept beside its original. That covers an exemplar carrying the `example_media` sentinel origin, a label imported from a plain md5 list, and a label saved under another dataset's importer — all common ways one file ends up recorded under two provenances.

It matches the reported evidence exactly. The pair carries the same label (nothing contradicts, because the second entry is derived from the vote the first one restored), and in `labels-detail` the two rows are indistinguishable apart from the element id — because that view renders `md5` but not `origin`, and the id is derived from `origin`. Reproduced as a failing test before the fix:

```
LABEL: {'md5': '9c49…2208', 'label': 'bad', 'origin_name': 'elsewhere.wav'}
LABEL: {'md5': '9c49…2208', 'label': 'bad', 'origin': {'importer': 'test', 'params': {}},
        'origin_name': 'test_media_1.wav', 'filename': 'test_media_1.wav', 'category': 'test'}
```

The issue's unverified suspicion is confirmed: **duplicated entries are double-weighted at training time.** `build_xy_from_labelset` iterates `labelset.elements` and emits one bag per element keyed by `stable_element_id`, which differs between the pair, so both bags reach the trainer and the calibrator.

## Changes

- **`_merge_labelsets_across_datasets`** (used by the post-vote sync *and* `POST /api/detectors/<name>/labels`) now decides ownership with the same `resolve_media_ids` the restore path uses, and takes the medias snapshot directly instead of a pre-computed key set. It also collapses duplicate identities in its own output, so a labelset that already carries duplicates heals on the next write in the owning dataset — no migration needed.
- **`POST /api/find/corrections-to-detector`** keyed its supersede-set the same way, so a correction landed *beside* the media's stale entry rather than replacing it: one media, two entries, contradicting labels. It now matches on the union of an element's identities (`element_identity_keys`, new in `vtscore/datasets/labelset.py`).
- **`_merge_entries_into_labelset`** (import-labels-into-detector) deduped on `(md5, label)`, so importing a label that disagreed with one already held appended a contradicting pair. It now keys on the same identity union and **replaces** the existing element (last write wins); restating a label already held is still skipped.
- **`restore_labels_from_detector`** now carries `region_box` into `vote_region_boxes`. Dropping it erased a drawn Good region the moment the next vote resynced the labelset: the restored vote was image-level, so the element it re-emitted was too. This was latent before — the boxed element survived as the *duplicate* — and becomes visible once the duplicate is collapsed.

Cross-dataset preservation is unchanged: an entry that resolves to nothing in the active dataset is still kept verbatim, which the existing `test_save_labels_preserves_cross_dataset_entries` and `test_foreign_origin_label_survives_a_vote_against_a_local_dataset` continue to pin.

## Tests

New `tests/detectors/test_labelset_no_duplicates.py` plus one case in `tests/detectors/test_find_verification.py`, covering the vote-sync path, the explicit save, the corrections fold, the import merge, `num_training` counting distinct media, region-box survival, and self-healing of an already-duplicated labelset. All eight fail on `dev` and pass here.

Full `./run-tests.sh`: 8789 passed, 6 skipped, all gates green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrxwnRKPjpor7CHvK4rpBa)_