### PR TITLE
Refuse a branch whose tree is stale, before it clobbers dev again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,7 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 - **CLI autodetect + exporter**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --dataset <file.pkl> --settings <settings.json> --exporter server_json_file --filepath results.json`
 - **CLI autodetect + importer**: `bash .claude/hooks/ensure-test-deps.sh && python app.py --autodetect --importer server_folder --path /data/sounds --media-type audio --settings <settings.json>`
 - **Check eval/app sync**: `python scripts/check-eval-app-sync.py` (also a `./run-tests.sh` gate; re-pin with `--update` after reconciling the harness)
+- **Check for a stale tree**: `python scripts/check-phantom-base.py` (also the first `./run-tests.sh` gate; fails when the branch deletes files it never created. Override a deliberate deletion with `VTSEARCH_ALLOW_DELETIONS=1`)
 - **Check documentation**: `python scripts/check-docs.py` (also a `./run-tests.sh` gate; validates relative links, `#anchors`, backticked repo paths, absolute-path leaks, `docs/plans/*.md` citations anywhere in the tree, and code fences. Pure invariants — nothing to re-pin. Fix the doc, or add an allowlist entry with a reason if the path is runtime-generated or a deliberately fictional example)
 - **Regenerate doc inventories**: `python scripts/gen-docs-inventories.py` (fills the `<!-- BEGIN GENERATED: ... -->` regions in the docs from the live registries — embedders, plugin families, demo datasets; `--check` is a `./run-tests.sh` gate, so registry changes require rerunning this and committing the result)
 - **Install deps**: `bash scripts/install.sh` (auto-detects CPU vs GPU; pass `cpu`/`gpu` to force, or a `cuXYZ` tag to override the GPU wheel, e.g. `bash scripts/install.sh cu121`)
@@ -349,6 +350,7 @@ Wrapping everything: a wall-clock cap (`VTSEARCH_TEST_TIMEOUT`, default **1800s 
 
 | Gate | Command it runs | Notes |
 |------|-----------------|-------|
+| Stale tree | `scripts/check-phantom-base.py` | **Runs first.** Refuses a branch whose tree matches an *ancestor* of `origin/dev` rather than `origin/dev` — the signature of a stale checkout committed onto a fresh HEAD, which has silently reverted five merged PRs. Compares against the working tree, so it fires before the clobber is committed. A deliberate deletion (a shipped plan file) passes with `VTSEARCH_ALLOW_DELETIONS=1`. |
 | Lint | `ruff check .` | |
 | Format | `ruff format --check .` | Fix with `ruff format .`. |
 | Spelling | `codespell --toml pyproject.toml` | |

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -294,10 +294,28 @@ fi
 # stopping at the first failure costs nothing.
 # ---------------------------------------------------------------------------
 
+# Stale-tree ("phantom base") check.
+#
+# Runs before every other gate, because a clobbered tree passes all of them by
+# construction: when a branch reverts the PRs that merged just before it, the
+# feature and its tests go together, so there is nothing left to fail. Five
+# PRs have done exactly that (#2741, #2793, #2821, #3184 and the three
+# restored in #3206); one reached `main`. Linting the wrong tree cleanly is
+# not information, so this asks *whether it is the right tree* first.
+#
+# Compares against the working tree rather than HEAD: the deletions exist
+# before they are committed, which is often when tests run. Pure git, ~40ms.
+# See scripts/check-phantom-base.py for the signal and its false-positive rate.
+echo "Checking for a stale tree..."
+if ! python scripts/check-phantom-base.py ; then
+    _blocked "branch deletes files it never created (stale tree)"
+    exit 1
+fi
+
 # Ruff lint + format check.
-# Runs first because it's fast (~0.5s) and catches mistakes the pytest /
-# frontend stages can't see, e.g. F401 unused-import on TYPE_CHECKING
-# imports whose only "use" is inside a string-form forward reference.
+# Fast (~0.5s), and catches mistakes the pytest / frontend stages can't see,
+# e.g. F401 unused-import on TYPE_CHECKING imports whose only "use" is inside
+# a string-form forward reference.
 echo "Running ruff check..."
 if ! ruff check . ; then
     _blocked "ruff check failed"

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -53,7 +53,6 @@ ALLOWED_PATHS: dict[str, str] = {
     # Runtime-generated: written by a running app, absent from a clean checkout.
     "data/": "runtime data directory (gitignored); settings, detectors, datasets, uploads",
     "static/": "Angular build output (gitignored)",
-    "slides/_out/": "rendered slide decks (slides/render.sh); gitignored",
     "vtsearch/_version.txt": "baked into Docker images only; gitignored",
     "frontend/node_modules/": "npm install output",
     "frontend/src/app/api/": "generated API client (npm run generate-api-client)",

--- a/scripts/check-phantom-base.py
+++ b/scripts/check-phantom-base.py
@@ -1,0 +1,174 @@
+"""Refuse a branch whose tree is consistent with an *ancestor* of its base.
+
+Five times now, a PR has silently reverted the PRs that merged just before it
+(#2741, #2793, #2821, #3184, and the three restored in #3206). Every occurrence
+had the same shape, and it is not the shape the reports assumed: the branch's
+**merge-base was `origin/dev`'s tip**, zero commits behind. What was stale was
+the *worktree*. HEAD moved forward onto fresh `dev` while the checkout still
+held the old content, and the difference was staged wholesale — so the commit
+records a deletion for every file `dev` had gained in the meantime.
+
+That is why nothing caught it. A staleness check on the merge-base reads 0
+commits behind and passes. The suite passes too, and cannot do otherwise: a
+clobber removes a feature *and its tests* in one motion, so the deletions are
+self-consistent. #2821's revert rode `dev` into `main` in the 2026-08-04
+release before anyone noticed.
+
+The signal this gate uses instead is the tree itself. Walk back the first-parent
+chain from the merge-base; if some ancestor makes the set of deleted paths
+**empty**, then the branch's content matches that ancestor rather than the base
+it claims — a stale tree. Across 303 merges on `dev` this flagged 7 branches: 4
+genuine clobbers (all of them) and 3 deliberate deletions.
+
+Two findings from that sweep are load-bearing here:
+
+- **Size proves nothing.** Two of the real clobbers deleted 2 and 3 files —
+  smaller than nothing separates them from the deliberate one-file deletions.
+  There is no magnitude threshold to hide behind, so the gate reports every hit.
+- **The comparison must reach the worktree.** The clobber exists as uncommitted
+  deletions before it is ever committed; `git status` showed 43 of them the
+  whole time. Diffing `origin/dev...HEAD` alone misses it when tests run before
+  the commit, so every diff below ends at the working tree, not at HEAD.
+
+Rename detection runs at 40%, not git's default 50%: the one false positive
+that was a pure rename scored 47% and would otherwise read as a deletion.
+
+The deliberate-deletion escape hatch is `VTSEARCH_ALLOW_DELETIONS=1`. It is
+expected to be needed about once per 100 PRs — `CLAUDE.md` tells you to delete
+a plan file when it ships, and that is what the remaining false positives were.
+
+Run from the repo root:
+    python scripts/check-phantom-base.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# How far back along first-parent to look for the branch's real base. The
+# observed clobbers sat 4-37 commits behind; 200 is far past any of them while
+# keeping the walk to a few milliseconds.
+MAX_WALK = 200
+
+# Git's default rename threshold is 50%. The single pure-rename false positive
+# in the historical sweep (scripts/reconcile-dev-labels.py ->
+# reconcile-solved-labels.py, #3155) scored 47%, so it read as a deletion.
+RENAME_THRESHOLD = "40%"
+
+OVERRIDE_ENV = "VTSEARCH_ALLOW_DELETIONS"
+
+
+def _git(*args: str) -> str:
+    """Run a git command, returning stripped stdout ('' on failure)."""
+    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        ["git", *args],  # noqa: S607 - git resolved from PATH
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def _deleted_vs_worktree(ref: str) -> set[str]:
+    """Paths present in `ref` but gone from the working tree.
+
+    Compares against the *worktree*, not HEAD, so an uncommitted clobber is
+    caught before it is ever recorded. Renames are resolved first, so moving a
+    file does not read as deleting it.
+    """
+    out = _git(
+        "diff",
+        "--diff-filter=D",
+        "--name-only",
+        f"--find-renames={RENAME_THRESHOLD}",
+        ref,
+    )
+    return set(out.splitlines()) if out else set()
+
+
+def _describe(ref: str) -> str:
+    return _git("log", "-1", "--format=%h %cs %s", ref) or ref
+
+
+def find_phantom_base(base_ref: str) -> tuple[str, set[str]] | None:
+    """Return (apparent_base, deleted_paths) if the tree looks stale.
+
+    `None` means either the branch deletes nothing, or its deletions are real:
+    no ancestor of the merge-base explains them away.
+    """
+    merge_base = _git("merge-base", "HEAD", base_ref)
+    if not merge_base:
+        return None
+
+    deleted = _deleted_vs_worktree(merge_base)
+    if not deleted:
+        return None
+
+    chain = _git("rev-list", "--first-parent", f"--max-count={MAX_WALK}", merge_base).splitlines()
+    # chain[0] is the merge-base itself, which we already know has deletions.
+    for ancestor in chain[1:]:
+        if not _deleted_vs_worktree(ancestor):
+            return ancestor, deleted
+    return None
+
+
+def main() -> int:
+    base_ref = os.environ.get("VTSEARCH_BASE_REF", "origin/dev")
+
+    if not _git("rev-parse", "--verify", "--quiet", base_ref):
+        print(f"No {base_ref} to diff against; skipping the phantom-base check.")
+        return 0
+
+    hit = find_phantom_base(base_ref)
+    if hit is None:
+        print("Phantom-base check: OK")
+        return 0
+
+    apparent_base, deleted = hit
+
+    if os.environ.get(OVERRIDE_ENV):
+        print(f"Phantom-base check: {len(deleted)} deletion(s) allowed via {OVERRIDE_ENV}.")
+        return 0
+
+    merge_base = _git("merge-base", "HEAD", base_ref)
+    behind = _git("rev-list", "--count", f"{apparent_base}..{merge_base}")
+
+    print(
+        f"This branch deletes {len(deleted)} file(s) that it never created.\n"
+        f"\n"
+        f"Its tree matches an ancestor of {base_ref}, not {base_ref} itself:\n"
+        f"\n"
+        f"  claimed base   {_describe(merge_base)}\n"
+        f"  actual content {_describe(apparent_base)}   ({behind} commits earlier)\n"
+        f"\n"
+        f"That is the signature of a stale checkout committed onto a fresh HEAD:\n"
+        f"the work that landed on {base_ref} in between is being reverted "
+        f"wholesale.\n"
+        f"Nothing will fail as a result — a clobber removes a feature and its "
+        f"tests\ntogether — which is why this is a gate and not a warning.\n"
+        f"\n"
+        f"Deleted without ever being touched by this branch:\n"
+    )
+    for path in sorted(deleted):
+        print(f"  {path}")
+    print(
+        f"\n"
+        f"To recover, rebuild the branch on {base_ref} and re-apply your own\n"
+        f"change; do not revert the clobbering commit, which also carries work\n"
+        f"you want:\n"
+        f"\n"
+        f"  git stash          # if the clobber is still uncommitted\n"
+        f"  git fetch origin --prune && git reset --hard {base_ref}\n"
+        f"\n"
+        f"If every deletion above is deliberate (deleting a shipped plan file,\n"
+        f"say), re-run with:\n"
+        f"\n"
+        f"  {OVERRIDE_ENV}=1 ./run-tests.sh\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_lib/core/test_phantom_base_gate.py
+++ b/tests_lib/core/test_phantom_base_gate.py
@@ -1,0 +1,206 @@
+"""The stale-tree gate itself: `scripts/check-phantom-base.py`.
+
+The gate exists because five PRs silently reverted the work that merged just
+before them, and nothing noticed for as long as two days (#2821's revert
+reached `main`). Every one of them shared a shape that the obvious checks miss:
+the merge-base was `origin/dev`'s tip -- zero commits behind -- while the
+*worktree* held pre-merge content, so the commit recorded a deletion for every
+file `dev` had gained meanwhile.
+
+So the tests below pin the properties that make the gate able to see that, each
+of which a plausible simpler implementation would get wrong:
+
+* it fires on a fresh-parent/stale-tree branch, and names the ancestor the
+  content actually came from -- that ancestor is what a restore needs, since
+  the clobbering commit also carries work worth keeping;
+* it sees a clobber that has not been committed yet, because that is how the
+  damage exists first and `run-tests.sh` may run before the commit;
+* it stays quiet on a deliberate deletion of a long-standing file, which no
+  ancestor can explain away;
+* it stays quiet on a rename scoring between 40% and 50%, which git's default
+  threshold reports as a deletion (the one such false positive in the
+  historical sweep scored 47%);
+* it never leans on the *size* of the deletion, because two of the four real
+  clobbers deleted only 2 and 3 files;
+* the deliberate-deletion override releases it, since `CLAUDE.md` requires
+  deleting a plan file when it ships.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-phantom-base.py"
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        ["git", "-c", "user.email=t@example.com", "-c", "user.name=T", *args],  # noqa: S607 - git resolved from PATH
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _run_gate(repo: Path, base_ref: str = "base", **env_extra: str):
+    """Run the gate inside `repo`, returning (exit_code, output)."""
+    import os
+
+    env = {**os.environ, "VTSEARCH_BASE_REF": base_ref, **env_extra}
+    env.pop("VTSEARCH_ALLOW_DELETIONS", None)
+    env.update(env_extra)
+    proc = subprocess.run(  # noqa: S603  # interpreter + repo-local script path, no shell
+        [sys.executable, str(SCRIPT)],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A repo whose `base` branch has advanced three commits past `first`."""
+    r = tmp_path / "r"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "base", ".")
+    (r / "kept.txt").write_text("kept\n")
+    (r / "ancient.txt").write_text("ancient\n")
+    _commit(r, "first")
+    (r / "landed_a.txt").write_text("feature a\n")
+    _commit(r, "land A")
+    (r / "landed_b.txt").write_text("feature b\n")
+    _commit(r, "land B")
+    return r
+
+
+def _stale_checkout(repo: Path, drop: list[str]) -> None:
+    """Reproduce the mechanism: fresh HEAD, worktree missing what base gained."""
+    _git(repo, "checkout", "-q", "-b", "work")
+    for name in drop:
+        (repo / name).unlink()
+    (repo / "my_feature.txt").write_text("the legitimate change\n")
+
+
+class TestFiresOnAClobber:
+    def test_flags_a_stale_tree_committed_onto_a_fresh_parent(self, repo: Path):
+        _stale_checkout(repo, ["landed_a.txt", "landed_b.txt"])
+        _commit(repo, "my feature")
+
+        code, out = _run_gate(repo)
+
+        assert code == 1
+        assert "deletes 2 file(s) that it never created" in out
+        assert "landed_a.txt" in out
+        assert "landed_b.txt" in out
+        # The branch's own work must not be reported as a deletion.
+        assert "my_feature.txt" not in out
+
+    def test_names_the_ancestor_the_content_actually_came_from(self, repo: Path):
+        first = _git(repo, "rev-list", "--max-parents=0", "HEAD")
+        _stale_checkout(repo, ["landed_a.txt", "landed_b.txt"])
+        _commit(repo, "my feature")
+
+        code, out = _run_gate(repo)
+
+        assert code == 1
+        # A restore has to start from the real base, so the gate must say which.
+        assert first[:8] in out
+        assert "2 commits earlier" in out
+
+    def test_sees_a_clobber_that_is_not_committed_yet(self, repo: Path):
+        """The damage exists in the worktree before it is ever recorded."""
+        _stale_checkout(repo, ["landed_a.txt", "landed_b.txt"])
+        # Deliberately no commit.
+
+        code, out = _run_gate(repo)
+
+        assert code == 1
+        assert "landed_a.txt" in out
+
+    def test_flags_a_two_file_clobber_the_same_as_a_large_one(self, repo: Path):
+        """Size is not evidence: real clobbers ran as small as 2 files."""
+        _stale_checkout(repo, ["landed_a.txt"])
+        _commit(repo, "my feature")
+
+        code, out = _run_gate(repo)
+
+        assert code == 1
+        assert "deletes 1 file(s)" in out
+
+
+class TestStaysQuiet:
+    def test_clean_branch_that_deletes_nothing(self, repo: Path):
+        _git(repo, "checkout", "-q", "-b", "work")
+        (repo / "my_feature.txt").write_text("added only\n")
+        _commit(repo, "my feature")
+
+        code, out = _run_gate(repo)
+
+        assert code == 0
+        assert "OK" in out
+
+    def test_deliberate_deletion_of_a_long_standing_file(self, repo: Path):
+        """No ancestor explains it away, so it is a real deletion."""
+        _git(repo, "checkout", "-q", "-b", "work")
+        (repo / "ancient.txt").unlink()
+        _commit(repo, "drop the shipped plan")
+
+        code, out = _run_gate(repo)
+
+        assert code == 0
+
+    def test_rename_scoring_between_40_and_50_percent(self, repo: Path):
+        """git's default 50% threshold would read this as a deletion."""
+        _git(repo, "checkout", "-q", "-b", "work")
+        (repo / "renamed_from.py").write_text("".join(f"original line {i}\n" for i in range(20)))
+        _commit(repo, "add the file that will be renamed")
+
+        lines = [f"original line {i}\n" for i in range(20)]
+        for i in range(10):
+            lines[i] = f"wholly other text {i}\n"
+        (repo / "renamed_to.py").write_text("".join(lines))
+        (repo / "renamed_from.py").unlink()
+        _commit(repo, "rename it")
+
+        # Pin the premise: this really is in the band git's default misses.
+        status = _git(repo, "diff", "--find-renames=10%", "--name-status", "HEAD~1", "HEAD")
+        assert status.startswith("R04"), f"premise broken, got {status!r}"
+
+        code, out = _run_gate(repo)
+
+        assert code == 0, out
+
+
+class TestEscapeHatches:
+    def test_override_releases_a_deliberate_deletion(self, repo: Path):
+        _stale_checkout(repo, ["landed_a.txt", "landed_b.txt"])
+        _commit(repo, "my feature")
+
+        code, out = _run_gate(repo, VTSEARCH_ALLOW_DELETIONS="1")
+
+        assert code == 0
+        assert "VTSEARCH_ALLOW_DELETIONS" in out
+
+    def test_missing_base_ref_skips_rather_than_fails(self, repo: Path):
+        _stale_checkout(repo, ["landed_a.txt"])
+        _commit(repo, "my feature")
+
+        code, out = _run_gate(repo, base_ref="origin/nonexistent")
+
+        assert code == 0
+        assert "skipping" in out

--- a/tests_lib/core/test_phantom_base_gate.py
+++ b/tests_lib/core/test_phantom_base_gate.py
@@ -111,7 +111,10 @@ class TestFiresOnAClobber:
         assert "my_feature.txt" not in out
 
     def test_names_the_ancestor_the_content_actually_came_from(self, repo: Path):
-        first = _git(repo, "rev-list", "--max-parents=0", "HEAD")
+        root = _git(repo, "rev-list", "--max-parents=0", "HEAD")
+        # Ask git for the abbreviation it would print; %h is 7 chars in a
+        # repo this small and longer in a real one.
+        first = _git(repo, "rev-parse", "--short", root)
         _stale_checkout(repo, ["landed_a.txt", "landed_b.txt"])
         _commit(repo, "my feature")
 
@@ -119,7 +122,7 @@ class TestFiresOnAClobber:
 
         assert code == 1
         # A restore has to start from the real base, so the gate must say which.
-        assert first[:8] in out
+        assert first in out
         assert "2 commits earlier" in out
 
     def test_sees_a_clobber_that_is_not_committed_yet(self, repo: Path):


### PR DESCRIPTION
Closes #3205.

Five merged PRs have silently reverted the work that landed just before them — #2741, #2793, #2821, #3184, and the three restored in #3206. One rode `dev` into `main` in the 2026-08-04 release before anyone noticed.

## The mechanism is not the one #3205 described

The issue attributed this to a branch cut from a stale base. It isn't. In **every** occurrence the merge-base *was* `origin/dev`'s tip — zero commits behind:

```
merge-base(dev, branch) = c93b4342 = origin/dev tip   →   commits behind: 0
parent of 2bb2f054b     = c93b4342, which HAS stack.py,
                          scan_exif_orientation.py, gpu_node/…
```

What was stale was the **tree**:

| diff | files | deletions |
|---|---|---|
| `a1ef82b0` (dev tip *before* the three merges) → `2bb2f054` | 11 | **0** |
| `c93b4342` (the actual parent) → `2bb2f054` | 54 | 43 |

The commit's tree is exactly "pre-merge `dev` + the legitimate 11-file feature." `563517a9` matches: 0 deletions vs `bcb2bd95`, 16 vs its actual parent. HEAD moved forward onto fresh `dev` while the checkout still held old content, and the difference was staged wholesale.

That rules out the control #3205 favoured — a staleness check on the merge-base reads 0 commits behind and passes. It also explains why the suite never helped: a clobber removes a feature *and its tests* in one motion, so the deletions are self-consistent and nothing is left to fail. The full correction is [on the issue](https://github.com/samggreenberg/VTSearch/issues/3205#issuecomment-5364269727).

Two of the five were also **never counted** — both already diagnosed in their own restore commits (`b9c7e8ec`, `4db33ace`) and never connected to the pattern.

## The check

Walk back the first-parent chain from the merge-base; if some ancestor makes the set of deleted paths **empty**, the branch's content matches that ancestor rather than the base it claims. Across 303 merges on `dev`:

| PR | verdict | phantom deletions |
|---|---|---|
| #3184 | **clobber** | 21 |
| #2793 | **clobber** | 16 |
| #2741 | **clobber** | 3 |
| #2821 | **clobber** | 2 |
| #2878, #2792 | plan file deleted on ship | 1 each |
| #3155 | rename | — (cleared) |

4/4 real clobbers caught, ~40 ms, and it reports the ancestor the content actually came from — which is what a restore needs, since the clobbering commit also carries work worth keeping.

Three things the sweep decided:

- **Compare against the working tree, not HEAD.** The deletions exist before they are committed, which is when `run-tests.sh` often runs.
- **Do not threshold on size.** Two real clobbers deleted 2 and 3 files — indistinguishable by count from a deliberate one-file deletion.
- **Rename detection at 40%, not git's default 50%.** The one pure rename scored 47% and would otherwise read as a deletion.

It runs **first**, because a clobbered tree passes every other gate by construction. Deliberate deletions — `CLAUDE.md` requires deleting a plan file when it ships — pass with `VTSEARCH_ALLOW_DELETIONS=1`, expected about once per 100 PRs.

## What's not covered

A clobber confined to hunks inside surviving files still slips through; filed as #3210 with the two obvious generalizations already measured and disproven. No occurrence to date would have escaped this gate.

## Also here

`scripts/check-docs.py` had a duplicated `slides/_out/` allowlist key (ruff F601, failing on `dev`). Python already kept the later definition, so removing the stray changes nothing but the lint error.

## Testing

Full `./run-tests.sh`: **RUN PASSED**, 8875 passed / 6 skipped, pyright, pip-audit, npm audit and Vitest all OK. Nine new tests in `tests_lib/core/test_phantom_base_gate.py` pin the properties a simpler implementation would get wrong, including the uncommitted-clobber and 40%-rename cases. Detached HEAD and shallow clones degrade to a skip rather than a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f8vEhei7LjqBZSDAd8xQC

---
_Generated by [Claude Code](https://claude.ai/code/session_013f8vEhei7LjqBZSDAd8xQC)_