### PR TITLE
Mirror the example stack inside seed-importer tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,16 @@ not list every commit. Use `git log` for the full history.
 
 ### Changed
 
+- **A seed importer's results now appear on its own tab.** Running a seed
+  importer in the New Detector modal used to switch the user to the media
+  tab, where the batch had been appended — an odd jump mid-import, and one
+  that hid the form they were still working in. The example stack is now
+  mirrored under each seed importer's form, so seeds land in view where they
+  were added. It stays one list: the mirrored rows carry the same Seed badges
+  and Remove buttons, and edits from either tab hit the same stack. Picking an
+  exemplar by hand still lands on the media tab, which is where the picker
+  lives. (#3192)
+
 - **Image preprocessing now names its backend instead of inheriting one.**
   Every image embedder builds its processor by asking `transformers` for the
   `torchvision` backend outright (`VTSEARCH_IMAGE_PROCESSOR_BACKEND`, new

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -1174,6 +1174,13 @@ declared fields rendered as a dynamic form. Nothing ships in-tree, so a
 vanilla install shows no extra tabs; the family exists for third-party
 packages.
 
+A run's results appear **on the importer's own tab**, under its form: the
+media tab's example stack is mirrored there, so a batch lands in view where
+the user asked for it rather than switching them to the media tab
+(issue #3192). It is one list, not a copy — the seed tab's Remove buttons
+edit the same stack the media tab shows, and only the media tab carries the
+"+ Add" browse affordance, since a seed tab adds through its own form.
+
 ### Seeds are queries, not labels
 
 Every item a seed importer returns is stored on the detector as

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.html
@@ -106,6 +106,12 @@
                 errorFallback="Failed to fetch seeds"
                 (imported)="onSeedsImported($any($event))"
               ></vt-plugin-import-form>
+              @if (seedNotice()) {
+                <p class="info-text">{{ seedNotice() }}</p>
+              }
+              @if (hasMediaExample) {
+                <ng-container [ngTemplateOutlet]="exampleStack" [ngTemplateOutletContext]="{ showAdd: false }"></ng-container>
+              }
             </div>
           } @else if (exampleTab() === 'text') {
             <div class="example-panel">
@@ -131,36 +137,7 @@
           } @else {
             <div class="example-panel">
               @if (hasMediaExample) {
-                <div class="example-stack">
-                  @for (example of mediaExamples(); track example.value; let i = $index) {
-                    <div class="example-row">
-                      @if (exampleThumbnailUrl(example); as thumbUrl) {
-                        @if (example.mediaType === 'audio') {
-                          <!-- Audio waveform alpha mask (issue #2369): surface box
-                               with the wave masked in the accent so it recolours
-                               with the theme. -->
-                          <span class="example-thumbnail" role="img" [attr.aria-label]="example.display">
-                            <span
-                              class="example-thumbnail-wave waveform-mask"
-                              [style.-webkit-mask-image]="'url(' + thumbUrl + ')'"
-                              [style.mask-image]="'url(' + thumbUrl + ')'"></span>
-                          </span>
-                        } @else {
-                          <img class="example-thumbnail" [src]="thumbUrl" [alt]="example.display" (error)="onExampleThumbError(i)" />
-                        }
-                      } @else {
-                        <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
-                      }
-                      <span class="example-label" [title]="example.display">{{ example.display }}</span>
-                      @if (example.seed) {
-                        <span class="example-seed-badge"
-                          title="An unlabeled seed: it steers the first sort but is not counted as a Good vote.">Seed</span>
-                      }
-                      <button type="button" class="btn btn--secondary btn--sm" (click)="removeMediaExample(i)" title="Remove this example">Remove</button>
-                    </div>
-                  }
-                  <button type="button" class="btn btn--secondary btn--sm add-example-btn" (click)="openMediaPicker()" title="Add another example. The detector starts from what the examples have in common.">+ Add</button>
-                </div>
+                <ng-container [ngTemplateOutlet]="exampleStack" [ngTemplateOutletContext]="{ showAdd: true }"></ng-container>
               } @else {
                 <button type="button" class="btn btn--secondary btn--sm media-btn" (click)="openMediaPicker()" title="Browse demos, server folders, or upload a file to pick an example">{{ browseMediaLabel }}</button>
                 <vt-drop-zone
@@ -168,9 +145,6 @@
                   sublabel="or click to upload from this computer"
                   (filesSelected)="onLocalFileDropped($event)"
                 ></vt-drop-zone>
-              }
-              @if (seedNotice()) {
-                <p class="info-text">{{ seedNotice() }}</p>
               }
             </div>
           }
@@ -548,3 +522,42 @@
     (cancelled)="onCropCancelled()">
   </vt-media-crop-modal>
 }
+
+<!-- The picked-example stack, shared by the media tab and every seed-importer
+     tab (issue #3192): one list, rendered wherever the user is adding to it, so
+     an import lands in view instead of throwing the user onto another tab.
+     ``showAdd`` gates the browse button — a seed tab adds through its own form. -->
+<ng-template #exampleStack let-showAdd="showAdd">
+  <div class="example-stack">
+    @for (example of mediaExamples(); track example.value; let i = $index) {
+      <div class="example-row">
+        @if (exampleThumbnailUrl(example); as thumbUrl) {
+          @if (example.mediaType === 'audio') {
+            <!-- Audio waveform alpha mask (issue #2369): surface box
+                 with the wave masked in the accent so it recolours
+                 with the theme. -->
+            <span class="example-thumbnail" role="img" [attr.aria-label]="example.display">
+              <span
+                class="example-thumbnail-wave waveform-mask"
+                [style.-webkit-mask-image]="'url(' + thumbUrl + ')'"
+                [style.mask-image]="'url(' + thumbUrl + ')'"></span>
+            </span>
+          } @else {
+            <img class="example-thumbnail" [src]="thumbUrl" [alt]="example.display" (error)="onExampleThumbError(i)" />
+          }
+        } @else {
+          <svg class="example-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3zm2 7.5 2.5-3 1.75 2L10.5 6.5 13 11H4v-.5zM5.5 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/></svg>
+        }
+        <span class="example-label" [title]="example.display">{{ example.display }}</span>
+        @if (example.seed) {
+          <span class="example-seed-badge"
+            title="An unlabeled seed: it steers the first sort but is not counted as a Good vote.">Seed</span>
+        }
+        <button type="button" class="btn btn--secondary btn--sm" (click)="removeMediaExample(i)" title="Remove this example">Remove</button>
+      </div>
+    }
+    @if (showAdd) {
+      <button type="button" class="btn btn--secondary btn--sm add-example-btn" (click)="openMediaPicker()" title="Add another example. The detector starts from what the examples have in common.">+ Add</button>
+    }
+  </div>
+</ng-template>

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -430,6 +430,10 @@ describe('NewDetectorModalComponent', () => {
   });
 
   it('appends an imported batch to the stack as unlabeled seeds', () => {
+    component.seedImporters.set([
+      { name: 'holder', display_name: 'Holder', description: 'Near misses' } as never,
+    ]);
+    component.setExampleTab('holder');
     component.mediaType.set('');
 
     component.onSeedsImported({
@@ -445,9 +449,60 @@ describe('NewDetectorModalComponent', () => {
     expect(component.mediaExamples().every((e) => e.seed)).toBe(true);
     // Media type is inferred from the original filename's extension.
     expect(component.mediaExamples()[0].mediaType).toBe('audio');
-    // The stack is where the user prunes what arrived, so land them on it.
-    expect(component.exampleTab()).toBe('media');
+    // The stack is mirrored under the importer's own form, so the batch shows
+    // up where it was added rather than yanking the user to the media tab.
+    expect(component.exampleTab()).toBe('holder');
     expect(component.seedNotice()).toBe('Added 2 seeds.');
+  });
+
+  it('mirrors the example stack inside the seed importer tab (issue #3192)', () => {
+    component.seedImporters.set([
+      { name: 'holder', display_name: 'Holder', description: 'Near misses' } as never,
+    ]);
+    component.setExampleTab('holder');
+    fixture.detectChanges();
+
+    // Nothing imported yet: the form stands alone, no stack.
+    const panel = () => fixture.nativeElement.querySelector('.example-panel');
+    expect(panel().querySelector('.example-stack')).toBeNull();
+
+    component.onSeedsImported({
+      count: 2,
+      truncated: false,
+      items: [
+        { filename: 'aaa.wav', original_name: 'near-miss-1.wav', origin: null },
+        { filename: 'bbb.wav', original_name: 'near-miss-2.wav', origin: null },
+      ],
+    });
+    fixture.detectChanges();
+
+    // Same rows the media tab renders, still on the seed importer's tab —
+    // including the Seed badges and per-row Remove buttons.
+    const rows = panel().querySelectorAll('.example-stack .example-row');
+    expect(rows.length).toBe(2);
+    expect(panel().querySelectorAll('.example-seed-badge').length).toBe(2);
+    expect(panel().querySelector('vt-plugin-import-form')).toBeTruthy();
+    // The seed tab adds through its own form, so it omits the browse button.
+    expect(panel().querySelector('.add-example-btn')).toBeNull();
+
+    // Removing from the mirrored stack edits the one shared list.
+    component.removeMediaExample(0);
+    fixture.detectChanges();
+    expect(component.mediaExamples().map((e) => e.value)).toEqual(['bbb.wav']);
+    expect(panel().querySelectorAll('.example-stack .example-row').length).toBe(1);
+  });
+
+  it('still lands a hand-picked example on the media tab', () => {
+    component.seedImporters.set([
+      { name: 'holder', display_name: 'Holder', description: 'Near misses' } as never,
+    ]);
+    component.setExampleTab('holder');
+
+    // A pick made through the media picker belongs to the media tab, which is
+    // where the picker lives — only seeds stay put.
+    component.onDatasourceImported({ filename: 'bbb.wav', original_name: 'bark.wav' });
+
+    expect(component.exampleTab()).toBe('media');
   });
 
   it('says so when a batch comes back empty or truncated', () => {

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, HostListener, inject, input, OnInit, output, signal } from '@angular/core';
 
+import { NgTemplateOutlet } from '@angular/common';
+
 import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
@@ -86,7 +88,7 @@ interface MediaExampleItem {
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-new-detector-modal',
   standalone: true,
-  imports: [FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, PluginImportFormComponent, FieldHintIconComponent, ProgressBarComponent],
+  imports: [NgTemplateOutlet, FormsModule, ModalComponent, IconComponent, MediaCropModalComponent, DropZoneComponent, SourcePickerComponent, PluginImportFormComponent, FieldHintIconComponent, ProgressBarComponent],
   templateUrl: './new-detector-modal.component.html',
   styleUrl: './new-detector-modal.component.scss',
 })
@@ -364,11 +366,16 @@ export class NewDetectorModalComponent implements OnInit {
   }
 
   /** Append a picked media example to the stack. Clears any pending text
-   *  (text and media examples are mutually exclusive), switches to the
-   *  media tab, and auto-fills the name from the first example.
+   *  (text and media examples are mutually exclusive) and auto-fills the name
+   *  from the first example.
    *
    *  ``seed`` marks an unlabeled seed contributed by a seed importer, which
-   *  rides in the same stack but is submitted with ``labeled: false``. */
+   *  rides in the same stack but is submitted with ``labeled: false``.
+   *
+   *  A hand-picked example lands the user on the media tab, where the picker
+   *  they just used lives. A seed does not (issue #3192): the seed-importer
+   *  tab renders the same stack, so the batch appears where it was added
+   *  instead of throwing the user onto the media tab mid-import. */
   private addMediaExample(
     value: string,
     display: string,
@@ -381,7 +388,7 @@ export class NewDetectorModalComponent implements OnInit {
       { value, display, mediaType, thumbFailed: false, origin: origin ?? null, seed },
     ]);
     this.pendingText.set('');
-    this.exampleTab.set('media');
+    if (!seed) this.exampleTab.set('media');
     this.autoFillNameFromExample();
   }
 
@@ -620,9 +627,10 @@ export class NewDetectorModalComponent implements OnInit {
    *  instead of looking like it silently did nothing. */
   readonly seedNotice = signal('');
 
-  /** A seed importer returned a batch: append every saved item to the media
-   *  stack as an unlabeled seed and land the user on the stack so they can
-   *  see (and prune) what arrived. */
+  /** A seed importer returned a batch: append every saved item to the shared
+   *  example stack as an unlabeled seed. The stack is mirrored under the seed
+   *  importer's own form, so the batch appears in place — the user stays on
+   *  this tab and can see (and prune) what arrived. */
   onSeedsImported(result: SeedImportResult): void {
     const items = result?.items ?? [];
     for (const item of items) {


### PR DESCRIPTION
Running a seed importer in the New Detector modal appended the batch to the media example stack and then switched the user to the media tab to show it. That jump lands them somewhere they did not ask to be, and hides the importer form they were still working in.

Treated as the UI feature it is rather than a tab-switch bug: the media tab's example stack is lifted into a shared `ng-template` and rendered on the seed importer's own tab too, under its form, so a batch appears where it was added.

## What changed

- **`new-detector-modal.component.html`** — the `.example-stack` markup moves into a root-level `<ng-template #exampleStack let-showAdd="showAdd">`, rendered by both the media panel (`showAdd: true`) and the seed-importer panel (`showAdd: false`). The seed panel also carries the outcome notice ("Added 3 seeds.") that the media panel used to show after the switch.
- **`new-detector-modal.component.ts`** — `addMediaExample` only forces the media tab for a *hand-picked* example (`if (!seed)`). A hand pick still lands on the media tab, which is where the picker it came from lives.

It is one list, not a copy: the mirrored rows carry the same Seed badges and Remove buttons, and edits from either tab hit the same `mediaExamples` signal. The seed tab omits the "+ Add" browse button, since it adds through its own form.

## Verification

- Full `./run-tests.sh`: **RUN PASSED**, 8858 passed / 6 skipped, all gates green.
- Three new/updated Vitest specs: the imported batch keeps the active tab, the seed panel renders the mirrored rows + badges (and no "+ Add") with `removeMediaExample` editing the shared list, and a hand-picked example still switches to media.
- Driven in chromium against a running app with a temporary local seed-importer plugin (not committed): after "Add seeds" the active tab stayed `Near Misses` with 3 rows / 3 Seed badges / 0 "+ Add", and the media tab showed the same 3 rows plus its "+ Add".

Docs: `docs/EXTENDING-plugins.md` (Adding a Seed Importer) and a `CHANGELOG.md` entry under Unreleased → Changed. No screenshot reshoot needed — the framed `new-detector` shot captures the Text panel on a vanilla install, which has no seed-importer tabs.

Closes #3192


---
_Generated by [Claude Code](https://claude.ai/code/session_014TtpGEueXFDboVbZeUTn8p)_