### PR TITLE
Demo downloads: name the unreachable host, escalate the connect budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A demo download that can't reach its host now says so in a sentence, and
+  tries harder before giving up.** Loading the Apollo 11 Mission Audio demo
+  while archive.org was refusing connections failed with a hundred-line
+  `MaxRetryError` traceback pasted into the Dataset-load-failed box, after
+  six identical 10-second connection attempts — and the progress bar said
+  "resuming" a file that had never downloaded a single byte. The failure now
+  reads *"Couldn't reach archive.org: the connection timed out before the
+  server answered, on all 6 attempts. The site may be down or blocked by your
+  network/proxy…"*, the connect budget escalates across retries (10 s → 30 s)
+  so a host that is merely slow to accept isn't written off six times over,
+  the retry notice says "retrying" until there are bytes to resume, and the
+  track-list fetch that precedes the download gets the same retry budget
+  instead of dying on a single unlucky handshake. (#3216)
+
 - **CLI autodetect no longer reports every media as a hit, and no longer
   disagrees with the GUI's Find.** A run against a dataset and detector that
   the GUI cut at ~0.475 came back with a threshold of `-0.375` and a positive

--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -993,17 +993,19 @@ class _FakeResponse:
 
     Yields the given *chunks* from ``iter_content``; if *fail_after_chunks* is
     set, raises ``ChunkedEncodingError`` once that many chunks have been yielded
-    (simulating a mid-stream connection drop / ``IncompleteRead``).
+    (simulating a mid-stream connection drop / ``IncompleteRead``).  *text* is
+    the whole-body view the small-payload fetches read instead of streaming.
     """
 
     is_redirect = False
     is_permanent_redirect = False
 
-    def __init__(self, chunks, status_code=200, headers=None, fail_after_chunks=None):
+    def __init__(self, chunks, status_code=200, headers=None, fail_after_chunks=None, text=""):
         self._chunks = list(chunks)
         self.status_code = status_code
         self.headers = headers or {}
         self._fail_after_chunks = fail_after_chunks
+        self.text = text
         self.closed = False
 
     def raise_for_status(self):
@@ -1244,8 +1246,7 @@ class TestFetchTextWithRetry:
 
         from vtscore.datasets.downloader import core as dl_core
 
-        response = _FakeResponse([], status_code=200)
-        response.text = '{"files": []}'
+        response = _FakeResponse([], status_code=200, text='{"files": []}')
         monkeypatch.setattr(requests.Session, "get", lambda self, url, *a, **k: response)
 
         assert dl_core.fetch_text_with_retry("https://archive.org/metadata/x") == '{"files": []}'
@@ -1256,8 +1257,7 @@ class TestFetchTextWithRetry:
 
         from vtscore.datasets.downloader import core as dl_core
 
-        response = _FakeResponse([], status_code=200)
-        response.text = "ok"
+        response = _FakeResponse([], status_code=200, text="ok")
         calls = []
 
         def fake_get(self, url, *args, **kwargs):

--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -1110,5 +1110,189 @@ class TestDownloadResume:
         self._install(monkeypatch, dropping)
 
         dest = tmp_path / "archive.tar"
-        with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
             dl_core.download_file_with_progress("https://example.com/archive.tar", dest, on_progress=lambda *a: None)
+
+        # The user-facing message is a sentence naming the host, not a nested
+        # urllib3 MaxRetryError dump (issue #3216).
+        message = str(excinfo.value)
+        assert "example.com" in message
+        assert "https://example.com/archive.tar" not in message
+        assert excinfo.value.attempts == dl_core._MAX_DOWNLOAD_ATTEMPTS
+        # The original exception stays reachable for the server-side traceback.
+        assert isinstance(excinfo.value.__cause__, requests.exceptions.ChunkedEncodingError)
+
+
+class TestConnectFailureHandling:
+    """Connection-level failures retry with an escalating connect budget and
+    end in one actionable sentence rather than a urllib3 dump (issue #3216)."""
+
+    @staticmethod
+    def _install_failing_get(monkeypatch, exc_factory, succeed_after=None):
+        """Patch ``requests.Session.get`` to raise *exc_factory()* on every call
+        (or until *succeed_after* calls have been made, then hand back a tiny
+        200 response).  Records each call's timeout and neutralizes the backoff
+        sleep.  Returns the list of recorded timeouts."""
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        timeouts = []
+
+        def fake_get(self, url, *args, timeout=None, **kwargs):
+            timeouts.append(timeout)
+            if succeed_after is not None and len(timeouts) > succeed_after:
+                return _FakeResponse([b"payload"], status_code=200, headers={"content-length": "7"})
+            raise exc_factory()
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        monkeypatch.setattr(dl_core.time, "sleep", lambda *a, **k: None)
+        return timeouts
+
+    def test_connect_budget_escalates_across_attempts(self, tmp_path, monkeypatch):
+        """A host slow to *accept* must not be written off on the same 10 s
+        budget six times over."""
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        timeouts = self._install_failing_get(monkeypatch, lambda: requests.exceptions.ConnectTimeout("connect timeout"))
+
+        with pytest.raises(dl_core.RemoteUnreachableError):
+            dl_core.download_file_with_progress(
+                "https://archive.org/download/x/y.mp3", tmp_path / "y.mp3", on_progress=lambda *a: None
+            )
+
+        connect_budgets = [t[0] for t in timeouts]
+        assert connect_budgets == [10.0, 15.0, 20.0, 30.0, 30.0, 30.0]
+        assert {t[1] for t in timeouts} == {dl_core._READ_TIMEOUT_S}
+
+    def test_connect_timeout_message_names_the_host(self, tmp_path, monkeypatch):
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        self._install_failing_get(monkeypatch, lambda: requests.exceptions.ConnectTimeout("connect timeout"))
+
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
+            dl_core.download_file_with_progress(
+                "https://archive.org/download/Apollo11Audio/11-03301.mp3",
+                tmp_path / "11-03301.mp3",
+                on_progress=lambda *a: None,
+            )
+
+        message = str(excinfo.value)
+        assert message.startswith("Couldn't reach archive.org:")
+        assert "timed out" in message
+        assert "retry" in message
+        assert excinfo.value.url == "https://archive.org/download/Apollo11Audio/11-03301.mp3"
+
+    def test_retry_message_says_retrying_before_any_bytes_land(self, tmp_path, monkeypatch):
+        """ "Resuming ... at 0 bytes" read as a stalled transfer when in fact
+        nothing had ever connected."""
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        self._install_failing_get(
+            monkeypatch, lambda: requests.exceptions.ConnectTimeout("connect timeout"), succeed_after=2
+        )
+
+        reported = []
+        dl_core.download_file_with_progress(
+            "https://archive.org/download/x/y.mp3", tmp_path / "y.mp3", on_progress=lambda *a: reported.append(a)
+        )
+
+        retry_messages = [a[1] for a in reported if "Connection interrupted" in a[1]]
+        assert retry_messages, "the retries were never reported"
+        assert all("retrying y.mp3" in m for m in retry_messages)
+        assert not any("resuming" in m or "0 bytes" in m for m in retry_messages)
+
+    def test_retry_message_says_resuming_once_bytes_are_on_disk(self, tmp_path, monkeypatch):
+        from vtscore.datasets.downloader import core as dl_core
+
+        payload = b"z" * 512
+        chunks = [payload[:256], payload[256:]]
+        first = _FakeResponse(chunks, status_code=200, headers={"content-length": "512"}, fail_after_chunks=1)
+        second = _FakeResponse(
+            chunks[1:],
+            status_code=206,
+            headers={"content-length": "256", "Content-Range": "bytes 256-511/512"},
+        )
+        TestDownloadResume._install(monkeypatch, [first, second])
+
+        reported = []
+        dl_core.download_file_with_progress(
+            "https://example.com/archive.tar", tmp_path / "archive.tar", on_progress=lambda *a: reported.append(a)
+        )
+
+        retry_messages = [a[1] for a in reported if "Connection interrupted" in a[1]]
+        assert retry_messages == [
+            f"Connection interrupted at 256 bytes - resuming archive.tar (attempt 2/{dl_core._MAX_DOWNLOAD_ATTEMPTS})..."
+        ]
+
+
+class TestFetchTextWithRetry:
+    """Manifest/index fetches share the transfer's retry budget and error shape.
+
+    A one-shot GET for a few KB of JSON used to be strictly more fragile than
+    the multi-GB download it precedes.
+    """
+
+    def test_returns_the_body_on_success(self, monkeypatch):
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        response = _FakeResponse([], status_code=200)
+        response.text = '{"files": []}'
+        monkeypatch.setattr(requests.Session, "get", lambda self, url, *a, **k: response)
+
+        assert dl_core.fetch_text_with_retry("https://archive.org/metadata/x") == '{"files": []}'
+        assert response.closed
+
+    def test_retries_a_transient_connect_failure(self, monkeypatch):
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        response = _FakeResponse([], status_code=200)
+        response.text = "ok"
+        calls = []
+
+        def fake_get(self, url, *args, **kwargs):
+            calls.append(url)
+            if len(calls) < 3:
+                raise requests.exceptions.ConnectTimeout("connect timeout")
+            return response
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        monkeypatch.setattr(dl_core.time, "sleep", lambda *a, **k: None)
+
+        reported = []
+        result = dl_core.fetch_text_with_retry(
+            "https://archive.org/metadata/x", "the track list", lambda *a: reported.append(a)
+        )
+
+        assert result == "ok"
+        assert len(calls) == 3
+        # The retry notice names the fetch, not a filename it doesn't have.
+        assert [a[1] for a in reported] == [
+            f"Connection interrupted - retrying the track list (attempt {n}/{dl_core._MAX_DOWNLOAD_ATTEMPTS})..."
+            for n in (2, 3)
+        ]
+
+    def test_exhausted_attempts_raise_the_named_host_error(self, monkeypatch):
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        def fake_get(self, url, *args, **kwargs):
+            raise requests.exceptions.ConnectTimeout("connect timeout")
+
+        monkeypatch.setattr(requests.Session, "get", fake_get)
+        monkeypatch.setattr(dl_core.time, "sleep", lambda *a, **k: None)
+
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
+            dl_core.fetch_text_with_retry("https://archive.org/metadata/x", on_progress=lambda *a: None)
+        assert "archive.org" in str(excinfo.value)

--- a/tests_lib/downloads/test_longform_audio_download.py
+++ b/tests_lib/downloads/test_longform_audio_download.py
@@ -78,6 +78,24 @@ class TestApollo11Manifest:
         with patch.object(audio_module, "_fetch_text", return_value=json.dumps(payload)):
             assert audio_module.apollo11_audio_manifest() == [("x.mp3", 0)]
 
+    def test_the_fetch_shares_the_download_retry_budget(self, monkeypatch):
+        """A one-shot GET for the track list would be strictly more fragile
+        than the multi-GB transfer it precedes (issue #3216)."""
+        from vtscore.datasets.downloader import audio as audio_module
+        from vtscore.datasets.downloader import core as dl_core
+
+        seen = {}
+
+        def fake_fetch(url, label="", on_progress=None):
+            seen["url"], seen["label"] = url, label
+            return json.dumps(_APOLLO_METADATA)
+
+        monkeypatch.setattr(dl_core, "fetch_text_with_retry", fake_fetch)
+        audio_module.apollo11_audio_manifest()
+
+        assert seen["url"].startswith(dl_core.ARCHIVE_ORG_METADATA_URL)
+        assert seen["label"], "the retry notice needs a name for this fetch"
+
 
 class TestDownloadApollo11Audio:
     def test_downloads_only_the_given_tracks(self, tmp_path):

--- a/vtscore/datasets/downloader/__init__.py
+++ b/vtscore/datasets/downloader/__init__.py
@@ -123,11 +123,13 @@ from vtscore.datasets.downloader.core import (
     VISUAL_GENOME_OBJECTS_DOWNLOAD_SIZE_MB,
     VISUAL_GENOME_OBJECTS_URL,
     ProgressCallback,
+    RemoteUnreachableError,
     _default_progress,
     _download_and_extract,
     _move_tree_contents,
     _validate_archive,
     download_file_with_progress,
+    fetch_text_with_retry,
 )
 
 # Audio downloaders
@@ -299,7 +301,9 @@ __all__ = [
     "VISUAL_GENOME_IMAGES_URL",
     "VISUAL_GENOME_OBJECTS_DOWNLOAD_SIZE_MB",
     "VISUAL_GENOME_OBJECTS_URL",
+    "RemoteUnreachableError",
     "download_file_with_progress",
+    "fetch_text_with_retry",
     # Audio
     "apollo11_audio_manifest",
     "birdvox_full_night_manifest",

--- a/vtscore/datasets/downloader/audio.py
+++ b/vtscore/datasets/downloader/audio.py
@@ -250,15 +250,15 @@ def download_tut_sound_events_2017(on_progress: Optional[ProgressCallback] = Non
 # ---------------------------------------------------------------------------
 
 
-def _fetch_text(url: str) -> str:
-    """GET *url* through the SSRF-guarded session and return its body as text."""
-    session = _core.guarded_session()
-    response = _core.open_validated_stream(session, url)
-    try:
-        response.raise_for_status()
-        return response.text
-    finally:
-        response.close()
+def _fetch_text(url: str, label: str = "") -> str:
+    """GET *url* through the SSRF-guarded session and return its body as text.
+
+    Routed through :func:`~vtscore.datasets.downloader.core.fetch_text_with_retry`
+    so a manifest/index fetch gets the same retry budget as the transfer it
+    precedes: these are the Internet Archive and NARA, and a single unlucky
+    handshake here used to sink the whole load before a byte was downloaded.
+    """
+    return _core.fetch_text_with_retry(url, label)
 
 
 def _download_files_into(
@@ -299,7 +299,7 @@ def apollo11_audio_manifest() -> list[tuple[str, int]]:
     import json  # noqa: PLC0415
 
     url = f"{_core.ARCHIVE_ORG_METADATA_URL}/{_core.APOLLO11_AUDIO_ITEM}"
-    payload = json.loads(_fetch_text(url))
+    payload = json.loads(_fetch_text(url, "the Apollo 11 track list"))
     tracks = [
         (f["name"], int(f.get("size") or 0))
         for f in payload.get("files", [])
@@ -447,7 +447,7 @@ def nixon_tape_conversation_urls(tape: str) -> list[str]:
     """
     import re  # noqa: PLC0415
 
-    html = _fetch_text(f"{_core.NIXON_TAPES_PAGE_URL}/{tape}")
+    html = _fetch_text(f"{_core.NIXON_TAPES_PAGE_URL}/{tape}", f"the tape {tape} index")
     return sorted(set(re.findall(_core.NIXON_TAPE_MP3_PATTERN, html)))
 
 

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -15,6 +15,7 @@ import uuid
 import zipfile
 from pathlib import Path
 from typing import Callable, Literal, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -45,6 +46,15 @@ _RETRYABLE_EXCEPTIONS = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
 )
+# ``(connect, read)`` timeout per attempt.  The connect budget *escalates*: the
+# first attempt fails fast so a genuinely dead host does not stall a load for
+# minutes before saying so, but a host that is merely slow to **accept** - the
+# Internet Archive under load routinely takes 20-30 s to complete a handshake -
+# gets progressively more room instead of being written off six times on the
+# same 10 s budget.  Attempts past the last step reuse it.
+_CONNECT_TIMEOUT_STEPS_S = (10.0, 15.0, 20.0, 30.0)
+_READ_TIMEOUT_S = 60.0
+
 
 # Demo dataset directory paths (derived from DATA_DIR)
 IMAGE_DIR = DATA_DIR / "images"
@@ -335,14 +345,31 @@ def _request_headers(url: str, headers: Optional[dict]) -> dict:
     return merged
 
 
-def _open_validated_stream(session: requests.Session, url: str, headers: Optional[dict] = None) -> requests.Response:
+def _timeout_for_attempt(attempt: int) -> tuple[float, float]:
+    """Return the ``(connect, read)`` timeout for 1-based retry *attempt*.
+
+    Walks :data:`_CONNECT_TIMEOUT_STEPS_S` and holds at its last entry, so a
+    host that needs longer than the fail-fast first budget to accept a socket
+    gets it on a later attempt rather than timing out identically every time.
+    """
+    step = _CONNECT_TIMEOUT_STEPS_S[min(attempt, len(_CONNECT_TIMEOUT_STEPS_S)) - 1]
+    return (step, _READ_TIMEOUT_S)
+
+
+def _open_validated_stream(
+    session: requests.Session,
+    url: str,
+    headers: Optional[dict] = None,
+    timeout: Optional[tuple[float, float]] = None,
+) -> requests.Response:
     """GET *url* as a stream with every redirect hop re-checked for SSRF.
 
     A thin binding of :func:`~vtscore.security.url_validation.open_validated_stream`
     to the downloader's needs: caller *headers* merged with a HuggingFace bearer
     token recomputed per hop, so the token follows a redirect only to another
     Hub host and never to a presigned CDN / Xet target.  Callers validate *url*
-    itself up front; this covers the hops after it.
+    itself up front; this covers the hops after it.  *timeout* defaults to the
+    first (fail-fast) entry of the escalating retry ladder.
 
     Returns the final, non-redirect response; the caller owns closing it.
     """
@@ -350,6 +377,7 @@ def _open_validated_stream(session: requests.Session, url: str, headers: Optiona
         session,
         url,
         headers_for_url=lambda hop: _request_headers(hop, headers),
+        timeout=timeout if timeout is not None else _timeout_for_attempt(1),
     )
 
 
@@ -374,18 +402,71 @@ def _total_size_from_headers(response: requests.Response, downloaded: int, expec
 
 
 def _backoff_and_notify(
-    on_progress: ProgressCallback, dest_path: Path, attempt: int, downloaded: int, total_size: int
+    on_progress: ProgressCallback, label: str, attempt: int, downloaded: int, total_size: int
 ) -> None:
-    """Report a recoverable interruption and sleep for an exponential backoff."""
+    """Report a recoverable interruption and sleep for an exponential backoff.
+
+    *label* names what is being fetched (a filename, or a short description for
+    a metadata fetch).  The wording follows the byte count: with nothing on disk
+    yet there is nothing to resume, and saying "resuming" at 0 bytes is exactly
+    the message that made a failed-to-even-connect load read as a stalled
+    transfer (see issue #3216).
+    """
     backoff = min(_RETRY_BACKOFF_BASE_S * (2 ** (attempt - 1)), _RETRY_BACKOFF_MAX_S)
+    where = f" at {downloaded:,} bytes" if downloaded else ""
+    verb = "resuming" if downloaded else "retrying"
     on_progress(
         "downloading",
-        f"Connection interrupted at {downloaded:,} bytes - resuming {dest_path.name} "
-        f"(attempt {attempt + 1}/{_MAX_DOWNLOAD_ATTEMPTS})...",
+        f"Connection interrupted{where} - {verb} {label} (attempt {attempt + 1}/{_MAX_DOWNLOAD_ATTEMPTS})...",
         downloaded,
         total_size,
     )
     time.sleep(backoff)
+
+
+class RemoteUnreachableError(RuntimeError):
+    """A fetch gave up because the remote host could not be reached.
+
+    Raised in place of the raw requests/urllib3 exception once every retry has
+    been spent on *connection-level* failures, so the dataset-load error the
+    user sees is one actionable sentence naming the host rather than a nested
+    ``MaxRetryError`` dump ending in a memory address.  Carries the originating
+    *url* and the number of *attempts* for logging; the underlying exception
+    stays reachable as ``__cause__`` (and is still printed to the server log by
+    the load pipeline's ``traceback.print_exc``).
+    """
+
+    def __init__(self, message: str, *, url: str = "", attempts: int = 0) -> None:
+        super().__init__(message)
+        self.url = url
+        self.attempts = attempts
+
+
+def _unreachable_error(url: str, exc: BaseException, attempts: int) -> RemoteUnreachableError:
+    """Build a short, user-facing :class:`RemoteUnreachableError` for *url*.
+
+    Names the *host* rather than the full URL (a 200-character archive.org
+    download path tells the user nothing they can act on) and says which way
+    the connection failed, because "timed out before connecting" and "dropped
+    mid-transfer" point at different things to check.
+    """
+    host = urlparse(url).hostname or url
+    if isinstance(exc, requests.exceptions.ConnectTimeout):
+        what = "the connection timed out before the server answered"
+    elif isinstance(exc, requests.exceptions.ReadTimeout):
+        what = "the server stopped sending data"
+    elif isinstance(exc, requests.exceptions.ChunkedEncodingError):
+        what = "the connection kept dropping mid-transfer"
+    else:
+        what = "the connection failed"
+    return RemoteUnreachableError(
+        f"Couldn't reach {host}: {what}, on all {attempts} attempts. "
+        f"The site may be down or blocked by your network/proxy - open it in a "
+        f"browser to check, then retry. Anything already downloaded is kept, so "
+        f"a retry picks up where this left off.",
+        url=url,
+        attempts=attempts,
+    )
 
 
 def _gated_error(url: str, status: int) -> GatedResourceError:
@@ -446,8 +527,9 @@ def download_file_with_progress(  # noqa: C901
 
     Raises:
         requests.HTTPError: If the server returns a non-retryable error status.
-        requests.exceptions.ChunkedEncodingError / ConnectionError / Timeout: If
-            the connection keeps failing after the final retry attempt.
+        RemoteUnreachableError: If the connection keeps failing after the final
+            retry attempt.  The underlying requests exception is its
+            ``__cause__``.
     """
     if on_progress is None:
         on_progress = _default_progress()
@@ -470,11 +552,11 @@ def download_file_with_progress(  # noqa: C901
 
         response = None
         try:
-            response = _open_validated_stream(session, url, headers)
+            response = _open_validated_stream(session, url, headers, _timeout_for_attempt(attempt))
 
             # Transient server-side error: back off and retry (resuming if we can).
             if response.status_code in _RETRYABLE_STATUS and not last_attempt:
-                _backoff_and_notify(on_progress, dest_path, attempt, downloaded, total_size)
+                _backoff_and_notify(on_progress, dest_path.name, attempt, downloaded, total_size)
                 continue
             # Auth-required: this is gated content we can't fetch with the
             # credentials we have.  Surface a short, actionable message instead
@@ -509,13 +591,63 @@ def download_file_with_progress(  # noqa: C901
                         on_progress("downloading", f"Downloading {dest_path.name}...", downloaded, total_size)
             on_progress("downloading", f"Downloading {dest_path.name}...", downloaded, total_size)
             return  # stream consumed cleanly
-        except _RETRYABLE_EXCEPTIONS:
+        except _RETRYABLE_EXCEPTIONS as exc:
             if last_attempt:
-                raise
-            _backoff_and_notify(on_progress, dest_path, attempt, downloaded, total_size)
+                raise _unreachable_error(url, exc, _MAX_DOWNLOAD_ATTEMPTS) from exc
+            _backoff_and_notify(on_progress, dest_path.name, attempt, downloaded, total_size)
         finally:
             if response is not None:
                 response.close()
+
+
+def fetch_text_with_retry(url: str, label: str = "", on_progress: Optional[ProgressCallback] = None) -> str:
+    """GET *url* through the SSRF-guarded session and return its body as text.
+
+    The small-payload counterpart to :func:`download_file_with_progress`, for
+    the manifest / index fetches that decide *what* to download: same retry
+    budget, same escalating connect timeout, same
+    :class:`RemoteUnreachableError` once the attempts are spent.  Without it a
+    one-shot GET for a few KB of JSON is strictly more fragile than the
+    multi-GB transfer it precedes, and fails with a raw urllib3 dump instead of
+    a sentence.
+
+    Args:
+        url: An already-validated HTTP(S) URL.
+        label: Short human-readable name for the fetch, used in the retry
+            progress message.  Defaults to the URL's last path segment.
+        on_progress: Optional progress callback.  Falls back to the
+            application-wide ``update_progress`` when ``None``.
+
+    Raises:
+        requests.HTTPError: If the server returns a non-retryable error status.
+        RemoteUnreachableError: If the connection keeps failing after the final
+            retry attempt.
+    """
+    if on_progress is None:
+        on_progress = _default_progress()
+    label = label or urlparse(url).path.rsplit("/", 1)[-1] or url
+
+    session = guarded_session()
+    for attempt in range(1, _MAX_DOWNLOAD_ATTEMPTS + 1):
+        last_attempt = attempt == _MAX_DOWNLOAD_ATTEMPTS
+        response = None
+        try:
+            response = _open_validated_stream(session, url, timeout=_timeout_for_attempt(attempt))
+            if response.status_code in _RETRYABLE_STATUS and not last_attempt:
+                _backoff_and_notify(on_progress, label, attempt, 0, 0)
+                continue
+            if response.status_code in _AUTH_REQUIRED_STATUS:
+                raise _gated_error(url, response.status_code)
+            response.raise_for_status()
+            return response.text
+        except _RETRYABLE_EXCEPTIONS as exc:
+            if last_attempt:
+                raise _unreachable_error(url, exc, _MAX_DOWNLOAD_ATTEMPTS) from exc
+            _backoff_and_notify(on_progress, label, attempt, 0, 0)
+        finally:
+            if response is not None:
+                response.close()
+    raise AssertionError("unreachable: the loop above always returns or raises")  # pragma: no cover
 
 
 def fetch_remote_signature(url: str) -> Optional[str]:


### PR DESCRIPTION
Closes #3216

## What happened

Loading **Apollo 11 Mission Audio (S)** while archive.org was refusing connections failed with a nested `MaxRetryError` — a hundred lines of urllib3 traceback, ending in a memory address — pasted verbatim into the *Dataset load failed* box. Nothing in it told the user what to do.

The retry machinery itself worked: `download_file_with_progress` already treats `ConnectTimeout` as retryable, so it made six attempts with backoff (that's the truncated "connection interr…" the GUI showed). But three things around it were wrong:

- Every one of those six attempts used the **same 10-second connect budget**. archive.org under load routinely takes 20–30 s to complete a handshake, so six identical fail-fast attempts are six identical failures, not increasing patience.
- The retry notice read *"Connection interrupted at 0 bytes - resuming 11-03301.mp3"* — offering to resume a file that had never transferred a byte. It read as a stalled transfer when in fact nothing had ever connected.
- The **track-list fetch** that precedes the download (`archive.org/metadata/Apollo11Audio`) was a bare one-shot GET with no retry at all — strictly more fragile than the multi-GB transfer it gates.

## What changed

- **`RemoteUnreachableError`** replaces the raw requests exception once every retry is spent on a connection-level failure. Its message names the *host* rather than a 200-character download path, says which way the connection failed (timed out before answering / stopped sending / kept dropping mid-transfer), and points at the next step:

  > Couldn't reach archive.org: the connection timed out before the server answered, on all 6 attempts. The site may be down or blocked by your network/proxy - open it in a browser to check, then retry. Anything already downloaded is kept, so a retry picks up where this left off.

  The original exception stays reachable as `__cause__`, so the server-side traceback the load pipeline prints is unchanged.

- **The connect budget escalates** across attempts — 10 / 15 / 20 / 30 s, held at 30 — instead of writing off a slow-to-accept host six times on the same budget. The 60 s read timeout is unchanged. Worst case for a genuinely dead host goes from ~90 s to ~165 s before the (now legible) failure.

- **The retry notice says "retrying \<file\>"** until there are bytes on disk to resume, and only then "resuming … at N bytes".

- **`fetch_text_with_retry`** gives manifest/index fetches the same retry budget, escalating timeout, and error shape as the transfer. The Apollo 11 track list and the Nixon tape indexes now go through it.

This does not change what happens when a host is truly unreachable — the load still fails. It changes how long we try first and what the user is told.

## Tests

`tests_lib/downloads/test_download_and_extract.py` — `TestConnectFailureHandling` (escalating budget, host-named message, retrying-vs-resuming wording) and `TestFetchTextWithRetry`. `test_raises_after_exhausting_attempts` now asserts the wrapped error and its `__cause__`. `tests_lib/downloads/test_longform_audio_download.py` pins the Apollo manifest fetch to the retrying helper.

Full `./run-tests.sh`: 8906 passed, all gates green.

---
_Generated by [Claude Code](https://claude.ai/code/session_016MEaXQ8EqfLGAwRt28q7Wa)_