### PR TITLE
Train window: end the Find session before it reads the votes

### DIFF
--- a/docs/api/find.md
+++ b/docs/api/find.md
@@ -239,3 +239,30 @@ leaving the current Find session frozen and marking it stale.
 
 Errors: **400** (no Find run yet), **404** (no active detector), **409**
 (detector vote state not aligned with the active dataset).
+
+### End the Find session
+
+```
+POST /api/find/end-session
+```
+
+**Requires** `X-Dataset-Id` **and** `X-Detector-Id`.
+
+Discards the active detector's live Find session — the whole-dataset
+presumptions `find-label` wrote into its vote dicts, the frozen scores, and the
+verified set — and re-derives its votes from its on-disk labelset.
+
+Find and training share one set of per-detector vote dicts, so this is what
+separates the two: the Train window calls it on entry, before it reads
+[`GET /api/votes`](medias.md). Without it a user who ran Find and went back to
+training saw every item in the collection already voted (Autopilot lands in a
+terminal phase on arrival), and the find-mode write-back guard kept each new
+training vote out of the labelset.
+
+Find-session state is in-memory only and is already dropped on a dataset
+switch; nothing durable is lost. Corrections folded in via
+`/api/find/corrections-to-detector` live in the labelset and survive.
+
+Idempotent — with no session to end it is a no-op reporting `ended: false`.
+
+→ `{"ok": true, "ended": true}`

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3585,6 +3585,22 @@
         ],
         "type": "object"
       },
+      "FindEndSessionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "ended": {
+            "type": "boolean"
+          },
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ended",
+          "ok"
+        ],
+        "type": "object"
+      },
       "FindEvidenceCoverageResponse": {
         "additionalProperties": false,
         "properties": {
@@ -13814,6 +13830,31 @@
         "summary": "Fold the Find corrections into the active detector's labelset for *future*\nscoring, leaving the current Find session frozen.",
         "tags": [
           "detector_scoring"
+        ]
+      }
+    },
+    "/api/find/end-session": {
+      "post": {
+        "description": "``/api/find-label`` leaves the detector's in-memory votes holding its own\ncall for *every* item in the dataset, flagged ``find_mode`` so they are kept\nout of the labelset.  Those presumptions are not training labels, and the\nTrain window reads the same vote dicts - so it must say \"I am training now\"\nbefore it reads them, or it shows the whole collection as voted and\nAutopilot lands in a terminal phase on arrival (issue #3212).\n\nIdempotent: with no session to end this is a no-op that reports\n``ended = false``.",
+        "operationId": "end_find_session_route",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindEndSessionResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Discard the active detector's live Find session, if it has one.",
+        "tags": [
+          "detector_find"
         ]
       }
     },

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -306,7 +306,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.layoutRef().nativeElement.style.setProperty('--right-width', `${this.rightWidth()}px`);
     this.pendingSnapOnLoad = true;
     this.mediaState.loadMedias();
-    this.voteState.loadVotes();
+    this.loadTrainingVotes();
     this.loadSettings();
     this.startStatusPolling();
     this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
@@ -393,7 +393,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.voteState.clear();
     this.pendingSnapOnLoad = true;
     this.mediaState.loadMedias();
-    this.voteState.loadVotes();
+    this.loadTrainingVotes();
     this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
       next: (status) => { this.datasetName.set(status.display_name || ''); },
     });
@@ -403,6 +403,30 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Arm the rehydrate effect: it fires `onLearnedSort` once the reloaded
     // votes land (counts go 0 → available) if the user is still in learned mode.
     this.pendingRehydrateLearned = this.sortState.sortMode === 'learned';
+  }
+
+  /**
+   * Load the votes this window trains from, ending any live Find session first.
+   *
+   * Find fills the *same* per-detector vote dicts as training does, but with
+   * the detector's own call for every item in the dataset — a presumption, not
+   * a human decision. Read as votes they make the whole collection look
+   * labeled, which lands Autopilot in a terminal phase the moment the user
+   * arrives, and the server-side find-mode guard keeps every vote cast here out
+   * of the labelset (#3212). Entering the Train window is the statement that
+   * this is training, so it says so before it reads the votes.
+   *
+   * The load runs either way: a failed hand-off is no reason to leave the
+   * window with no votes at all.
+   */
+  private loadTrainingVotes(): void {
+    this.detectorsFindApi
+      .endFindSession()
+      .pipe(takeUntil(this.pairScope$))
+      .subscribe({
+        next: () => this.voteState.loadVotes(),
+        error: () => this.voteState.loadVotes(),
+      });
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -67,6 +67,11 @@ describe('LabelViewComponent (zoneless dataset-name canary)', () => {
       httpMock.match('/api/medias/ids').forEach((req) =>
         req.flush([{ id: 1, media_type: 'audio' }]),
       );
+      // The Train window ends any live Find session before it reads the votes
+      // (#3212), so the GET below is only issued once this POST answers.
+      httpMock.match('/api/find/end-session').forEach((req) =>
+        req.flush({ ok: true, ended: false }),
+      );
       httpMock.match('/api/votes').forEach((req) =>
         req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
       );
@@ -148,6 +153,13 @@ describe('LabelViewComponent', () => {
         { id: 2, media_type: 'audio' },
       ]),
     );
+    // /api/find/end-session (the Train window's hand-off out of a Find
+    // session, #3212); loadVotes is chained onto its response, so the GET
+    // below only exists after this POST is answered and the tick lands it.
+    httpMock.match('/api/find/end-session').forEach(req =>
+      req.flush({ ok: true, ended: false }),
+    );
+    TestBed.tick();
     // /api/votes (label-view loadVotes)
     httpMock.match('/api/votes').forEach(req =>
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
@@ -222,6 +234,24 @@ describe('LabelViewComponent', () => {
     flushInitialRequests();
     expect(component.voteState.goodVotes.size).toBe(0);
     expect(component.voteState.badVotes.size).toBe(0);
+  });
+
+  it('ends a live Find session before it reads the votes (#3212)', () => {
+    // Find's bulk presumptions live in the same per-detector vote dicts the
+    // Train window trains from, so reading /api/votes first would show the whole
+    // collection as voted (and land Autopilot in a terminal phase on arrival).
+    const loadVotes = vi.spyOn(TestBed.inject(VoteStateService), 'loadVotes');
+    TestBed.tick();
+    TestBed.tick();
+    expect(loadVotes).not.toHaveBeenCalled();
+
+    const handoff = httpMock.expectOne('/api/find/end-session');
+    expect(handoff.request.method).toBe('POST');
+    handoff.flush({ ok: true, ended: true });
+    TestBed.tick();
+
+    // Only now, against the votes the hand-off restored from the labelset.
+    expect(loadVotes).toHaveBeenCalledTimes(1);
   });
 
   it('snaps both panels tight once medias first render', async () => {

--- a/frontend/src/app/services/detectors-find-api.service.ts
+++ b/frontend/src/app/services/detectors-find-api.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { FindCancelResponse } from '../generated/api-client/models/find-cancel-response';
+import type { FindEndSessionResponse } from '../generated/api-client/models/find-end-session-response';
 import type { FindCheckLabelsRequest } from '../generated/api-client/models/find-check-labels-request';
 import type { FindCheckLabelsResponse } from '../generated/api-client/models/find-check-labels-response';
 import type { FindLabelRequest } from '../generated/api-client/models/find-label-request';
@@ -15,6 +16,7 @@ import type { FindStatsResponse } from '../generated/api-client/models/find-stat
 import type { FindEvidenceCoverageResponse } from '../generated/api-client/models/find-evidence-coverage-response';
 import type { FindCorrectionsToDetectorResponse } from '../generated/api-client/models/find-corrections-to-detector-response';
 import { cancelFind } from '../generated/api-client/fn/detector-find/cancel-find';
+import { endFindSessionRoute } from '../generated/api-client/fn/detector-find/end-find-session-route';
 import { findCheckLabels } from '../generated/api-client/fn/detector-find/find-check-labels';
 import { findLabel } from '../generated/api-client/fn/detector-scoring/find-label';
 import { findStats } from '../generated/api-client/fn/detector-scoring/find-stats';
@@ -48,6 +50,15 @@ export class DetectorsFindApiService {
   /** Cancel any in-flight find / find-label / auto-detect scoring. */
   cancelFind(): Observable<FindCancelResponse> {
     return cancelFind(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  /** Discard the active detector's live Find session (if any), restoring its
+   *  votes from its labelset. Find's bulk presumptions live in the same vote
+   *  dicts the Train window trains from, so Train calls this on entry before it
+   *  reads them — otherwise the whole collection reads as voted and Autopilot
+   *  lands in a terminal phase on arrival (#3212). A no-op when Find never ran. */
+  endFindSession(): Observable<FindEndSessionResponse> {
+    return endFindSessionRoute(this.http, this.config.rootUrl).pipe(map((r) => r.body));
   }
 
   /** Detector-evaluation stats over the adopted Find label set (2x2 confusion

--- a/tests/detectors/test_find_end_session.py
+++ b/tests/detectors/test_find_end_session.py
@@ -1,0 +1,91 @@
+"""Tests for ``POST /api/find/end-session`` (issue #3212).
+
+A Find pass replaces the detector's in-memory votes with its own call for every
+item in the dataset.  Returning to the Train window with those presumptions
+still in place made the whole collection read as voted — Autopilot landed in a
+terminal phase on arrival, and the find-mode write-back guard kept every new
+training vote out of the labelset.  The Train window now ends the session on
+entry; these tests pin what that does.
+"""
+
+from __future__ import annotations
+
+import app as app_module
+from tests import load_detector_and_wait
+from tests.helpers import setup_trainable_model_in_registry
+from vtscore.state.core import get_active_detector_context
+from vtsearch.state import snapshot_medias
+
+
+def _detector_with_votes(client):
+    """A loaded detector holding three good + four bad training votes."""
+    detector_id = setup_trainable_model_in_registry(
+        "end-session", good_ids=[], bad_ids=[], snap=snapshot_medias()
+    )
+    load_detector_and_wait(client, detector_id)
+    for media_id in (1, 2, 3):
+        assert client.post(f"/api/medias/{media_id}/vote", json={"target": "good"}).status_code == 200
+    for media_id in (17, 18, 19, 20):
+        assert client.post(f"/api/medias/{media_id}/vote", json={"target": "bad"}).status_code == 200
+    return detector_id
+
+
+class TestEndFindSession:
+    """The Train window's on-entry hand-off out of a Find session."""
+
+    def test_find_labels_all_items_then_end_session_restores_training_votes(self, client):
+        detector_id = _detector_with_votes(client)
+
+        resp = client.post("/api/find-label", json={"detector_id": detector_id})
+        assert resp.status_code == 200, resp.get_json()
+        after_find = client.get("/api/votes").get_json()
+        # Every media carries a presumption, and they are not the training votes.
+        assert len(after_find["good"]) + len(after_find["bad"]) == app_module.NUM_MEDIAS
+        assert get_active_detector_context().find_mode is True
+
+        ended = client.post("/api/find/end-session")
+        assert ended.status_code == 200
+        assert ended.get_json() == {"ok": True, "ended": True}
+
+        after_end = client.get("/api/votes").get_json()
+        assert set(after_end["good"]) == {1, 2, 3}
+        assert set(after_end["bad"]) == {17, 18, 19, 20}
+        assert after_end["verified"] == []
+        assert get_active_detector_context().find_mode is False
+
+    def test_end_session_lets_training_votes_reach_the_labelset_again(self, client):
+        """A vote cast after the hand-off syncs; one cast in find mode does not."""
+        detector_id = _detector_with_votes(client)
+        client.post("/api/find-label", json={"detector_id": detector_id})
+
+        client.post("/api/find/end-session")
+        assert client.post("/api/medias/4/vote", json={"target": "good"}).status_code == 200
+
+        votes = client.get("/api/votes").get_json()
+        assert set(votes["good"]) == {1, 2, 3, 4}
+        assert votes["labelset_good_count"] == 4
+        assert votes["labelset_bad_count"] == 4
+
+    def test_end_session_is_a_no_op_without_a_session(self, client):
+        _detector_with_votes(client)
+
+        resp = client.post("/api/find/end-session")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"ok": True, "ended": False}
+
+        votes = client.get("/api/votes").get_json()
+        assert set(votes["good"]) == {1, 2, 3}
+        assert set(votes["bad"]) == {17, 18, 19, 20}
+
+    def test_end_session_drops_the_frozen_find_scores(self, client):
+        """The work-queue / boundary-walk reads go empty with the session."""
+        detector_id = _detector_with_votes(client)
+        client.post("/api/find-label", json={"detector_id": detector_id})
+        assert client.get("/api/find/queue-ids?filter=unverified_good").get_json()["count"] > 0
+
+        client.post("/api/find/end-session")
+
+        assert client.get("/api/find/queue-ids?filter=unverified_good").get_json()["count"] == 0
+        ctx = get_active_detector_context()
+        assert dict(ctx.find_scores) == {}
+        assert dict(ctx.find_initial_labels) == {}

--- a/tests/detectors/test_find_end_session.py
+++ b/tests/detectors/test_find_end_session.py
@@ -19,9 +19,7 @@ from vtsearch.state import snapshot_medias
 
 def _detector_with_votes(client):
     """A loaded detector holding three good + four bad training votes."""
-    detector_id = setup_trainable_model_in_registry(
-        "end-session", good_ids=[], bad_ids=[], snap=snapshot_medias()
-    )
+    detector_id = setup_trainable_model_in_registry("end-session", good_ids=[], bad_ids=[], snap=snapshot_medias())
     load_detector_and_wait(client, detector_id)
     for media_id in (1, 2, 3):
         assert client.post(f"/api/medias/{media_id}/vote", json={"target": "good"}).status_code == 200

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -232,6 +232,47 @@ def ensure_votes_match_active_dataset() -> None:
         resync_coverage_atlas_to_detector(ds_ctx, det_ctx)
 
 
+def end_find_session() -> bool:
+    """Discard the active detector's live Find session and re-derive its votes.
+
+    ``/api/find-label`` replaces the detector's in-memory votes with its own
+    per-item calls over the *whole* dataset and stamps ``find_mode`` so nothing
+    writes those presumptions back to the labelset.  That is right for the Find
+    window and wrong everywhere else: the Train window reads the same vote
+    dicts, so a user who ran Find and then went back to training saw every item
+    in the collection already "voted" - Autopilot jumped straight to a terminal
+    phase, and every genuine training vote cast there was silently kept out of
+    the labelset by the find-mode write-back guard (issue #3212).
+
+    Clears the session (votes, the frozen scores, the verified set) and lets
+    :func:`ensure_votes_match_active_dataset` restore the detector's real
+    training labels from the on-disk labelset.  Find-session state is in-memory
+    only by design and is already dropped on a dataset switch, so ending it here
+    loses nothing durable: the ranking and the verifications belong to the Find
+    window the user just left, and re-entering Find re-scores from scratch.
+
+    Returns ``True`` when a session was ended, ``False`` when there was none.
+    """
+    from vtscore.state.core import _state_lock, get_active_detector_context
+    from vtscore.state.votes import clear_votes
+
+    det_ctx = get_active_detector_context()
+    if not det_ctx.find_mode:
+        return False
+
+    # Drops the presumptions along with every Find-session field (find_mode
+    # included), the coverage atlas evidence, and the labeling-progress cache.
+    clear_votes()
+    with _state_lock:
+        # Force the rehydrate's freshness pre-check to miss.  Nothing about the
+        # (dataset, detector-file) pair changed while Find ran, so the check
+        # would otherwise early-return and leave the votes we just cleared
+        # empty instead of restoring the labelset's.
+        det_ctx.cached_labelset_mtime = 0.0
+    ensure_votes_match_active_dataset()
+    return True
+
+
 def _repoint_labelset_cache(det_ctx, path) -> None:
     """Re-point *det_ctx*'s cached labelset at the on-disk file, votes untouched.
 

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -21,13 +21,19 @@ from vtscore.concurrency.progress import CancelledError, find_progress, update_f
 from vtscore.detectors.training import train_and_threshold
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.utils.scores import sigmoid_to_finite_scores
-from vtsearch.routes._shared import find_idle, find_idle_on_crash, require_detector_header
+from vtsearch.routes._shared import (
+    find_idle,
+    find_idle_on_crash,
+    require_dataset_header,
+    require_detector_header,
+)
 from vtsearch.schemas.detectors import (
     FindBoundaryNextQuerySchema,
     FindBoundaryNextResponseSchema,
     FindCancelResponseSchema,
     FindCheckLabelsRequestSchema,
     FindCheckLabelsResponseSchema,
+    FindEndSessionResponseSchema,
     FindQueueIdsQuerySchema,
     FindQueueIdsResponseSchema,
     FindRequestSchema,
@@ -719,6 +725,28 @@ def cancel_find():
     """
     find_progress.cancel()
     return {"ok": True}
+
+
+@detector_find_bp.route("/api/find/end-session", methods=["POST"])
+@detector_find_bp.response(200, FindEndSessionResponseSchema)
+@require_dataset_header
+@require_detector_header
+def end_find_session_route():
+    """Discard the active detector's live Find session, if it has one.
+
+    ``/api/find-label`` leaves the detector's in-memory votes holding its own
+    call for *every* item in the dataset, flagged ``find_mode`` so they are kept
+    out of the labelset.  Those presumptions are not training labels, and the
+    Train window reads the same vote dicts - so it must say "I am training now"
+    before it reads them, or it shows the whole collection as voted and
+    Autopilot lands in a terminal phase on arrival (issue #3212).
+
+    Idempotent: with no session to end this is a no-op that reports
+    ``ended = false``.
+    """
+    from vtscore.detectors.dataset_sync import end_find_session  # noqa: PLC0415
+
+    return {"ok": True, "ended": end_find_session()}
 
 
 @detector_find_bp.route("/api/find/queue-ids", methods=["GET"])

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -43,6 +43,7 @@ Find endpoints (``vtsearch/routes/detectors/find.py``):
 * ``POST /api/find`` -> :class:`FindRequestSchema` ->
                       :class:`FindResponseSchema`
 * ``POST /api/find/cancel`` -> :class:`FindCancelResponseSchema`
+* ``POST /api/find/end-session`` -> :class:`FindEndSessionResponseSchema`
 
 Label endpoints (``vtsearch/routes/detectors/labels.py``):
 
@@ -847,6 +848,19 @@ class FindCancelResponseSchema(Schema):
     """
 
     ok = fields.Boolean(required=True)
+
+
+class FindEndSessionResponseSchema(Schema):
+    """Response for ``POST /api/find/end-session``.
+
+    ``ended`` is ``True`` when a live Find session was discarded and the
+    detector's votes re-derived from its labelset, ``False`` when there was
+    no session to end (the common case: the Train window says so on every
+    entry, whether or not Find ever ran).
+    """
+
+    ok = fields.Boolean(required=True)
+    ended = fields.Boolean(required=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Reported in #3212: create a detector, vote a few goods and bads, leave Training, open **Find**, leave Find, open **Training** again — and Autopilot announces the detector is trained, instead of continuing on to *Refine Boundary* / *Explore Diversity*.

## Root cause

`POST /api/find-label` replaces the active detector's in-memory votes with the detector's own call for **every** item in the dataset (`apply_labels_bulk_with_click_time(..., replace_all=True)`) and stamps `DetectorContext.find_mode` so those presumptions are kept out of the labelset.

Find and training share **one** set of per-detector vote dicts, and nothing ended that session when the user left the Find window. Reproduced against the API (3 good / 4 bad, then find-label, then re-read the votes on a 20-item dataset):

```
AFTER TRAIN: good=3 bad=4   labelset 3/4
AFTER FIND:  good=18 bad=2  labelset 3/4     ← the whole dataset reads as voted
```

So the Train window came back to two broken things:

* **Autopilot's phase check** saw `remainingUnlabeled == 0` and jumped straight to a terminal phase (`done` / `exhausted`) — the "training is done" hand-off — with no way to continue.
* **Every training vote cast there was silently discarded** from the labelset: `sync_labels_to_loaded_detector` refuses to write while `find_mode` is set, so labelling after a Find pass looked like it worked and saved nothing.

## The fix

`POST /api/find/end-session` — clears the Find session (the presumptions, the frozen scores, the verified set, `find_mode`) and re-derives the detector's votes from its on-disk labelset. Idempotent; reports `ended: false` when Find never ran.

The Train window calls it on entry and on a pair switch, chaining the votes load onto its response, so it never reads the vote dicts before saying "I am training now". Entering the Train window is the statement that separates the two modes — Find keeps its session across a Browse round-trip, which is why this hangs off Train's entry rather than Find's exit.

Find-session state is in-memory only by design and is already dropped on a dataset switch, so nothing durable is lost: the ranking and verifications belong to the window the user just left, and re-entering Find re-scores from scratch. Corrections folded in via `/api/find/corrections-to-detector` live in the labelset and survive.

## Changes

* `vtscore/detectors/dataset_sync.py` — `end_find_session()`.
* `vtsearch/routes/detectors/find.py` + `vtsearch/schemas/detectors.py` — the route and its response schema; `frontend/openapi.json` regenerated.
* `frontend/src/app/services/detectors-find-api.service.ts` — `endFindSession()`.
* `frontend/src/app/components/label-view/label-view.component.ts` — `loadTrainingVotes()`, used by `ngOnInit` and `reloadForNewPair`.
* `docs/api/find.md` — the endpoint and why it exists.

## Tests

* `tests/detectors/test_find_end_session.py` — the reported flow end to end: find-label labels everything, the hand-off restores the 3 good / 4 bad training votes and clears `find_mode`, a vote cast afterwards reaches the labelset again, the no-session case is a no-op, and the frozen scores / work queue go with the session.
* `label-view.zoneless.spec.ts` — the Train window POSTs the hand-off and only loads votes once it answers.

Full `./run-tests.sh`: 8902 passed, 6 skipped, all gates green.

Closes #3212


---
_Generated by [Claude Code](https://claude.ai/code/session_01JfN1QLoni6PrYyEN3zESuc)_