### PR TITLE
Make the cut decomposition telescope, and count the steps it drops

### DIFF
--- a/docs/experiments/gmm-cut/REMEASURE-2846.md
+++ b/docs/experiments/gmm-cut/REMEASURE-2846.md
@@ -220,6 +220,18 @@ Production arm, ramp 6–20, excess-cost units, against #2836's run:
 | finite-sim-set transfer | +0.0406 | +0.0407 |
 | total (`cross` → test oracle) | +0.0623 | +0.0623 |
 
+> **Both columns carry the same uncorrected-arithmetic defect** described in
+> [`REPORT.md`](REPORT.md): the terms sum to +0.0597 in this run and +0.0598 in
+> #2836's, against a stated +0.0623 for both. The analyzer averaged each term over whichever steps
+> had that link, and the oracle links go missing on steps where the oracle
+> variants emit no row, so the three oracle-dependent terms cover fewer steps
+> than `total`. Fixed in `analyze_cut.py`; corrected numbers need the analyzer
+> re-run over this run's cell CSVs. **The replication claim below is unaffected**
+> — it compares each term against its #2836 counterpart, and both runs were
+> aggregated the same way, so the agreement is between like and like. The +0.041
+> `transfer` finding is likewise unaffected in substance (65 % of the stated
+> total, 68 % of the summed terms).
+
 Four independent terms to within 0.0007 on a re-run whose trajectories differ
 (the production threshold changed, so the steps are not the same steps). This is
 the run's own evidence that the harness and the decomposition are sound, which is

--- a/docs/experiments/gmm-cut/REPORT.md
+++ b/docs/experiments/gmm-cut/REPORT.md
@@ -187,6 +187,20 @@ Decomposing today's gap on the production arm, in **excess-cost** units
 | **finite-sim-set transfer** | **+0.0406** | **65 %** |
 | total (`cross` → test oracle) | +0.0623 | |
 
+> **This table does not telescope, and the numbers above are the uncorrected
+> ones.** The four terms sum to +0.0598 against the stated +0.0623. The analyzer
+> averaged each column independently, so steps where an oracle variant emitted no
+> row (they do not fall back) were dropped from the three oracle-dependent terms
+> — identification, misspecification, transfer — while still counting toward
+> `total`. Those three are therefore means over a smaller, non-random subset of
+> steps than the total and the prior/loss term. The shares are computed against
+> the total, which is why they sum to 108 %. Fixed in `analyze_cut.py`, which now
+> aggregates over complete rows only and reports `n_incomplete` and a residual;
+> **corrected numbers need a re-run of the analyzer over this study's existing
+> cell CSVs** — a re-analysis, not a re-sweep. The headline is not at risk: the
+> transfer share is 65 % against the stated total and 68 % against the sum of the
+> terms.
+
 The prior term is real and worth fixing — that is the shipped change — but
 **about two thirds of the remaining gap is sim→test transfer, which no cut rule
 can address.** Cut-rule work has roughly 0.026 of headroom, not 0.062. That is

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -463,14 +463,61 @@ def oracle_distance(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
 # ------------------------------------------------------------------
 
 
+#: Every cut the chain differences, in order.  A row missing any one of these
+#: cannot contribute to *any* term without skewing the rest (see
+#: :func:`_complete_chain_rows`).
+DECOMPOSITION_CUTS: tuple[str, ...] = tuple(
+    dict.fromkeys([c for _n, a, b in DECOMPOSITION for c in (a, b)])
+)
+
+
+def _complete_chain_rows(frame: pd.DataFrame, chain: "list[str] | tuple[str, ...]") -> "pd.Series":
+    """Mask of rows where every link in ``chain`` is present.
+
+    The decomposition only telescopes when each term is averaged over the *same*
+    steps.  ``DataFrame.mean()`` skips NaN per column, so a row missing one link
+    silently shrinks that link's sample while leaving ``total`` at full size -
+    the terms then sum to something other than the total, by an amount nobody
+    can see.  Oracle variants are exactly the links that go missing: they do not
+    fall back, so a step where the oracle cut is not finite emits no row at all
+    (``vtscore.eval.voting_iterations._safe_gmm_variant_rows``).  Dropping those
+    rows wholesale is what keeps the arithmetic honest; the callers report how
+    many were dropped rather than swallowing it.
+    """
+    present = [c for c in chain if c in frame.columns]
+    if len(present) != len(chain):
+        return pd.Series(False, index=frame.index)
+    return frame[present].notna().all(axis=1)
+
+
+def _with_incomplete_count(agg: pd.DataFrame, rows: pd.DataFrame, keys: list[str]) -> pd.DataFrame:
+    """Attach ``n_incomplete`` (rows dropped for a missing chain link) to ``agg``.
+
+    Outer-merged, so a group whose rows were *all* incomplete still appears -
+    with empty terms and its true drop count - instead of vanishing from the
+    table as though it had never been measured.
+    """
+    dropped = rows[~rows["_complete"]].groupby(keys).size().rename("n_incomplete").reset_index()
+    out = agg.merge(dropped, on=keys, how="outer")
+    for col in ("n", "n_incomplete"):
+        if col in out.columns:
+            out[col] = out[col].fillna(0).astype(int)
+    return out
+
+
 def decomposition_table(diag: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
     """The four-term chain in threshold units, per (arm, geometry, window).
 
-    ``residual`` is the telescoping check: the four terms must sum to
-    ``tau_cross - tau_test_oracle`` exactly, so a non-zero residual means a NaN
-    dropped a link rather than a real disagreement.
+    Aggregated over **complete** rows only - those carrying every cut in the
+    chain - so that all four terms and ``total`` average the same steps and the
+    sum telescopes exactly.  ``n`` counts the rows that made it; ``n_incomplete``
+    counts the rows dropped for a missing link, which is the number that used to
+    disappear silently.  ``residual`` is then the arithmetic check it was always
+    described as: it must be 0, and a non-zero value means the terms genuinely
+    disagree rather than that a NaN ate a link.
     """
     d = diag.copy()
+    d["_complete"] = _complete_chain_rows(d, DECOMPOSITION_CUTS)
     for name, a, b in DECOMPOSITION:
         d[f"term_{name}"] = d[a] - d[b]
     d["total"] = d["tau_cross"] - d["tau_test_oracle"]
@@ -486,7 +533,8 @@ def decomposition_table(diag: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
             "residual": ("residual", "mean"),
             "n": ("total", "size"),
         }
-        g = w.groupby(["arm", "geometry"]).agg(**agg).reset_index()
+        g = w[w["_complete"]].groupby(["arm", "geometry"]).agg(**agg).reset_index()
+        g = _with_incomplete_count(g, w, ["arm", "geometry"])
         g.insert(0, "window", wname)
         out.append(g)
     tbl = pd.concat(out, ignore_index=True) if out else pd.DataFrame()
@@ -502,6 +550,13 @@ def cost_decomposition(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
     moves it a little across the elbow is not.  Each link is the difference of
     ``raw_cut_cost`` between consecutive rules on the same step, with the last
     link measured against the test-set oracle cost.
+
+    Like :func:`decomposition_table`, aggregated over complete rows only, with
+    ``n_incomplete`` counting the dropped ones and ``cost_residual`` pinning the
+    telescoping.  The oracle links are the ones that go missing here - a step
+    where ``pooled_supervised`` or ``pooled_sim_oracle`` emitted no row pivots to
+    NaN - and they feed three of the four terms, so averaging around them shrank
+    exactly the terms this study reads.
     """
     v = df[df["gmm_variant"].isin(COST_CHAIN)]
     keys = ["arm", "category", "seed", "t", "n_votes"]
@@ -520,19 +575,24 @@ def cost_decomposition(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
         common.log(f"cost decomposition skipped - no rows for {missing}")
         return pd.DataFrame()
     wide = wide.join(oracle.to_frame("oracle_cost"), how="inner").reset_index()
+    wide["_complete"] = _complete_chain_rows(wide, [*COST_CHAIN, "oracle_cost"])
 
     wide["cost_prior_loss"] = wide["pooled_cross"] - wide["pooled_priorfree"]
     wide["cost_identification"] = wide["pooled_priorfree"] - wide["pooled_supervised"]
     wide["cost_misspecification"] = wide["pooled_supervised"] - wide["pooled_sim_oracle"]
     wide["cost_transfer"] = wide["pooled_sim_oracle"] - wide["oracle_cost"]
     wide["cost_total"] = wide["pooled_cross"] - wide["oracle_cost"]
+    terms = ["cost_prior_loss", "cost_identification", "cost_misspecification", "cost_transfer"]
+    wide["cost_residual"] = wide["cost_total"] - sum(wide[c] for c in terms)
 
-    cols = ["cost_prior_loss", "cost_identification", "cost_misspecification", "cost_transfer", "cost_total"]
+    cols = [*terms, "cost_total", "cost_residual"]
     out = []
     for wname, (lo, hi) in WINDOWS.items():
         w = wide[(wide["n_votes"] >= lo) & (wide["n_votes"] <= hi)]
-        g = w.groupby("arm")[cols].mean().reset_index()
-        g["n"] = w.groupby("arm")[cols[0]].size().to_numpy()
+        complete = w[w["_complete"]]
+        g = complete.groupby("arm")[cols].mean().reset_index()
+        g["n"] = complete.groupby("arm")[cols[0]].size().to_numpy()
+        g = _with_incomplete_count(g, w, ["arm"])
         g.insert(0, "window", wname)
         out.append(g)
     tbl = pd.concat(out, ignore_index=True) if out else pd.DataFrame()
@@ -999,6 +1059,12 @@ def decisions(
             if terms:
                 out["dominant_error_term"] = max(terms, key=lambda k: terms[k])
                 out["error_terms_cost"] = terms
+                # The terms are only comparable to each other, and to `total`, if
+                # every one of them averaged the same steps.  Both numbers say so
+                # explicitly rather than leaving a reader to re-add the column.
+                row = c.iloc[0]
+                out["error_terms_residual"] = float(row.get("cost_residual", float("nan")))
+                out["error_terms_n_incomplete"] = int(row.get("n_incomplete", 0))
     # The leading hypothesis is confirmed only if the prior/loss term dominates.
     out["leading_hypothesis_confirmed"] = out["dominant_error_term"] == "prior_loss"
     # One key per tail model, named after it.  The old single `tail_alpha_stable`

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -466,9 +466,7 @@ def oracle_distance(df: pd.DataFrame, agg_dir: Path) -> pd.DataFrame:
 #: Every cut the chain differences, in order.  A row missing any one of these
 #: cannot contribute to *any* term without skewing the rest (see
 #: :func:`_complete_chain_rows`).
-DECOMPOSITION_CUTS: tuple[str, ...] = tuple(
-    dict.fromkeys([c for _n, a, b in DECOMPOSITION for c in (a, b)])
-)
+DECOMPOSITION_CUTS: tuple[str, ...] = tuple(dict.fromkeys([c for _n, a, b in DECOMPOSITION for c in (a, b)]))
 
 
 def _complete_chain_rows(frame: pd.DataFrame, chain: "list[str] | tuple[str, ...]") -> "pd.Series":

--- a/scripts/experiments/calibration/selftest_analyze_cut.py
+++ b/scripts/experiments/calibration/selftest_analyze_cut.py
@@ -549,7 +549,8 @@ def main() -> int:
             ok &= _check(f"cost term {term}", abs(got - planted_cost) < 1e-9, f"{got:.5f} vs {planted_cost}")
         ok &= _check(
             "summary reports the decomposition's own integrity",
-            abs(float(dec["error_terms_residual"])) < 1e-9 and int(dec["error_terms_n_incomplete"]) == n_incomplete_expected,
+            abs(float(dec["error_terms_residual"])) < 1e-9
+            and int(dec["error_terms_n_incomplete"]) == n_incomplete_expected,
             f"residual={dec.get('error_terms_residual')} n_incomplete={dec.get('error_terms_n_incomplete')}",
         )
         for term, planted in PLANTED_TERMS.items():

--- a/scripts/experiments/calibration/selftest_analyze_cut.py
+++ b/scripts/experiments/calibration/selftest_analyze_cut.py
@@ -12,6 +12,9 @@ they come back out:
   steps per cell would inflate every p-value's confidence);
 * the decomposition telescopes and names the term that was actually planted as
   dominant;
+* a step whose oracle links are missing is **dropped from every term**, not
+  averaged around: the terms and ``total`` must cover the same steps or the chain
+  stops summing to the total, silently, in exactly the terms this study reads;
 * a rule whose *blended* cost wins while its *raw cut* does not is reported as
   such, since that is the trap the plan pre-registers;
 * the ship test is decided against the run's **own base row**, not against the
@@ -74,6 +77,20 @@ PROD_EDGE = -0.10
 FALLBACK_VARIANT = "pooled_gumbel_priorfree"
 FALLBACK_REASON = "modes_swapped"
 FALLBACK_STEPS = [t for t in range(2, 31) if t >= 21]
+#: Steps where the oracle links are **missing**, planted inside the ramp window.
+#: The field condition: oracle variants do not fall back, so a step whose oracle
+#: cut is not finite emits no row at all and the analyzer's pivot fills NaN.
+INCOMPLETE_STEPS = {8, 9}
+#: The links that go absent on those steps - both oracle variants, which between
+#: them feed three of the four terms.
+INCOMPLETE_LINKS = ("pooled_supervised", "pooled_sim_oracle")
+#: How far the *surviving* links are displaced on those steps.  Applied to both
+#: ends of the ``prior_loss`` link so that term is unchanged and only ``total``
+#: moves - which is exactly the imbalance a per-column ``mean()`` cannot see, and
+#: what makes averaging around the hole (rather than dropping the step) show up
+#: as a decomposition that no longer telescopes.
+INCOMPLETE_DISPLACEMENT = 0.05
+
 #: A rule present in the cells that the analyzer's ``SHIPPABLE`` allowlist does
 #: not know about.  Planted deliberately: the allowlist gates the ship decision,
 #: so an unlisted rule is omitted from the verdict while still showing up in the
@@ -160,7 +177,10 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
                     # it - which on the anchored cells it no longer does.
                     anchored = seed in ANCHORED_SEEDS
                     threshold = 0.55
+                    incomplete = t in INCOMPLETE_STEPS
                     for variant in ["", *variants]:
+                        if incomplete and variant in INCOMPLETE_LINKS:
+                            continue
                         is_base = variant == ""
                         effect = RAMP_EFFECT if (variant == WINNER and in_ramp) else 0.0
                         if in_ramp and variant in _TAIL_EFFECT_BY_VARIANT:
@@ -171,6 +191,8 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
                         # for the decoy, which wins only after blending.
                         decoy = variant == "pooled_gumbel_cross" and in_ramp
                         raw_cost = _CHAIN_RAW_COST.get(variant, base_cost) + (0.02 if decoy else 0.0)
+                        if incomplete and variant in ("pooled_cross", "pooled_priorfree"):
+                            raw_cost += INCOMPLETE_DISPLACEMENT
                         fell = variant == FALLBACK_VARIANT and t in FALLBACK_STEPS
                         row = dict(ident)
                         row.update(
@@ -268,9 +290,9 @@ def _fabricate(root: Path, rng: np.random.Generator) -> None:
                             tau_gumbel_any_cross=tau_cross,
                             tau_gumbel_any_priorfree=tau_priorfree,
                             tau_gumbel_any_rate=tau_priorfree,
-                            tau_supervised=tau_supervised,
-                            tau_sim_oracle=tau_sim_oracle,
-                            tau_test_oracle=tau_test_oracle,
+                            tau_supervised=np.nan if incomplete else tau_supervised,
+                            tau_sim_oracle=np.nan if incomplete else tau_sim_oracle,
+                            tau_test_oracle=tau_test_oracle - (INCOMPLETE_DISPLACEMENT if incomplete else 0.0),
                             oracle_lo_sf_gauss=0.02,
                             oracle_lo_sf_evt=0.02,
                         )
@@ -490,8 +512,46 @@ def main() -> int:
             len(decoy) == 1 and decoy.iloc[0]["mean_d_raw_cut_cost"] > 0 > decoy.iloc[0]["mean_d_cost"],
         )
 
+        # Steps with a missing chain link must be dropped whole, from the terms
+        # *and* from `total`.  Averaging around them leaves every term looking
+        # sane on its own while the chain no longer sums to the total - which is
+        # unfindable from the table unless the residual and the drop count are
+        # both reported.  `INCOMPLETE_DISPLACEMENT` is planted so that a
+        # per-column mean would miss the total by a visible amount.
+        n_incomplete_expected = len(CATEGORIES) * len(SEEDS) * len(INCOMPLETE_STEPS)
+        n_ramp_steps = len([t for t in range(2, 31) if 6 <= t <= 20])
+        n_complete_expected = len(CATEGORIES) * len(SEEDS) * (n_ramp_steps - len(INCOMPLETE_STEPS))
+
         pooled = decomp[(decomp["window"] == "ramp_6_20") & (decomp["geometry"] == "pooled")]
         ok &= _check("decomposition telescopes", bool((pooled["residual"].abs() < 1e-9).all()))
+        ok &= _check(
+            "incomplete steps dropped from the threshold-unit chain",
+            bool((pooled["n"] == n_complete_expected).all())
+            and bool((pooled["n_incomplete"] == n_incomplete_expected).all()),
+            f"n={list(pooled['n'])} n_incomplete={list(pooled['n_incomplete'])}",
+        )
+
+        costs = pd.read_csv(root / "agg" / "cut_cost_decomposition.csv")
+        cost_ramp = costs[costs["window"] == "ramp_6_20"]
+        ok &= _check(
+            "cost decomposition telescopes",
+            bool((cost_ramp["cost_residual"].abs() < 1e-9).all()),
+            f"max |residual| = {cost_ramp['cost_residual'].abs().max():.6f}",
+        )
+        ok &= _check(
+            "incomplete steps dropped from the cost chain",
+            bool((cost_ramp["n"] == n_complete_expected).all())
+            and bool((cost_ramp["n_incomplete"] == n_incomplete_expected).all()),
+            f"n={list(cost_ramp['n'])} n_incomplete={list(cost_ramp['n_incomplete'])}",
+        )
+        for term, planted_cost in PLANTED_COST_TERMS.items():
+            got = float(cost_ramp[f"cost_{term}"].iloc[0])
+            ok &= _check(f"cost term {term}", abs(got - planted_cost) < 1e-9, f"{got:.5f} vs {planted_cost}")
+        ok &= _check(
+            "summary reports the decomposition's own integrity",
+            abs(float(dec["error_terms_residual"])) < 1e-9 and int(dec["error_terms_n_incomplete"]) == n_incomplete_expected,
+            f"residual={dec.get('error_terms_residual')} n_incomplete={dec.get('error_terms_n_incomplete')}",
+        )
         for term, planted in PLANTED_TERMS.items():
             got = float(pooled[f"term_{term}"].iloc[0])
             # prior_loss carries the shared jitter, which averages out over cells.


### PR DESCRIPTION
The four-term decomposition tables in `docs/experiments/gmm-cut/` don't add up: the terms sum to **+0.0598** (#2836) and **+0.0597** (#2879's re-measure) against a stated total of **+0.0623** in both. Same ~0.0025 gap in two independent runs, so not a transcription slip.

## Cause

`analyze_cut.py` averaged each term with a per-column `mean()`, which skips NaN independently per column. The oracle variants (`pooled_supervised`, `pooled_sim_oracle`) don't fall back — a step whose oracle cut isn't finite emits no row at all (`vtscore/eval/voting_iterations.py`) — so those steps pivot to NaN and were dropped from the three oracle-dependent terms while still counting toward `total`. Those three terms are means over a smaller, non-random subset of steps than the total and the prior/loss term.

The `residual` column existed to catch exactly this and structurally could not: a NaN link makes the row's residual NaN too, so `.mean()` skipped it and the guard read `0.0` while rows were vanishing. Its docstring claimed "a non-zero residual means a NaN dropped a link" — the one thing it could never report.

## Changes

- Both tables aggregate over complete rows only, so every term and `total` cover the same steps and the chain telescopes exactly.
- `n_incomplete` counts what was dropped, outer-merged so a fully-incomplete group still appears with its true count instead of vanishing.
- `cost_residual` pins the cost-unit chain the way `residual` pins the threshold-unit one.
- `summary_cut.json` carries both next to `dominant_error_term` — the verdict they qualify.
- The two report tables are annotated with the defect, its direction, and that corrected numbers need the analyzer re-run over the existing cell CSVs.

## Verification

The selftest plants the field condition: two ramp steps with both oracle links absent and the surviving links displaced, so averaging around the hole misses the total by a fixed, visible amount rather than failing loudly.

Checked against the **old** analyzer on the same fixture, which reports the pathology exactly:

```
OLD: sum(terms)=0.13500  total=0.14167  GAP=+0.00667  n=180  n_incomplete=<absent>
NEW: sum(terms)=0.13500  total=0.13500  GAP=+0.00000  n=156  n_incomplete=24
```

`0.05 × 24/180 = 0.00667` — the displacement times the dropped fraction. All 36 selftest checks pass; full `./run-tests.sh` green (8854 passed, pyright / pip-audit / npm audit / Vitest all OK).

## What this does not do

Recompute the published numbers — the run data lives on the cluster and isn't reachable from this session. Tracked in **#3187** (a re-analysis of existing cells, not a re-sweep).

Neither headline moves: `transfer` is 65% of the stated total and 68% of the summed terms, and the re-measure's replication claim compares each term against its #2836 counterpart with both runs aggregated identically.

Refs #2883, refs #2836, refs #2879, refs #3187.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J7bQ2r23vNQmN2kJeiyme5)_