### PR TITLE
Survive a single unavailable file in a multi-file demo download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,22 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **One file a host won't serve no longer sinks a whole multi-file demo
+  download.** The Apollo 11 Mission Audio demo pulls its tracks as separate
+  files from the Internet Archive, which serves each one from a data node that
+  can answer HTTP 500 for minutes at a time while its siblings stay healthy.
+  A single such track spent its six retries, then failed the entire dataset
+  load with a raw `500 Server Error` naming a `dn721903.ca.archive.org` URL the
+  user had never asked for. A file the host refuses is now set aside, retried
+  once after the rest of the set (by which point a wobbling node has usually
+  recovered), and otherwise skipped with a note in the progress line — the
+  download only fails when more than a quarter of the set is missing, and a
+  skipped track is fetched the next time the dataset loads. When a server does
+  keep returning 500/502/503/504/429 until the retries run out, that now reads
+  as *"archive.org kept returning an internal server error (HTTP 500) on all 6
+  attempts. That is a problem on the server's side, not yours…"* rather than a
+  raw `HTTPError` ending in a CDN node URL. (#3227)
+
 - **A demo download that can't reach its host now says so in a sentence, and
   tries harder before giving up.** Loading the Apollo 11 Mission Audio demo
   while archive.org was refusing connections failed with a hundred-line

--- a/tests_lib/downloads/test_download_and_extract.py
+++ b/tests_lib/downloads/test_download_and_extract.py
@@ -1234,6 +1234,91 @@ class TestConnectFailureHandling:
         ]
 
 
+class TestRetryableStatusExhaustion:
+    """A retryable status the server never stops returning ends in the same
+    actionable sentence a connection failure does (issue #3227).
+
+    The Internet Archive answered HTTP 500 for one Apollo track on all six
+    attempts; ``raise_for_status`` surfaced that as a raw ``HTTPError`` naming
+    the redirect's data-node URL, which says neither which site failed nor that
+    the failure was the server's rather than the user's.
+    """
+
+    def test_download_retries_a_500_then_names_the_host(self, tmp_path, monkeypatch):
+        from vtscore.datasets.downloader import core as dl_core
+
+        responses = [_FakeResponse([], status_code=500) for _ in range(dl_core._MAX_DOWNLOAD_ATTEMPTS)]
+        calls = TestDownloadResume._install(monkeypatch, responses)
+
+        url = "https://archive.org/download/Apollo11Audio/11-03303.mp3"
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
+            dl_core.download_file_with_progress(url, tmp_path / "11-03303.mp3", on_progress=lambda *a: None)
+
+        # Every attempt was spent before giving up.
+        assert len(calls) == dl_core._MAX_DOWNLOAD_ATTEMPTS
+        message = str(excinfo.value)
+        assert message.startswith("archive.org kept returning an internal server error (HTTP 500)")
+        assert "server's side, not yours" in message
+        # Not the raw HTTPError, and not a URL the user can't act on.
+        assert url not in message
+        assert excinfo.value.url == url
+        assert excinfo.value.attempts == dl_core._MAX_DOWNLOAD_ATTEMPTS
+
+    def test_a_recovering_server_still_downloads(self, tmp_path, monkeypatch):
+        """The 500 path must stay a *retry*, not become a fail-fast."""
+        from vtscore.datasets.downloader import core as dl_core
+
+        payload = b"ID3" + b"\x00" * 61
+        responses = [
+            _FakeResponse([], status_code=503),
+            _FakeResponse([], status_code=500),
+            _FakeResponse([payload], status_code=200, headers={"content-length": str(len(payload))}),
+        ]
+        TestDownloadResume._install(monkeypatch, responses)
+
+        dest = tmp_path / "11-03303.mp3"
+        dl_core.download_file_with_progress(str("https://archive.org/x"), dest, on_progress=lambda *a: None)
+
+        assert dest.read_bytes() == payload
+
+    def test_rate_limit_reads_as_a_rate_limit(self, tmp_path, monkeypatch):
+        from vtscore.datasets.downloader import core as dl_core
+
+        responses = [_FakeResponse([], status_code=429) for _ in range(dl_core._MAX_DOWNLOAD_ATTEMPTS)]
+        TestDownloadResume._install(monkeypatch, responses)
+
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
+            dl_core.download_file_with_progress(
+                "https://huggingface.co/datasets/x/y.tar", tmp_path / "y.tar", on_progress=lambda *a: None
+            )
+        assert "a rate-limit refusal (HTTP 429)" in str(excinfo.value)
+
+    def test_a_non_retryable_status_still_raises_http_error(self, tmp_path, monkeypatch):
+        """404 is not the server wobbling - it is the URL being wrong, and it
+        must not be dressed up as a transient outage."""
+        import requests
+
+        from vtscore.datasets.downloader import core as dl_core
+
+        calls = TestDownloadResume._install(monkeypatch, [_FakeResponse([], status_code=404)])
+
+        with pytest.raises(requests.HTTPError):
+            dl_core.download_file_with_progress(
+                "https://archive.org/download/x/gone.mp3", tmp_path / "gone.mp3", on_progress=lambda *a: None
+            )
+        assert len(calls) == 1, "a 404 must not burn the retry budget"
+
+    def test_text_fetch_names_the_host_too(self, monkeypatch):
+        from vtscore.datasets.downloader import core as dl_core
+
+        responses = [_FakeResponse([], status_code=502) for _ in range(dl_core._MAX_DOWNLOAD_ATTEMPTS)]
+        TestDownloadResume._install(monkeypatch, responses)
+
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
+            dl_core.fetch_text_with_retry("https://archive.org/metadata/Apollo11Audio", on_progress=lambda *a: None)
+        assert str(excinfo.value).startswith("archive.org kept returning a bad-gateway error (HTTP 502)")
+
+
 class TestFetchTextWithRetry:
     """Manifest/index fetches share the transfer's retry budget and error shape.
 

--- a/tests_lib/downloads/test_longform_audio_download.py
+++ b/tests_lib/downloads/test_longform_audio_download.py
@@ -207,6 +207,132 @@ class TestLoadDemoSourceApollo11:
         assert [c["filename"] for c in clips.values()] == ["mission_audio/present.mp3"]
 
 
+class TestPerFileFailureTolerance:
+    """One file the host won't serve must not sink a hundred-file download.
+
+    The Internet Archive serves each file of an item from a data node that can
+    answer HTTP 500 for minutes while its siblings stay healthy; that took out a
+    whole Apollo 11 load over a single track (issue #3227).
+    """
+
+    @staticmethod
+    def _downloader(failing: dict[str, int], payload=b"ID3"):
+        """Return a ``download_file_with_progress`` stand-in that fails for each
+        name in *failing* the given number of times, then succeeds.
+
+        Returns ``(fn, attempts)`` where *attempts* records every requested
+        filename in order.
+        """
+        from vtscore.datasets.downloader import core as dl_core
+
+        attempts: list[str] = []
+        remaining = dict(failing)
+
+        def _download(url, dest, expected_size=0, on_progress=None):
+            name = url.rsplit("/", 1)[-1]
+            attempts.append(name)
+            if remaining.get(name, 0) > 0:
+                remaining[name] -= 1
+                raise dl_core.RemoteUnreachableError("archive.org kept returning …", url=url)
+            Path(dest).write_bytes(payload)
+
+        return _download, attempts
+
+    def _run(self, tmp_path, tracks, downloader, on_progress=None):
+        from vtscore.datasets import downloader as dl_module
+
+        with (
+            patch.object(dl_module.core, "DATA_DIR", tmp_path),
+            patch.object(dl_module.core, "download_file_with_progress", downloader),
+        ):
+            return dl_module.download_apollo11_audio(tracks, on_progress=on_progress or (lambda *a: None))
+
+    def test_a_dead_track_is_retried_at_the_end_and_then_skipped(self, tmp_path):
+        tracks = [(f"t{i:02d}.mp3", 10) for i in range(8)]
+        download, attempts = self._downloader({"t02.mp3": 99})
+
+        result = self._run(tmp_path, tracks, download)
+
+        # The other seven tracks are on disk; the load is not lost.
+        assert sorted(p.name for p in result.glob("*.mp3")) == [f"t{i:02d}.mp3" for i in range(8) if i != 2]
+        # The failure was retried once, after the rest of the set had run.
+        assert attempts.count("t02.mp3") == 2
+        assert attempts[-1] == "t02.mp3"
+
+    def test_the_end_of_set_retry_recovers_a_transient_failure(self, tmp_path):
+        """A node that wobbles for one file gets the whole rest of the download
+        as backoff before we write the track off."""
+        tracks = [(f"t{i:02d}.mp3", 10) for i in range(4)]
+        download, attempts = self._downloader({"t01.mp3": 1})
+
+        result = self._run(tmp_path, tracks, download)
+
+        assert sorted(p.name for p in result.glob("*.mp3")) == [f"t{i:02d}.mp3" for i in range(4)]
+        assert attempts.count("t01.mp3") == 2
+
+    def test_a_hard_http_status_on_one_file_is_tolerated_too(self, tmp_path):
+        """A single 404 (a track dropped from the item) is still just one file."""
+        import requests
+
+        def _download(url, dest, expected_size=0, on_progress=None):
+            if url.endswith("t03.mp3"):
+                raise requests.HTTPError("404 Client Error")
+            Path(dest).write_bytes(b"ID3")
+
+        tracks = [(f"t{i:02d}.mp3", 10) for i in range(8)]
+        result = self._run(tmp_path, tracks, _download)
+
+        assert len(list(result.glob("*.mp3"))) == 7
+
+    def test_too_many_failures_still_fail_the_load(self, tmp_path):
+        """Tolerating one bad file must not quietly hand back a gutted dataset."""
+        from vtscore.datasets.downloader import core as dl_core
+
+        tracks = [(f"t{i:02d}.mp3", 10) for i in range(8)]
+        download, _ = self._downloader({f"t{i:02d}.mp3": 99 for i in range(3)})
+
+        with pytest.raises(dl_core.RemoteUnreachableError) as excinfo:
+            self._run(tmp_path, tracks, download)
+        assert "3 of 8 files could not be downloaded" in str(excinfo.value)
+
+    def test_a_single_file_set_that_fails_is_a_failed_load(self, tmp_path):
+        from vtscore.datasets.downloader import core as dl_core
+
+        download, _ = self._downloader({"only.mp3": 99})
+        with pytest.raises(dl_core.RemoteUnreachableError):
+            self._run(tmp_path, [("only.mp3", 10)], download)
+
+    def test_cancellation_is_never_swallowed(self, tmp_path):
+        """A cancelled load is about the run, not the file: it must stop the
+        download rather than be counted as one more skippable track."""
+        from vtscore.concurrency.progress import CancelledError
+
+        def _download(url, dest, expected_size=0, on_progress=None):
+            raise CancelledError("Operation cancelled by user")
+
+        with pytest.raises(CancelledError):
+            self._run(tmp_path, [(f"t{i:02d}.mp3", 10) for i in range(8)], _download)
+
+    def test_a_gated_dataset_is_never_swallowed(self, tmp_path):
+        from vtscore.security.hf_auth import GatedResourceError
+
+        def _download(url, dest, expected_size=0, on_progress=None):
+            raise GatedResourceError("Sign in with HuggingFace", url=url, status=403)
+
+        with pytest.raises(GatedResourceError):
+            self._run(tmp_path, [(f"t{i:02d}.mp3", 10) for i in range(8)], _download)
+
+    def test_the_skip_is_reported_not_silent(self, tmp_path):
+        tracks = [(f"t{i:02d}.mp3", 10) for i in range(8)]
+        download, _ = self._downloader({"t02.mp3": 99})
+        reported: list = []
+
+        self._run(tmp_path, tracks, download, on_progress=lambda *a: reported.append(a))
+
+        messages = [a[1] for a in reported]
+        assert any("skipped 1 of 8 files" in m for m in messages)
+
+
 # ---------------------------------------------------------------------------
 # BirdVox-full-night
 # ---------------------------------------------------------------------------

--- a/tests_lib/downloads/test_longform_audio_download.py
+++ b/tests_lib/downloads/test_longform_audio_download.py
@@ -322,15 +322,39 @@ class TestPerFileFailureTolerance:
         with pytest.raises(GatedResourceError):
             self._run(tmp_path, [(f"t{i:02d}.mp3", 10) for i in range(8)], _download)
 
-    def test_the_skip_is_reported_not_silent(self, tmp_path):
+    def test_the_skip_toasts_rather_than_passing_silently(self, tmp_path):
+        """A progress line would be overwritten by the next load stage within
+        the second, so the skip has to be a notification to be seen at all."""
+        from vtscore.concurrency import notifications
+
         tracks = [(f"t{i:02d}.mp3", 10) for i in range(8)]
         download, _ = self._downloader({"t02.mp3": 99})
-        reported: list = []
+        seen: list = []
 
-        self._run(tmp_path, tracks, download, on_progress=lambda *a: reported.append(a))
+        notifications.notifications.subscribe(seen.append)
+        try:
+            self._run(tmp_path, tracks, download)
+        finally:
+            notifications.notifications.unsubscribe(seen.append)
 
-        messages = [a[1] for a in reported]
-        assert any("skipped 1 of 8 files" in m for m in messages)
+        assert len(seen) == 1
+        assert seen[0].level == "warning"
+        assert seen[0].message == "Apollo 11 audio: 1 of 8 files couldn't be downloaded"
+        assert "t02.mp3" in (seen[0].detail or "")
+
+    def test_a_clean_download_toasts_nothing(self, tmp_path):
+        from vtscore.concurrency import notifications
+
+        download, _ = self._downloader({})
+        seen: list = []
+
+        notifications.notifications.subscribe(seen.append)
+        try:
+            self._run(tmp_path, [(f"t{i:02d}.mp3", 10) for i in range(4)], download)
+        finally:
+            notifications.notifications.unsubscribe(seen.append)
+
+        assert seen == []
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -12,6 +12,19 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **`RemoteUnreachableError` now also covers a retryable HTTP status that
+  outlives the retry budget.** `download_file_with_progress` and
+  `fetch_text_with_retry` used to end a run of 500/502/503/504/429 responses by
+  calling `raise_for_status()`, so the caller got a raw `requests.HTTPError`
+  naming whichever CDN node the redirect landed on. Both now raise
+  `RemoteUnreachableError` with a sentence naming the host and the status.
+  Non-retryable statuses (404 and friends) still raise `HTTPError` unchanged,
+  and gated 401/403 still raise `GatedResourceError`.
+- **A multi-file demo download tolerates individual files the host refuses.**
+  The per-file sets (Apollo 11, the Nixon tapes) set a failed file aside, retry
+  it once after the rest of the set, then skip it with a `notify()` warning,
+  failing the download only when more than a quarter of the set is missing.
+
 - **`LINEAR_SVM_HEAD` is the production detector head**, replacing
   `LINEAR_HEAD`. Both sentinels build the same `Linear(D, 1)`; the new one is
   fitted by `vtscore.training.svm.fit_linear_svm_head` (squared hinge + L2 via

--- a/vtscore/datasets/downloader/audio.py
+++ b/vtscore/datasets/downloader/audio.py
@@ -320,9 +320,9 @@ def _download_files_into(
     """Download ``(url, filename, size)`` *items* into *dest_dir*, skipping cached ones.
 
     Files the remote refuses to serve are set aside and retried once after the
-    rest of the set, then skipped; the download only fails if more than
-    :data:`_MAX_FAILED_FRACTION` of the set ends up missing.  See that constant
-    for why one bad file must not sink the whole download.
+    rest of the set, then skipped with a warning notification; the download only
+    fails if more than :data:`_MAX_FAILED_FRACTION` of the set ends up missing.
+    See that constant for why one bad file must not sink the whole download.
 
     Raises:
         RemoteUnreachableError: If too much of the set could not be fetched.
@@ -360,11 +360,18 @@ def _download_files_into(
             f"which is too much of the dataset to load without. {last_exc}",
             url=still_failed[0][1][0],
         ) from last_exc
-    on_progress(
-        "downloading",
-        f"{dataset_name}: skipped {len(still_failed)} of {total} files the server wouldn't serve",
-        total,
-        total,
+    # A toast, not a progress line: the progress channel holds one current
+    # snapshot and the next load stage overwrites it within the second, so a
+    # skip reported there is a skip the user never sees.
+    from vtscore.concurrency.notifications import notify  # noqa: PLC0415
+
+    names = [item[1] for _i, item in still_failed]
+    listed = ", ".join(names[:5]) + (f" and {len(names) - 5} more" if len(names) > 5 else "")
+    notify(
+        f"{dataset_name}: {len(still_failed)} of {total} files couldn't be downloaded",
+        level="warning",
+        detail=f"The server wouldn't serve {listed}. The rest of the set downloaded and the dataset loaded normally.",
+        source="Dataset download",
     )
 
 

--- a/vtscore/datasets/downloader/audio.py
+++ b/vtscore/datasets/downloader/audio.py
@@ -5,6 +5,8 @@ import shutil
 from pathlib import Path
 from typing import Optional
 
+import requests
+
 from vtscore.datasets.downloader import core as _core
 from vtscore.datasets.downloader.core import ProgressCallback
 
@@ -261,6 +263,54 @@ def _fetch_text(url: str, label: str = "") -> str:
     return _core.fetch_text_with_retry(url, label)
 
 
+# A per-file demo set is dozens to hundreds of separate transfers from one
+# third-party host, so the odds that *some* file fails are far higher than for
+# the single-archive demos.  The Internet Archive in particular serves each file
+# from a data node that can answer HTTP 500 for minutes on end while its
+# siblings stay healthy, which is what sank a whole Apollo 11 load over one
+# track of thirty (issue #3227).  Losing a handful of hours-long recordings out
+# of a hundred costs the user nothing they would notice - losing the load does -
+# so a failed file is set aside, retried once at the end of the set (by which
+# point a transient node error has usually cleared), and only fails the load if
+# too many of them pile up.  A skipped file is simply absent from *dest_dir*, so
+# the next load of the same dataset fetches it rather than treating it as done.
+_MAX_FAILED_FRACTION = 0.25
+
+# Per-file failures worth setting aside rather than sinking the set: the remote
+# gave up (connection or a retryable status exhausted its budget), or answered
+# with a hard status such as 404 for this one file.  Everything else - a
+# cancelled load, a gated dataset, a full disk - is about the *run*, not the
+# file, and must still stop it.
+_TOLERATED_FILE_FAILURES = (_core.RemoteUnreachableError, requests.HTTPError)
+
+
+def _download_one_file_into(
+    dest_dir: Path,
+    item: tuple[str, str, int],
+    dataset_name: str,
+    on_progress: ProgressCallback,
+    index: int,
+    total: int,
+) -> None:
+    """Fetch one ``(url, filename, size)`` *item*, or report it already cached.
+
+    The file lands on a ``.part`` sibling first and is renamed into place only
+    once the transfer completes, so the presence of the final name is an honest
+    "this file is whole" marker and an interrupted run resumes per file rather
+    than restarting the set.  ``download_file_with_progress`` itself resumes a
+    partial ``.part`` via an HTTP ``Range`` request.
+    """
+    url, filename, size = item
+    final = dest_dir / filename
+    if final.exists():
+        on_progress("downloading", f"{dataset_name}: {filename} (cached)", index + 1, total)
+        return
+    partial = dest_dir / f"{filename}.part"
+    _core.download_file_with_progress(url, partial, expected_size=size, on_progress=on_progress)
+    partial.replace(final)
+    on_progress("downloading", f"{dataset_name}: downloaded {filename}", index + 1, total)
+
+
 def _download_files_into(
     dest_dir: Path,
     items: list[tuple[str, str, int]],
@@ -269,23 +319,53 @@ def _download_files_into(
 ) -> None:
     """Download ``(url, filename, size)`` *items* into *dest_dir*, skipping cached ones.
 
-    Each file lands on a ``.part`` sibling first and is renamed into place only
-    once the transfer completes, so the presence of the final name is an honest
-    "this file is whole" marker and an interrupted run resumes per file rather
-    than restarting the set.  ``download_file_with_progress`` itself resumes a
-    partial ``.part`` via an HTTP ``Range`` request.
+    Files the remote refuses to serve are set aside and retried once after the
+    rest of the set, then skipped; the download only fails if more than
+    :data:`_MAX_FAILED_FRACTION` of the set ends up missing.  See that constant
+    for why one bad file must not sink the whole download.
+
+    Raises:
+        RemoteUnreachableError: If too much of the set could not be fetched.
+            The last per-file failure is its ``__cause__``.
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
     total = len(items)
-    for i, (url, filename, size) in enumerate(items):
-        final = dest_dir / filename
-        if final.exists():
-            on_progress("downloading", f"{dataset_name}: {filename} (cached)", i + 1, total)
-            continue
-        partial = dest_dir / f"{filename}.part"
-        _core.download_file_with_progress(url, partial, expected_size=size, on_progress=on_progress)
-        partial.replace(final)
-        on_progress("downloading", f"{dataset_name}: downloaded {filename}", i + 1, total)
+    failed: list[tuple[int, tuple[str, str, int]]] = []
+    last_exc: BaseException | None = None
+
+    for i, item in enumerate(items):
+        try:
+            _download_one_file_into(dest_dir, item, dataset_name, on_progress, i, total)
+        except _TOLERATED_FILE_FAILURES as exc:
+            last_exc = exc
+            failed.append((i, item))
+            on_progress("downloading", f"{dataset_name}: {item[1]} unavailable - will retry at the end", i + 1, total)
+
+    # Second pass: downloading the rest of the set has bought each failure
+    # minutes of backoff, which is usually all a wobbling data node needed.
+    still_failed: list[tuple[int, tuple[str, str, int]]] = []
+    for i, item in failed:
+        on_progress("downloading", f"{dataset_name}: retrying {item[1]}...", i + 1, total)
+        try:
+            _download_one_file_into(dest_dir, item, dataset_name, on_progress, i, total)
+        except _TOLERATED_FILE_FAILURES as exc:
+            last_exc = exc
+            still_failed.append((i, item))
+
+    if not still_failed:
+        return
+    if len(still_failed) > total * _MAX_FAILED_FRACTION:
+        raise _core.RemoteUnreachableError(
+            f"{dataset_name}: {len(still_failed)} of {total} files could not be downloaded, "
+            f"which is too much of the dataset to load without. {last_exc}",
+            url=still_failed[0][1][0],
+        ) from last_exc
+    on_progress(
+        "downloading",
+        f"{dataset_name}: skipped {len(still_failed)} of {total} files the server wouldn't serve",
+        total,
+        total,
+    )
 
 
 def apollo11_audio_manifest() -> list[tuple[str, int]]:

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -39,6 +39,16 @@ _RETRY_BACKOFF_BASE_S = 1.0
 _RETRY_BACKOFF_MAX_S = 30.0
 # Transient HTTP statuses worth retrying (rate-limit + gateway/CDN hiccups).
 _RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+# How each retryable status reads in the message we show once the budget for it
+# is spent.  Phrased as what the *server* did, because the point of the sentence
+# is to tell the user the failure is not on their end.
+_STATUS_EXPLANATIONS = {
+    429: "a rate-limit refusal",
+    500: "an internal server error",
+    502: "a bad-gateway error",
+    503: "a service-unavailable error",
+    504: "a gateway timeout",
+}
 # Connection-level failures (dropped/incomplete read, reset, read timeout) that
 # a resume can recover from.  An IncompleteRead surfaces as ChunkedEncodingError.
 _RETRYABLE_EXCEPTIONS = (
@@ -425,15 +435,18 @@ def _backoff_and_notify(
 
 
 class RemoteUnreachableError(RuntimeError):
-    """A fetch gave up because the remote host could not be reached.
+    """A fetch gave up because the remote kept failing.
 
     Raised in place of the raw requests/urllib3 exception once every retry has
-    been spent on *connection-level* failures, so the dataset-load error the
-    user sees is one actionable sentence naming the host rather than a nested
-    ``MaxRetryError`` dump ending in a memory address.  Carries the originating
-    *url* and the number of *attempts* for logging; the underlying exception
-    stays reachable as ``__cause__`` (and is still printed to the server log by
-    the load pipeline's ``traceback.print_exc``).
+    been spent - either on *connection-level* failures (nothing ever answered)
+    or on a *retryable status* the server kept returning (500/502/503/504/429).
+    Both end the same way for the user, so both surface as one actionable
+    sentence naming the host rather than a nested ``MaxRetryError`` dump ending
+    in a memory address, or a raw ``HTTPError`` ending in a 200-character CDN
+    node URL.  Carries the originating *url* and the number of *attempts* for
+    logging; the underlying exception stays reachable as ``__cause__`` (and is
+    still printed to the server log by the load pipeline's
+    ``traceback.print_exc``).
     """
 
     def __init__(self, message: str, *, url: str = "", attempts: int = 0) -> None:
@@ -464,6 +477,28 @@ def _unreachable_error(url: str, exc: BaseException, attempts: int) -> RemoteUnr
         f"The site may be down or blocked by your network/proxy - open it in a "
         f"browser to check, then retry. Anything already downloaded is kept, so "
         f"a retry picks up where this left off.",
+        url=url,
+        attempts=attempts,
+    )
+
+
+def _status_error(url: str, status: int, attempts: int) -> RemoteUnreachableError:
+    """Build a short, user-facing error for a retryable status that outlived the
+    retry budget.
+
+    The counterpart of :func:`_unreachable_error` for the case where the server
+    *did* answer, over and over, with a status we were willing to wait out
+    (issue #3227: the Internet Archive served HTTP 500 for one Apollo track on
+    every attempt).  ``raise_for_status`` would otherwise surface that as a raw
+    ``HTTPError`` naming the redirect's data-node URL - which tells the user
+    neither which site failed nor that the failure is the server's, not theirs.
+    """
+    host = urlparse(url).hostname or url
+    return RemoteUnreachableError(
+        f"{host} kept returning {_STATUS_EXPLANATIONS.get(status, 'an error')} "
+        f"(HTTP {status}) on all {attempts} attempts. That is a problem on the "
+        f"server's side, not yours - wait a few minutes and retry. Anything "
+        f"already downloaded is kept, so a retry picks up where this left off.",
         url=url,
         attempts=attempts,
     )
@@ -527,9 +562,10 @@ def download_file_with_progress(  # noqa: C901
 
     Raises:
         requests.HTTPError: If the server returns a non-retryable error status.
-        RemoteUnreachableError: If the connection keeps failing after the final
-            retry attempt.  The underlying requests exception is its
-            ``__cause__``.
+        RemoteUnreachableError: If the connection keeps failing, or the server
+            keeps returning a retryable status, after the final retry attempt.
+            A connection failure leaves the underlying requests exception as
+            its ``__cause__``.
     """
     if on_progress is None:
         on_progress = _default_progress()
@@ -554,10 +590,14 @@ def download_file_with_progress(  # noqa: C901
         try:
             response = _open_validated_stream(session, url, headers, _timeout_for_attempt(attempt))
 
-            # Transient server-side error: back off and retry (resuming if we can).
-            if response.status_code in _RETRYABLE_STATUS and not last_attempt:
-                _backoff_and_notify(on_progress, dest_path.name, attempt, downloaded, total_size)
-                continue
+            # Transient server-side error: back off and retry (resuming if we
+            # can), and once the budget is spent say so in a sentence rather
+            # than letting raise_for_status dump the CDN node URL.
+            if response.status_code in _RETRYABLE_STATUS:
+                if not last_attempt:
+                    _backoff_and_notify(on_progress, dest_path.name, attempt, downloaded, total_size)
+                    continue
+                raise _status_error(url, response.status_code, _MAX_DOWNLOAD_ATTEMPTS)
             # Auth-required: this is gated content we can't fetch with the
             # credentials we have.  Surface a short, actionable message instead
             # of a raw HTTPError, and don't retry (it can't succeed unchanged).
@@ -620,8 +660,8 @@ def fetch_text_with_retry(url: str, label: str = "", on_progress: Optional[Progr
 
     Raises:
         requests.HTTPError: If the server returns a non-retryable error status.
-        RemoteUnreachableError: If the connection keeps failing after the final
-            retry attempt.
+        RemoteUnreachableError: If the connection keeps failing, or the server
+            keeps returning a retryable status, after the final retry attempt.
     """
     if on_progress is None:
         on_progress = _default_progress()
@@ -633,9 +673,11 @@ def fetch_text_with_retry(url: str, label: str = "", on_progress: Optional[Progr
         response = None
         try:
             response = _open_validated_stream(session, url, timeout=_timeout_for_attempt(attempt))
-            if response.status_code in _RETRYABLE_STATUS and not last_attempt:
-                _backoff_and_notify(on_progress, label, attempt, 0, 0)
-                continue
+            if response.status_code in _RETRYABLE_STATUS:
+                if not last_attempt:
+                    _backoff_and_notify(on_progress, label, attempt, 0, 0)
+                    continue
+                raise _status_error(url, response.status_code, _MAX_DOWNLOAD_ATTEMPTS)
             if response.status_code in _AUTH_REQUIRED_STATUS:
                 raise _gated_error(url, response.status_code)
             response.raise_for_status()


### PR DESCRIPTION
Closes #3227

## What happened

The Apollo 11 Mission Audio (S) load died on the third track:

```
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url:
https://dn721903.ca.archive.org/0/items/Apollo11Audio/11-03303.mp3
```

Two separate defects behind one crash.

**One bad file sinks the whole set.** Apollo (and the Nixon tapes) pull dozens
to hundreds of *separate* files from one third-party host. The Internet Archive
serves each file from a data node that can answer HTTP 500 for minutes at a
time while its siblings stay healthy — the first two tracks downloaded fine.
`_download_files_into` let that one file's exception propagate, so 500 on
`11-03303.mp3` cost the user all 30 tracks, and every retry of the load started
the same gamble again.

**The message was the server's, not the user's.** 500 *is* in `_RETRYABLE_STATUS`
and the six attempts did run; when they were spent, `raise_for_status()` surfaced
a raw `HTTPError` naming the redirect's data-node URL. That says neither which
site failed nor that the failure was on the server's side. #3216/#3222 fixed
exactly this shape for *connection* failures and left the status path behind.

## What changed

- **A retryable status that outlives the retry budget raises
  `RemoteUnreachableError`**, same as an exhausted connection does — one
  sentence naming the host and what it kept doing: *"archive.org kept returning
  an internal server error (HTTP 500) on all 6 attempts. That is a problem on
  the server's side, not yours — wait a few minutes and retry."* Applies to
  `download_file_with_progress` and to the manifest/index `fetch_text_with_retry`.
  Non-retryable statuses still raise `HTTPError` without burning the budget
  (a 404 is the URL being wrong, not the server wobbling), and gated 401/403
  still raise `GatedResourceError`.

- **A file the host refuses is set aside, not fatal.** `_download_files_into`
  collects failures, retries each one after the rest of the set has run (which
  buys a wobbling node minutes of natural backoff, and recovered the track in
  practice), then skips what still won't come. The download fails only when more
  than a quarter of the set is missing — losing three of thirty hours-long
  recordings is invisible; losing the load is not. A skipped Apollo track is
  simply absent from `data/apollo11_audio`, so the next load fetches it.

- **The skip is a toast, not a progress line.** The progress channel holds one
  snapshot that the next load stage overwrites within the second, so a skip
  reported there is a skip nobody sees. This is precisely what
  `vtscore.concurrency.notifications.notify()` exists for — keep going, and say
  what was dropped.

Cancellation, gated datasets and disk errors are about the *run*, not the file,
and still stop the download; only `RemoteUnreachableError` and `HTTPError` are
tolerated per file.

## Testing

`./run-tests.sh` — 8933 passed, all gates green.

New coverage: retryable-status exhaustion (500/502/429) naming the host in both
fetch paths, a 404 still raising `HTTPError` on the first try, a recovering
server still downloading, the end-of-set retry recovering a transient failure,
a dead track being skipped while the other seven land, too many failures still
failing the load, a one-file set that fails being a failed load, cancellation
and gating never being swallowed, and the skip toasting exactly once.

archive.org is outside this environment's network policy, so the fix is
exercised against the fault injected at the transport layer rather than against
the live host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbezyLonWtiny5yTDRJejo

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbezyLonWtiny5yTDRJejo)_