### PR TITLE
Add speaker-view slide renderer and calibration author notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,15 @@ Breaking backwards compatibility is acceptable; do not add shims, feature flags,
 
 VTSearch is a desktop web app. **Do not design, implement, or test for mobile or narrow viewports.** No responsive breakpoints, no touch-targeted controls, no mobile-only layouts, no concerns about portrait orientation. If a design discussion raises "what about mobile?", the answer is "we don't care." When evaluating a layout, assume a standard desktop viewport and skip mobile considerations entirely.
 
+## Render and attach slide decks (when you change `slides/`)
+
+**Any session that changes the slide codebase must end by rendering the affected decks and attaching the PDFs in the conversation** (via `SendUserFile`), so the user can see the result in-browser without checking out the branch and running the build themselves. "Changes the slide codebase" means any edit under `slides/` — fragments, `.deck` manifests, the theme, figures, or the build/render tooling.
+
+- **Which decks:** every deck whose output the change affects. A fragment edit affects the decks whose manifests name it (grep `slides/decks/*.deck`); a theme, `build.py`, or `render.sh` change affects all decks. When in doubt, render more rather than fewer.
+- **How:** `cd slides && ./render.sh <deck> pdf` for each affected deck. The cloud container has a browser; if Marp can't find it, use `CHROME_PATH=/opt/pw-browsers/chromium`. When presenter notes or the speaker pipeline changed, also render `./render.sh <deck> pdf --speaker` and attach that variant too.
+- **When:** at the end of the session, from the final state of the branch (after the last commit that touches `slides/`), so what the user sees is what the PR ships. Attach with a one-line caption naming the deck(s).
+- Rendered PDFs stay in gitignored `slides/_out/` — attach them, never commit them.
+
 ## Screenshot reshoots (when you change the GUI)
 
 User-facing docs embed screenshots captured by a Playwright harness that **needs a real browser**. The cloud container *does* have one (see "Environment Notes" below), so the default when you change a framed GUI surface is to **reshoot in the same session**: run `scripts/screenshots/refresh.sh`, review `git diff docs/user/assets/`, and commit the regenerated PNGs. **Do not let that drift go silently unrecorded.**

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -2,6 +2,7 @@
 #
 #   make                      every deck -> _out/*.pdf
 #   make scale26-review       one deck   -> _out/scale26-review.pdf
+#   make speaker              every deck -> _out/*.speaker.pdf (notes visible)
 #   make html FMT=html        every deck -> _out/*.html
 #   make watch DECK=sponsor-brief   live preview in a browser
 #   make check                preflight every manifest, build nothing
@@ -13,9 +14,15 @@ FMT   ?= pdf
 DECKS := $(basename $(notdir $(wildcard decks/*.deck)))
 FIGS  := $(wildcard figs/*)
 
-.PHONY: all check list clean watch $(DECKS)
+.PHONY: all speaker check list clean watch $(DECKS)
 
 all: $(addprefix _out/,$(addsuffix .$(FMT),$(DECKS)))
+
+# Speaker view: each page is a miniature of the rendered slide beside its
+# presenter notes. Two-pass (audience slides -> PNGs -> speaker deck), so it
+# delegates to render.sh rather than to the pattern rules below.
+speaker:
+	@for d in $(DECKS); do ./render.sh $$d $(FMT) --speaker || exit 1; done
 
 # Bare deck name builds that one deck, e.g. `make sponsor-brief`.
 $(DECKS): %: _out/%.$(FMT)

--- a/slides/README.md
+++ b/slides/README.md
@@ -30,6 +30,7 @@ Needs node and python3. Nothing to install — `npx` fetches Marp on first run
 ```bash
 ./render.sh scale26-review          # -> _out/scale26-review.pdf
 ./render.sh sponsor-brief html      # or html / pptx
+./render.sh calibration-brief pdf --speaker  # -> _out/calibration-brief.speaker.pdf
 ./build.py --check                  # preflight all manifests, build nothing
 ./build.py --list                   # decks, slide counts, unused fragments
 ```
@@ -82,6 +83,16 @@ defined in the theme and set per-slide with `<!-- _class: full -->`.
 
 Any HTML comment that isn't a Marp directive becomes a **presenter note** —
 visible in `--preview` and exported into PPTX/HTML notes, not on the slide.
+Write them as real speaking notes: wordier than the slide, covering what to
+say, not just provenance.
+
+PDF has no native speaker view, so there are two renderers for the same deck.
+The plain build ignores the notes; the **speaker build**
+(`./render.sh <deck> pdf --speaker`) produces `_out/<deck>.speaker.pdf` beside
+the audience `_out/<deck>.pdf`, PowerPoint notes-page style: each page shows a
+miniature of the real rendered slide (pixel-identical — it *is* a PNG of the
+audience deck, rendered in a first pass) with that slide's notes beside it.
+Same fragments, same manifest — the notes are authored once, as comments.
 
 **Never put a bare `---` in a fragment**: Marp reads it as a slide break and
 would silently split one slide into two. `build.py` errors on it. Use `***`

--- a/slides/build.py
+++ b/slides/build.py
@@ -7,9 +7,19 @@ otherwise fail late (missing fragment, missing figure, a stray `---` inside a
 fragment that would silently split one slide into two).
 
     ./build.py scale26-review        # -> _build/scale26-review.md
+    ./build.py --speaker scale26-review  # -> _build/scale26-review.speaker.md
     ./build.py --all
     ./build.py --check               # preflight only, write nothing
     ./build.py --list                # decks, slide counts, unused fragments
+
+The --speaker variant renders presenter notes *visibly*, PowerPoint
+notes-page style: each speaker page shows a miniature of the real rendered
+slide beside the notes for it. Notes are the HTML comments that are not Marp
+directives — the same comments Marp exports as PPTX/HTML presenter notes, so
+they are authored once. The speaker build references per-slide PNGs of the
+audience deck under _build/imgs/, which render.sh produces first; run
+`./render.sh <deck> pdf --speaker` rather than calling this mode directly.
+The audience build is untouched.
 """
 
 from __future__ import annotations
@@ -29,6 +39,15 @@ BUILD = ROOT / "_build"
 IMAGE_RE = re.compile(r"!\[[^\]]*\]\(\s*([^)\s]+)")
 # A line that is exactly a Marp slide separator.
 RULE_RE = re.compile(r"^-{3,}\s*$")
+# An HTML comment, possibly spanning lines.
+COMMENT_RE = re.compile(r"<!--(.*?)-->", re.DOTALL)
+# A line that sets a Marp/Marpit directive (`_class: lead`, `paginate: false`,
+# ...). A comment whose every non-blank line matches is a directive comment;
+# any other comment is a presenter note (mirrors Marp's own reading).
+DIRECTIVE_LINE_RE = re.compile(
+    r"^\s*_?(?:marp|theme|style|class|paginate|header|footer|color|transition"
+    r"|headingDivider|math|lang|size|background[A-Za-z]*)\s*:"
+)
 
 # Front-matter keys we default when a manifest doesn't set them.
 DEFAULT_FRONTMATTER = {"marp": "true", "theme": "vtsearch", "paginate": "true"}
@@ -97,6 +116,53 @@ def rewrite_images(text: str) -> str:
     return IMAGE_RE.sub(repoint, text)
 
 
+def is_directive_comment(body: str) -> bool:
+    lines = [line for line in body.splitlines() if line.strip()]
+    return bool(lines) and all(DIRECTIVE_LINE_RE.match(line) for line in lines)
+
+
+def fragment_notes(text: str) -> list[str]:
+    """Extract a fragment's presenter notes (non-directive HTML comments).
+
+    Note text is markdown; the continuation-line indentation of the comment
+    style is stripped so it can't be misread as a code block.
+    """
+    notes: list[str] = []
+    for match in COMMENT_RE.finditer(text):
+        body = match.group(1)
+        if is_directive_comment(body):
+            continue
+        # Reflow: Marp renders single newlines as hard breaks, so joining the
+        # comment's wrapped lines with "\n" would keep its ragged wrapping.
+        # Collapse each blank-line-separated block to one line instead.
+        paragraphs = [
+            " ".join(line.strip() for line in block.split("\n") if line.strip()) for block in re.split(r"\n\s*\n", body)
+        ]
+        cleaned = "\n\n".join(p for p in paragraphs if p)
+        if cleaned:
+            notes.append(cleaned)
+    return notes
+
+
+def speaker_page(deck: str, index: int, text: str) -> str:
+    """Build one speaker page: the rendered slide beside its notes.
+
+    The miniature is the per-slide PNG of the audience deck (rendered by
+    render.sh into _build/imgs/ before this runs), so the speaker sees exactly
+    what the audience sees, pixel for pixel — page number included. The path
+    is written repo-`slides/`-relative like every fragment figure, and
+    rewrite_images repoints it for _build/.
+    """
+    image = f"_build/imgs/{deck}.{index:03d}.png"
+    notes = fragment_notes(text) or ["*(no presenter notes on this slide)*"]
+    return (
+        "<!-- _class: speaker -->\n<!-- _paginate: false -->\n\n"
+        '<div class="speaker-page">\n<div class="speaker-slide">\n\n'
+        f"![Slide {index}]({image})\n\n"
+        '</div>\n<div class="speaker-notes">\n\n' + "\n\n".join(notes) + "\n\n</div>\n</div>"
+    )
+
+
 def check_fragment(name: str, text: str, problems: list[str]) -> None:
     for lineno, line in enumerate(text.splitlines(), 1):
         if RULE_RE.match(line):
@@ -113,8 +179,8 @@ def check_fragment(name: str, text: str, problems: list[str]) -> None:
             problems.append(f"fragments/{name}.md:{line}: figure not found: {target}")
 
 
-def assemble(deck: str, write: bool) -> list[str]:
-    """Preflight one deck; write _build/<deck>.md unless write=False.
+def assemble(deck: str, write: bool, speaker: bool = False) -> list[str]:
+    """Preflight one deck; write _build/<deck>[.speaker].md unless write=False.
 
     Returns the list of problems found (empty means the deck is clean).
     """
@@ -126,14 +192,20 @@ def assemble(deck: str, write: bool) -> list[str]:
     problems: list[str] = []
     bodies: list[str] = []
 
-    for name in names:
+    for index, name in enumerate(names, 1):
         fragment = SLIDES / f"{name}.md"
         if not fragment.exists():
             problems.append(f"{deck}.deck: missing fragment: fragments/{name}.md")
             continue
         text = fragment.read_text().strip("\n")
         check_fragment(name, text, problems)
-        bodies.append(text)
+        if speaker and write and not (BUILD / "imgs" / f"{deck}.{index:03d}.png").exists():
+            problems.append(
+                f"{deck}.deck: missing slide image _build/imgs/{deck}.{index:03d}.png — "
+                f"the speaker build needs the audience deck rendered to per-slide PNGs "
+                f"first; use `./render.sh {deck} pdf --speaker`, which does both"
+            )
+        bodies.append(speaker_page(deck, index, text) if speaker else text)
 
     if problems or not write:
         return problems
@@ -143,7 +215,7 @@ def assemble(deck: str, write: bool) -> list[str]:
     header = "\n".join(f"{k}: {yaml_scalar(v)}" for k, v in merged.items())
 
     BUILD.mkdir(exist_ok=True)
-    out = BUILD / f"{deck}.md"
+    out = BUILD / (f"{deck}.speaker.md" if speaker else f"{deck}.md")
     body = rewrite_images("\n\n---\n\n".join(bodies))
     out.write_text(f"---\n{header}\n---\n\n{body}\n")
 
@@ -188,6 +260,11 @@ def cmd_list() -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
     parser.add_argument("deck", nargs="?", help="deck name (without .deck)")
+    parser.add_argument(
+        "--speaker",
+        action="store_true",
+        help="render presenter notes visibly; writes _build/<deck>.speaker.md",
+    )
     parser.add_argument("--all", action="store_true", help="build every deck")
     parser.add_argument("--check", action="store_true", help="preflight only")
     parser.add_argument("--list", action="store_true", help="show decks and orphans")
@@ -204,7 +281,7 @@ def main() -> int:
     problems: list[str] = []
     for deck in targets:
         try:
-            problems += assemble(deck, write=not args.check)
+            problems += assemble(deck, write=not args.check, speaker=args.speaker)
         except DeckError as exc:
             problems.append(str(exc))
 

--- a/slides/fragments/_template.md
+++ b/slides/fragments/_template.md
@@ -19,7 +19,10 @@
   A `---` line here would split this fragment into two slides; build.py errors
   on it. Use `***` if you want a horizontal rule.
 
-  Any HTML comment that is not a Marp directive becomes a presenter note.
+  Any HTML comment that is not a Marp directive becomes a presenter note —
+  hidden in the audience build, rendered beside a miniature of the slide by
+  the speaker build (./render.sh <deck> pdf --speaker). Write notes as real
+  speaking notes: wordier than the slide, covering what to say.
 -->
 
 ### Kicker

--- a/slides/fragments/anchored-gmm.md
+++ b/slides/fragments/anchored-gmm.md
@@ -8,8 +8,23 @@
 - One fit sees haystack *and* labels; one cut falls out
 - The blend's hand-tuned ramp becomes **derived**: γ = κn / (κn + N)
 
-<!-- fit_anchored_score_gmm (#2852), then fold-anchored (#2853): fit per
-     calibration fold on held-out anchors, transfer cuts as quantile ranks so
-     no raw score crosses model scales. "The labels' job is to identify the
-     components, not to estimate them" — at κ=0.3, γ ≈ 2.5%. Figure: real
-     vtscore fits on synthetic scores. -->
+<!-- The blend averages two finished answers; iteration 4 fuses the evidence
+     before answering. Mechanically it is semi-supervised EM on the same
+     two-component mixture: the unlabeled haystack contributes soft
+     responsibilities as usual, while each voted item is clamped one-hot to
+     its component — a Good vote belongs to the high component with certainty
+     — and carries weight κ instead of 1. One fit sees both data sources; one
+     cut falls out (fit_anchored_score_gmm, #2852).
+
+     The conceptual line to deliver: the labels' job is to *identify* the
+     components, not to estimate them. The haystack has all the shape
+     information; what it cannot know is which mound is "Good". A handful of
+     clamped votes pins that down. And the blend's hand-tuned ramp is now
+     derived instead of designed: the labels' effective share of the fit is
+     γ = κn/(κn + N), which grows automatically with the vote count n — at
+     κ = 0.3, γ is around 2.5%.
+
+     One refinement to mention (#2853): production fits per calibration fold
+     on held-out anchors and transfers cuts as quantile ranks, so no raw score
+     ever crosses model scales. Figure: real vtscore fits on synthetic
+     scores. -->

--- a/slides/fragments/anchored-kappa.md
+++ b/slides/fragments/anchored-kappa.md
@@ -8,6 +8,19 @@
 - Run B, two decades wider: the optimum is interior, **κ = 0.3**, 6/6
 - And κ\* keeps falling as votes accumulate: 3 → 0.1 over the horizon
 
-<!-- Run A's recommendation merged an hour into run B's cell array. Honest
-     lesson slide: grid edges are not optima, and a constant κ is a compromise
-     across regimes — κ ∝ 1/n is open work. -->
+<!-- This is a deliberate honest-lessons slide; play it straight, not as a
+     confession. Run A swept κ over 1, 3, 10, 30, 100, and κ = 1 won — the
+     smallest value on the grid, which should have been read as "the optimum
+     is off the edge", not "the optimum is 1". Instead the recommendation
+     merged to production about an hour into run B's cell array. Run B, with
+     the grid extended two decades down, found the true optimum interior at
+     κ = 0.3, winning in all six environments — so the shipped setting was
+     beaten in every environment measured, within a day of shipping.
+
+     Two lessons to state explicitly. Process: a winner on the edge of its own
+     grid is a prompt to extend the grid, and shipping before the wider run
+     finishes is how you ship from the edge. Substance: κ* is not even a
+     constant — it keeps falling as votes accumulate, from around 3 early to
+     around 0.1 deep, so any fixed κ is a compromise across regimes. A
+     schedule κ ∝ 1/n is the obvious one-line follow-up arm, and it reappears
+     on the roadmap slide. -->

--- a/slides/fragments/anchored-results.md
+++ b/slides/fragments/anchored-results.md
@@ -6,8 +6,20 @@
 - Beats the shipped blend on region voting: −0.026 to −0.032
 - Best single global setting in **6 of 6** environments (κ = 0.3)
 
-<!-- docs/experiments/population-anchored-calibration/REPORT.md (#2852/#2864,
-     runs A+B: 568 cells, 6 environments = 3 datasets x 4 embedders x both
-     voting modes). Unconditional since #2863 — the blend survives only as the
-     no-folds fallback. Binary voting is a dead heat vs cap50, caltech101 a
-     small loss: the win does not transfer everywhere, and that is on record. -->
+<!-- Two runs stand behind this slide
+     (docs/experiments/population-anchored-calibration/REPORT.md, #2852 and
+     #2864): run A on the deep regime, then run B sweeping the anchor mass two
+     decades wider across six environments — three datasets, four embedders,
+     both voting modes, 568 cells in all. Headline: the fused fit cuts paired
+     regret against pure cross-calibration by 0.044 in the deep regime, beats
+     the shipped blend on region voting by 0.026 to 0.032, and κ = 0.3 is the
+     best single global setting in all six environments. This is what ships
+     today, unconditionally — #2863 deleted the safe-thresholds off-switch,
+     and the blend survives only as the no-folds fallback.
+
+     Then give the caveats yourself, before anyone asks, because they are on
+     record in the report: on binary voting fusion is a dead heat with the
+     cap50 blend, and caltech101 shows a small loss. The win does not transfer
+     everywhere, and saying so is part of why the result is credible. The next
+     slide is an honest-lessons slide about how this one nearly shipped
+     wrong. -->

--- a/slides/fragments/anchored.short.md
+++ b/slides/fragments/anchored.short.md
@@ -7,4 +7,20 @@
 - Votes clamped one-hot **inside** the fit — no late averaging
 - **−0.044** regret vs pure x-cal; best global setting in 6/6 environments
 
-<!-- Brief-deck cut of anchored-gmm + anchored-results. -->
+<!-- Brief-deck cut of anchored-gmm + anchored-results. The idea in one line:
+     stop averaging two finished answers and fuse the evidence instead — one
+     semi-supervised EM fit where the unlabeled haystack contributes soft
+     responsibilities and each vote is clamped one-hot to its component at a
+     small mass κ. The labels' job is to identify the components, not to
+     estimate them; the haystack carries the shape, the votes pin down which
+     mound is "Good", and the blend's hand-tuned ramp becomes a derived
+     quantity that grows with the vote count on its own.
+
+     The measurement, from 568 Grid cells across six environments: regret down
+     0.044 against pure cross-calibration in the deep regime, and κ = 0.3 the
+     best single global setting in all six. This is the production threshold
+     today, unconditionally. If time allows, add the two honest caveats from
+     the report: binary voting is a dead heat with the old blend, and the
+     winning κ came from run B after run A had already shipped a value from
+     the edge of its grid — the fuller decks make a whole slide of that
+     lesson. -->

--- a/slides/fragments/blend-results.md
+++ b/slides/fragments/blend-results.md
@@ -6,7 +6,23 @@
 - FNR −0.071 with FPR flat — not bought with permissiveness
 - Keeps paying *after* handoff: a better cut surfaces better items to vote on
 
-<!-- docs/experiments/safe-thresholds/REPORT.md (#2799). Turned on for
-     everyone. The third bullet is selection feedback — visible only because
-     this was an A/B over whole trajectories, not a within-step counterfactual.
-     Also eliminated the cold-start "admit nothing" cuts on the control arm. -->
+<!-- The A/B (docs/experiments/safe-thresholds/REPORT.md, #2799) is the
+     cleanest result in the deck; spend time on why it is clean, not just how
+     big. Three reasons. First, it is not bought with permissiveness: the
+     recurring failure mode in earlier threshold work was a "fix" that games
+     the weighted cost by cutting lower and wrecking precision — here FNR
+     drops 0.071 while FPR is flat, meaning the cut lands closer to the
+     model's own oracle, which is what "better calibrated" is supposed to
+     mean. Second, ranking is untouched (average precision moves +0.001,
+     n.s.): the blend changes where the line is drawn, not how the pool is
+     ordered.
+
+     Third — the subtle one, worth slowing down for — it keeps paying after
+     its authority ends. Past 20 votes the blend IS pure cross-calibration,
+     yet the ON arm stays ahead. The only path for that gain is selection
+     feedback: the threshold drives Autopilot's Hard pick, so a better cut
+     surfaces better items to vote on, and the whole trajectory improves. A
+     within-step counterfactual cannot see this at all, which is exactly why
+     the study was run as an A/B over whole trajectories. Turned on for
+     everyone; it also eliminated the cold-start "admit nothing" cuts on the
+     control arm. -->

--- a/slides/fragments/blend-schedule.md
+++ b/slides/fragments/blend-schedule.md
@@ -8,6 +8,22 @@
 - Winners cap x-cal at **half weight, forever**: region −0.058, binary −0.019
 - 300 clicks ≈ **13 positives** — x-cal converges in positives, not clicks
 
-<!-- docs/experiments/mixin-schedule/REPORT.md (#2841). Every schedule that
-     hands over gives its advantage back at the moment it does, monotone in
-     release point. slow_cap50 ships for region voting, cap50 for binary. -->
+<!-- Iteration 3½ went back and swept the three baked-in choices
+     (docs/experiments/mixin-schedule/REPORT.md, #2841): nine schedules, and
+     re-run at ten times the original horizon to make sure the answer was a
+     finding and not an artefact. The surprise is the headline: every single
+     schedule that fully hands over to the learned cut gives its advantage
+     back at the moment it does, monotone in release point. The winners never
+     hand over — they cap cross-calibration at half weight, forever.
+
+     Give the intuition before the numbers: this is NOT because the GMM is
+     better in the limit — it is inconsistent and cannot be. It is a horizon
+     effect: 300 clicks buys a median of about 13 positives, and the learned
+     cut converges in positives, not clicks, so "the limit" where x-cal wins
+     outright is simply never reached inside a real session. The first-pass
+     answer (a plain slower ramp) was wrong for exactly this reason: it
+     reached pure x-cal at 40 labels and decayed to nothing past it.
+
+     What shipped: slow_cap50 for region voting (−0.058), cap50 for binary
+     (−0.019) — the two voting modes genuinely want different curves, a mode
+     split that returns in iteration 4's caveats. -->

--- a/slides/fragments/blend.md
+++ b/slides/fragments/blend.md
@@ -6,6 +6,16 @@
 - `w` ramps with votes: pure GMM ≤ 6, pure x-cal ≥ 20
 - The GMM absorbs the cold start; the labels take over
 
-<!-- "Safe thresholds", #2798/#2799. One hard-coded line at first:
-     w = clip((n-6)/14, 0, 1). Three unmeasured choices baked in — endpoints,
-     shape, statistic — which is what iteration 3½ sweeps. -->
+<!-- The two estimators fail in opposite regimes — x-cal is starved early and
+     right late, the GMM is well-fed early and biased forever — so the obvious
+     move is a weighted average of the two *thresholds*, with the weight
+     ramping along the vote count. Six votes or fewer, trust the mixture
+     entirely; twenty or more, hand over to the labels; interpolate linearly
+     between. This shipped as "safe thresholds" (#2798, #2799).
+
+     Be honest about how crude the first version was, because it sets up
+     iteration 3½: one hard-coded line, w = clip((n−6)/14, 0, 1), with three
+     unmeasured choices baked in — the endpoints of the ramp, the shape of the
+     ramp, and the statistic driving it (raw click count, when the thing that
+     actually matters is positives). Cheap, shippable, and the single biggest
+     win in the line, which is the next slide. -->

--- a/slides/fragments/calib-problem.md
+++ b/slides/fragments/calib-problem.md
@@ -4,6 +4,15 @@
 
 ## cost = *w*<sub>f</sub>·FPR + *w*<sub>n</sub>·FNR — and at 6 votes you may hold one positive.
 
-<!-- The Inclusion knob is a reweighting of this cost; every study in the deck
-     scores it. The threshold, not the ranking, is what the user experiences:
-     what gets shown, exported, auto-labeled. -->
+<!-- Separate the two jobs cleanly, because the whole deck lives in the gap
+     between them. Training produces a ranking of the pool; the audience never
+     experiences the ranking directly. What they experience is the threshold:
+     which items are shown, exported, auto-labeled. A perfect ranking with a
+     bad cut still looks broken to the user.
+
+     Define the cost once, here, and note that the Inclusion knob is exactly a
+     reweighting of w_f against w_n — every study in this deck scores this
+     same cost, so "better" always means the same thing. Then land the second
+     line hard: the threshold must be estimated from the user's own votes, and
+     six votes deep you may be holding one positive example. Everything that
+     follows is a fight against that scarcity. -->

--- a/slides/fragments/calib-roadmap.md
+++ b/slides/fragments/calib-roadmap.md
@@ -6,6 +6,20 @@
 - **Schedule the anchor mass** — κ\* falls with votes; κ ∝ 1/n is a one-line arm
 - **Un-strand binary voting** — fusion ties the blend there; gate or split it
 
-<!-- Keep to three. #2883 is the designated successor; the binary regression
-     (fusion ≤ cap50 on both binary environments, with the off-switch deleted)
-     is on record in the anchored report. -->
+<!-- Deliberately three items and no more; the headline states the strategy
+     the epilogue earned — the cut axis is closed, so the open work attacks
+     the fit. Take them in order. Transfer characterization (#2883) is the
+     designated successor line: the error decomposition says sim-to-test
+     transfer is where the remaining regret lives, and nobody has yet
+     characterized what the calibration set fails to say about the pool.
+     Scheduling the anchor mass follows straight from the kappa caution: κ*
+     falls as votes accumulate, so a κ ∝ 1/n schedule is a one-line arm that
+     replaces a compromise constant with the trend the data already showed.
+     And binary voting is on record as stranded: fusion ties the cap50 blend
+     on both binary environments, but #2863 deleted the off-switch, so binary
+     users run a threshold that never beat their best alternative — either
+     gate fusion by mode or split the setting.
+
+     If asked "why not a better cut rule" after all this: that is the point of
+     the epilogue — the axis is measured to be empty, so none of these three
+     is a cut rule. -->

--- a/slides/fragments/evt-close.md
+++ b/slides/fragments/evt-close.md
@@ -8,7 +8,22 @@
 - The label-reading oracle of **every** cut rule: −0.0055 vs production, n.s.
 - What remains is **sim → test transfer** — no cut rule can touch it
 
-<!-- REMEASURE-2846.md + REPORT-2881.md. The strongest evidence iteration 4
-     was the right investment: once anchoring shipped, even a rule that reads
-     the true labels can't significantly beat production. Pre-registration is
-     what lets a negative close a line for good. -->
+<!-- The answer (REMEASURE-2846.md and REPORT-2881.md): measured against the
+     anchored fit that had shipped in the meantime, the EVT rule is worse —
+     +0.0069 even at its own best tuning, significant at p = 0.001. But the
+     line-closing result is the second bullet, so give it the emphasis: the
+     label-reading oracle of the ENTIRE cut-rule family — the best any rule of
+     this shape could possibly do, granted the true labels — now beats
+     production by only 0.0055, not significant. The axis is spent: once
+     anchoring shipped, there is nothing left on it for any rule to win.
+
+     Point at the decomposition figure for where the remaining error actually
+     lives: sim-to-test transfer — the calibration scores are not drawn from
+     quite the same distribution as the test pool — which no cut rule can
+     touch by construction, because a cut rule only chooses a point on the
+     calibration-side distribution.
+
+     Close the arc: this negative is the strongest evidence iteration 4 was
+     the right investment. And name the process point: pre-registration is
+     what lets a negative close a line for good — a post-hoc sweep that came
+     back negative would just invite one more variant. -->

--- a/slides/fragments/evt-line.md
+++ b/slides/fragments/evt-line.md
@@ -6,7 +6,21 @@
 - Gumbel/EVT family: a max over regions is an extreme-value statistic — fit one
 - Pre-registered, swept twice, repaired once…
 
-<!-- docs/experiments/gmm-cut/REPORT.md (#2836): the prior-free lam cancels
-     the mixture weights the Bayes crossing smuggled in; captures 60% of the
-     oracle headroom. The EVT premise was principled and testable — which is
-     the point of telling it. -->
+<!-- Change of pace for the epilogue: the iterations so far changed what data
+     the threshold sees; this line asked whether, holding the mixture fit
+     fixed, a smarter *cut rule* than the naive midpoint could win. It opened
+     with a genuine success (docs/experiments/gmm-cut/REPORT.md, #2836): the
+     prior-free crossing — the Bayes crossing with the mixture weights
+     correctly divided out, weights the midpoint was silently smuggling in —
+     shipped at −0.0044 cost with FPR and FNR both falling, capturing about
+     60% of the headroom that a label-reading oracle showed was available. A
+     small win, but a clean one, and it proved the axis had something on it.
+
+     Then the ambitious idea: on region voting a media score is a max over
+     region scores, and the max of many draws is an extreme-value statistic —
+     so the high tail should be Gumbel-shaped, and fitting the tail family the
+     data actually implies should beat any Gaussian rule. Stress that this
+     premise is principled and testable, and that the sweep was pre-registered
+     before any result came back — because the next slide is what the
+     measurement said, and pre-registration is what makes that answer mean
+     something. Leave the ellipsis hanging as the transition. -->

--- a/slides/fragments/evt.short.md
+++ b/slides/fragments/evt.short.md
@@ -5,5 +5,18 @@
 - Gumbel/EVT rules: pre-registered, measured twice, **closed** as a negative
 - Even the label-reading oracle of every cut rule no longer beats production
 
-<!-- Brief-deck cut of evt-line + evt-close. The negative is the proof that
-     the anchored fit won. -->
+<!-- Brief-deck cut of evt-line + evt-close. The last idea on the cut axis
+     was principled: a region-voting score is a max over regions, a max is an
+     extreme-value statistic, so fit the Gumbel tail the data implies instead
+     of a Gaussian rule. It was pre-registered, swept twice, repaired once —
+     and lost: worse than production even at its own best tuning.
+
+     The bullet that closes the line is the second one, so land it carefully:
+     the label-reading oracle of the ENTIRE cut-rule family — the best any
+     rule of this shape could do, granted the true labels — no longer
+     significantly beats production. Once the anchored fit shipped, there was
+     nothing left on the axis for any rule to win; what remains is
+     sim-to-test transfer, which no cut rule can touch. Frame the negative as
+     the proof that iteration 4 was the right investment, and credit
+     pre-registration as what lets a negative close a line for good instead
+     of inviting one more variant. -->

--- a/slides/fragments/gmm-blend.short.md
+++ b/slides/fragments/gmm-blend.short.md
@@ -8,4 +8,18 @@
 - Averaged against x-cal: cost **−0.074** in the A/B
 - Refined: never hand over completely
 
-<!-- Brief-deck cut of gmm-idea + blend + blend-schedule. -->
+<!-- Brief-deck cut of gmm-idea + blend + blend-schedule — three moves on one
+     slide, so keep each to a sentence or two. Move one: flip the data source.
+     Fit a two-component mixture to the 50 000 unlabeled scores of the whole
+     haystack and cut between the modes — nothing to starve, but inconsistent:
+     its high component means "confidently scored", not "true match", and no
+     vote ever corrects it. Move two: average the rival thresholds with a
+     weight that ramps along the vote count, GMM early, labels later. That
+     A/B was the single biggest win in the line — cost down 0.074, and FNR
+     fell with FPR flat, so it was not bought with permissiveness.
+
+     Move three is the refinement in the figure: sweeping nine handoff
+     schedules showed every one that fully hands over to the learned cut gives
+     the win back when it does — 300 clicks is only ~13 positives, and the
+     learned cut converges in positives, not clicks. So the shipped schedules
+     cap the handoff at half weight, forever. -->

--- a/slides/fragments/gmm-fragility.md
+++ b/slides/fragments/gmm-fragility.md
@@ -6,7 +6,19 @@
 - But it never learns: pure GMM hits **+0.24** cost when false positives cost 4×
 - Use it early. Not alone.
 
-<!-- docs/experiments/mixin-schedule/REPORT.md (#2841). The GMM is an
-     inconsistent estimator — its high component is "confidently scored", not
-     "true match" (fitted w_hi 0.35 vs true prevalence 0.09, #2836). This slide
-     motivates the blend. -->
+<!-- The measurement (docs/experiments/mixin-schedule/REPORT.md, #2841) is
+     more generous to the GMM than expected, and it is worth being fair about
+     that before condemning it: of every schedule measured on region voting,
+     pure GMM sits closest to the oracle cut — mean gap 0.023 against
+     production's 0.036 — and it was among the best at the shipped operating
+     point. "Just use the GMM all the time" was not an obviously bad idea.
+
+     Then the two structural failures. It is an inconsistent estimator: its
+     high component means "confidently scored", not "true match" — the fitted
+     high-component weight was 0.35 against a true prevalence of 0.09 (#2836)
+     — and no number of votes ever corrects it, because it never reads one.
+     And that bias is asymmetric in exactly the wrong way: reweight the cost
+     so false positives matter four times more — which is just an
+     Inclusion-averse user, not a hypothetical — and pure GMM blows up by
+     +0.24 cost. So the verdict that motivates the next slide: use it early,
+     when the labels have nothing, but never alone. -->

--- a/slides/fragments/gmm-idea.md
+++ b/slides/fragments/gmm-idea.md
@@ -8,7 +8,17 @@
 - Cut at the <span class="cut">midpoint</span> between the <span class="neg">low</span> and <span class="pos">high</span> modes
 - 50 000 scores instead of tens — nothing to starve
 
-<!-- fit_score_gmm / calculate_gmm_threshold. The figure is the real vtscore
-     fit on synthetic scores. The midpoint survived two attempts to replace it
-     with a crossing rule — #2836 later proved it IS the rate-optimal cut under
-     equal variances. -->
+<!-- Flip the data source entirely: instead of the tens of labeled votes, use
+     the tens of thousands of *unlabeled* scores the detector already assigns
+     to the whole haystack. The score histogram is bimodal — a big mound of
+     clear rejects, a smaller mound of high scorers — so fit a two-component
+     Gaussian mixture (fit_score_gmm) and cut at the midpoint between the two
+     component means (calculate_gmm_threshold). The figure is a real vtscore
+     fit on synthetic scores, and the colours match: rust for the low
+     component, green for the high, blue for the cut.
+
+     Two asides worth making. The midpoint looks naive and survived two
+     attempts to replace it with something smarter — the epilogue will show
+     #2836 proving it IS the rate-optimal cut under equal variances. And note
+     what this estimator costs: nothing here ever looks at a vote, which is
+     both its superpower and, next slide, its ceiling. -->

--- a/slides/fragments/outline-calibration.md
+++ b/slides/fragments/outline-calibration.md
@@ -10,6 +10,16 @@
 4. **Fuse them instead of averaging** *— the partially-labeled fit, shipped today*
 5. **Epilogue: the cut-rule line** *— pre-registered, measured twice, closed*
 
-<!-- Each iteration is [the idea, then what the Grid said about it]. Point out
-     now that the arc ends in a negative result — it is the proof that
-     iteration 4 was the right investment, not a loose end. -->
+<!-- Walk the list slowly; the whole talk is legible from this slide. The
+     rhythm of every section is the same — the idea first, then what the Grid
+     said about it — so the audience always knows whether they are hearing a
+     proposal or a measurement.
+
+     Emphasize the shape of the arc: two estimators with opposite failure
+     modes (one consistent but starved, one well-fed but inconsistent), then
+     the obvious fix (average them), then the principled fix (fuse them in a
+     single fit). Say explicitly, now, that item 5 is a negative result and
+     that it is here on purpose: once the fused fit shipped, even a cut rule
+     that reads the true labels could not beat production, which is the
+     strongest evidence iteration 4 was the right investment rather than a
+     loose end. -->

--- a/slides/fragments/positives.md
+++ b/slides/fragments/positives.md
@@ -8,5 +8,17 @@
 - One trace sat at **3 positives for 120 votes**
 - **3.7%** of runs never found a single one
 
-<!-- This is the headline result. Everything downstream — calibration, cut
-     rules, head choice — is starved by this, not limited by itself. -->
+<!-- This is the headline empirical fact of the whole line; give it room.
+     Voting is cheap but positives are rare, so labels accumulate lopsidedly:
+     after 150 votes the median run holds only 4 to 11 positives, and the
+     tails are brutal — point at the trace that sat on 3 positives for 120
+     straight votes, and note that about one run in twenty-seven never found a
+     single positive at all.
+
+     Draw the general conclusion explicitly: every labeled-data component
+     downstream — calibration, cut rules, even the choice of model head — is
+     starved by this, not limited by its own cleverness. Any estimator whose
+     variance scales with the number of positives is going to be wild exactly
+     when the user is watching most closely, at the start. That is the case
+     for bringing in a data source that cannot starve, which is the next
+     iteration. -->

--- a/slides/fragments/thanks.md
+++ b/slides/fragments/thanks.md
@@ -5,3 +5,10 @@
 
 ## Questions
 ### sam.greenberg@gmail.com
+
+<!-- Invite questions, and offer the receipts: every number in the talk lives
+     in a committed report under docs/experiments/, so any slide can be
+     followed to its evidence. Good seeds if the room is quiet: why the
+     midpoint survived every attempt to out-smart it, what a κ schedule would
+     look like, or what "characterize transfer" (#2883) will actually
+     measure. -->

--- a/slides/fragments/title-calibration.md
+++ b/slides/fragments/title-calibration.md
@@ -4,5 +4,15 @@
 
 ## How VTSearch calibration went from conformal cuts to a partially-labeled mixture
 
-<!-- Each iteration: the idea, then what the Grid said about it. Every number
-     in this deck is from a committed report in docs/experiments/. -->
+<!-- Frame the talk before touching any mechanism: this is the story of one
+     production decision — where VTSearch draws the include/exclude line on a
+     detector's scores — told as five iterations, each of which shipped or
+     died on a measurement. It is a story about process as much as about the
+     threshold: every idea here was run on the Grid before it was believed.
+
+     Two promises to make up front. First, every number in the deck comes from
+     a committed report in docs/experiments/ — nothing is from memory, and
+     anyone can go read the report behind any slide. Second, the arc ends with
+     a negative result, on purpose: the last iteration is a pre-registered
+     idea that lost, and the deck argues that closing a line cleanly is a
+     result worth presenting. -->

--- a/slides/fragments/xcal-results.md
+++ b/slides/fragments/xcal-results.md
@@ -6,6 +6,18 @@
 - But folds redraw every vote, and the cut is a **low quantile over tens of positives**
 - Cold start: "admit nothing" spikes, budget overshoot below ~20 votes
 
-<!-- docs/experiments/calibration/REPORT.md (#2781). The three structural
-     deficits that never decay with label count: tiny positive sample, fold-to-
-     final scale transfer, per-retrain variance. Sets up everything after. -->
+<!-- The first calibration study (docs/experiments/calibration/REPORT.md,
+     #2781) had a happy half and a structural half; give them in that order.
+     The happy half: the runaway-threshold bug was the conformal walk pinning
+     its cut to the lowest calibration positive, and #2784's fix removed
+     essentially all regret in the clean binary-voting regime — so the rule,
+     when fed, works.
+
+     Then the structural half, which no bug fix touches: three deficits that
+     do not decay with more of the same data. The cut is a low quantile over
+     tens of positives, so its variance is dominated by the handful of rarest
+     points; the folds are redrawn on every vote, so the threshold jumps
+     retrain to retrain; and fold-model scores must transfer to the final
+     model's scale. Below roughly 20 votes this shows up as degenerate "admit
+     nothing" cuts and budget overshoot. This slide is the setup for the whole
+     talk: iteration 1 is right in the limit and unusable at the start. -->

--- a/slides/fragments/xcal.md
+++ b/slides/fragments/xcal.md
@@ -6,6 +6,17 @@
 - Pool the folds; take one **conformal quantile** cut
 - Inclusion biases the quantile — never the training
 
-<!-- The starting point, pre-history of the line. Two folds, stratified,
-     pooled rather than averaged so the Inclusion knob keeps resolution.
-     Consistent estimator: with enough labels this is the right answer. -->
+<!-- This is the pre-history of the line, the textbook answer everything else
+     is measured against. Walk the mechanism: the final model's scores on its
+     own training votes are optimistically shifted, so you cannot cut on them
+     directly. Instead split the votes into two stratified folds, train a
+     model per fold, and score each vote with the model that never saw it —
+     honest scores, at the price of training extra models on half the data.
+
+     Two design choices worth a sentence each: the folds are pooled rather
+     than averaged, so the Inclusion knob keeps its resolution over the merged
+     score set; and Inclusion enters only by biasing which quantile is cut,
+     never by reweighting training, so the ranking is identical at every knob
+     setting. Close on the property that defines the iteration: this is a
+     consistent estimator — with enough labels it converges to the right
+     answer. The next slide is about what happens before "enough". -->

--- a/slides/fragments/xcal.short.md
+++ b/slides/fragments/xcal.short.md
@@ -5,4 +5,13 @@
 - Pooled held-out folds, one conformal quantile cut
 - Right in the limit — wild when positives are scarce
 
-<!-- Brief-deck cut of xcal + xcal-results. -->
+<!-- Brief-deck cut of xcal + xcal-results; one slide carries the whole
+     iteration, so give the mechanism in one breath and the verdict in the
+     next. Mechanism: split the votes into folds, train a model per fold,
+     score each vote with the model that never saw it, pool, and cut one
+     conformal quantile — honest scores, and a consistent estimator that is
+     provably right with enough labels. Verdict: "enough labels" is doing all
+     the work. The cut is a low quantile over tens of positives, folds redraw
+     every vote, and below about 20 votes it degenerates into "admit nothing"
+     spikes. Plant the phrase "consistent but starved" — the next slide's GMM
+     is its exact mirror image, and the tension between them is the talk. -->

--- a/slides/render.sh
+++ b/slides/render.sh
@@ -1,24 +1,54 @@
 #!/usr/bin/env bash
-# Build one deck without make:  ./render.sh scale26-review [pdf|html|pptx]
+# Build one deck without make:  ./render.sh scale26-review [pdf|html|pptx] [--speaker]
+# --speaker builds the speaker view -> _out/<deck>.speaker.<fmt>: each page is
+# a miniature of the real rendered slide beside its presenter notes. It renders
+# the audience deck to per-slide PNGs first, so it is a two-pass build.
 set -euo pipefail
 cd "$(dirname "$0")"
 
-deck=${1:?usage: ./render.sh <deck-name> [pdf|html|pptx]}
-fmt=${2:-pdf}
+deck=${1:?usage: ./render.sh <deck-name> [pdf|html|pptx] [--speaker]}
+shift
+fmt=pdf
+speaker=
+for arg in "$@"; do
+    case "$arg" in
+        --speaker) speaker=1 ;;
+        pdf|html|pptx) fmt=$arg ;;
+        *) echo "unknown argument: $arg" >&2; exit 1 ;;
+    esac
+done
 
-./build.py "$deck"
+MARP=(npx --yes @marp-team/marp-cli@4)
 mkdir -p _out
 
 # Marp warns but exits 0 when a figure path doesn't resolve, producing a deck
 # with holes where the figures should be. Treat that warning as fatal.
-log=$(mktemp)
-trap 'rm -f "$log"' EXIT
-npx --yes @marp-team/marp-cli@4 "_build/$deck.md" \
-    --theme-set themes/ --allow-local-files -o "_out/$deck.$fmt" 2>&1 | tee "$log"
+run_marp() {
+    local log
+    log=$(mktemp)
+    "${MARP[@]}" "$@" --theme-set themes/ --allow-local-files 2>&1 | tee "$log"
+    if grep -q "local files are missing" "$log"; then
+        rm -f "$log"
+        echo "ERROR: Marp could not resolve some figures." >&2
+        return 1
+    fi
+    rm -f "$log"
+}
 
-if grep -q "local files are missing" "$log"; then
-    rm -f "_out/$deck.$fmt"
-    echo "ERROR: Marp could not resolve some figures. Deck removed." >&2
-    exit 1
+./build.py "$deck"
+
+if [[ -n $speaker ]]; then
+    mkdir -p _build/imgs
+    rm -f "_build/imgs/$deck".*.png
+    run_marp "_build/$deck.md" --images png -o "_build/imgs/$deck.png" \
+        || { echo "ERROR: slide-image pass failed." >&2; exit 1; }
+    ./build.py --speaker "$deck"
+    out="_out/$deck.speaker.$fmt"
+    run_marp "_build/$deck.speaker.md" -o "$out" \
+        || { rm -f "$out"; echo "ERROR: speaker deck removed." >&2; exit 1; }
+else
+    out="_out/$deck.$fmt"
+    run_marp "_build/$deck.md" -o "$out" \
+        || { rm -f "$out"; echo "ERROR: deck removed." >&2; exit 1; }
 fi
-echo "-> _out/$deck.$fmt"
+echo "-> $out"

--- a/slides/themes/vtsearch.css
+++ b/slides/themes/vtsearch.css
@@ -217,6 +217,40 @@ section.full h2 {
 section.caveat { background: #f7f8fa; }
 section.caveat h2 { color: var(--ink-soft); }
 
+/* --- Speaker pages (speaker builds only) ----------------------------- */
+
+/* The speaker build (`render.sh <deck> pdf --speaker`) emits one of these per
+   slide: a miniature PNG of the real rendered slide on the left, the
+   presenter notes beside it. Audience builds never emit the class, so these
+   rules are inert there. Notes sit at 20px — the speaker PDF is read at
+   laptop distance, but the type floor holds anyway. */
+section.speaker {
+  justify-content: flex-start;
+  padding: 36px 42px;
+}
+section.speaker .speaker-page {
+  display: flex;
+  gap: 34px;
+  align-items: flex-start;
+  height: 100%;
+}
+section.speaker .speaker-slide {
+  flex: 0 0 44%;
+}
+section.speaker .speaker-slide img {
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  box-shadow: 0 2px 10px rgba(20, 24, 31, 0.10);
+}
+section.speaker .speaker-notes {
+  flex: 1;
+  font-size: 20px;
+  line-height: 1.38;
+  color: var(--ink);
+}
+section.speaker .speaker-notes p { margin: 0 0 0.55em; }
+
 /* --- Pagination ------------------------------------------------------ */
 
 /* No running footer: the audience knows which talk they are in. Only the page


### PR DESCRIPTION
## What

**A speaker renderer for the markdown slide decks, plus real speaking notes on every calibration slide.**

PowerPoint-style author notes already half-existed: any non-directive HTML comment in a fragment is a Marp presenter note, exported into PPTX/HTML — but invisible in PDF, the format the decks actually ship in. This PR adds the missing renderer:

- `./render.sh <deck> pdf --speaker` produces `_out/<deck>.speaker.pdf` beside the audience `_out/<deck>.pdf`. Each speaker page is PowerPoint notes-page style: a miniature of the real rendered slide on the left (pixel-identical — it *is* a per-slide PNG of the audience deck, rendered in a first pass) with that slide's notes in a column beside it.
- `build.py --speaker` assembles the speaker markdown: it extracts each fragment's note comments (reflowing the comment's hard-wrapped lines, since Marp renders single newlines as hard breaks) and emits one `speaker-page` per slide. Notes are authored once, as comments — the audience build is untouched.
- The theme grows `section.speaker` rules (inert in audience builds); the miniature carries its own page number, so the speaker page suppresses the outer one via `_paginate: false`.
- `make speaker` builds every deck's speaker variant (delegates to `render.sh`, since the build is two-pass).

**Author notes**: every fragment used by the two calibration decks (`calibration-brief`, `calibration-deep-dive`) — 22 fragments including the `.short` variants, title, outline, roadmap, and thanks — now carries a full speaking note: wordier than the slide, covering what to say, what to emphasize, and the transition, grounded in the numbers and provenance of the committed reports under `docs/experiments/`.

**CLAUDE.md**: new standing rule per the user's request — any session that changes `slides/` must end by rendering the affected decks and attaching the PDFs in the conversation, so the result is viewable in-browser without checking out the branch.

## Testing

- Full `./run-tests.sh`: **RUN PASSED** (8866 passed, all gates green), re-run after rebasing onto the current `dev` (the SVM-head merge landed mid-session).
- `./build.py --check` passes for all 5 decks (the speaker mode adds no new gate surface).
- Both calibration decks rendered end-to-end (audience + speaker PDFs) with the container's chromium; sample pages inspected visually for layout, reflow, and pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqdDBvYyoSehcx7SLnTbfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqdDBvYyoSehcx7SLnTbfu)_