### PR TITLE
Gate slides-only changes with a slides-only test group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,7 @@ VTSearch is a desktop web app. **Do not design, implement, or test for mobile or
 
 ## Render and attach slide decks (when you change `slides/`)
 
-**Any session that changes the slide codebase must end by rendering the affected decks and attaching the PDFs in the conversation** (via `SendUserFile`), so the user can see the result in-browser without checking out the branch and running the build themselves. "Changes the slide codebase" means any edit under `slides/` — fragments, `.deck` manifests, the theme, figures, or the build/render tooling.
+**Any session that changes the slide codebase must end by rendering the affected decks and attaching the PDFs in the conversation** (via `SendUserFile`), so the user can see the result in-browser without checking out the branch and running the build themselves. "Changes the slide codebase" means any edit under `slides/` that can change what a rendered deck looks like — fragments, `.deck` manifests, the theme, figures, or the build/render tooling. Prose that renders nothing (`README.md`, `STYLE.md`) is the one exception: there is no output to show, so attaching a deck identical to the last one is noise rather than evidence.
 
 - **Which decks:** every deck whose output the change affects. A fragment edit affects the decks whose manifests name it (grep `slides/decks/*.deck`); a theme, `build.py`, or `render.sh` change affects all decks. When in doubt, render more rather than fewer.
 - **How:** `cd slides && ./render.sh <deck> pdf` for each affected deck. The cloud container has a browser; if Marp can't find it, use `CHROME_PATH=/opt/pw-browsers/chromium`. When presenter notes or the speaker pipeline changed, also render `./render.sh <deck> pdf --speaker` and attach that variant too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,7 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 
 - **Run tests (CPU, fast)**: `./run-tests.sh` (runs every gate listed under "What `run-tests.sh` gates" below, then pytest)
 - **Run tests by group**: `./run-tests.sh core`, `./run-tests.sh sorting`, `./run-tests.sh api` (see Test Groups below; every invocation runs the cheap serial gates — linters, doc checks, snapshot drift — first, but a group run **skips the heavy whole-repo gates** (pyright, pip-audit, and the frontend gates unless the group is `core`/`frontend`) to keep the inner loop fast; it says so in its output. `VTSEARCH_FULL_GATES=1` forces them. A **full** `./run-tests.sh` runs everything and is mandatory before pushing. `core` and `frontend` additionally run the frontend build + `npm audit`, and `frontend` alone also runs the Vitest unit suite)
+- **Run tests for a slides-only change**: `./run-tests.sh slides` (~4s; the four gates a deck can trip. This is the *complete* gate for a change confined to `slides/` — see the Test Groups table — and it refuses to run if the branch touches anything else)
 - **Run tests with coverage**: `VTSEARCH_COVERAGE=1 ./run-tests.sh` (opt-in; adds ~10-20% overhead)
 - **Run multiple groups**: `./run-tests.sh core sorting api`
 - **Run tests with extra args**: `./run-tests.sh core -- -x --tb=long` (args after `--` go to pytest)
@@ -373,7 +374,7 @@ Wrapping everything: a wall-clock cap (`VTSEARCH_TEST_TIMEOUT`, default **1800s 
 | Frontend unit tests | `cd frontend && npm run test:ci` | Full run or `frontend` **only** — deliberately off the fast `core` path | Headless Vitest. |
 | Python tests | `pytest tests/ tests_lib/ -n auto --dist loadgroup` | Every run except a `frontend`-only group | |
 
-**Group runs skip the whole-repo stage-3 gates** (pyright, pip-audit, and the frontend gates unless the group asks for them) so the edit/test loop stays in the seconds — the skip is announced in the output, and `VTSEARCH_FULL_GATES=1` forces the complete chain on a group run. Stage 1 runs on every invocation. This is a deliberate trade: the fast inner loop may miss a type error or CVE, which is why **a full `./run-tests.sh` remains mandatory before pushing.**
+**Group runs skip the whole-repo stage-3 gates** (pyright, pip-audit, and the frontend gates unless the group asks for them) so the edit/test loop stays in the seconds — the skip is announced in the output, and `VTSEARCH_FULL_GATES=1` forces the complete chain on a group run. Stage 1 runs on every invocation. This is a deliberate trade: the fast inner loop may miss a type error or CVE, which is why **a full `./run-tests.sh` remains mandatory before pushing** — with exactly one exception, `./run-tests.sh slides`, whose narrower scope is a proof rather than a gamble (see the Test Groups table) and which blocks itself the moment the diff stops being slides-only.
 
 ## Test Groups
 
@@ -393,6 +394,7 @@ Tests are grouped by folder under `tests/` and `tests_lib/`. Each folder is a py
 | `converters` | Media converters (document, video, image) |
 | `projection` | VTSBrowse UMAP projection + hex-tile pyramid (library tier) |
 | `frontend` | Frontend-only gate: Angular `build:prod` + `npm audit` + the headless Vitest unit suite. No Python tests; `./run-tests.sh frontend` skips pytest. Also runs as part of the full `./run-tests.sh`. |
+| `slides` | Slide-deck gate: `ruff`, `codespell`, `check-docs.py`, `slides/build.py --check`. No Python tests, no whole-repo gates. **The one group that also gates a push**, because a change confined to `slides/` cannot reach the rest of the repo: nothing imports `slides/build.py`, `pyrightconfig.json` excludes it, and no test in either tree reads a deck. Self-policing — the group refuses to run when the branch changes anything outside `slides/`, so the exemption can't be taken by mistake. Also runs as part of the full `./run-tests.sh`. |
 | `gpu` | CUDA-only tests (excluded by default) |
 
 **Recommended workflow**: Run `./run-tests.sh <group>` for the area you changed, then `./run-tests.sh` for the full suite.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -642,8 +642,8 @@ dependencies automatically and supports grouped test subsets:
 ```
 
 Available groups: `core`, `api`, `sorting`, `datasets`, `io`, `detectors`,
-`downloads`, `integration`, `cli`, `converters`, `projection`, `frontend`
-(plus `gpu` and `vtscore-clean`, which run separately). See
+`downloads`, `integration`, `cli`, `converters`, `projection`, `frontend`,
+`slides` (plus `gpu` and `vtscore-clean`, which run separately). See
 [`CLAUDE.md`](../CLAUDE.md) for the full group-to-file mapping.
 
 You can also run pytest directly:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,6 +383,7 @@ markers = [
     "converters: document and media converters",
     "projection: VTSBrowse UMAP projection and hex-tile pyramid",
     "frontend: frontend-only gate (Angular build + npm audit + Vitest unit suite); has no Python tests, runs via ./run-tests.sh frontend",
+    "slides: slide-deck gate (ruff, codespell, check-docs, deck preflight); has no Python tests, runs via ./run-tests.sh slides",
 ]
 # --timeout: per-test wall-clock cap, so one hung test fails with a traceback
 #   naming it instead of stalling the whole run. 300s is ~10x the slowest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,10 +7,13 @@
 #   ./run-tests.sh sorting      # sorting group + the cheap gates
 #   ./run-tests.sh core sorting # core + sorting groups
 #   ./run-tests.sh vtscore-clean  # run tests_lib/ with Flask import blocked
+#   ./run-tests.sh slides       # slide-deck gates only (~8s, no Python tests)
 #
 # Available groups: core, api, sorting, datasets, io, detectors,
 #                   downloads, integration, cli, converters, projection,
-#                   frontend (build + audit + Vitest, no Python tests), gpu
+#                   frontend (build + audit + Vitest, no Python tests),
+#                   slides (the four gates a deck can trip, no Python
+#                   tests — see the note below), gpu
 #
 # Each group is a folder under tests/ AND tests_lib/. Marker assignment is
 # automatic: any file at tests[_lib]/<group>/test_*.py gets marked <group>
@@ -57,6 +60,16 @@
 # a five-second group. The skip is announced on every group run, because the
 # full run is what actually gates a push. Set VTSEARCH_FULL_GATES=1 to force
 # the complete chain on a group run.
+#
+# `slides` goes further and is the one group that also gates a push, because a
+# change confined to slides/ cannot reach anything else in the repo: nothing
+# imports slides/build.py (it is a standalone script), pyrightconfig.json does
+# not include it, and no test in either tree touches a deck. So the group runs
+# only the four gates that can actually observe a deck — ruff (build.py),
+# codespell (slide prose), check-docs.py (fragments are tracked markdown), and
+# build.py --check — and skips pytest and every whole-repo gate. ~8s against
+# ~3.5min. The exemption is self-policing: the group refuses to run when the
+# branch touches anything outside slides/, so it cannot be taken by mistake.
 # ---------------------------------------------------------------------------
 
 set -euo pipefail
@@ -217,12 +230,64 @@ if [[ ${#TEST_GROUPS[@]} -eq 1 && "${TEST_GROUPS[0]}" == "frontend" ]]; then
     _run_pytest=false
 fi
 
+# `slides` is the same shape: no Python tests, so pytest is skipped rather than
+# asked for an empty `-m slides` selection. Unlike every other group this one
+# is also a legitimate pre-push gate; see the staging note at the top and the
+# guard immediately below, which is what makes that safe.
+_is_slides_run=false
+if [[ ${#TEST_GROUPS[@]} -eq 1 && "${TEST_GROUPS[0]}" == "slides" ]]; then
+    _is_slides_run=true
+    _run_pytest=false
+fi
+
 _blocked() {
     echo ""
     echo "============================================================"
     echo "TESTS BLOCKED: $1"
     echo "============================================================"
 }
+
+# Guard on the `slides` fast path.
+#
+# The group's whole justification is that a change confined to slides/ cannot
+# affect anything the skipped gates check. That premise is about the *diff*,
+# not about intent, so it is worth verifying rather than trusting: the failure
+# mode this prevents is someone believing their change is slides-only, taking
+# the 8s path, and pushing an unchecked edit to real code.
+#
+# "Confined to slides/" means everything this branch changes relative to dev —
+# committed, staged, unstaged, and untracked alike. Untracked files count
+# because a stray new .py would be linted by a full run and is exactly the kind
+# of thing that should not ride along unchecked.
+#
+# Strict on purpose: a docs/ or CLAUDE.md edit alongside the deck also fails
+# this, because the doc-inventory gate can see markdown that this group skips.
+# Run the full suite for a mixed change; it is the honest cost of one.
+if $_is_slides_run; then
+    _slides_base=$(git merge-base HEAD origin/dev 2>/dev/null || true)
+    if [[ -z "$_slides_base" ]]; then
+        echo "Note: no origin/dev to diff against; skipping the slides-only guard."
+    else
+        _outside=$(
+            {
+                git diff --name-only "$_slides_base" HEAD
+                git diff --name-only HEAD
+                git ls-files --others --exclude-standard
+            } | sort -u | grep -v '^slides/' || true
+        )
+        if [[ -n "$_outside" ]]; then
+            _blocked "'slides' is a slides-only gate, but this branch changes other files"
+            echo ""
+            echo "The group skips pytest and every whole-repo gate, which is only"
+            echo "sound when nothing outside slides/ has changed. Outside slides/:"
+            echo ""
+            echo "$_outside" | sed 's/^/  /'
+            echo ""
+            echo "Run the full suite instead:  ./run-tests.sh"
+            exit 1
+        fi
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 # Stage 1: cheap gates. Serial and fail-fast — the whole set is ~8s, so
@@ -260,73 +325,80 @@ if ! python scripts/check-docs.py ; then
     exit 1
 fi
 
-echo "Running deptry..."
-if ! python -m deptry . ; then
-    _blocked "deptry found dependency issues"
-    exit 1
-fi
+# Skipped on a `slides` run: none of these can see a deck. deptry reads
+# imports, the OpenAPI and doc-inventory snapshots are generated from the
+# app's registries, and the rest scan Dockerfiles / user-docs screenshots /
+# vtscore. The guard above has already established that nothing outside
+# slides/ changed, so there is nothing here for them to find.
+if ! $_is_slides_run; then
+    echo "Running deptry..."
+    if ! python -m deptry . ; then
+        _blocked "deptry found dependency issues"
+        exit 1
+    fi
 
-# OpenAPI snapshot drift check: regenerate the flask-smorest spec from
-# the live app and diff against the checked-in snapshot at
-# frontend/openapi.json. The frontend's generated TS client is built
-# from this snapshot, so a stale file means the generated client lags
-# the real API. Cheap (~2s) and runs every invocation.
-echo "Checking OpenAPI snapshot drift..."
-_openapi_regen=$(mktemp)
-_openapi_dump_log=$(mktemp)
-if ! python scripts/dump_openapi.py > "$_openapi_regen" 2> "$_openapi_dump_log"; then
-    _blocked "OpenAPI spec dump failed"
-    cat "$_openapi_dump_log"
+    # OpenAPI snapshot drift check: regenerate the flask-smorest spec from
+    # the live app and diff against the checked-in snapshot at
+    # frontend/openapi.json. The frontend's generated TS client is built
+    # from this snapshot, so a stale file means the generated client lags
+    # the real API. Cheap (~2s) and runs every invocation.
+    echo "Checking OpenAPI snapshot drift..."
+    _openapi_regen=$(mktemp)
+    _openapi_dump_log=$(mktemp)
+    if ! python scripts/dump_openapi.py > "$_openapi_regen" 2> "$_openapi_dump_log"; then
+        _blocked "OpenAPI spec dump failed"
+        cat "$_openapi_dump_log"
+        rm -f "$_openapi_regen" "$_openapi_dump_log"
+        exit 1
+    fi
+    if ! diff -u frontend/openapi.json "$_openapi_regen" > /dev/null; then
+        _blocked "OpenAPI snapshot is stale"
+        echo "Run 'npm run regenerate-openapi-snapshot' (or"
+        echo "'python scripts/dump_openapi.py > frontend/openapi.json') and"
+        echo "commit the result."
+        diff -u frontend/openapi.json "$_openapi_regen" | head -80
+        rm -f "$_openapi_regen" "$_openapi_dump_log"
+        exit 1
+    fi
     rm -f "$_openapi_regen" "$_openapi_dump_log"
-    exit 1
-fi
-if ! diff -u frontend/openapi.json "$_openapi_regen" > /dev/null; then
-    _blocked "OpenAPI snapshot is stale"
-    echo "Run 'npm run regenerate-openapi-snapshot' (or"
-    echo "'python scripts/dump_openapi.py > frontend/openapi.json') and"
-    echo "commit the result."
-    diff -u frontend/openapi.json "$_openapi_regen" | head -80
-    rm -f "$_openapi_regen" "$_openapi_dump_log"
-    exit 1
-fi
-rm -f "$_openapi_regen" "$_openapi_dump_log"
 
-# Generated doc-inventory drift check: regenerate the registry-backed
-# tables embedded in the docs (embedders, plugin families, demo datasets,
-# ...) and fail if any committed region is stale. Same shape as the
-# OpenAPI snapshot gate above; see scripts/gen-docs-inventories.py.
-echo "Checking generated doc inventories..."
-if ! python scripts/gen-docs-inventories.py --check ; then
-    _blocked "generated doc inventories are stale"
-    echo "Run 'python scripts/gen-docs-inventories.py' and commit the"
-    echo "result."
-    exit 1
-fi
+    # Generated doc-inventory drift check: regenerate the registry-backed
+    # tables embedded in the docs (embedders, plugin families, demo datasets,
+    # ...) and fail if any committed region is stale. Same shape as the
+    # OpenAPI snapshot gate above; see scripts/gen-docs-inventories.py.
+    echo "Checking generated doc inventories..."
+    if ! python scripts/gen-docs-inventories.py --check ; then
+        _blocked "generated doc inventories are stale"
+        echo "Run 'python scripts/gen-docs-inventories.py' and commit the"
+        echo "result."
+        exit 1
+    fi
 
-echo "Checking Dockerfiles..."
-if ! python scripts/check-dockerfiles.py ; then
-    _blocked "Dockerfile check failed"
-    exit 1
-fi
+    echo "Checking Dockerfiles..."
+    if ! python scripts/check-dockerfiles.py ; then
+        _blocked "Dockerfile check failed"
+        exit 1
+    fi
 
-# User-docs screenshot wiring: every manifest shot id has both theme PNGs on
-# disk, and every screenshot the user docs embed maps to a manifest id. Cheap,
-# browser-free (see docs/plans/user-docs-screenshots.md); the pixel-diff
-# (check.sh) needs chromium and stays a manual chore.
-echo "Checking user-docs screenshot wiring..."
-if ! python scripts/screenshots/wiring-check.py ; then
-    _blocked "user-docs screenshot wiring check failed"
-    exit 1
-fi
+    # User-docs screenshot wiring: every manifest shot id has both theme PNGs on
+    # disk, and every screenshot the user docs embed maps to a manifest id. Cheap,
+    # browser-free (see docs/plans/user-docs-screenshots.md); the pixel-diff
+    # (check.sh) needs chromium and stays a manual chore.
+    echo "Checking user-docs screenshot wiring..."
+    if ! python scripts/screenshots/wiring-check.py ; then
+        _blocked "user-docs screenshot wiring check failed"
+        exit 1
+    fi
 
-# vtscore package docs: every top-level module / sub-package of vtscore/ is
-# covered by a packages/ doc, and no doc cites a file.py:NNN line anchor (they
-# rot on the next edit; cite module-and-symbol instead). Regex sweep, imports
-# nothing, ~0.1s. See scripts/check-vtscore-docs.py for the policy.
-echo "Checking vtscore package docs..."
-if ! python scripts/check-vtscore-docs.py ; then
-    _blocked "vtscore package docs check failed"
-    exit 1
+    # vtscore package docs: every top-level module / sub-package of vtscore/ is
+    # covered by a packages/ doc, and no doc cites a file.py:NNN line anchor (they
+    # rot on the next edit; cite module-and-symbol instead). Regex sweep, imports
+    # nothing, ~0.1s. See scripts/check-vtscore-docs.py for the policy.
+    echo "Checking vtscore package docs..."
+    if ! python scripts/check-vtscore-docs.py ; then
+        _blocked "vtscore package docs check failed"
+        exit 1
+    fi
 fi
 
 # Slide decks: every deck manifest names fragments that exist and figures that
@@ -344,10 +416,12 @@ fi
 # resolution). This gate notices when one of those app surfaces changes, so the
 # eval default arm can't quietly stop being the shipped algorithm. Parses
 # source, imports nothing, ~0.3s.
-echo "Checking eval/app sync..."
-if ! python scripts/check-eval-app-sync.py ; then
-    _blocked "eval framework is out of sync with the app"
-    exit 1
+if ! $_is_slides_run; then
+    echo "Checking eval/app sync..."
+    if ! python scripts/check-eval-app-sync.py ; then
+        _blocked "eval framework is out of sync with the app"
+        exit 1
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -478,7 +552,13 @@ fi
 if [[ ${#_lane_names[@]} -gt 0 ]]; then
     echo "Running in parallel with the tests: ${_lane_names[*]}"
 fi
-if ! $_run_whole_repo_gates; then
+if $_is_slides_run; then
+    # Deliberately not the "a full run is the gate before pushing" notice below:
+    # for a change confined to slides/ this *is* the gate. Say what was skipped
+    # and why it is sound, so the claim stays auditable rather than folkloric.
+    echo "Slides-only run: pytest and every whole-repo gate skipped — nothing"
+    echo "outside slides/ changed, and no test or type-check reads a deck."
+elif ! $_run_whole_repo_gates; then
     echo "Group run: skipping pyright and pip-audit. A full './run-tests.sh' is"
     echo "the gate before pushing (or set VTSEARCH_FULL_GATES=1 to force them)."
 fi
@@ -588,6 +668,8 @@ if [[ ${#_failed_lanes[@]} -gt 0 || $_pytest_status -ne 0 ]]; then
 fi
 if $_run_pytest; then
     echo "RUN PASSED (all gates green; pytest summary above)"
+elif $_is_slides_run; then
+    echo "RUN PASSED (slides-only; this is the full gate for a slides-only change)"
 else
     echo "RUN PASSED (frontend-only; no Python tests in the 'frontend' group)"
 fi

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -60,6 +60,11 @@ ALLOWED_PATHS: dict[str, str] = {
     # hooks, so it is absent until the frontend has been built once -- and this
     # gate runs before that build, so a cold container would otherwise fail here.
     "frontend/src/app/generated/": "generated build stamp (frontend prebuild/pretest hook); gitignored",
+    # Marp build products. Both are gitignored, so they exist only on a machine
+    # that has rendered a deck since checkout -- which made this gate pass on
+    # the author's box and fail on a fresh clone.
+    "slides/_build/": "assembled deck markdown (slides/build.py); gitignored",
+    "slides/_out/": "rendered decks (slides/render.sh); gitignored",
     # Another repository's tree. Backticked because it reads as a path, but it
     # is the evaluation-framework repo's, and nothing here will ever create it.
     "scripts/sod/": "lives in the evaluation-framework repo, not this one (#2847)",

--- a/slides/README.md
+++ b/slides/README.md
@@ -17,6 +17,16 @@ _out/       rendered decks (gitignored)
 `build.py --check` runs as a `./run-tests.sh` gate, so a deck that names a
 missing fragment or figure fails the suite rather than rotting quietly.
 
+**Test a deck change with `./run-tests.sh slides`** — about four seconds, versus
+three and a half minutes for the full suite. It is not a shortcut you are
+trading safety for: it runs every gate that can observe a deck (ruff over
+`build.py`, codespell over slide prose, `check-docs.py` over the fragments, and
+the manifest preflight) and skips only checks that provably cannot see one —
+nothing imports `build.py`, pyright does not read it, and no test in either tree
+opens a deck. For a change confined to `slides/` it is the whole gate, and it
+refuses to run once the branch touches anything else, so it cannot quietly
+become one.
+
 **Read [`STYLE.md`](STYLE.md) before writing or editing a deck.** It holds the
 house rules that apply to every talk — no running footer, real subscripts,
 colour reserved for meaning, the 20px type floor, and the opening outline


### PR DESCRIPTION
## What

Editing a word on a slide cost a full `./run-tests.sh` — ~3.5 minutes re-verifying things the change provably cannot touch. This adds a `slides` group that runs in **~4 seconds** and is the *complete* gate for a change confined to `slides/`.

### Why the narrow scope is a proof, not a gamble

Only four gates can observe a deck change:

| Gate | Why it's relevant |
|---|---|
| `ruff check` / `ruff format --check` | `slides/build.py` is Python |
| `codespell` | typos in slide prose — the most valuable one here |
| `check-docs.py` | fragments are tracked markdown (40 of the 230 files it scans) |
| `slides/build.py --check` | missing fragment / unresolvable figure |

Everything else is structurally incapable of failing on one:

- `slides/build.py` is imported by nothing — it's a standalone script — and `pyrightconfig.json` includes only `vtsearch`, `vtscore`, `tests`, `tests_lib`, so pyright never reads it.
- No test in either tree opens a deck. The one file that mentions slides, `tests_lib/core/test_docs_gate.py`, exercises `check-docs.py`'s fragment path-resolution rule — it tests the gate script, not the decks.
- deptry, OpenAPI drift, doc inventories, dockerfiles, screenshot wiring, vtscore docs, eval/app sync, the Angular build, npm audit, Vitest, pip-audit: no code path reaches `slides/`.

The group follows the existing `frontend` precedent (a group with no Python tests that short-circuits pytest), and is registered as a pytest marker for the same reason `frontend` is, so `./run-tests.sh slides core` still resolves.

### Self-policing

The premise is about the *diff*, not intent, so it's verified rather than trusted: the group refuses to run when the branch changes anything outside `slides/`, counting committed, unstaged, and untracked files alike. The failure mode it prevents is someone believing their change is slides-only, taking the 4s path, and pushing unchecked code. Strict on purpose — a `docs/` or `CLAUDE.md` edit alongside the deck also blocks it, since the doc-inventory gate can see markdown this group skips.

```
TESTS BLOCKED: 'slides' is a slides-only gate, but this branch changes other files

The group skips pytest and every whole-repo gate, which is only
sound when nothing outside slides/ has changed. Outside slides/:

  vtscore/stray_helper.py

Run the full suite instead:  ./run-tests.sh
```

### Drive-by fix

Testing this in a fresh clone surfaced a real bug shipped in #3200: `CLAUDE.md` cites `slides/_out/`, which is gitignored, so `check-docs.py` **passed on a machine that had rendered a deck and failed on a clean checkout**. Both Marp build dirs are now allowlisted as the runtime-generated paths they are — the same treatment `static/` and `frontend/node_modules/` already get.

Also scopes the render-and-attach rule from #3200 to edits that can change rendered output, so a `slides/README.md` change doesn't demand a deck identical to the last one.

## Testing

- Full `./run-tests.sh`: **RUN PASSED** (8866 passed, all gates green).
- Guard verified in a scratch clone across all three cases: slides-only edit passes (3.75s), untracked figure inside `slides/` passes, untracked file outside `slides/` blocks.
- `-m "slides or core"` collects 894 tests with no unknown-marker error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqdDBvYyoSehcx7SLnTbfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqdDBvYyoSehcx7SLnTbfu)_