### PR TITLE
Show a plugin field's template variables in the form, not just on submit

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -234,6 +234,36 @@ placeholder into a filename. Every substituted value is run through
 `sanitize_template_value()`, so a detector named `../../etc/passwd`
 cannot escape the directory implied by an admin-configured template.
 
+**Declaring the variable is also what makes the GUI show the value.**
+Run-now plugin forms (the Export modal, the Auto-Detect results export)
+resolve a field's *declared* `template_vars` client-side when they build
+the form, so a field carrying `default="{detector_name}"` opens showing
+the detector's actual name instead of the raw placeholder — the user can
+see and edit the value before running. Undeclared placeholders are left
+alone (the `portable_detector` exporter withholds `detector_name` on
+purpose so it can substitute per-detector itself), and anything the
+browser can't resolve yet stays templated for the server to fill in. The
+server-side pass remains authoritative; the frontend copy is a preview.
+
+The corollary is the one anti-pattern to avoid: **don't resolve the
+active detector inside your `export()` / `run()` body.**
+
+```python
+# Wrong: the value only exists at run time, so the form shows an empty box.
+def export(self, results, field_values):
+    name = field_values["name"] or get_active_detector_context().name
+
+# Right: the framework fills it in, and the GUI can show it up front.
+PluginField(key="name", default="{detector_name}", template_vars=("detector_name",))
+```
+
+Persisted plugin configs — Auto-Find's saved exporter fields, a
+detector's labelset-sync source — deliberately keep the placeholder
+verbatim rather than a resolved value, because those templates are
+re-resolved on *every* later run: that is what gives a daily Auto-Find a
+fresh `results_{YYYY}.{MM}.{DD}.csv` and each detector its own
+`labels/{detector_name}.json`.
+
 ### Notifying the user (toasts)
 
 Sometimes a plugin hits a problem that is worth *mentioning* but not worth

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -536,6 +536,16 @@ without the stack one keypress closed them all and lost the outer form.
   outer view to return to and correctly has no back button. The full rule,
   including the canonical markup and the persistent-tab exception, is in
   [`CLAUDE.md`](../CLAUDE.md) under "Nested-modal back buttons".
+- **Plugin-field forms preview their template variables.** A modal that builds
+  a form from a plugin's `fields` (Export, Auto-Detect results) seeds each
+  value through `PluginTemplateVarsService`, which resolves the *declared*
+  `template_vars` — `{detector_name}`, `{username}`, the date parts — so the
+  user sees and can edit the value the server would substitute rather than a
+  raw placeholder (issue #3199). Only declared names are touched, and anything
+  unresolvable stays templated for the server. Never do this in a form whose
+  values are **persisted** (Auto-Find's saved exporter fields, a labelset-sync
+  source): those templates are meant to re-resolve on every later run. See
+  `utils/plugin-template-vars.ts`.
 
 ### Lazy loading and the bundle budget
 

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -9,6 +9,7 @@ import {
   ClipboardCopyComponent,
 } from '../../clipboard-copy/clipboard-copy.component';
 import { ExportersApiService } from '../../../services/exporters-api.service';
+import { PluginTemplateVarsService } from '../../../services/plugin-template-vars.service';
 import {
   AutoDetectHit,
   AutoDetectResultsData,
@@ -28,6 +29,7 @@ import { openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
 })
 export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   private exportersApi = inject(ExportersApiService);
+  private templateVars = inject(PluginTemplateVarsService);
 
   readonly data = input<AutoDetectResultsData>({ results: {} });
   readonly closed = output<void>();
@@ -154,7 +156,10 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
     this.exportFieldValues = {};
     for (const field of fields) {
       if (field.default) {
-        this.exportFieldValues[field.key] = field.default;
+        // Resolve the field's declared `template_vars` so a default like
+        // `"{detector_name}"` shows the real name instead of the placeholder
+        // (issue #3199); the server substitutes again, idempotently, on run.
+        this.exportFieldValues[field.key] = this.templateVars.resolveDefault(field);
       }
     }
   }

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -407,6 +407,83 @@ describe('ExportModalComponent', () => {
     });
   });
 
+  // Issue #3199: a plugin field whose default is templated on the active
+  // detector used to render its raw `{detector_name}` placeholder, because the
+  // substitution only ever happened server-side, at run time.
+  describe('templated field defaults', () => {
+    /** An exporter with a non-`filepath` field templated on the detector. */
+    const namedExporter = {
+      name: 'labelset_api',
+      display_name: 'Labelset API',
+      fields: [
+        {
+          key: 'label_set_name',
+          field_type: 'text',
+          default: '{detector_name}',
+          template_vars: ['detector_name'],
+        },
+        {
+          key: 'undeclared',
+          field_type: 'text',
+          default: '{detector_name}',
+        },
+      ],
+    };
+
+    /** Land a detector registry naming `d1`, as the app-level refresh would. */
+    function flushRegistry(): void {
+      TestBed.inject(DatasetStateService).refresh();
+      httpMock.expectOne('/api/datasets/registry').flush({ datasets: [] });
+      httpMock
+        .expectOne('/api/detectors/registry')
+        .flush({ detectors: [{ id: 'd1', name: 'Birdsong' }] });
+    }
+
+    it('resolves a declared detector_name into the form value', async () => {
+      fixture.componentRef.setInput('detectorName', 'Sirens');
+      await flushInit();
+      component.selectExporterTab(namedExporter as never);
+      expect(component.formValues['label_set_name']).toBe('Sirens');
+    });
+
+    it('leaves a placeholder the field never declared', async () => {
+      fixture.componentRef.setInput('detectorName', 'Sirens');
+      await flushInit();
+      component.selectExporterTab(namedExporter as never);
+      // `portable_detector` withholds the declaration on purpose so it can
+      // substitute per-detector itself; the preview must respect that.
+      expect(component.formValues['undeclared']).toBe('{detector_name}');
+    });
+
+    it('leaves the placeholder for the server when no detector is known', async () => {
+      await flushInit();
+      component.selectExporterTab(namedExporter as never);
+      expect(component.formValues['label_set_name']).toBe('{detector_name}');
+    });
+
+    it('backfills the name when the detector registry resolves late', async () => {
+      await flushInit();
+      TestBed.inject(ActiveContextService).setActivePair('ds1', 'd1');
+      component.selectExporterTab(namedExporter as never);
+      expect(component.formValues['label_set_name']).toBe('{detector_name}');
+
+      flushRegistry();
+      TestBed.tick();
+      expect(component.formValues['label_set_name']).toBe('Birdsong');
+    });
+
+    it('leaves a user-edited value alone when the name arrives late', async () => {
+      await flushInit();
+      TestBed.inject(ActiveContextService).setActivePair('ds1', 'd1');
+      component.selectExporterTab(namedExporter as never);
+      component.formValues['label_set_name'] = 'mine';
+
+      flushRegistry();
+      TestBed.tick();
+      expect(component.formValues['label_set_name']).toBe('mine');
+    });
+  });
+
   it('emits closed on close', async () => {
     await flushInit();
     vi.spyOn(component.closed, 'emit');

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -24,6 +24,7 @@ import { ActiveDetectorService } from '../../../services/active-detector.service
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
 import { ExportersApiService } from '../../../services/exporters-api.service';
 import { LabelSessionService } from '../../../services/label-session.service';
+import { PluginTemplateVarsService } from '../../../services/plugin-template-vars.service';
 import { SortingApiService } from '../../../services/sorting-api.service';
 import type { LabelFilter } from '../../../services/sorting-api.service';
 import { ToastService } from '../../../services/toast.service';
@@ -69,6 +70,7 @@ export class ExportModalComponent implements OnInit {
   private readonly datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private readonly exportersApi = inject(ExportersApiService);
   private readonly labelSession = inject(LabelSessionService);
+  private readonly templateVars = inject(PluginTemplateVarsService);
   private readonly sortingApi = inject(SortingApiService);
   private readonly activeDetector = inject(ActiveDetectorService);
   private readonly toast = inject(ToastService);
@@ -199,8 +201,12 @@ export class ExportModalComponent implements OnInit {
       const exporter = this.selectedExporter ?? this.activeTabExporter;
       if (!exporter) return;
       if (!detectorName && !datasetName) return;
-      if (this.formValues['filepath'] !== this.lastAutoFilename) return;
-      this.applyDefaultFilename(exporter);
+      if (this.formValues['filepath'] === this.lastAutoFilename) {
+        this.applyDefaultFilename(exporter);
+      }
+      // Same late-arrival story for any *other* field whose default is
+      // templated on the detector name (issue #3199).
+      this.reapplyTemplateDefaults(exporter);
     });
   }
 
@@ -456,7 +462,18 @@ export class ExportModalComponent implements OnInit {
    *  option when a select field has no default (so the form is never sitting
    *  on a blank pulldown that the user has to actively populate). */
   private defaultFor(field: ImporterField): string {
-    if (field.default) return field.default;
+    if (field.default) {
+      // A default that uses the field's declared `template_vars` is resolved
+      // for display, so `"{detector_name}"` opens as the detector's actual
+      // name rather than the raw placeholder (issue #3199). The server
+      // substitutes again on submit - idempotently, since the placeholder is
+      // already gone - and anything this client can't resolve (no detector
+      // loaded yet) stays templated for the server to fill in, exactly as
+      // before.
+      return this.templateVars.resolveDefault(field, {
+        detectorName: this.effectiveDetectorName(),
+      });
+    }
     if (
       field.field_type === 'select' &&
       !field.dynamic_options &&
@@ -472,6 +489,43 @@ export class ExportModalComponent implements OnInit {
    *  against the live field value to tell "still ours" from "user-edited"
    *  before the constructor effect regenerates it. */
   private lastAutoFilename = '';
+
+  /** Per-field values this component last auto-filled from a templated
+   *  default, for the same "still ours" test as `lastAutoFilename` — the
+   *  detector name can land after the form was built, and re-resolving must
+   *  never overwrite something the user typed. */
+  private lastAutoValues: Record<string, string> = {};
+
+  /** Seed `formValues` from *exporter*'s field defaults, recording what was
+   *  auto-filled so a late-resolving template var can refresh it. */
+  private initFormValues(exporter: ExporterEntry): void {
+    this.formValues = {};
+    this.lastAutoValues = {};
+    for (const f of this.exporterFieldsOf(exporter)) {
+      const value = this.defaultFor(f);
+      this.formValues[f.key] = value;
+      this.lastAutoValues[f.key] = value;
+    }
+  }
+
+  /** Re-resolve templated defaults once a variable they need arrives.
+   *
+   *  `detector_name` is the case that bites: the detector registry can settle
+   *  after the modal opened, which used to leave a `{detector_name}` default
+   *  showing its placeholder forever. Only fields still holding exactly what
+   *  we auto-filled are rewritten, so a user edit is never clobbered.
+   *  `filepath` is skipped — `applyDefaultFilename` owns that one and builds a
+   *  richer name (filter + detector + dataset) than the plugin's template. */
+  private reapplyTemplateDefaults(exporter: ExporterEntry): void {
+    for (const f of this.exporterFieldsOf(exporter)) {
+      if (f.key === 'filepath') continue;
+      if (!f.default || !f.template_vars?.length) continue;
+      if (this.formValues[f.key] !== this.lastAutoValues[f.key]) continue;
+      const value = this.defaultFor(f);
+      this.formValues[f.key] = value;
+      this.lastAutoValues[f.key] = value;
+    }
+  }
 
   /** Apply the dynamic default filename to the filepath form field if present. */
   private applyDefaultFilename(exporter: ExporterEntry): void {
@@ -495,10 +549,7 @@ export class ExportModalComponent implements OnInit {
       return;
     }
     this.selectedExporter = exporter;
-    this.formValues = {};
-    for (const f of fields) {
-      this.formValues[f.key] = this.defaultFor(f);
-    }
+    this.initFormValues(exporter);
     this.applyDefaultFilename(exporter);
     this.actionError.set('');
     this.status.set('');
@@ -508,10 +559,7 @@ export class ExportModalComponent implements OnInit {
   selectExporterTab(exporter: ExporterEntry): void {
     this.activeTab = exporter.name;
     this.selectedExporter = exporter;
-    this.formValues = {};
-    for (const f of this.exporterFieldsOf(exporter)) {
-      this.formValues[f.key] = this.defaultFor(f);
-    }
+    this.initFormValues(exporter);
     this.applyDefaultFilename(exporter);
     this.actionError.set('');
     this.status.set('');

--- a/frontend/src/app/services/plugin-template-vars.service.ts
+++ b/frontend/src/app/services/plugin-template-vars.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+import { ActiveDetectorService } from './active-detector.service';
+import { AuthService } from './auth.service';
+import type { ImporterField } from '../models/api.models';
+import {
+  resolveTemplateVars,
+  type TemplateVarContext,
+} from '../utils/plugin-template-vars';
+
+/**
+ * Resolves a plugin field's declared `{template_vars}` for *display*, using the
+ * app's live view of who and what the server would resolve them against.
+ *
+ * The substitution itself is the server's job and stays there; this is the
+ * preview half, so a field whose default is `"{detector_name}"` opens showing
+ * the detector's name instead of the raw placeholder (issue #3199). See
+ * `utils/plugin-template-vars.ts` for the rules — in particular that it belongs
+ * only in **run-now** forms, never in a persisted plugin config whose template
+ * must survive to be re-resolved on each later run.
+ */
+@Injectable({ providedIn: 'root' })
+export class PluginTemplateVarsService {
+  private readonly activeDetector = inject(ActiveDetectorService);
+  private readonly auth = inject(AuthService);
+
+  private readonly authStatus = toSignal(this.auth.status$, { initialValue: null });
+
+  /** Logged-in user, `''` until `/api/auth/status` lands. */
+  readonly username = computed(() => this.authStatus()?.user ?? '');
+
+  /**
+   * The context the server would resolve against: the active detector and the
+   * signed-in user. `overrides` lets a caller name the detector it is actually
+   * acting on when that differs from the active one (the Dashboard exports a
+   * row's detector, which need not be the active one).
+   */
+  context(overrides?: Partial<TemplateVarContext>): TemplateVarContext {
+    return {
+      detectorName: this.activeDetector.detectorName(),
+      detectorId: this.activeDetector.detectorId(),
+      username: this.username(),
+      ...overrides,
+    };
+  }
+
+  /** `field`'s declared default with its declared template vars resolved. */
+  resolveDefault(field: ImporterField, overrides?: Partial<TemplateVarContext>): string {
+    return this.resolve(field.default ?? '', field, overrides);
+  }
+
+  /** `value` with `field`'s declared template vars resolved. */
+  resolve(
+    value: string,
+    field: ImporterField,
+    overrides?: Partial<TemplateVarContext>,
+  ): string {
+    return resolveTemplateVars(value, field.template_vars, this.context(overrides), field.field_type);
+  }
+}

--- a/frontend/src/app/utils/plugin-template-vars.spec.ts
+++ b/frontend/src/app/utils/plugin-template-vars.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveTemplateVars, sanitizeTemplateValue } from './plugin-template-vars';
+
+const CTX = {
+  detectorName: 'MyDetector',
+  detectorId: 'det-1',
+  username: 'alice',
+  now: new Date(Date.UTC(2026, 7, 20, 4, 5, 6)),
+};
+
+describe('sanitizeTemplateValue', () => {
+  it.each([
+    ['plain', 'plain'],
+    ['a/b', 'a_b'],
+    ['a\\b', 'a_b'],
+    ['..', '_'],
+    ['.', '_'],
+    ['...', '_'],
+    ['', '_'],
+    ['../../etc/passwd', '.._.._etc_passwd'],
+  ])('sanitizes %s -> %s', (input, expected) => {
+    expect(sanitizeTemplateValue(input)).toBe(expected);
+  });
+});
+
+describe('resolveTemplateVars', () => {
+  it('substitutes a declared detector_name', () => {
+    expect(resolveTemplateVars('{detector_name}', ['detector_name'], CTX)).toBe('MyDetector');
+  });
+
+  it('leaves a placeholder the field does not declare', () => {
+    // The portable_detector exporter deliberately withholds `detector_name`
+    // so it can substitute per-detector itself; the preview must respect that.
+    expect(resolveTemplateVars('data/{detector_name}.zip', ['YYYYMMDD'], CTX)).toBe(
+      'data/{detector_name}.zip',
+    );
+  });
+
+  it('leaves a declared placeholder that cannot be resolved yet', () => {
+    expect(resolveTemplateVars('{detector_name}', ['detector_name'], { ...CTX, detectorName: '' })).toBe(
+      '{detector_name}',
+    );
+  });
+
+  it('formats date variables in UTC', () => {
+    expect(
+      resolveTemplateVars(
+        '{YYYY}.{MM}.{DD}/{YYYYMMDD}/{YYYYMMDD-HHMMSS}',
+        ['YYYY', 'MM', 'DD', 'YYYYMMDD', 'YYYYMMDD-HHMMSS'],
+        CTX,
+      ),
+    ).toBe('2026.08.20/20260820/20260820-040506');
+  });
+
+  it('substitutes every occurrence of a placeholder', () => {
+    expect(resolveTemplateVars('{username}/{username}', ['username'], CTX)).toBe('alice/alice');
+  });
+
+  it('sanitizes a resolved value the way the server does', () => {
+    expect(
+      resolveTemplateVars('data/{detector_name}.json', ['detector_name'], {
+        ...CTX,
+        detectorName: '../evil',
+      }),
+    ).toBe('data/.._evil.json');
+  });
+
+  it('leaves non-text-like field types alone', () => {
+    expect(resolveTemplateVars('{detector_name}', ['detector_name'], CTX, 'number')).toBe(
+      '{detector_name}',
+    );
+    expect(resolveTemplateVars('{detector_name}', ['detector_name'], CTX, 'server_path')).toBe(
+      'MyDetector',
+    );
+  });
+
+  it('is a no-op without declared vars or without a value', () => {
+    expect(resolveTemplateVars('{detector_name}', [], CTX)).toBe('{detector_name}');
+    expect(resolveTemplateVars('{detector_name}', undefined, CTX)).toBe('{detector_name}');
+    expect(resolveTemplateVars('', ['detector_name'], CTX)).toBe('');
+  });
+
+  it('ignores a variable name it does not know', () => {
+    expect(resolveTemplateVars('{bogus}', ['bogus'], CTX)).toBe('{bogus}');
+  });
+});

--- a/frontend/src/app/utils/plugin-template-vars.ts
+++ b/frontend/src/app/utils/plugin-template-vars.ts
@@ -1,0 +1,142 @@
+/**
+ * Client-side preview of the `{template_vars}` the server substitutes into
+ * plugin field values.
+ *
+ * A plugin field can declare `template_vars=("detector_name", "YYYYMMDD", …)`,
+ * and `vtscore.plugins.normalize.normalize_field_values` resolves those
+ * placeholders **server-side, at run time**. That is the authoritative
+ * substitution and it stays that way — nothing here changes what the plugin
+ * finally receives.
+ *
+ * What it *did* mean, though, is that a field whose default is
+ * `"{detector_name}"` rendered in the GUI as the literal string
+ * `{detector_name}` (or, when the plugin resolved the value lazily in its own
+ * body, as an empty box). The user never saw the value they were about to
+ * export with, and had nothing to edit (issue #3199). These helpers close that
+ * gap by resolving the *declared* variables for display, so the form opens on
+ * the same string the server would have produced.
+ *
+ * Three rules keep the preview honest:
+ *
+ * 1. **Only declared variables are touched.** A `{detector_name}` in a field
+ *    that doesn't declare it is left alone, because the server would leave it
+ *    alone too — the `portable_detector` exporter deliberately withholds that
+ *    declaration so it can substitute per-detector itself.
+ * 2. **Unresolvable variables are left as placeholders.** When the detector
+ *    registry hasn't landed yet, `{detector_name}` stays literal rather than
+ *    collapsing to an empty string, so the server still fills it in on submit.
+ *    That makes the worst case exactly the old behaviour.
+ * 3. **Resolved values are sanitised the same way the server sanitises them**
+ *    (`vtscore.security.path_validation.sanitize_template_value`), so the
+ *    preview can't promise a path the server would spell differently.
+ *
+ * Only ever use this for **run-now** forms (the Export modal, the Auto-Detect
+ * results export). A *persisted* plugin config — Auto-Find's saved exporter
+ * fields, a detector's labelset-sync source — must keep the placeholder
+ * verbatim: those templates are re-resolved on every later run, which is the
+ * whole point of `results_{YYYY}.{MM}.{DD}.csv` on a daily Auto-Find and of
+ * `labels/{detector_name}.json` on a sync source. Freezing them at edit time
+ * would quietly pin every future run to the day the box was filled in.
+ */
+
+/** Field types whose values the server template-substitutes (`_TEXT_LIKE_TYPES`). */
+const TEXT_LIKE_FIELD_TYPES: ReadonlySet<string> = new Set([
+  'text',
+  'url',
+  'email',
+  'password',
+  'folder',
+  'server_path',
+  'select',
+]);
+
+/** Values the caller can supply for the non-date template variables. */
+export interface TemplateVarContext {
+  /** Resolves `{detector_name}`; `''` when no detector is known yet. */
+  detectorName?: string;
+  /** Resolves `{detector_id}`; `''` when no detector is known yet. */
+  detectorId?: string;
+  /** Resolves `{username}`; `''` when auth status hasn't landed. */
+  username?: string;
+  /** Clock for the date variables. Defaults to now; injectable for tests. */
+  now?: Date;
+}
+
+/**
+ * Mirror of `sanitize_template_value`: make a resolved value safe to splice
+ * into a path template. Path separators and NULs become `_`, and an empty or
+ * all-dots value collapses to `_` (`.` and `..` address directories).
+ */
+export function sanitizeTemplateValue(value: string): string {
+  const sanitized = value.replace(/[/\\\0]/g, '_');
+  if (!sanitized || /^\.+$/.test(sanitized)) return '_';
+  return sanitized;
+}
+
+/** Zero-pad to two digits. */
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+/**
+ * Resolve one date/time variable in UTC — the server formats with
+ * `datetime.now(timezone.utc)`, so a local-time preview would be off by the
+ * viewer's offset (and name a different day either side of midnight).
+ */
+function resolveDateVar(name: string, now: Date): string | null {
+  const yyyy = String(now.getUTCFullYear()).padStart(4, '0');
+  const mm = pad2(now.getUTCMonth() + 1);
+  const dd = pad2(now.getUTCDate());
+  switch (name) {
+    case 'YYYYMMDD-HHMMSS':
+      return `${yyyy}${mm}${dd}-${pad2(now.getUTCHours())}${pad2(now.getUTCMinutes())}${pad2(now.getUTCSeconds())}`;
+    case 'YYYYMMDD':
+      return `${yyyy}${mm}${dd}`;
+    case 'YYYY':
+      return yyyy;
+    case 'MM':
+      return mm;
+    case 'DD':
+      return dd;
+    default:
+      return null;
+  }
+}
+
+/** Resolve a single `{var}`, or `null` when this client can't (rule 2 above). */
+function resolveVar(name: string, ctx: TemplateVarContext): string | null {
+  const dated = resolveDateVar(name, ctx.now ?? new Date());
+  if (dated !== null) return dated;
+  if (name === 'detector_name') return ctx.detectorName || null;
+  if (name === 'detector_id') return ctx.detectorId || null;
+  if (name === 'username') return ctx.username || null;
+  // Unknown to this client (a newer server variable, or a plugin typo the
+  // server will reject on submit): leave it for the server to deal with.
+  return null;
+}
+
+/**
+ * Substitute the *declared* `templateVars` in `value` for display.
+ *
+ * Returns `value` unchanged when nothing is declared, when the field type
+ * isn't one the server substitutes, or when no declared placeholder resolves.
+ */
+export function resolveTemplateVars(
+  value: string,
+  templateVars: readonly string[] | null | undefined,
+  ctx: TemplateVarContext,
+  fieldType?: string,
+): string {
+  if (!value || !templateVars?.length) return value;
+  if (fieldType !== undefined && !TEXT_LIKE_FIELD_TYPES.has(fieldType)) return value;
+
+  let out = value;
+  for (const name of templateVars) {
+    const placeholder = `{${name}}`;
+    if (!out.includes(placeholder)) continue;
+    const resolved = resolveVar(name, ctx);
+    if (resolved === null) continue;
+    out = out.split(placeholder).join(sanitizeTemplateValue(resolved));
+  }
+  return out;
+}

--- a/vtscore/docs/extending/results-exporters.md
+++ b/vtscore/docs/extending/results-exporters.md
@@ -143,6 +143,14 @@ user's `{YYYYMMDD}` ends up literally in the filename. Declaring a name
 outside the supported set raises `ValueError` on the first request, so
 typos fail loudly.
 
+**Declaring is also what makes the GUI show the value.** Run-now plugin
+forms resolve a field's *declared* variables client-side while building
+the form, so a field carrying `default="{detector_name}"` opens showing
+the detector's real name instead of the raw placeholder - visible and
+editable before the user hits Export. Resolving the active detector
+inside your `export()` body instead gets you an empty box in the UI and
+a value that appears out of nowhere on submit.
+
 ## Server-path and URL validation
 
 **A declared field is already validated.** Because a field typed


### PR DESCRIPTION
## The gap

A plugin field can declare `template_vars` (`{detector_name}`, `{username}`, the date parts) and `vtscore.plugins.normalize` substitutes them into the value **server-side, at run time**. Nothing ever told the *frontend* about that, so:

- a field whose `default` is `"{detector_name}"` rendered the raw placeholder, and
- a plugin that resolved the active detector inside its own `export()` body (`if not name: name = get_active_detector_context().name`) rendered an empty box.

Either way the user never saw the value they were about to export with, and had nothing to edit — the value simply appeared, out of nowhere, on submit. That is exactly what #3199 hit.

## The fix

Resolve a field's **declared** template vars client-side while a *run-now* plugin form is built, so the field opens on the string the server would produce. Three rules keep the preview honest:

- **Only declared variables are touched.** `portable_detector` deliberately withholds `detector_name` so it can substitute per-detector itself; its `data/{detector_name}-detector.zip` default is left exactly as it is.
- **An unresolvable variable stays a placeholder** for the server to fill in — so the worst case (detector registry hasn't landed yet) is precisely the old behaviour, not an empty string.
- **Resolved values are sanitised the way `sanitize_template_value` sanitises them**, and dates are formatted in UTC like the server's, so the preview can't promise a path the server would spell differently.

The server-side pass stays authoritative and stays idempotent: a value whose placeholder is already gone passes through it unchanged.

The Export modal additionally re-resolves when the detector name arrives late (the #2819 lifecycle gap), reusing the same "still holds what we auto-filled" guard as `applyDefaultFilename`, so a user edit is never clobbered.

**Persisted plugin configs are deliberately excluded.** Auto-Find's saved exporter fields and a detector's labelset-sync source must keep the placeholder verbatim, because those templates are re-resolved on *every* later run — that is what gives a daily Auto-Find a fresh `results_{YYYY}.{MM}.{DD}.csv` and each detector its own `labels/{detector_name}.json`. Freezing them at edit time would silently pin every future run to the day the box was filled in.

## Changes

- `frontend/src/app/utils/plugin-template-vars.ts` — pure resolver + the `sanitize_template_value` mirror.
- `frontend/src/app/services/plugin-template-vars.service.ts` — binds it to `ActiveDetectorService` / `AuthService`.
- Wired into the Export modal and the Auto-Detect results export (the two run-now exporter forms).
- Docs: `docs/EXTENDING-plugins.md`, `vtscore/docs/extending/results-exporters.md` (including the "don't resolve the detector inside `export()`" anti-pattern the issue ran into), and a `docs/FRONTEND.md` note on the run-now-only rule.

## Testing

Full `./run-tests.sh`: `RUN PASSED` — 8866 pytest tests, pyright, pip-audit, npm audit, and the Vitest suite all green. New coverage: 17 unit tests for the resolver (declared-only, unresolvable-stays-templated, UTC dates, sanitisation, field-type gate) and 5 Export-modal specs (resolves, respects an undeclared placeholder, backfills on a late registry, leaves a user edit alone).

Closes #3199


---
_Generated by [Claude Code](https://claude.ai/code/session_01C3SPfvTyh2UKxeHHg677EE)_