### PR TITLE
exporters: name the payload kinds instead of sniffing the dict shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,23 @@ Never ask the user whether to subscribe to PR activity, and never call `subscrib
 
 ## Backwards Compatibility
 
-Breaking backwards compatibility is acceptable; do not add shims, feature flags, legacy re-exports, or other compatibility layers to preserve old behavior. Just make the clean change. When a change does break backwards compatibility, mention it to the user so they're aware.
+**Which surface breaks decides how much care it's owed.** The two cases pull in opposite directions, so name the surface before deciding.
+
+### Saved data and internal surfaces: break freely
+
+Persisted artifacts (settings files, detector JSON, dataset pickles, cached sidecars, exported files) and anything internal to the app (routes talking to our own SPA, module layout, function signatures inside `vtsearch`) may be broken without ceremony. VTSearch does not produce long-lived exports that have to survive version to version, and both halves of the app ship together. Do **not** add migration shims, feature flags, legacy re-exports, or compatibility layers to preserve old behavior here. Just make the clean change, and mention the break to the user so they're aware.
+
+### Extension-facing surfaces: don't break casually
+
+A third-party developer may have written code against our plugin ABCs (`LabelsetExporter`, `DatasetImporter`, `MediaConverter`, and their siblings), the registry sentinels (`EXPORTER`, `IMPORTER`, …), the `vtscore.*` entry-point groups, or the public `vtscore` library API. Breaking those forces someone outside this repo to refactor working code, on our schedule. That is a real cost, and it is paid by someone who never agreed to it.
+
+This is not an absolute bar — a genuinely better contract can be worth it — but it must be a deliberate decision, not a side effect:
+
+- **Prefer additive.** A new method alongside the old one, with the base class delegating so an existing plugin keeps working, is usually available and usually cheap. Reach for it first.
+- **Keep the cheap escape hatches.** A module-level alias for a renamed class, or a default implementation that delegates to the old method, costs a line or two and preserves every out-of-tree caller. Unlike a data migration, these do not rot.
+- **When a hard break is right, make it loud, not silent.** A plugin that no longer satisfies the contract should be rejected with a message naming what's missing — never half-work.
+- **Say so where extension authors will see it:** an `[Unreleased]` entry in `vtscore/CHANGELOG.md`, plus the relevant guide under `docs/EXTENDING-plugins.md` / `vtscore/docs/extending/`.
+- **Raise it with the user before committing to it.** An extension-facing break is a decision to make on purpose, out loud.
 
 ## Frontend Scope: Desktop Only
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -246,11 +246,11 @@ browser can't resolve yet stays templated for the server to fill in. The
 server-side pass remains authoritative; the frontend copy is a preview.
 
 The corollary is the one anti-pattern to avoid: **don't resolve the
-active detector inside your `export()` / `run()` body.**
+active detector inside your export / `run()` body.**
 
 ```python
 # Wrong: the value only exists at run time, so the form shows an empty box.
-def export(self, results, field_values):
+def export_find_results(self, results, field_values):
     name = field_values["name"] or get_active_detector_context().name
 
 # Right: the framework fills it in, and the GUI can show it up front.
@@ -347,7 +347,7 @@ Most plugin families use sub-packages, which pair well with per-plugin
 | Data Importers       | `vtscore.datasets.importers`      | `IMPORTER`             | `DatasetImporter`     | `vtscore.importers`             |
 | Datasource Importers | `vtscore.datasource_importers`    | `DATASOURCE_IMPORTER`  | `DataSourceImporter`  | `vtscore.datasource_importers`  |
 | Seed Importers       | `vtscore.seed_importers`          | `SEED_IMPORTER`        | `SeedImporter`        | `vtscore.seed_importers`        |
-| Results Exporters    | `vtscore.exporters`               | `EXPORTER`             | `LabelsetExporter`    | `vtscore.exporters`             |
+| Results Exporters    | `vtscore.exporters`               | `EXPORTER`             | `ResultsExporter`     | `vtscore.exporters`             |
 | Label Importers      | `vtscore.labels.importers`        | `LABEL_IMPORTER`       | `LabelImporter`       | `vtscore.label_importers`       |
 | Settings Importers   | `vtsearch.settings_io.importers`   | `SETTINGS_IMPORTER`    | `SettingsImporter`    | `vtsearch.settings_importers`   |
 | Settings Exporters   | `vtsearch.settings_io.exporters`   | `SETTINGS_EXPORTER`    | `SettingsExporter`    | `vtsearch.settings_exporters`   |
@@ -1397,14 +1397,31 @@ Results exporters deliver autodetect results **or labels** to a destination
 (file, webhook, email, Holder, etc.).  Auto-discovered; no changes to
 routes needed.
 
-Exporters receive **two possible result formats** and should detect which:
+An exporter is a **destination**; *what* gets sent there is a separate axis,
+with three **payload kinds**. Implement a method per kind you support:
 
-- **Auto-detect results**: `{"media_type": "audio", "results": {...}}`
-- **Labels**: `{"labels": [...], "selected_columns": [...]}` (from the
-  label export flow with `enrich=true`)
+| Kind | Method | Payload | Produced by |
+|------|--------|---------|-------------|
+| `find_results` | `export_find_results()` | `{"media_type", "detectors_run", "results": {det: {hits, negative_hits, threshold, total_hits}}}` | `POST /api/auto-detect`, Auto-Find auto-export, CLI `--autodetect` |
+| `labelset` | `export_labelset()` | `{"labels": [LabeledElement], "selected_columns": [...]}` | the Export modal |
+| `detector_bundles` | `export_cli_detectors()` | the trained classifiers | CLI `--pipeline` / `--autodetect` |
 
-Check `if "labels" in results` to distinguish them.  The built-in
-CSV/JSON/webhook exporters handle both formats.
+Most destinations carry more than one: a CSV file is a fine home for either a
+scored run or a labelset, and the built-in CSV/JSON/webhook/email exporters
+implement both. Implement only the kinds you actually understand — the pickers
+offer you for the kinds you claim, and the route answers 400 for anything else
+rather than letting you deliver an empty export.
+
+`supported_payloads` is **derived** from which methods you overrode; there is
+nothing to declare, and therefore nothing to forget.
+
+**Legacy single-method exporters still work.** Before the kinds were named, an
+exporter implemented one `export()` and told the shapes apart itself with
+`if "labels" in results`. The default `export_find_results()` /
+`export_labelset()` delegate to `export()`, so an existing out-of-tree plugin
+needs no changes; it is credited with both kinds (nothing can tell which it
+handles) and logs a line at import pointing at the named methods. New exporters
+should implement those instead.
 
 ### File structure
 
@@ -1415,15 +1432,16 @@ vtscore/exporters/<your_exporter>/
 
 ### What to implement
 
-Subclass `LabelsetExporter` from `vtscore.exporters.base`.
+Subclass `ResultsExporter` from `vtscore.exporters.base`. (`LabelsetExporter`
+remains a permanent alias for the same class, so existing imports keep working.)
 
 ```python
 # vtscore/exporters/sftp/__init__.py
 
-from vtscore.exporters.base import LabelsetExporter, PluginField
+from vtscore.exporters.base import PluginField, ResultsExporter
 
 
-class SftpLabelsetExporter(LabelsetExporter):
+class SftpResultsExporter(ResultsExporter):
     name = "sftp"
     display_name = "SFTP Upload"
     description = "Upload results JSON to a remote SFTP server."
@@ -1438,28 +1456,8 @@ class SftpLabelsetExporter(LabelsetExporter):
         ),
     ]
 
-    def export(self, results: dict, field_values: dict) -> dict:
-        """Export results to an SFTP server.
-
-        Args:
-            results: The full auto-detect results dict.  Shape:
-                {
-                    "media_type": "audio",
-                    "detectors_run": 2,
-                    "results": {
-                        "detector_name": {
-                            "detector_name": "...",
-                            "threshold": 0.5,
-                            "total_hits": 15,
-                            "hits": [{...}, ...]
-                        }
-                    }
-                }
-            field_values: Mapping of PluginField.key to user-supplied value.
-
-        Returns:
-            A dict with a "message" key (shown as confirmation to the user).
-        """
+    def _upload(self, payload: dict, field_values: dict) -> dict:
+        """Write *payload* as JSON to the remote path."""
         import json
         import paramiko
 
@@ -1472,29 +1470,44 @@ class SftpLabelsetExporter(LabelsetExporter):
                     password=field_values["password"])
         sftp = ssh.open_sftp()
         with sftp.open(path, "w") as f:
-            f.write(json.dumps(results, indent=2))
+            f.write(json.dumps(payload, indent=2))
         sftp.close()
         ssh.close()
 
         return {"message": f"Uploaded to {host}:{path}"}
 
+    def export_find_results(self, results: dict, field_values: dict) -> dict:
+        """Upload a scored run (hit lists, scores, thresholds)."""
+        return self._upload(results, field_values)
 
-EXPORTER = SftpLabelsetExporter()
+    def export_labelset(self, labelset: dict, field_values: dict) -> dict:
+        """Upload a detector's labels (origins, vote provenance)."""
+        return self._upload(labelset, field_values)
+
+
+EXPORTER = SftpResultsExporter()
 ```
 
-### LabelsetExporter class reference
+Implementing only one of the two is fine and common — a Holder-style exporter
+that files items by the label a human gave them declares `export_labelset()`
+alone, and is then absent from the find-results pickers by construction.
 
-**Required to implement:**
+### ResultsExporter class reference
+
+**Required to implement:** at least one payload method.
 
 | Member | Signature | Description |
 |--------|-----------|-------------|
-| `export()` | `(results: dict, field_values: dict) -> dict` | Perform the export; return dict with `"message"` key |
+| `export_find_results()` | `(results: dict, field_values: dict) -> dict` | Export a scored run; return dict with `"message"` key |
+| `export_labelset()` | `(labelset: dict, field_values: dict) -> dict` | Export a detector's labels; same return contract |
 
 **Optional overrides:**
 
 | Member | Signature | Description |
 |--------|-----------|-------------|
-| `export_cli()` | `(results: dict, field_values: dict) -> dict` | CLI variant; default delegates to `export()` |
+| `export()` | `(results: dict, field_values: dict) -> dict` | Legacy single-method form. Both named methods delegate here when unoverridden, which is what keeps pre-existing plugins working; prefer the named methods in new code |
+| `export_cli_detectors()` | `(detectors: list[dict], field_values: dict) -> dict` | Export the trained classifiers instead of their output (CLI/pipeline only) |
+| `export_cli()` | `(results: dict, field_values: dict) -> dict` | CLI variant; default delegates to `export_find_results()` |
 | `supports_streaming` | `property -> bool` | Whether this exporter can write results incrementally. Default `False`. |
 | `export_cli_streaming()` | `(header: dict, records: Iterator[tuple[str, dict]], field_values: dict) -> dict` | Write hits incrementally as scored chunks stream in. Required when `supports_streaming` is `True`. |
 
@@ -1557,15 +1570,15 @@ return it. A delivery exporter whose remote hands back a permalink returns the
 same key.
 
 ```python
-class ReviewSiteExporter(LabelsetExporter):
+class ReviewSiteExporter(ResultsExporter):
     name = "review_site"
     display_name = "Review Site"
     description = "Open the labelset in Review Site."
     opens_url = True
     fields = []          # required, even when empty — there is no default
 
-    def export(self, results: dict, field_values: dict) -> dict:
-        ids = ",".join(e["md5"] for e in results.get("labels", []))
+    def export_labelset(self, labelset: dict, field_values: dict) -> dict:
+        ids = ",".join(e["md5"] for e in labelset.get("labels", []))
         url = validate_browser_url(f"https://review.example.com/?ids={quote(ids, safe='')}")
         return {"message": "Opening the labelset in Review Site.", "open_url": url}
 ```

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -176,8 +176,8 @@ See [EXTENDING-plugins.md § Adding a Data Importer](EXTENDING-plugins.md#adding
 See [EXTENDING-plugins.md § Adding a Results Exporter](EXTENDING-plugins.md#adding-a-results-exporter).
 
 - [ ] Create `vtscore/exporters/<name>/__init__.py`
-- [ ] Subclass `LabelsetExporter`, set `name`, `display_name`, `description`, `fields`
-- [ ] Implement `export(self, results, field_values)`: return a dict with a `"message"` key
+- [ ] Subclass `ResultsExporter`, set `name`, `display_name`, `description`, `fields`
+- [ ] Implement a payload method per kind you support — `export_find_results(self, results, field_values)` for a scored run, `export_labelset(self, labelset, field_values)` for a detector's labels: return a dict with a `"message"` key
 - [ ] To send the user to a web page instead of (or as well as) delivering the labelset, return an `"open_url"` and set `opens_url = True` if you always return one — see [Opening a browser tab](EXTENDING-plugins.md#opening-a-browser-tab-open_url)
 - [ ] Expose `EXPORTER = YourExporter()` at module level
 - [ ] If the plugin needs extra packages, add them to `[project.dependencies]` in `pyproject.toml` and re-run your editable install

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -58,6 +58,10 @@ to go stale. Keep the grouping in sync when you add or delete a plan — one lin
 - [`cli-stream-massive-images.md`](cli-stream-massive-images.md)
 - [`cli-detector-converter.md`](cli-detector-converter.md)
 
+## Plugins and I/O
+
+- [`exporter-payload-contract.md`](exporter-payload-contract.md)
+
 ## Cross-cutting audits
 
 - [`codebase-audit-2026-08.md`](codebase-audit-2026-08.md)

--- a/docs/plans/exporter-payload-contract.md
+++ b/docs/plans/exporter-payload-contract.md
@@ -1,232 +1,71 @@
 # Design: the exporter payload contract
 
-Proposed rework of the results-exporter plugin contract so that "which payload
-an exporter accepts" is a fact the framework knows, rather than something each
-plugin rediscovers at runtime with a dict-key sniff. Motivated by
-[#3219](https://github.com/samggreenberg/VTSearch/issues/3219).
-
-Nothing here has shipped; this file is the design under review.
+Open follow-ups from the results-exporter payload-kind rework
+([#3219](https://github.com/samggreenberg/VTSearch/issues/3219)).
 
 ## Background
 
-One ABC, `LabelsetExporter` (`vtscore/exporters/base.py`), currently serves
-three structurally different payloads:
+An exporter is a **destination**; what gets sent there is a separate axis, with
+three payload kinds — `find_results` (a scored run), `labelset` (a detector's
+labels), and `detector_bundles` (the trained classifiers). `ResultsExporter`
+carries a method per kind, and `supported_payloads` is *derived* from which
+methods a subclass overrides rather than declared, so each picker offers an
+exporter only for the kinds it can actually read. See
+`vtscore/exporters/base.py` and
+[`vtscore/docs/extending/results-exporters.md`](../../vtscore/docs/extending/results-exporters.md).
 
-| Payload kind | Shape | Produced by | Reaches the plugin via |
-|---|---|---|---|
-| Find results | `{media_type, detectors_run, results: {det: {hits, negative_hits, threshold, total_hits}}, missing_detectors}` | `POST /api/auto-detect` (`vtsearch/routes/detectors/scoring.py`), the Auto-Find autorun export in the same module, CLI `--autodetect` | `export()` |
-| Labelset | `{labels: [LabeledElement], selected_columns: [...]}` | the Export modal (`frontend/src/app/components/modals/export-modal/`) → `POST /api/exporters/export` | `export()` — the same method |
-| Trained detectors | `list[descriptor]` | the CLI pipeline only | `export_cli_detectors()`, gated by the `needs_trained_detectors` boolean |
+Two constraints shaped it, and both still bind anything built on top:
 
-The first two are told apart by a runtime shape sniff **inside each plugin** —
-`if "labels" in results` in `server_csv_file`, `server_json_file`, `webhook`,
-`open_url`, and `gui`. The third kind already uses the shape this design
-generalises (a declared capability plus its own method), and is the reason not
-to add a second boolean: the pattern stops paying at three kinds.
-
-### Why the sniff has to go
-
-It is not a tidiness complaint. Three things are wrong today:
-
-- **`email_smtp` is silently broken in the Export modal.** It never sniffs — it
-  reads only `results.get("results", {})` — but both pickers list the same
-  unfiltered registry, so "Send by Email" is offered for a labelset export. It
-  sends `Subject: VTSearch Auto-Detect: 0 hit(s) on unknown dataset` with an
-  empty body, returns a success dict, and the modal fires its "Exported N
-  labels" toast. No test passes a labels payload to it.
-- **`holder` is the mirror bug, pre-armed.** It reads `results.get("labels")`
-  only, and is held back solely by `hidden_from_picker = True  # flip to False
-  once API clients are implemented`. Flipping that comment ships the same
-  failure into the Auto-Find picker.
-- **The base class documents one payload of the three, and gets that one
-  wrong.** `LabelsetExporter.export()`'s docstring describes the find-results
-  shape without `negative_hits` or `missing_detectors`, and does not mention the
-  labelset shape at all. The prose docs (`docs/EXTENDING-plugins.md`,
-  `vtscore/docs/extending/results-exporters.md`) *do* explain both shapes, which
-  is the wrong way round: an extension author reads the ABC.
-
-A documentation fix cannot reach any of this, because every failure is a silent
-success. Only a contract can.
-
-### How different the two payloads actually are
-
-Less than the issue assumes, and that is what rules out a hard ABC split.
-`build_media_hit` (`vtscore/utils/hits.py`) emits `md5`, `origin`,
-`origin_name`, `filename`, `category` plus clip fields; `LabeledElement`
-(`vtscore/datasets/labelset.py`) carries the same five. The delta is
-`score` / `threshold` / `total_hits` / `id` on the find-results side against
-`region_box` / `metadata` / `selected_columns` on the labelset side.
-
-So the payloads differ at their edges — and the five shared keys are precisely
-the ones that make an export re-importable. The *delivery* machinery (SMTP
-session, atomic write, path templating, browser-URL validation, streaming batch
-sizing) is identical across both.
-
-## The design
-
-### One base class, three named payload methods
-
-Keep a single registry entry per destination. Replace `export()` with three
-methods, each taking the payload it is named for:
-
-```python
-class ResultsExporter(PluginBase):
-    def export_find_results(self, results, field_values) -> dict: ...
-    def export_labelset(self, labelset, field_values) -> dict: ...
-    def export_detector_bundles(self, detectors, field_values) -> dict: ...
-```
-
-Base implementations raise `UnsupportedPayloadError` — a `ValueError` subclass,
-so `POST /api/exporters/export`'s existing `except ValueError → 400` turns an
-unsupported pairing into a clean rejection instead of a 500. The message names
-the exporter and the kind.
-
-**A hard ABC split is the wrong axis.** Destination and payload are orthogonal.
-Two ABCs mean either two classes per destination — two registry entries, two
-picker rows both labelled "Server CSV File", two saved field-value blobs keyed
-by exporter name in settings — or a mixin arrangement that recreates the shared
-base just deleted. Contrast `SettingsExporter`
-(`vtsearch/settings_io/exporters/base.py`), which *is* a separate ABC and
-should stay one: it shares no registry, route, modal, or field semantics with
-results exporters. Labelset and find-results share all of them.
-
-### Support is derived, never declared
-
-`supported_payloads` is computed from which methods the subclass actually
-overrides, not from a class attribute the author sets:
-
-```python
-@classmethod
-def supported_payloads(cls) -> frozenset[str]: ...  # compares cls.export_X to ResultsExporter.export_X
-```
-
-A declared flag is a second place to forget something, and forgetting is the
-present bug's whole mechanism. A derived set cannot drift from the
-implementation. (A subclass of a concrete exporter inherits its parent's
-overrides, which is the correct answer.)
-
-It is serialised on `to_dict()` beside `opens_url`, so `GET /api/exporters`
-states each exporter's capability, and `ExporterEntrySchema` grows the field.
-
-### The route names the kind; it never guesses
-
-`RunExportRequestSchema` gains a required `payload_kind`
-(`"find_results" | "labelset"`), and the permissive `results` body field is
-renamed `payload`. No default value — a default is a sniff with extra steps.
-The Export modal sends `labelset`; the Auto-Detect Results modal and the
-Auto-Find autorun path send `find_results`. The CLI dispatches on
-`supported_payloads()` rather than on `needs_trained_detectors`.
-
-### Both pickers filter
-
-The Export modal lists exporters whose `supported_payloads` contains
-`labelset`; the Auto-Find settings picker (and the Auto-Detect Results modal)
-lists `find_results`. `holder` then becomes safe to un-hide. A saved Auto-Find
-exporter that no longer qualifies is reported through the
-`{exporter, success: false, error}` status block `_run_autofind_export` already
-returns for an unknown exporter — a scored find is too valuable to sink over a
-misconfigured export.
-
-### No framework-level payload adapter
-
-Tempting, and wrong. The one adapter that exists today —
-`gui._labelset_to_display` — fabricates `media_type: "labels (3 good, 1 bad)"`
-and `detectors_run: 0`, which is display-only fiction that reads fine in a modal
-and would read as nonsense in an email subject or a CSV header. A generic
-adapter would let an exporter *appear* to support a mode it does not understand:
-the empty-email failure with a nicer wrapper. Each exporter implements the modes
-it means.
-
-### Streaming stays a find-results mode
-
-`supports_streaming` / `export_cli_streaming` only ever carried
-`(detector_name, hit)` records, so it is find-results streaming and should say
-so: rename to `export_find_results_streaming`. There is deliberately no labelset
-streaming mode — the NDJSON label stream in `vtsearch/routes/labels/vote.py` is a
-built-in route, not a plugin path, and inventing a plugin-side twin is scope this
-design does not need.
-
-### Naming
-
-`LabelsetExporter` → `ResultsExporter`, matching what every doc already calls the
-family ("Results exporters") and retiring a name its own guide apologises for
-("named for historical reasons"). `_PLUGIN_NAME_SUFFIXES` in
-`vtscore/plugins/__init__.py` swaps `"LabelsetExporter"` for `"ResultsExporter"`,
-kept ahead of the bare `"Exporter"` fallback so `HolderResultsExporter` still
-derives `holder`. Concrete classes rename to match; every in-tree one declares
-`name` explicitly, so no registry key moves.
-
-### Where each in-tree exporter lands
-
-| Exporter | Supports | Change |
-|---|---|---|
-| `server_csv_file` | find results, labelset | split the existing sniff into the two methods |
-| `server_json_file` | find results, labelset | same |
-| `webhook` | find results, labelset | same |
-| `open_url` | find results, labelset | same |
-| `gui` | find results, labelset | same; `_labelset_to_display` becomes the body of `export_labelset` |
-| `email_smtp` | find results, labelset | **gains** a labelset mode — the issue's actual use case |
-| `holder` | labelset | can be un-hidden once its API clients exist |
-| `portable_detector` | detector bundles | `needs_trained_detectors` deleted |
+- **The ABC is not split, and shouldn't be.** Destination and payload are
+  orthogonal, so two base classes would mean two registry entries and two
+  picker rows per destination (or a mixin that recreates the shared base).
+  `SettingsExporter` stays a genuinely separate ABC because it shares no
+  registry, route, modal, or field semantics; labelset and find-results share
+  all of them, plus five of nine payload keys.
+- **The legacy `export()` path is permanent.** Out-of-tree plugins implement it
+  and sniff the dict shape themselves; the named methods delegate to it, so
+  they keep working untouched. Do not delete that delegation to tidy the base
+  class up.
 
 ## Open work
 
 <!-- item-sep -->
 
-- **Confirm the naming before any code moves.** `ResultsExporter` is the
-  proposal; the issue floats `LabelsetExporter` + `FindResultsExporter` as two
-  ABCs, which this design rejects on the orthogonal-axes argument above. The
-  rename touches `_PLUGIN_NAME_SUFFIXES`, eight concrete classes, both
-  extension guides, and the schema docstrings, so it is cheap to decide now and
-  tedious to revisit later.
+- **Decide what `negative_hits` means to an exporter.** The find-results
+  payload has carried `negative_hits` since the route was written, the CLI
+  emits them under `keep_negatives`, and **no exporter reads the key** — every
+  export is positives-only. That is now *documented* in
+  `export_find_results`'s contract, which was the minimum; the behavioural
+  question is still open. Either leave it conventional, or give exporters a way
+  to opt in (a `PluginField` on the file/webhook exporters, or a second records
+  stream for the streaming path). Worth settling deliberately rather than by
+  the accident of what the first exporter happened to read.
 
 <!-- item-sep -->
 
-- **Decide what `negative_hits` means to an exporter.** The find-results payload
-  has carried `negative_hits` since the route was written, the CLI emits them
-  under `keep_negatives`, and **no exporter reads the key** — every export is
-  positives-only, and nothing says so. Either document the drop in
-  `export_find_results`'s contract, or give exporters a way to opt in (a
-  `PluginField`, or a second records stream). This is a real behavioural
-  question, not a docstring chore, and it should be settled while the contract
-  is open rather than bolted on after.
-
-<!-- item-sep -->
-
-- **Promote the implementation slices to issues once the design is agreed.**
-  Per `CLAUDE.md`, concrete shippable work lives in issues, not in a plan body.
-  The natural cuts are: the ABC plus derived capability; the route and schema
-  change with its OpenAPI snapshot regeneration; the two picker filters; the
-  per-exporter method splits; `email_smtp`'s new labelset mode with the
-  regression test that is missing today; and the doc pass across the ABC
-  docstring, `docs/EXTENDING-plugins.md`, and
-  `vtscore/docs/extending/results-exporters.md`. Leave one-line `#N` pointers
-  here if the umbrella is worth keeping.
+- **Un-hide the `holder` exporter.** It is `hidden_from_picker = True  # flip to
+  False once API clients are implemented`, and that comment is now the only
+  thing keeping it back: as a labelset-only exporter it is filtered out of the
+  find-results pickers by construction, so flipping the flag can no longer
+  expose it to a payload it cannot read. Blocked on the Holder API clients, not
+  on the contract.
 
 <!-- item-sep -->
 
 - **Per-AutoRun exporter selection.** The second half of
-  [#3219](https://github.com/samggreenberg/VTSearch/issues/3219), not designed
-  here, but it depends on this one: a per-AutoRun picker is only well-defined
-  once "which exporters accept a find-results payload" is something the API
-  states.
+  [#3219](https://github.com/samggreenberg/VTSearch/issues/3219): let a detector
+  moved to AutoRun carry its own exporter choice, falling back to the global
+  Auto-Find setting when unset. Not designed here. The open design question is
+  the one the issue thread raises — whether an exporter preference is really
+  per-detector or per-user — and it is worth answering before building the UI.
 
 <!-- item-sep -->
 
-## Notes for whoever implements it
+- **No labelset streaming mode.** `export_cli_streaming` is find-results only,
+  and deliberately so: the NDJSON label stream in
+  `vtsearch/routes/labels/vote.py` is a built-in route rather than a plugin
+  path, so a plugin-side twin has no caller today. If a labelset export ever
+  needs to outgrow RAM, that is the shape to add — not a widening of the
+  existing streaming method, whose records are `(detector_name, hit)` tuples.
 
-- **Third-party entry-point exporters break.** `vtscore.exporters` is a public
-  entry-point group, and an out-of-tree plugin implementing `export()` stops
-  working. Per `CLAUDE.md` that is acceptable and gets no shim — but the break
-  should be *loud*: with the base `export()` gone, the framework sees an empty
-  `supported_payloads()`, so the plugin is filtered out of both pickers and
-  rejected by the route with a message naming the missing methods, rather than
-  half-working.
-- **Gates to re-run beyond the suite:** regenerate the OpenAPI snapshot
-  (`cd frontend && npm run regenerate-openapi-snapshot`) for the schema change.
-  The plugin-family counts in the generated doc inventories are unchanged (eight
-  exporters stay eight). Exporters are not mirrored by
-  `scripts/check-eval-app-sync.py`, so that gate is untouched.
-- **`vtscore/CHANGELOG.md`** gets an `[Unreleased] › Changed` entry for the
-  library-tier breaking change; the `vtscore.__version__` bump waits for a
-  release cut, per `CLAUDE.md`.
+<!-- item-sep -->

--- a/docs/plans/exporter-payload-contract.md
+++ b/docs/plans/exporter-payload-contract.md
@@ -1,0 +1,232 @@
+# Design: the exporter payload contract
+
+Proposed rework of the results-exporter plugin contract so that "which payload
+an exporter accepts" is a fact the framework knows, rather than something each
+plugin rediscovers at runtime with a dict-key sniff. Motivated by
+[#3219](https://github.com/samggreenberg/VTSearch/issues/3219).
+
+Nothing here has shipped; this file is the design under review.
+
+## Background
+
+One ABC, `LabelsetExporter` (`vtscore/exporters/base.py`), currently serves
+three structurally different payloads:
+
+| Payload kind | Shape | Produced by | Reaches the plugin via |
+|---|---|---|---|
+| Find results | `{media_type, detectors_run, results: {det: {hits, negative_hits, threshold, total_hits}}, missing_detectors}` | `POST /api/auto-detect` (`vtsearch/routes/detectors/scoring.py`), the Auto-Find autorun export in the same module, CLI `--autodetect` | `export()` |
+| Labelset | `{labels: [LabeledElement], selected_columns: [...]}` | the Export modal (`frontend/src/app/components/modals/export-modal/`) → `POST /api/exporters/export` | `export()` — the same method |
+| Trained detectors | `list[descriptor]` | the CLI pipeline only | `export_cli_detectors()`, gated by the `needs_trained_detectors` boolean |
+
+The first two are told apart by a runtime shape sniff **inside each plugin** —
+`if "labels" in results` in `server_csv_file`, `server_json_file`, `webhook`,
+`open_url`, and `gui`. The third kind already uses the shape this design
+generalises (a declared capability plus its own method), and is the reason not
+to add a second boolean: the pattern stops paying at three kinds.
+
+### Why the sniff has to go
+
+It is not a tidiness complaint. Three things are wrong today:
+
+- **`email_smtp` is silently broken in the Export modal.** It never sniffs — it
+  reads only `results.get("results", {})` — but both pickers list the same
+  unfiltered registry, so "Send by Email" is offered for a labelset export. It
+  sends `Subject: VTSearch Auto-Detect: 0 hit(s) on unknown dataset` with an
+  empty body, returns a success dict, and the modal fires its "Exported N
+  labels" toast. No test passes a labels payload to it.
+- **`holder` is the mirror bug, pre-armed.** It reads `results.get("labels")`
+  only, and is held back solely by `hidden_from_picker = True  # flip to False
+  once API clients are implemented`. Flipping that comment ships the same
+  failure into the Auto-Find picker.
+- **The base class documents one payload of the three, and gets that one
+  wrong.** `LabelsetExporter.export()`'s docstring describes the find-results
+  shape without `negative_hits` or `missing_detectors`, and does not mention the
+  labelset shape at all. The prose docs (`docs/EXTENDING-plugins.md`,
+  `vtscore/docs/extending/results-exporters.md`) *do* explain both shapes, which
+  is the wrong way round: an extension author reads the ABC.
+
+A documentation fix cannot reach any of this, because every failure is a silent
+success. Only a contract can.
+
+### How different the two payloads actually are
+
+Less than the issue assumes, and that is what rules out a hard ABC split.
+`build_media_hit` (`vtscore/utils/hits.py`) emits `md5`, `origin`,
+`origin_name`, `filename`, `category` plus clip fields; `LabeledElement`
+(`vtscore/datasets/labelset.py`) carries the same five. The delta is
+`score` / `threshold` / `total_hits` / `id` on the find-results side against
+`region_box` / `metadata` / `selected_columns` on the labelset side.
+
+So the payloads differ at their edges — and the five shared keys are precisely
+the ones that make an export re-importable. The *delivery* machinery (SMTP
+session, atomic write, path templating, browser-URL validation, streaming batch
+sizing) is identical across both.
+
+## The design
+
+### One base class, three named payload methods
+
+Keep a single registry entry per destination. Replace `export()` with three
+methods, each taking the payload it is named for:
+
+```python
+class ResultsExporter(PluginBase):
+    def export_find_results(self, results, field_values) -> dict: ...
+    def export_labelset(self, labelset, field_values) -> dict: ...
+    def export_detector_bundles(self, detectors, field_values) -> dict: ...
+```
+
+Base implementations raise `UnsupportedPayloadError` — a `ValueError` subclass,
+so `POST /api/exporters/export`'s existing `except ValueError → 400` turns an
+unsupported pairing into a clean rejection instead of a 500. The message names
+the exporter and the kind.
+
+**A hard ABC split is the wrong axis.** Destination and payload are orthogonal.
+Two ABCs mean either two classes per destination — two registry entries, two
+picker rows both labelled "Server CSV File", two saved field-value blobs keyed
+by exporter name in settings — or a mixin arrangement that recreates the shared
+base just deleted. Contrast `SettingsExporter`
+(`vtsearch/settings_io/exporters/base.py`), which *is* a separate ABC and
+should stay one: it shares no registry, route, modal, or field semantics with
+results exporters. Labelset and find-results share all of them.
+
+### Support is derived, never declared
+
+`supported_payloads` is computed from which methods the subclass actually
+overrides, not from a class attribute the author sets:
+
+```python
+@classmethod
+def supported_payloads(cls) -> frozenset[str]: ...  # compares cls.export_X to ResultsExporter.export_X
+```
+
+A declared flag is a second place to forget something, and forgetting is the
+present bug's whole mechanism. A derived set cannot drift from the
+implementation. (A subclass of a concrete exporter inherits its parent's
+overrides, which is the correct answer.)
+
+It is serialised on `to_dict()` beside `opens_url`, so `GET /api/exporters`
+states each exporter's capability, and `ExporterEntrySchema` grows the field.
+
+### The route names the kind; it never guesses
+
+`RunExportRequestSchema` gains a required `payload_kind`
+(`"find_results" | "labelset"`), and the permissive `results` body field is
+renamed `payload`. No default value — a default is a sniff with extra steps.
+The Export modal sends `labelset`; the Auto-Detect Results modal and the
+Auto-Find autorun path send `find_results`. The CLI dispatches on
+`supported_payloads()` rather than on `needs_trained_detectors`.
+
+### Both pickers filter
+
+The Export modal lists exporters whose `supported_payloads` contains
+`labelset`; the Auto-Find settings picker (and the Auto-Detect Results modal)
+lists `find_results`. `holder` then becomes safe to un-hide. A saved Auto-Find
+exporter that no longer qualifies is reported through the
+`{exporter, success: false, error}` status block `_run_autofind_export` already
+returns for an unknown exporter — a scored find is too valuable to sink over a
+misconfigured export.
+
+### No framework-level payload adapter
+
+Tempting, and wrong. The one adapter that exists today —
+`gui._labelset_to_display` — fabricates `media_type: "labels (3 good, 1 bad)"`
+and `detectors_run: 0`, which is display-only fiction that reads fine in a modal
+and would read as nonsense in an email subject or a CSV header. A generic
+adapter would let an exporter *appear* to support a mode it does not understand:
+the empty-email failure with a nicer wrapper. Each exporter implements the modes
+it means.
+
+### Streaming stays a find-results mode
+
+`supports_streaming` / `export_cli_streaming` only ever carried
+`(detector_name, hit)` records, so it is find-results streaming and should say
+so: rename to `export_find_results_streaming`. There is deliberately no labelset
+streaming mode — the NDJSON label stream in `vtsearch/routes/labels/vote.py` is a
+built-in route, not a plugin path, and inventing a plugin-side twin is scope this
+design does not need.
+
+### Naming
+
+`LabelsetExporter` → `ResultsExporter`, matching what every doc already calls the
+family ("Results exporters") and retiring a name its own guide apologises for
+("named for historical reasons"). `_PLUGIN_NAME_SUFFIXES` in
+`vtscore/plugins/__init__.py` swaps `"LabelsetExporter"` for `"ResultsExporter"`,
+kept ahead of the bare `"Exporter"` fallback so `HolderResultsExporter` still
+derives `holder`. Concrete classes rename to match; every in-tree one declares
+`name` explicitly, so no registry key moves.
+
+### Where each in-tree exporter lands
+
+| Exporter | Supports | Change |
+|---|---|---|
+| `server_csv_file` | find results, labelset | split the existing sniff into the two methods |
+| `server_json_file` | find results, labelset | same |
+| `webhook` | find results, labelset | same |
+| `open_url` | find results, labelset | same |
+| `gui` | find results, labelset | same; `_labelset_to_display` becomes the body of `export_labelset` |
+| `email_smtp` | find results, labelset | **gains** a labelset mode — the issue's actual use case |
+| `holder` | labelset | can be un-hidden once its API clients exist |
+| `portable_detector` | detector bundles | `needs_trained_detectors` deleted |
+
+## Open work
+
+<!-- item-sep -->
+
+- **Confirm the naming before any code moves.** `ResultsExporter` is the
+  proposal; the issue floats `LabelsetExporter` + `FindResultsExporter` as two
+  ABCs, which this design rejects on the orthogonal-axes argument above. The
+  rename touches `_PLUGIN_NAME_SUFFIXES`, eight concrete classes, both
+  extension guides, and the schema docstrings, so it is cheap to decide now and
+  tedious to revisit later.
+
+<!-- item-sep -->
+
+- **Decide what `negative_hits` means to an exporter.** The find-results payload
+  has carried `negative_hits` since the route was written, the CLI emits them
+  under `keep_negatives`, and **no exporter reads the key** — every export is
+  positives-only, and nothing says so. Either document the drop in
+  `export_find_results`'s contract, or give exporters a way to opt in (a
+  `PluginField`, or a second records stream). This is a real behavioural
+  question, not a docstring chore, and it should be settled while the contract
+  is open rather than bolted on after.
+
+<!-- item-sep -->
+
+- **Promote the implementation slices to issues once the design is agreed.**
+  Per `CLAUDE.md`, concrete shippable work lives in issues, not in a plan body.
+  The natural cuts are: the ABC plus derived capability; the route and schema
+  change with its OpenAPI snapshot regeneration; the two picker filters; the
+  per-exporter method splits; `email_smtp`'s new labelset mode with the
+  regression test that is missing today; and the doc pass across the ABC
+  docstring, `docs/EXTENDING-plugins.md`, and
+  `vtscore/docs/extending/results-exporters.md`. Leave one-line `#N` pointers
+  here if the umbrella is worth keeping.
+
+<!-- item-sep -->
+
+- **Per-AutoRun exporter selection.** The second half of
+  [#3219](https://github.com/samggreenberg/VTSearch/issues/3219), not designed
+  here, but it depends on this one: a per-AutoRun picker is only well-defined
+  once "which exporters accept a find-results payload" is something the API
+  states.
+
+<!-- item-sep -->
+
+## Notes for whoever implements it
+
+- **Third-party entry-point exporters break.** `vtscore.exporters` is a public
+  entry-point group, and an out-of-tree plugin implementing `export()` stops
+  working. Per `CLAUDE.md` that is acceptable and gets no shim — but the break
+  should be *loud*: with the base `export()` gone, the framework sees an empty
+  `supported_payloads()`, so the plugin is filtered out of both pickers and
+  rejected by the route with a message naming the missing methods, rather than
+  half-working.
+- **Gates to re-run beyond the suite:** regenerate the OpenAPI snapshot
+  (`cd frontend && npm run regenerate-openapi-snapshot`) for the schema change.
+  The plugin-family counts in the generated doc inventories are unchanged (eight
+  exporters stay eight). Exporters are not mirrored by
+  `scripts/check-eval-app-sync.py`, so that gate is untouched.
+- **`vtscore/CHANGELOG.md`** gets an `[Unreleased] › Changed` entry for the
+  library-tier breaking change; the `vtscore.__version__` bump waits for a
+  release cut, per `CLAUDE.md`.

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3355,6 +3355,12 @@
           "opens_url": {
             "type": "boolean"
           },
+          "supported_payloads": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "ui_mode": {
             "type": "string"
           }
@@ -3367,6 +3373,7 @@
           "icon",
           "name",
           "opens_url",
+          "supported_payloads",
           "ui_mode"
         ],
         "type": "object"
@@ -5458,6 +5465,18 @@
           "field_values": {
             "additionalProperties": {},
             "type": "object"
+          },
+          "payload_kind": {
+            "default": null,
+            "description": "Which payload ``results`` carries. Omit and the handler infers it from the dict shape, which is what pre-payload-kind API clients get; send it explicitly and the handler rejects an exporter that does not implement that kind instead of letting it deliver an empty export.",
+            "enum": [
+              "find_results",
+              "labelset",
+              "detector_bundles",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
           },
           "results": {
             "additionalProperties": {},

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.spec.ts
@@ -48,8 +48,13 @@ describe('AutoDetectResultsModalComponent', () => {
   async function flushInit(): Promise<void> {
     await settleZoneless(fixture);
     httpMock.expectOne('/api/exporters').flush([
-      { name: 'json', label: 'JSON', fields: [] },
-      { name: 'csv', label: 'CSV', fields: [{ key: 'path', field_type: 'text', label: 'Path' }] },
+      { name: 'json', label: 'JSON', fields: [], supported_payloads: ['find_results'] },
+      {
+        name: 'csv',
+        label: 'CSV',
+        fields: [{ key: 'path', field_type: 'text', label: 'Path' }],
+        supported_payloads: ['find_results', 'labelset'],
+      },
     ]);
     await settleZoneless(fixture);
   }

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -56,9 +56,13 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({
       next: (list) => {
-        // Drop exporters the plugin author flagged hidden_from_picker so they
-        // never surface in this destination picker (matches the export modal).
-        const visible = list.filter((exp) => !exp.hidden_from_picker);
+        // Drop exporters the plugin author flagged hidden_from_picker, and
+        // those that can't read a scored run - this picker's destination is
+        // always find results (matches the export modal, which filters on
+        // `labelset` instead).
+        const visible = list.filter(
+          (exp) => !exp.hidden_from_picker && (exp.supported_payloads ?? []).includes('find_results'),
+        );
         this.exporters.set(visible);
         if (visible.length > 0) {
           this.selectedExporter.set(visible[0].name);

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -15,8 +15,27 @@ describe('ExportModalComponent', () => {
   let httpMock: HttpTestingController;
 
   const mockExporters = [
-    { name: 'server_json_file', display_name: 'Server JSON', fields: [] },
-    { name: 'hidden', display_name: 'Hidden', hidden_from_picker: true, fields: [] },
+    {
+      name: 'server_json_file',
+      display_name: 'Server JSON',
+      fields: [],
+      supported_payloads: ['find_results', 'labelset'],
+    },
+    {
+      name: 'hidden',
+      display_name: 'Hidden',
+      hidden_from_picker: true,
+      fields: [],
+      supported_payloads: ['labelset'],
+    },
+    // Visible in the picker, but can only read a scored run — this modal
+    // sends a labelset, so it must be filtered out (issue #3219).
+    {
+      name: 'find_only',
+      display_name: 'Find Only',
+      fields: [],
+      supported_payloads: ['find_results'],
+    },
   ];
   const mockLabels = {
     labels: [
@@ -24,7 +43,14 @@ describe('ExportModalComponent', () => {
       { md5: 'b', label: 'bad', filename: 'b.wav' },
       { md5: 'c', label: 'good', filename: 'c.wav', is_correction: true },
     ],
-    available_columns: ['label', 'md5', 'filename', 'category', 'extra', 'name'],
+    available_columns: [
+      'label',
+      'md5',
+      'filename',
+      'category',
+      'extra',
+      'name',
+    ],
   };
 
   beforeEach(async () => {
@@ -46,7 +72,9 @@ describe('ExportModalComponent', () => {
   // `rxResource`, whose loaders run in a root effect rather than during
   // `detectChanges()`; tick to issue the GETs (the labels read also waits for
   // `ngOnInit` to set the input-derived filter), then settle before asserting.
-  async function flushInit(exporters: unknown[] = mockExporters): Promise<void> {
+  async function flushInit(
+    exporters: unknown[] = mockExporters,
+  ): Promise<void> {
     // Zoneless + rxResource: TestBed.tick() runs ngOnInit and the resource
     // loader effects to issue the GETs. whenStable() can't be used — a loading
     // rxResource holds the app unstable — so the rxResource specs drive CD with
@@ -56,7 +84,9 @@ describe('ExportModalComponent', () => {
     // released by `ngOnInit`'s signal flip a microtask later, so settle first
     // to let all three become pending before flushing.
     await settleResource();
-    httpMock.expectOne('/api/dataset/status').flush({ display_name: 'My Dataset' });
+    httpMock
+      .expectOne('/api/dataset/status')
+      .flush({ display_name: 'My Dataset' });
     httpMock.expectOne('/api/exporters').flush(exporters);
     httpMock.expectOne((r) => r.url === '/api/labels/export').flush(mockLabels);
     await settleResource();
@@ -71,6 +101,23 @@ describe('ExportModalComponent', () => {
     await flushInit();
     expect(component.exporters().length).toBe(1);
     expect(component.exporters()[0].name).toBe('server_json_file');
+  });
+
+  // This modal sends a labelset. Offering an exporter that only reads a scored
+  // run is how a labelset email used to go out empty and still report success
+  // (issue #3219), so the picker filters on the capability, not just on
+  // `hidden_from_picker`.
+  it('drops exporters that cannot read a labelset', async () => {
+    await flushInit();
+    expect(component.exporters().map((e) => e.name)).not.toContain('find_only');
+  });
+
+  it('tells the API which payload kind it is sending', async () => {
+    await flushInit();
+    component.startExporter(mockExporters[0] as never);
+    const req = httpMock.expectOne('/api/exporters/export');
+    expect(req.request.body.payload_kind).toBe('labelset');
+    req.flush({ success: true });
   });
 
   it('builds columns from available_columns once labels resolve', async () => {
@@ -122,7 +169,11 @@ describe('ExportModalComponent', () => {
     // real dict and serializes it as JSON.
     component.startExporter(mockExporters[0] as never);
     const req = httpMock.expectOne('/api/exporters/export');
-    expect(req.request.body.results.selected_columns).toEqual(['md5', 'origin', 'origin_name']);
+    expect(req.request.body.results.selected_columns).toEqual([
+      'md5',
+      'origin',
+      'origin_name',
+    ]);
     req.flush({ message: 'ok' });
   });
 
@@ -158,7 +209,9 @@ describe('ExportModalComponent', () => {
     component.startExporter(mockExporters[0] as never);
     httpMock.expectOne('/api/exporters/export').flush({ success: true });
     expect(successSpy).toHaveBeenCalledTimes(1);
-    expect(successSpy.mock.calls[0][0].message).toBe('Exported 2 labels to Server JSON');
+    expect(successSpy.mock.calls[0][0].message).toBe(
+      'Exported 2 labels to Server JSON',
+    );
   });
 
   // An exporter can return an `open_url` for the browser to open in a new tab,
@@ -170,16 +223,24 @@ describe('ExportModalComponent', () => {
       display_name: 'Open in Website',
       opens_url: true,
       fields: [],
+      supported_payloads: ['find_results', 'labelset'],
     };
 
     /** A stand-in for the `Window` handle `window.open` hands back. */
     function fakeWindow() {
-      return { closed: false, opener: {}, location: { href: '' }, close: vi.fn() };
+      return {
+        closed: false,
+        opener: {},
+        location: { href: '' },
+        close: vi.fn(),
+      };
     }
 
     /** Stub `window.open`, returning *handle* as the opened window. */
     function stubWindowOpen(handle: unknown) {
-      return vi.spyOn(window, 'open').mockReturnValue(handle as unknown as Window);
+      return vi
+        .spyOn(window, 'open')
+        .mockReturnValue(handle as unknown as Window);
     }
 
     // `window` outlives the TestBed, so a spy left installed on it carries its
@@ -233,7 +294,10 @@ describe('ExportModalComponent', () => {
       const win = fakeWindow();
       openSpy.mockReturnValue(win as unknown as Window);
       toast.action!.onClick();
-      expect(openSpy).toHaveBeenLastCalledWith('https://example.com/r', '_blank');
+      expect(openSpy).toHaveBeenLastCalledWith(
+        'https://example.com/r',
+        '_blank',
+      );
     });
 
     it('reports an opened tab rather than an export in the toast message', async () => {
@@ -268,20 +332,24 @@ describe('ExportModalComponent', () => {
       expect(successSpy.mock.calls[0][0].action?.label).toBe('Open');
     });
 
-    it.each(['javascript:alert(1)', 'data:text/html,x', 'file:///etc/passwd', '/relative'])(
-      'refuses to open a %s URL even if the server sent one',
-      async (url) => {
-        await flushInit();
-        const win = fakeWindow();
-        stubWindowOpen(win);
-        component.startExporter(openUrlExporter as never);
-        httpMock.expectOne('/api/exporters/export').flush({ success: true, open_url: url });
-        // The tab was claimed on click, but nothing unsafe is navigated to and
-        // the blank tab doesn't outlive the export.
-        expect(win.location.href).toBe('');
-        expect(win.close).toHaveBeenCalled();
-      },
-    );
+    it.each([
+      'javascript:alert(1)',
+      'data:text/html,x',
+      'file:///etc/passwd',
+      '/relative',
+    ])('refuses to open a %s URL even if the server sent one', async (url) => {
+      await flushInit();
+      const win = fakeWindow();
+      stubWindowOpen(win);
+      component.startExporter(openUrlExporter as never);
+      httpMock
+        .expectOne('/api/exporters/export')
+        .flush({ success: true, open_url: url });
+      // The tab was claimed on click, but nothing unsafe is navigated to and
+      // the blank tab doesn't outlive the export.
+      expect(win.location.href).toBe('');
+      expect(win.close).toHaveBeenCalled();
+    });
 
     it('closes the claimed tab when the export fails outright', async () => {
       await flushInit();
@@ -290,7 +358,10 @@ describe('ExportModalComponent', () => {
       component.startExporter(openUrlExporter as never);
       httpMock
         .expectOne('/api/exporters/export')
-        .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+        .flush(
+          { message: 'boom' },
+          { status: 500, statusText: 'Server Error' },
+        );
       expect(win.close).toHaveBeenCalled();
     });
 
@@ -306,7 +377,9 @@ describe('ExportModalComponent', () => {
     it('labels the action button with the destination site', async () => {
       await flushInit([openUrlExporter]);
       component.selectExporterTab(openUrlExporter as never);
-      expect(component.activeTabAction).toBe('Open Labelset in Open in Website');
+      expect(component.activeTabAction).toBe(
+        'Open Labelset in Open in Website',
+      );
     });
   });
 
@@ -361,7 +434,9 @@ describe('ExportModalComponent', () => {
     const fileExporter = {
       name: 'server_json_file',
       display_name: 'Server JSON',
-      fields: [{ key: 'filepath', field_type: 'text', default: 'data/labels.json' }],
+      fields: [
+        { key: 'filepath', field_type: 'text', default: 'data/labels.json' },
+      ],
     };
 
     /** Land a detector registry naming `d1`, as the app-level refresh would. */
@@ -377,7 +452,9 @@ describe('ExportModalComponent', () => {
       fixture.componentRef.setInput('detectorName', 'Sirens');
       await flushInit();
       component.selectExporterTab(fileExporter as never);
-      expect(component.formValues['filepath']).toBe('data/Good-Sirens-My Dataset.json');
+      expect(component.formValues['filepath']).toBe(
+        'data/Good-Sirens-My Dataset.json',
+      );
     });
 
     // The lifecycle gap behind issue #2819: the filename is built once, at
@@ -387,12 +464,16 @@ describe('ExportModalComponent', () => {
       await flushInit();
       TestBed.inject(ActiveContextService).setActivePair('ds1', 'd1');
       component.selectExporterTab(fileExporter as never);
-      expect(component.formValues['filepath']).toBe('data/Good-My Dataset.json');
+      expect(component.formValues['filepath']).toBe(
+        'data/Good-My Dataset.json',
+      );
 
       flushRegistry();
       TestBed.tick();
       expect(component.effectiveDetectorName()).toBe('Birdsong');
-      expect(component.formValues['filepath']).toBe('data/Good-Birdsong-My Dataset.json');
+      expect(component.formValues['filepath']).toBe(
+        'data/Good-Birdsong-My Dataset.json',
+      );
     });
 
     it('leaves a user-edited filename alone when the name arrives late', async () => {
@@ -493,7 +574,11 @@ describe('ExportModalComponent', () => {
 
   describe('preview column resize', () => {
     /** Build a detached preview-style table and return its parts. */
-    function makeTable(): { table: HTMLTableElement; th1: HTMLElement; handle: HTMLElement } {
+    function makeTable(): {
+      table: HTMLTableElement;
+      th1: HTMLElement;
+      handle: HTMLElement;
+    } {
       const table = document.createElement('table');
       const thead = document.createElement('thead');
       const tr = document.createElement('tr');

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -96,7 +96,14 @@ export class ExportModalComponent implements OnInit {
   });
 
   readonly exporters = computed<ExporterEntry[]>(() =>
-    (this.exportersResource.value() ?? []).filter((e) => !e.hidden_from_picker),
+    // Two filters, and they answer different questions. `hidden_from_picker`
+    // is the plugin author saying "not in a generic list"; `supported_payloads`
+    // is the framework saying "this one cannot read a labelset". Offering an
+    // exporter that can't is how a labelset email used to go out empty and
+    // still report success (#3219).
+    (this.exportersResource.value() ?? []).filter(
+      (e) => !e.hidden_from_picker && (e.supported_payloads ?? []).includes('labelset'),
+    ),
   );
 
   /** Labels fetched from the server. */
@@ -644,6 +651,7 @@ export class ExportModalComponent implements OnInit {
         exporter_name: exporter.name,
         field_values: fieldValues,
         results: labelsData,
+        payload_kind: 'labelset',
       })
       .subscribe({
         next: (response) => {

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -29,7 +29,11 @@ import { SortingApiService } from '../../../services/sorting-api.service';
 import type { LabelFilter } from '../../../services/sorting-api.service';
 import { ToastService } from '../../../services/toast.service';
 import { ImporterField } from '../../../models/api.models';
-import { openBlankTab, openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
+import {
+  openBlankTab,
+  openExternalUrl,
+  safeExternalUrl,
+} from '../../../utils/external-url';
 import type { ExporterEntry } from '../../../generated/api-client/models/exporter-entry';
 import type { LabeledElement } from '../../../generated/api-client/models/labeled-element';
 
@@ -90,7 +94,8 @@ export class ExportModalComponent implements OnInit {
   private readonly labelsResource = rxResource({
     params: () => (this.labelsReady() ? this.serverFilter : undefined),
     stream: () => {
-      const labelFilter = this.serverFilter === 'both' ? undefined : this.serverFilter;
+      const labelFilter =
+        this.serverFilter === 'both' ? undefined : this.serverFilter;
       return this.sortingApi.exportLabels(false, { enrich: true, labelFilter });
     },
   });
@@ -102,7 +107,9 @@ export class ExportModalComponent implements OnInit {
     // exporter that can't is how a labelset email used to go out empty and
     // still report success (#3219).
     (this.exportersResource.value() ?? []).filter(
-      (e) => !e.hidden_from_picker && (e.supported_payloads ?? []).includes('labelset'),
+      (e) =>
+        !e.hidden_from_picker &&
+        (e.supported_payloads ?? []).includes('labelset'),
     ),
   );
 
@@ -111,7 +118,9 @@ export class ExportModalComponent implements OnInit {
     () => this.labelsResource.value()?.labels ?? [],
   );
   readonly labelsLoaded = computed(
-    () => this.labelsResource.hasValue() || this.labelsResource.error() !== undefined,
+    () =>
+      this.labelsResource.hasValue() ||
+      this.labelsResource.error() !== undefined,
   );
 
   /** Error from a failed export action; the read failures are merged in below. */
@@ -147,7 +156,9 @@ export class ExportModalComponent implements OnInit {
   readonly submitting = signal(false);
 
   /** Dataset display name for default filenames. */
-  private readonly datasetName = computed(() => this.statusResource.value()?.display_name || '');
+  private readonly datasetName = computed(
+    () => this.statusResource.value()?.display_name || '',
+  );
 
   /** Base columns that are always present. */
   private static readonly BASE_COLUMNS: { key: string; label: string }[] = [
@@ -179,7 +190,10 @@ export class ExportModalComponent implements OnInit {
    *  the label session carried. A signal, not a getter, so a name that lands
    *  after the modal opened still reaches the default filename below. */
   readonly effectiveDetectorName = computed(
-    () => this.detectorName() || this.activeDetector.detectorName() || this.labelSession.modelName,
+    () =>
+      this.detectorName() ||
+      this.activeDetector.detectorName() ||
+      this.labelSession.modelName,
   );
 
   constructor() {
@@ -263,7 +277,9 @@ export class ExportModalComponent implements OnInit {
 
   /** Build column definitions from available_columns or fall back to defaults. */
   private buildColumns(availableColumns?: string[]): void {
-    const baseKeys = new Set(ExportModalComponent.BASE_COLUMNS.map((c) => c.key));
+    const baseKeys = new Set(
+      ExportModalComponent.BASE_COLUMNS.map((c) => c.key),
+    );
     const alwaysKeys = new Set(ExportModalComponent.ALWAYS_EXPORT_KEYS);
     // Start with base columns
     this.columns = ExportModalComponent.BASE_COLUMNS.map((c) => ({
@@ -323,7 +339,11 @@ export class ExportModalComponent implements OnInit {
   /** Once true, the table uses `table-layout: fixed` with explicit widths. */
   tableFixed = false;
 
-  private colResize: { key: string; startX: number; startWidth: number } | null = null;
+  private colResize: {
+    key: string;
+    startX: number;
+    startWidth: number;
+  } | null = null;
 
   /** Begin dragging a column divider: freeze current widths, then track the
    *  grabbed column so `onColResizeMove` can size it. */
@@ -536,7 +556,9 @@ export class ExportModalComponent implements OnInit {
 
   /** Apply the dynamic default filename to the filepath form field if present. */
   private applyDefaultFilename(exporter: ExporterEntry): void {
-    const filepathField = this.exporterFieldsOf(exporter).find((f) => f.key === 'filepath');
+    const filepathField = this.exporterFieldsOf(exporter).find(
+      (f) => f.key === 'filepath',
+    );
     if (filepathField) {
       const staticDefault = filepathField.default || '';
       // Derive extension from the static default (e.g. ".json", ".csv") or fall back
@@ -600,10 +622,12 @@ export class ExportModalComponent implements OnInit {
     if (!exp) return 'Export';
     // A declared `opens_url` beats the name-sniffing below: the exporter has
     // told us the run ends in a new browser tab, so the button says so.
-    if (exp.opens_url) return `Open Labelset in ${exp.display_name || exp.name}`;
+    if (exp.opens_url)
+      return `Open Labelset in ${exp.display_name || exp.name}`;
     const name = (exp.display_name || exp.name).toLowerCase();
     if (name.includes('email') || name.includes('smtp')) return 'Send';
-    if (name.includes('csv') || name.includes('file') || name.includes('json')) return 'Save';
+    if (name.includes('csv') || name.includes('file') || name.includes('json'))
+      return 'Save';
     if (name.includes('webhook')) return 'Send';
     return 'Export';
   }
@@ -626,10 +650,15 @@ export class ExportModalComponent implements OnInit {
     this.exportLabelsWith(this.selectedExporter, { ...this.formValues });
   }
 
-  exportLabelsWith(exporter: ExporterEntry, fieldValues: Record<string, string>): void {
+  exportLabelsWith(
+    exporter: ExporterEntry,
+    fieldValues: Record<string, string>,
+  ): void {
     const exporterLabel = exporter.display_name || exporter.name;
     const labelCount = this.filteredLabels.length;
-    this.status.set(`Exporting ${labelCount.toLocaleString()} labels to ${exporterLabel}…`);
+    this.status.set(
+      `Exporting ${labelCount.toLocaleString()} labels to ${exporterLabel}…`,
+    );
     this.actionError.set('');
     this.submitting.set(true);
 
@@ -664,7 +693,9 @@ export class ExportModalComponent implements OnInit {
           const openUrl = safeExternalUrl(response?.open_url);
           let opened = false;
           if (openUrl) {
-            opened = pendingTab ? pendingTab.navigate(openUrl) : openExternalUrl(openUrl);
+            opened = pendingTab
+              ? pendingTab.navigate(openUrl)
+              : openExternalUrl(openUrl);
           } else {
             // The exporter advertised a URL and didn't produce one; don't leave
             // a blank tab sitting there.
@@ -678,7 +709,9 @@ export class ExportModalComponent implements OnInit {
           // why nothing happened rather than leaving the user staring at an
           // unchanged screen.
           let message = `Exported ${labelCount.toLocaleString()} label${plural} to ${exporterLabel}`;
-          let detail = fieldValues['filepath'] ? `Destination: ${fieldValues['filepath']}` : undefined;
+          let detail = fieldValues['filepath']
+            ? `Destination: ${fieldValues['filepath']}`
+            : undefined;
           if (openUrl) {
             message = opened
               ? `Opened ${labelCount.toLocaleString()} label${plural} in ${exporterLabel}`
@@ -696,7 +729,11 @@ export class ExportModalComponent implements OnInit {
             // through — it doubles as the blocked-popup escape hatch and as a
             // way to reopen a tab the user closed by accident.
             action: openUrl
-              ? { label: 'Open', title: openUrl, onClick: () => openExternalUrl(openUrl) }
+              ? {
+                  label: 'Open',
+                  title: openUrl,
+                  onClick: () => openExternalUrl(openUrl),
+                }
               : undefined,
             // A blocked tab makes that button the only way to reach the site,
             // so the toast has to outlive the 5s success default — otherwise
@@ -720,7 +757,12 @@ export class ExportModalComponent implements OnInit {
   getExporterIconType(exp: ExporterEntry): string {
     const icon = exp.icon || '';
     if (icon === '📧' || icon.includes('📧')) return 'email';
-    if (icon === '🖥️' || icon === '\uD83D\uDDA5' || icon === '\uD83D\uDDA5\uFE0F') return 'server';
+    if (
+      icon === '🖥️' ||
+      icon === '\uD83D\uDDA5' ||
+      icon === '\uD83D\uDDA5\uFE0F'
+    )
+      return 'server';
     if (icon === '🌐' || icon === '\uD83C\uDF10') return 'webhook';
     // An exporter that ends in a new browser tab reads as a link, whichever
     // emoji its author picked.
@@ -737,7 +779,9 @@ export class ExportModalComponent implements OnInit {
   get modalTitle(): string {
     if (this.serverFilter === 'unverified') {
       // The left work-queue export opens on the above-threshold good slice.
-      return this.labelFilter === 'good' ? 'Export Unverified Good' : 'Export Unverified';
+      return this.labelFilter === 'good'
+        ? 'Export Unverified Good'
+        : 'Export Unverified';
     }
     if (this.serverFilter === 'verified') return 'Export Verified';
     return 'Export';

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
@@ -30,6 +30,7 @@ describe('AutoFindSettingsComponent', () => {
       description: 'Write results to a JSON file',
       icon: 'download',
       hidden_from_picker: false,
+      supported_payloads: ['find_results', 'labelset'],
       ui_mode: 'form',
       fields: [
         { key: 'filepath', field_type: 'text', label: 'File path', default: '/out.json' },
@@ -42,6 +43,7 @@ describe('AutoFindSettingsComponent', () => {
       description: 'Email the results',
       icon: 'mail',
       hidden_from_picker: false,
+      supported_payloads: ['find_results', 'labelset'],
       ui_mode: 'form',
       fields: [] as ImporterField[],
     },
@@ -51,6 +53,7 @@ describe('AutoFindSettingsComponent', () => {
       description: 'hidden',
       icon: '',
       hidden_from_picker: true,
+      supported_payloads: ['find_results'],
       ui_mode: 'form',
       fields: [] as ImporterField[],
     },

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -85,7 +85,13 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (list) => {
-          this.exporters.set((list || []).filter((exp) => !exp.hidden_from_picker));
+          // Auto-Find runs its export on a scored run, so only exporters that
+        // implement that payload belong in this picker.
+        this.exporters.set(
+          (list || []).filter(
+            (exp) => !exp.hidden_from_picker && (exp.supported_payloads ?? []).includes('find_results'),
+          ),
+        );
           this.loadingExporters.set(false);
         },
         error: () => {

--- a/tests/detectors/test_autofind_export.py
+++ b/tests/detectors/test_autofind_export.py
@@ -68,6 +68,20 @@ class TestAutofindExportOpenUrl:
         assert status["success"] is True
         assert status["open_url"] == "https://example.com/r?ids=abc"
 
+    def test_an_exporter_that_cannot_read_a_scored_run_is_reported(self, isolated_settings):
+        """A saved Auto-Find choice can outlive what the exporter accepts.
+
+        Reported through the status block rather than raised: the scored
+        results are valuable on their own, so a misconfigured export must not
+        sink the request - and must not be handed a shape it cannot read.
+        """
+        settings.set_autofind_exporter("holder")
+        status = _run_autofind_export(dict(_SAMPLE_RESULTS))
+        assert status is not None
+        assert status["success"] is False
+        assert "cannot export find results" in status["error"]
+        assert "labelset" in status["error"]
+
     def test_unusable_url_is_dropped_not_forwarded(self, isolated_settings):
         """The same scheme allowlist the export route applies — a plugin must
         not be able to push a ``javascript:`` URL at the browser from here."""
@@ -79,7 +93,7 @@ class TestAutofindExportOpenUrl:
         settings.set_autofind_exporter("gui")
         with patch.object(
             type(get_exporter("gui")),
-            "export",
+            "export_find_results",
             return_value={"message": "Shown.", "open_url": "javascript:alert(1)"},
         ):
             status = _run_autofind_export(dict(_SAMPLE_RESULTS))

--- a/tests/detectors/test_clipper_workflow.py
+++ b/tests/detectors/test_clipper_workflow.py
@@ -951,9 +951,9 @@ class TestCsvExportClipColumns:
     """CSV autodetect export should include clip columns when present."""
 
     def test_csv_includes_clip_start_end(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exporter = ServerCsvLabelsetExporter()
+        exporter = ServerCsvResultsExporter()
         results = {
             "detectors_run": 1,
             "results": {
@@ -982,7 +982,7 @@ class TestCsvExportClipColumns:
             },
         }
         filepath = tmp_path / "results.csv"
-        exporter.export(results, {"filepath": str(filepath)})
+        exporter.export_find_results(results, {"filepath": str(filepath)})
 
         import csv
 
@@ -995,9 +995,9 @@ class TestCsvExportClipColumns:
         assert rows[1]["clip_end"] == "4.0"
 
     def test_csv_includes_clip_box(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exporter = ServerCsvLabelsetExporter()
+        exporter = ServerCsvResultsExporter()
         results = {
             "detectors_run": 1,
             "results": {
@@ -1017,7 +1017,7 @@ class TestCsvExportClipColumns:
             },
         }
         filepath = tmp_path / "results.csv"
-        exporter.export(results, {"filepath": str(filepath)})
+        exporter.export_find_results(results, {"filepath": str(filepath)})
 
         import csv
 
@@ -1028,9 +1028,9 @@ class TestCsvExportClipColumns:
         assert rows[0]["clip_box"] == "0,0,100,100"
 
     def test_csv_omits_clip_columns_without_clips(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exporter = ServerCsvLabelsetExporter()
+        exporter = ServerCsvResultsExporter()
         results = {
             "detectors_run": 1,
             "results": {
@@ -1044,7 +1044,7 @@ class TestCsvExportClipColumns:
             },
         }
         filepath = tmp_path / "results.csv"
-        exporter.export(results, {"filepath": str(filepath)})
+        exporter.export_find_results(results, {"filepath": str(filepath)})
 
         import csv
 

--- a/tests/io/test_csv_webhook_exporters.py
+++ b/tests/io/test_csv_webhook_exporters.py
@@ -88,9 +88,9 @@ class TestCsvExporterCLI:
     """CLI argument parsing for the CSV exporter."""
 
     def test_adds_filepath_arg(self):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -99,9 +99,9 @@ class TestCsvExporterCLI:
 
     def test_filepath_default(self):
         from vtscore.config import DATA_DIR
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -111,15 +111,15 @@ class TestCsvExporterCLI:
         assert args.filepath == f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.csv"
 
     def test_validate_passes(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         exp.validate_cli_field_values({"filepath": str(tmp_path / "out.csv")})
 
     def test_validate_missing_filepath(self):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         with pytest.raises(ValueError, match="Missing required argument: --filepath"):
             exp.validate_cli_field_values({})
 
@@ -133,38 +133,38 @@ class TestCsvExporterExport:
     """Tests for the CSV export() method."""
 
     def test_creates_csv_file(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
-        result = exp.export(results, {"filepath": str(filepath)})
+        result = exp.export_find_results(results, {"filepath": str(filepath)})
         assert filepath.exists()
         assert "message" in result
         assert "Saved" in result["message"]
 
     def test_csv_has_correct_header(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_find_results(results, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             header = next(reader)
         assert header == ["detector", "threshold", "filename", "category", "score", "origin", "origin_name"]
 
     def test_csv_has_correct_row_count(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_find_results(results, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             rows = list(reader)
@@ -172,13 +172,13 @@ class TestCsvExporterExport:
         assert len(rows) == 4
 
     def test_csv_row_values(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = _make_sample_results()
         filepath = tmp_path / "output.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_find_results(results, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             next(reader)  # skip header
@@ -189,30 +189,30 @@ class TestCsvExporterExport:
         assert first_row[4] == "0.95"
 
     def test_csv_empty_results(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = {"media_type": "audio", "detectors_run": 0, "results": {}}
         filepath = tmp_path / "empty.csv"
 
-        result = exp.export(results, {"filepath": str(filepath)})
+        result = exp.export_find_results(results, {"filepath": str(filepath)})
         assert filepath.exists()
         assert "0 hit(s)" in result["message"]
 
     def test_csv_creates_parent_dirs(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = _make_sample_results()
         filepath = tmp_path / "sub" / "dir" / "output.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_find_results(results, {"filepath": str(filepath)})
         assert filepath.exists()
 
     def test_csv_multiple_detectors(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = {
             "media_type": "audio",
             "detectors_run": 2,
@@ -236,7 +236,7 @@ class TestCsvExporterExport:
         }
         filepath = tmp_path / "multi.csv"
 
-        result = exp.export(results, {"filepath": str(filepath)})
+        result = exp.export_find_results(results, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             rows = list(reader)
@@ -283,16 +283,16 @@ class TestCsvExporterLabelsFormat:
     """Tests for CSV export of labels with selected columns."""
 
     def test_labels_format_uses_selected_columns(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {
+        exp = ServerCsvResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["label", "filename", "category"],
         }
         filepath = tmp_path / "labels.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             header = next(reader)
@@ -300,31 +300,31 @@ class TestCsvExporterLabelsFormat:
         assert header == ["label", "filename", "category", "origin"]
 
     def test_labels_format_correct_row_count(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {
+        exp = ServerCsvResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["label", "filename"],
         }
         filepath = tmp_path / "labels.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f))
         assert len(rows) == 4  # 1 header + 3 labels
 
     def test_labels_format_row_values(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {
+        exp = ServerCsvResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["label", "filename", "category"],
         }
         filepath = tmp_path / "labels.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             next(reader)  # skip header
@@ -333,16 +333,16 @@ class TestCsvExporterLabelsFormat:
         assert first_row == ["good", "clip1.wav", "birds", ""]
 
     def test_labels_format_includes_metadata_columns(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {
+        exp = ServerCsvResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["filename", "source", "quality"],
         }
         filepath = tmp_path / "labels.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             reader = csv.reader(f)
             header = next(reader)
@@ -352,16 +352,16 @@ class TestCsvExporterLabelsFormat:
 
     def test_labels_format_missing_metadata_gives_empty(self, tmp_path):
         """When a metadata column is missing from an entry, output empty string."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {
+        exp = ServerCsvResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["filename", "quality"],
         }
         filepath = tmp_path / "labels.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f))
         # Third entry (clip3.wav) has no "quality" in metadata; origin also empty
@@ -369,25 +369,25 @@ class TestCsvExporterLabelsFormat:
 
     def test_labels_format_changed_columns_reflected(self, tmp_path):
         """Changing selected_columns between exports produces different output."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
 
         # First export with all base columns
-        results1 = {
+        labelset1 = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["label", "md5", "origin_name", "filename", "category"],
         }
         filepath1 = tmp_path / "export1.csv"
-        exp.export(results1, {"filepath": str(filepath1)})
+        exp.export_labelset(labelset1, {"filepath": str(filepath1)})
 
         # Second export with only a metadata column
-        results2 = {
+        labelset2 = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["source"],
         }
         filepath2 = tmp_path / "export2.csv"
-        exp.export(results2, {"filepath": str(filepath2)})
+        exp.export_labelset(labelset2, {"filepath": str(filepath2)})
 
         with open(filepath1, newline="", encoding="utf-8") as f:
             header1 = next(csv.reader(f))
@@ -400,38 +400,38 @@ class TestCsvExporterLabelsFormat:
 
     def test_labels_format_no_selected_columns_uses_defaults(self, tmp_path):
         """When selected_columns is absent, fall back to base columns."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {"labels": SAMPLE_LABELS}
+        exp = ServerCsvResultsExporter()
+        labelset = {"labels": SAMPLE_LABELS}
         filepath = tmp_path / "labels.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         with open(filepath, newline="", encoding="utf-8") as f:
             header = next(csv.reader(f))
         assert header == ["label", "md5", "origin_name", "filename", "category", "origin"]
 
     def test_labels_format_message(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {
+        exp = ServerCsvResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["label", "filename"],
         }
         filepath = tmp_path / "labels.csv"
 
-        result = exp.export(results, {"filepath": str(filepath)})
+        result = exp.export_labelset(labelset, {"filepath": str(filepath)})
         assert "3 label(s)" in result["message"]
 
     def test_labels_format_empty_labels(self, tmp_path):
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
-        results = {"labels": [], "selected_columns": ["label", "filename"]}
+        exp = ServerCsvResultsExporter()
+        labelset = {"labels": [], "selected_columns": ["label", "filename"]}
         filepath = tmp_path / "empty.csv"
 
-        result = exp.export(results, {"filepath": str(filepath)})
+        result = exp.export_labelset(labelset, {"filepath": str(filepath)})
         assert "0 label(s)" in result["message"]
         with open(filepath, newline="", encoding="utf-8") as f:
             rows = list(csv.reader(f))
@@ -439,9 +439,9 @@ class TestCsvExporterLabelsFormat:
 
     def test_labels_format_origin_dict_serialised_as_json(self, tmp_path):
         """Origin dicts are JSON-serialised in CSV so they survive round-trip."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         origin = {"importer": "demo", "params": {"name": "flowers102"}}
         labels = [
             {
@@ -453,10 +453,10 @@ class TestCsvExporterLabelsFormat:
                 "origin": origin,
             }
         ]
-        results = {"labels": labels}
+        labelset = {"labels": labels}
         filepath = tmp_path / "with_origin.csv"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
 
         # Read back and verify origin column is valid JSON
         from vtscore.labels.importers.server_csv_file import _parse_csv_bytes
@@ -475,59 +475,59 @@ class TestJsonExporterLabelsFormat:
     """Tests for JSON export of labels with selected columns."""
 
     def test_labels_format_filters_to_selected_columns(self, tmp_path):
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
 
-        exp = ServerJsonLabelsetExporter()
-        results = {
+        exp = ServerJsonResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["label", "filename"],
         }
         filepath = tmp_path / "labels.json"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         written = json.loads(filepath.read_text())
         assert written["selected_columns"] == ["label", "filename"]
         for entry in written["labels"]:
             assert set(entry.keys()) == {"label", "filename"}
 
     def test_labels_format_includes_metadata(self, tmp_path):
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
 
-        exp = ServerJsonLabelsetExporter()
-        results = {
+        exp = ServerJsonResultsExporter()
+        labelset = {
             "labels": SAMPLE_LABELS,
             "selected_columns": ["filename", "source"],
         }
         filepath = tmp_path / "labels.json"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         written = json.loads(filepath.read_text())
         assert written["labels"][0] == {"filename": "clip1.wav", "source": "field"}
 
     def test_labels_format_no_selected_columns_keeps_all(self, tmp_path):
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
 
-        exp = ServerJsonLabelsetExporter()
-        results = {"labels": SAMPLE_LABELS}
+        exp = ServerJsonResultsExporter()
+        labelset = {"labels": SAMPLE_LABELS}
         filepath = tmp_path / "labels.json"
 
-        exp.export(results, {"filepath": str(filepath)})
+        exp.export_labelset(labelset, {"filepath": str(filepath)})
         written = json.loads(filepath.read_text())
         assert written["labels"] == SAMPLE_LABELS
 
     def test_labels_format_changed_columns(self, tmp_path):
         """Changing selected_columns between exports produces different JSON."""
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
 
-        exp = ServerJsonLabelsetExporter()
+        exp = ServerJsonResultsExporter()
 
-        results1 = {"labels": SAMPLE_LABELS, "selected_columns": ["label", "md5"]}
+        labelset1 = {"labels": SAMPLE_LABELS, "selected_columns": ["label", "md5"]}
         filepath1 = tmp_path / "export1.json"
-        exp.export(results1, {"filepath": str(filepath1)})
+        exp.export_labelset(labelset1, {"filepath": str(filepath1)})
 
-        results2 = {"labels": SAMPLE_LABELS, "selected_columns": ["source"]}
+        labelset2 = {"labels": SAMPLE_LABELS, "selected_columns": ["source"]}
         filepath2 = tmp_path / "export2.json"
-        exp.export(results2, {"filepath": str(filepath2)})
+        exp.export_labelset(labelset2, {"filepath": str(filepath2)})
 
         written1 = json.loads(filepath1.read_text())
         written2 = json.loads(filepath2.read_text())
@@ -536,13 +536,13 @@ class TestJsonExporterLabelsFormat:
         assert set(written2["labels"][0].keys()) == {"source"}
 
     def test_labels_format_message(self, tmp_path):
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
 
-        exp = ServerJsonLabelsetExporter()
-        results = {"labels": SAMPLE_LABELS, "selected_columns": ["label"]}
+        exp = ServerJsonResultsExporter()
+        labelset = {"labels": SAMPLE_LABELS, "selected_columns": ["label"]}
         filepath = tmp_path / "labels.json"
 
-        result = exp.export(results, {"filepath": str(filepath)})
+        result = exp.export_labelset(labelset, {"filepath": str(filepath)})
         assert "3 label(s)" in result["message"]
 
 
@@ -633,9 +633,9 @@ class TestWebhookExporterCLI:
     """CLI argument parsing for the Webhook exporter."""
 
     def test_adds_url_arg(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         parser = argparse.ArgumentParser()
         exp.add_cli_arguments(parser)
 
@@ -643,23 +643,23 @@ class TestWebhookExporterCLI:
         assert args.url == "https://example.com/hook"
 
     def test_validate_passes_with_url(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         # auth_header is optional, so only url is needed
         exp.validate_cli_field_values({"url": "https://example.com/hook"})
 
     def test_validate_missing_url(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         with pytest.raises(ValueError, match="Missing required argument: --url"):
             exp.validate_cli_field_values({})
 
     def test_validate_passes_without_auth_header(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         # Should not raise
         exp.validate_cli_field_values({"url": "https://example.com/hook"})
 
@@ -680,9 +680,9 @@ class TestWebhookExporterExport:
     """
 
     def test_posts_json_to_url(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -692,7 +692,7 @@ class TestWebhookExporterExport:
         with (
             mock.patch("requests.Session.post", return_value=mock_resp) as mock_post,
         ):
-            result = exp.export(results, {"url": "https://example.com/hook"})
+            result = exp.export_find_results(results, {"url": "https://example.com/hook"})
 
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args
@@ -701,9 +701,9 @@ class TestWebhookExporterExport:
         assert "200" in result["message"]
 
     def test_sends_auth_header_when_provided(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -713,15 +713,15 @@ class TestWebhookExporterExport:
         with (
             mock.patch("requests.Session.post", return_value=mock_resp) as mock_post,
         ):
-            exp.export(results, {"url": "https://example.com/hook", "auth_header": "Bearer my-token"})
+            exp.export_find_results(results, {"url": "https://example.com/hook", "auth_header": "Bearer my-token"})
 
         call_kwargs = mock_post.call_args
         assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer my-token"
 
     def test_no_auth_header_when_empty(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -731,15 +731,15 @@ class TestWebhookExporterExport:
         with (
             mock.patch("requests.Session.post", return_value=mock_resp) as mock_post,
         ):
-            exp.export(results, {"url": "https://example.com/hook", "auth_header": ""})
+            exp.export_find_results(results, {"url": "https://example.com/hook", "auth_header": ""})
 
         call_kwargs = mock_post.call_args
         assert "Authorization" not in call_kwargs.kwargs["headers"]
 
     def test_http_error_propagates(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -747,12 +747,12 @@ class TestWebhookExporterExport:
 
         with mock.patch("requests.Session.post", return_value=mock_resp):
             with pytest.raises(Exception, match="500 Server Error"):
-                exp.export(results, {"url": "https://example.com/hook"})
+                exp.export_find_results(results, {"url": "https://example.com/hook"})
 
     def test_message_contains_hit_count(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -760,15 +760,15 @@ class TestWebhookExporterExport:
         mock_resp.raise_for_status.return_value = None
 
         with mock.patch("requests.Session.post", return_value=mock_resp):
-            result = exp.export(results, {"url": "https://example.com/hook"})
+            result = exp.export_find_results(results, {"url": "https://example.com/hook"})
 
         assert "3 hit(s)" in result["message"]
         assert "1 detector(s)" in result["message"]
 
     def test_result_includes_status_code_and_url(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         results = _make_sample_results()
 
         mock_resp = mock.MagicMock()
@@ -776,7 +776,7 @@ class TestWebhookExporterExport:
         mock_resp.raise_for_status.return_value = None
 
         with mock.patch("requests.Session.post", return_value=mock_resp):
-            result = exp.export(results, {"url": "https://example.com/hook"})
+            result = exp.export_find_results(results, {"url": "https://example.com/hook"})
 
         assert result["status_code"] == 201
         assert result["url"] == "https://example.com/hook"
@@ -832,10 +832,10 @@ class TestFilepathTemplateExpansion:
 
     def test_consecutive_csv_exports_do_not_overwrite(self, tmp_path):
         """Two exports a second apart should land in distinct files."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         results = _make_sample_results()
         template = str(tmp_path / "out_{YYYYMMDD-HHMMSS}.csv")
 
@@ -844,9 +844,9 @@ class TestFilepathTemplateExpansion:
             from datetime import timezone
 
             mock_dt.now.return_value = real_dt(2026, 5, 16, 14, 30, 22, tzinfo=timezone.utc)
-            r1 = exp.export(results, normalize_field_values(exp, {"filepath": template}))
+            r1 = exp.export_find_results(results, normalize_field_values(exp, {"filepath": template}))
             mock_dt.now.return_value = real_dt(2026, 5, 16, 14, 30, 23, tzinfo=timezone.utc)
-            r2 = exp.export(results, normalize_field_values(exp, {"filepath": template}))
+            r2 = exp.export_find_results(results, normalize_field_values(exp, {"filepath": template}))
 
         # Both files exist with distinct, timestamp-stamped names.
         assert r1["filepath"] != r2["filepath"]
@@ -858,15 +858,17 @@ class TestFilepathTemplateExpansion:
         from datetime import datetime as real_dt
         from datetime import timezone
 
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = ServerJsonLabelsetExporter()
+        exp = ServerJsonResultsExporter()
         template = str(tmp_path / "j_{YYYYMMDD-HHMMSS}.json")
 
         with mock.patch("vtscore.plugins.normalize.datetime") as mock_dt:
             mock_dt.now.return_value = real_dt(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
-            result = exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
+            result = exp.export_find_results(
+                _make_sample_results(), normalize_field_values(exp, {"filepath": template})
+            )
 
         expected = tmp_path / "j_20260102-030405.json"
         assert expected.exists()
@@ -878,15 +880,17 @@ class TestFilepathTemplateExpansion:
         from datetime import datetime as real_dt
         from datetime import timezone
 
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = ServerJsonLabelsetExporter()
+        exp = ServerJsonResultsExporter()
         template = str(tmp_path / "d_{YYYYMMDD}" / "{YYYY}.{MM}.{DD}.json")
 
         with mock.patch("vtscore.plugins.normalize.datetime") as mock_dt:
             mock_dt.now.return_value = real_dt(2026, 4, 1, 23, 59, 59, tzinfo=timezone.utc)
-            result = exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
+            result = exp.export_find_results(
+                _make_sample_results(), normalize_field_values(exp, {"filepath": template})
+            )
 
         expected = tmp_path / "d_20260401" / "2026.04.01.json"
         assert expected.exists()
@@ -895,45 +899,45 @@ class TestFilepathTemplateExpansion:
     def test_username_template_expands(self, tmp_path):
         """The {username} template substitutes get_current_user(), sanitised."""
         from vtsearch.auth import thread_user
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = ServerJsonLabelsetExporter()
+        exp = ServerJsonResultsExporter()
         template = str(tmp_path / "{username}.json")
 
         with thread_user("alice"):
-            exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
+            exp.export_find_results(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
 
         assert (tmp_path / "alice.json").exists()
 
     def test_username_template_sanitises_path_separators(self, tmp_path):
         """A malicious username with ``/`` cannot escape the parent directory."""
         from vtsearch.auth import thread_user
-        from vtscore.exporters.server_json_file import ServerJsonLabelsetExporter
+        from vtscore.exporters.server_json_file import ServerJsonResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = ServerJsonLabelsetExporter()
+        exp = ServerJsonResultsExporter()
         template = str(tmp_path / "{username}.json")
 
         with thread_user("../evil"):
-            exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
+            exp.export_find_results(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
 
         # ``/`` and ``..`` are replaced with ``_``, so the result stays inside tmp_path.
         assert (tmp_path / ".._evil.json").exists()
 
     def test_detector_name_template_expands(self, tmp_path):
         """The {detector_name} template pulls from the active detector context."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
         from vtscore.state.core import DetectorContext, set_thread_detector_context
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         template = str(tmp_path / "{detector_name}.csv")
 
         ctx = DetectorContext("det-id-1", name="dog_bark")
         set_thread_detector_context(ctx)
         try:
-            exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
+            exp.export_find_results(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
         finally:
             set_thread_detector_context(None)
 
@@ -941,13 +945,13 @@ class TestFilepathTemplateExpansion:
 
     def test_detector_name_template_with_no_active_context_uses_placeholder(self, tmp_path):
         """An empty detector context (fallback) sanitises to ``_``."""
-        from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+        from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = ServerCsvLabelsetExporter()
+        exp = ServerCsvResultsExporter()
         template = str(tmp_path / "{detector_name}.csv")
 
-        exp.export(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
+        exp.export_find_results(_make_sample_results(), normalize_field_values(exp, {"filepath": template}))
 
         # sanitize_template_value("") -> "_"
         assert (tmp_path / "_.csv").exists()

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -16,6 +16,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+SAMPLE_LABELSET = {
+    "labels": [
+        {"md5": "aaa1", "label": "good", "filename": "one.wav", "origin_name": "one.wav"},
+        {"md5": "bbb2", "label": "good", "filename": "two.wav", "origin_name": "two.wav"},
+        {"md5": "ccc3", "label": "bad", "filename": "three.wav", "origin_name": "three.wav"},
+    ],
+    "selected_columns": ["label", "md5", "filename"],
+}
+
 SAMPLE_RESULTS = {
     "media_type": "audio",
     "detectors_run": 2,
@@ -134,6 +143,34 @@ class TestLabelsetExporterBase:
         with pytest.raises(NotImplementedError):
             exp.export({}, {})
 
+    def test_labelset_exporter_is_an_alias_of_results_exporter(self):
+        """The pre-payload-kinds name must keep resolving, permanently.
+
+        An out-of-tree exporter subclasses this name; renaming it without an
+        alias would break every one of them for a cosmetic gain.
+        """
+        from vtscore.exporters.base import LabelsetExporter, ResultsExporter
+
+        assert LabelsetExporter is ResultsExporter
+
+    def test_bare_base_supports_no_payload_kind(self):
+        from vtscore.exporters.base import ResultsExporter
+
+        assert ResultsExporter().supported_payloads == frozenset()
+
+    @pytest.mark.parametrize("method,kind", [("export_find_results", "find_results"), ("export_labelset", "labelset")])
+    def test_named_methods_refuse_an_unimplemented_kind(self, method, kind):
+        """The refusal is a ValueError, so the route answers 400 and not 500.
+
+        Asking a labelset-only exporter for a scored run is a bad request, not
+        a server fault.
+        """
+        from vtscore.exporters.base import ResultsExporter, UnsupportedPayloadError
+
+        assert issubclass(UnsupportedPayloadError, ValueError)
+        with pytest.raises(UnsupportedPayloadError, match=kind):
+            getattr(ResultsExporter(), method)({}, {})
+
     def test_to_dict_contains_standard_keys(self):
         from vtscore.exporters.base import PluginField, LabelsetExporter
 
@@ -217,7 +254,7 @@ class TestExporterRegistry:
 # ---------------------------------------------------------------------------
 
 
-class TestDisplayLabelsetExporter:
+class TestDisplayResultsExporter:
     def test_has_no_fields(self):
         from vtscore.exporters import get_exporter
 
@@ -228,7 +265,7 @@ class TestDisplayLabelsetExporter:
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("gui")
-        result = exp.export(SAMPLE_RESULTS, {})
+        result = exp.export_find_results(SAMPLE_RESULTS, {})
         assert "message" in result
         assert "display_results" in result
         assert result["display_results"] is SAMPLE_RESULTS
@@ -237,7 +274,7 @@ class TestDisplayLabelsetExporter:
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("gui")
-        result = exp.export(SAMPLE_RESULTS, {})
+        result = exp.export_find_results(SAMPLE_RESULTS, {})
         # 3 + 1 = 4 total hits
         assert "4" in result["message"]
         assert "2" in result["message"]  # 2 detectors
@@ -246,7 +283,7 @@ class TestDisplayLabelsetExporter:
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("gui")
-        result = exp.export(EMPTY_RESULTS, {})
+        result = exp.export_find_results(EMPTY_RESULTS, {})
         assert "message" in result
         assert result["display_results"] is EMPTY_RESULTS
 
@@ -315,7 +352,7 @@ class TestDisplayLabelsetExporter:
             ]
         }
         exp = get_exporter("gui")
-        result = exp.export(labelset_data, {})
+        result = exp.export_labelset(labelset_data, {})
         assert "display_results" in result
         dr = result["display_results"]
         # Should have the autodetect-results structure
@@ -418,7 +455,7 @@ class TestGuiOriginFormatting:
 # ---------------------------------------------------------------------------
 
 
-class TestServerJsonLabelsetExporter:
+class TestServerJsonResultsExporter:
     def test_has_filepath_field(self):
         from vtscore.exporters import get_exporter
 
@@ -432,7 +469,7 @@ class TestServerJsonLabelsetExporter:
         exp = get_exporter("server_json_file")
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "results.json"
-            result = exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            result = exp.export_find_results(SAMPLE_RESULTS, {"filepath": str(fpath)})
             assert "message" in result
             assert fpath.exists()
             written = json.loads(fpath.read_text())
@@ -445,7 +482,7 @@ class TestServerJsonLabelsetExporter:
         exp = get_exporter("server_json_file")
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "sub" / "dir" / "results.json"
-            exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            exp.export_find_results(SAMPLE_RESULTS, {"filepath": str(fpath)})
             assert fpath.exists()
 
     def test_export_message_contains_hit_count(self):
@@ -454,7 +491,7 @@ class TestServerJsonLabelsetExporter:
         exp = get_exporter("server_json_file")
         with tempfile.TemporaryDirectory() as tmpdir:
             fpath = Path(tmpdir) / "out.json"
-            result = exp.export(SAMPLE_RESULTS, {"filepath": str(fpath)})
+            result = exp.export_find_results(SAMPLE_RESULTS, {"filepath": str(fpath)})
             assert "4" in result["message"]  # 3 + 1 hits
 
     def test_to_dict_has_all_keys(self):
@@ -471,7 +508,7 @@ class TestServerJsonLabelsetExporter:
 # ---------------------------------------------------------------------------
 
 
-class TestEmailLabelsetExporter:
+class TestEmailResultsExporter:
     def test_has_required_fields(self):
         from vtscore.exporters import get_exporter
 
@@ -499,14 +536,14 @@ class TestEmailLabelsetExporter:
 
         exp = get_exporter("email_smtp")
         with pytest.raises(ValueError, match="Recipient"):
-            exp.export(SAMPLE_RESULTS, {"from": "me@example.com", "to": ""})
+            exp.export_find_results(SAMPLE_RESULTS, {"from": "me@example.com", "to": ""})
 
     def test_export_raises_on_missing_from(self):
         from vtscore.exporters import get_exporter
 
         exp = get_exporter("email_smtp")
         with pytest.raises(ValueError, match="Sender"):
-            exp.export(SAMPLE_RESULTS, {"from": "", "to": "you@example.com"})
+            exp.export_find_results(SAMPLE_RESULTS, {"from": "", "to": "you@example.com"})
 
     @pytest.mark.parametrize(
         "bad_addr",
@@ -519,7 +556,7 @@ class TestEmailLabelsetExporter:
 
         exp = get_exporter("email_smtp")
         with pytest.raises(ValueError, match="Recipient"):
-            exp.export(SAMPLE_RESULTS, {"from": "me@example.com", "to": bad_addr})
+            exp.export_find_results(SAMPLE_RESULTS, {"from": "me@example.com", "to": bad_addr})
 
     @pytest.mark.parametrize("bad_addr", ["@example.com", "me@", "me@localhost", "no domain@"])
     def test_export_rejects_malformed_sender(self, bad_addr):
@@ -527,7 +564,7 @@ class TestEmailLabelsetExporter:
 
         exp = get_exporter("email_smtp")
         with pytest.raises(ValueError, match="Sender"):
-            exp.export(SAMPLE_RESULTS, {"from": bad_addr, "to": "you@example.com"})
+            exp.export_find_results(SAMPLE_RESULTS, {"from": bad_addr, "to": "you@example.com"})
 
     def test_is_valid_email_accepts_normal_addresses(self):
         from vtscore.exporters.email_smtp import _is_valid_email
@@ -552,7 +589,7 @@ class TestEmailLabelsetExporter:
             patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
             patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
         ):
-            result = exp.export(
+            result = exp.export_find_results(
                 SAMPLE_RESULTS,
                 {"from": "me@my-domain.example", "to": "you@example.com"},
             )
@@ -578,6 +615,14 @@ class TestEmailLabelsetExporter:
 
         return email.message_from_string(raw_msg)["Subject"]
 
+    def _sent_bodies(self, mock_server) -> list[str]:
+        """Return the decoded text of every MIME part of the sent message."""
+        import email
+
+        _, _, raw_msg = mock_server.sendmail.call_args.args
+        msg = email.message_from_string(raw_msg)
+        return [part.get_payload(decode=True).decode("utf-8") for part in msg.walk() if not part.is_multipart()]
+
     def test_custom_subject_is_used(self):
         from vtscore.exporters import get_exporter
 
@@ -588,7 +633,7 @@ class TestEmailLabelsetExporter:
             patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
             patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
         ):
-            exp.export(
+            exp.export_find_results(
                 SAMPLE_RESULTS,
                 {"from": "me@my-domain.example", "to": "you@example.com", "subject": "Nightly run 2026-07-14"},
             )
@@ -605,7 +650,7 @@ class TestEmailLabelsetExporter:
             patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
             patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
         ):
-            exp.export(
+            exp.export_find_results(
                 SAMPLE_RESULTS,
                 {"from": "me@my-domain.example", "to": "you@example.com", "subject": ""},
             )
@@ -631,6 +676,237 @@ class TestEmailLabelsetExporter:
         assert "dog_bark" in html
         assert "cat_meow" in html
         assert "bark1.wav" in html
+
+    # -- labelset mode (issue #3219) --------------------------------------
+    #
+    # Before this existed the exporter understood only the scored-run shape,
+    # while both pickers offered it for either. A labelset export therefore
+    # mailed an empty body under a "0 hit(s) on unknown dataset" subject and
+    # still reported success. Nothing tested it, which is why it survived.
+
+    def test_labelset_email_carries_the_labels(self):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        mock_server, mock_smtp_cls = self._mock_smtp()
+
+        with (
+            patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
+            patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
+        ):
+            result = exp.export_labelset(
+                SAMPLE_LABELSET,
+                {"from": "me@my-domain.example", "to": "you@example.com"},
+            )
+
+        # The MIME parts are base64-encoded, so decode rather than substring-
+        # matching the raw envelope.
+        bodies = self._sent_bodies(mock_server)
+        assert any("one.wav" in b for b in bodies)
+        assert any("three.wav" in b for b in bodies)
+        assert "3 label(s)" in result["message"]
+
+    def test_labelset_subject_counts_labels_not_hits(self):
+        from vtscore.exporters import get_exporter
+
+        exp = get_exporter("email_smtp")
+        mock_server, mock_smtp_cls = self._mock_smtp()
+
+        with (
+            patch("vtscore.exporters.email_smtp._resolve_mx", return_value="mx.example.com"),
+            patch("vtscore.exporters.email_smtp.smtplib.SMTP", mock_smtp_cls),
+        ):
+            exp.export_labelset(
+                SAMPLE_LABELSET,
+                {"from": "me@my-domain.example", "to": "you@example.com", "subject": ""},
+            )
+
+        subject = self._sent_subject(mock_server)
+        assert "3 label(s)" in subject
+        assert "2 good, 1 bad" in subject
+        # The regression itself: the find-results subject, on a labelset.
+        assert "0 hit(s)" not in subject
+
+    def test_labelset_builders_render_label_origin_and_name(self):
+        from vtscore.exporters.email_smtp import _build_labelset_html, _build_labelset_plain
+
+        text = _build_labelset_plain(SAMPLE_LABELSET)
+        html = _build_labelset_html(SAMPLE_LABELSET)
+        for body in (text, html):
+            assert "one.wav" in body
+            assert "good" in body
+            assert "bad" in body
+        assert "<html>" in html
+
+    def test_labelset_builders_tolerate_a_malformed_origin(self):
+        """A bad origin must not sink an otherwise deliverable email."""
+        from vtscore.exporters.email_smtp import _build_labelset_plain
+
+        text = _build_labelset_plain({"labels": [{"md5": "z", "label": "good", "origin": {"nope": 1}}]})
+        assert "good" in text
+
+
+# ---------------------------------------------------------------------------
+# Payload kinds (issue #3219)
+# ---------------------------------------------------------------------------
+
+
+class TestSupportedPayloads:
+    """``supported_payloads`` is derived from the overrides, never declared."""
+
+    def test_in_tree_exporters_declare_what_they_can_read(self):
+        from vtscore.exporters import list_exporters
+
+        actual = {e.name: sorted(e.supported_payloads) for e in list_exporters()}
+        assert actual == {
+            "email_smtp": ["find_results", "labelset"],
+            "gui": ["find_results", "labelset"],
+            "holder": ["labelset"],
+            "open_url": ["find_results", "labelset"],
+            "portable_detector": ["detector_bundles"],
+            "server_csv_file": ["find_results", "labelset"],
+            "server_json_file": ["find_results", "labelset"],
+            "webhook": ["find_results", "labelset"],
+        }
+
+    def test_a_legacy_export_only_exporter_still_works_and_claims_both(self):
+        """The compatibility hinge: an out-of-tree plugin needs no changes.
+
+        It implements ``export()`` and sniffs the dict shape itself, so both
+        named methods route to it, and it is credited with both kinds because
+        nothing can tell which it actually handles.
+        """
+        from vtscore.exporters.base import ResultsExporter
+
+        class Legacy(ResultsExporter):
+            name = "legacy_probe"
+            fields = []
+
+            def export(self, results, field_values):
+                return {"message": "labels" if "labels" in results else "find"}
+
+        exp = Legacy()
+        assert sorted(exp.supported_payloads) == ["find_results", "labelset"]
+        assert exp.export_labelset({"labels": []}, {})["message"] == "labels"
+        assert exp.export_find_results({"results": {}}, {})["message"] == "find"
+
+    def test_overriding_one_named_method_claims_only_that_kind(self):
+        from vtscore.exporters.base import ResultsExporter
+
+        class LabelsOnly(ResultsExporter):
+            name = "labels_only_probe"
+            fields = []
+
+            def export_labelset(self, labelset, field_values):
+                return {"message": "ok"}
+
+        assert sorted(LabelsOnly().supported_payloads) == ["labelset"]
+
+    def test_a_subclass_inherits_its_parents_kinds(self):
+        from vtscore.exporters import get_exporter
+
+        class Narrowed(type(get_exporter("holder"))):
+            name = "holder_subclass_probe"
+
+        assert sorted(Narrowed().supported_payloads) == ["labelset"]
+
+    def test_get_exporters_reports_the_kinds(self, client):
+        res = client.get("/api/exporters")
+        assert res.status_code == 200
+        by_name = {e["name"]: e for e in res.get_json()}
+        assert by_name["server_csv_file"]["supported_payloads"] == ["find_results", "labelset"]
+
+
+class TestPayloadKindRouting:
+    """The route dispatches on the declared kind rather than sniffing."""
+
+    def test_labelset_kind_reaches_export_labelset(self, client, tmp_path):
+        from vtscore.exporters import get_exporter
+
+        exporter = get_exporter("server_json_file")
+        with patch.object(type(exporter), "export_labelset", return_value={"message": "ok"}) as spy:
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": str(tmp_path / "x.json")},
+                    "results": {"labels": []},
+                    "payload_kind": "labelset",
+                },
+            )
+        assert res.status_code == 200
+        spy.assert_called_once()
+
+    def test_find_results_kind_reaches_export_find_results(self, client, tmp_path):
+        from vtscore.exporters import get_exporter
+
+        exporter = get_exporter("server_json_file")
+        with patch.object(type(exporter), "export_find_results", return_value={"message": "ok"}) as spy:
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": str(tmp_path / "x.json")},
+                    "results": SAMPLE_RESULTS,
+                    "payload_kind": "find_results",
+                },
+            )
+        assert res.status_code == 200
+        spy.assert_called_once()
+
+    def test_an_unsupported_pairing_is_a_400_not_a_silent_empty_export(self, client):
+        """The bug this contract exists to make impossible.
+
+        Holder reads labels only. Asked for a scored run it must be refused
+        outright, rather than handed a shape it cannot read and left to deliver
+        nothing while reporting success.
+        """
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "holder",
+                "field_values": {},
+                "results": SAMPLE_RESULTS,
+                "payload_kind": "find_results",
+            },
+        )
+        assert res.status_code == 400
+        message = res.get_json()["message"]
+        assert "find_results" in message
+        assert "labelset" in message
+
+    def test_an_unknown_kind_is_rejected_by_the_schema(self, client):
+        res = client.post(
+            "/api/exporters/export",
+            json={
+                "exporter_name": "server_json_file",
+                "field_values": {},
+                "results": {},
+                "payload_kind": "nonsense",
+            },
+        )
+        assert res.status_code == 422
+
+    @pytest.mark.parametrize(
+        "payload,method",
+        [({"labels": []}, "export_labelset"), ({"results": {}}, "export_find_results")],
+    )
+    def test_an_omitted_kind_falls_back_to_the_shape(self, client, tmp_path, payload, method):
+        """Pre-payload-kind API clients keep working."""
+        from vtscore.exporters import get_exporter
+
+        exporter = get_exporter("server_json_file")
+        with patch.object(type(exporter), method, return_value={"message": "ok"}) as spy:
+            res = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": "server_json_file",
+                    "field_values": {"filepath": str(tmp_path / "x.json")},
+                    "results": payload,
+                },
+            )
+        assert res.status_code == 200
+        spy.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -894,7 +1170,7 @@ class TestExportEndpoint:
 
         with caplog.at_level(logging.ERROR, logger="vtsearch.routes.labels.exporters"):
             with patch(
-                "vtscore.exporters.server_json_file.ServerJsonLabelsetExporter.export",
+                "vtscore.exporters.server_json_file.ServerJsonResultsExporter.export_find_results",
                 side_effect=OSError("No space left on device"),
             ):
                 res = client.post(
@@ -918,7 +1194,7 @@ class TestExportEndpoint:
 
         with caplog.at_level(logging.ERROR, logger="vtsearch.routes.labels.exporters"):
             with patch(
-                "vtscore.exporters.server_json_file.ServerJsonLabelsetExporter.export",
+                "vtscore.exporters.server_json_file.ServerJsonResultsExporter.export_find_results",
                 side_effect=PermissionError("Permission denied"),
             ):
                 res = client.post(
@@ -1000,7 +1276,7 @@ class TestOpenUrlResponseKey:
         exporter = get_exporter("gui")
         with patch.object(
             type(exporter),
-            "export",
+            "export_find_results",
             return_value={"message": "done", "open_url": "javascript:alert(1)"},
         ):
             res = client.post(
@@ -1017,7 +1293,7 @@ class TestOpenUrlResponseKey:
         exporter = get_exporter("gui")
         with patch.object(
             type(exporter),
-            "export",
+            "export_find_results",
             return_value={"message": "done", "open_url": "http://localhost:9000/viewer"},
         ):
             res = client.post(

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -621,7 +621,14 @@ class TestEmailResultsExporter:
 
         _, _, raw_msg = mock_server.sendmail.call_args.args
         msg = email.message_from_string(raw_msg)
-        return [part.get_payload(decode=True).decode("utf-8") for part in msg.walk() if not part.is_multipart()]
+        bodies = []
+        for part in msg.walk():
+            if part.is_multipart():
+                continue
+            payload = part.get_payload(decode=True)
+            assert isinstance(payload, bytes)
+            bodies.append(payload.decode("utf-8"))
+        return bodies
 
     def test_custom_subject_is_used(self):
         from vtscore.exporters import get_exporter

--- a/tests_lib/core/test_ssrf_validation.py
+++ b/tests_lib/core/test_ssrf_validation.py
@@ -668,10 +668,10 @@ class TestWebhookExporterSSRF:
         # Phase B: ``validate_url`` runs at the framework boundary, not
         # inside ``exp.export()``.  Verify the framework's normalize
         # pass fires on the exporter's declared ``url`` field.
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         with mock.patch(
             "vtscore.security.url_validation.socket.getaddrinfo",
             return_value=[(2, 1, 0, "", ("192.168.1.1", 0))],
@@ -680,17 +680,17 @@ class TestWebhookExporterSSRF:
                 normalize_field_values(exp, {"url": "http://192.168.1.1:9090/hook"})
 
     def test_export_rejects_non_http_scheme(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
         from vtscore.plugins.normalize import normalize_field_values
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         with pytest.raises(ValueError, match="http or https"):
             normalize_field_values(exp, {"url": "ftp://evil.example/hook"})
 
     def test_export_allows_public_url(self):
-        from vtscore.exporters.webhook import WebhookLabelsetExporter
+        from vtscore.exporters.webhook import WebhookResultsExporter
 
-        exp = WebhookLabelsetExporter()
+        exp = WebhookResultsExporter()
         mock_resp = mock.MagicMock()
         mock_resp.status_code = 200
         mock_resp.raise_for_status.return_value = None
@@ -700,7 +700,7 @@ class TestWebhookExporterSSRF:
             return_value=[(2, 1, 0, "", ("93.184.216.34", 0))],
         ):
             with mock.patch("requests.Session.post", return_value=mock_resp):
-                result = exp.export(
+                result = exp.export_find_results(
                     {"detectors_run": 0, "results": {}},
                     {"url": "https://example.com/hook"},
                 )

--- a/tests_lib/io/test_csv_label_roundtrip.py
+++ b/tests_lib/io/test_csv_label_roundtrip.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import csv
 
-from vtscore.exporters.server_csv_file import ServerCsvLabelsetExporter
+from vtscore.exporters.server_csv_file import ServerCsvResultsExporter
 from vtscore.labels.importers.server_csv_file import _parse_csv_bytes
 
 # Names that begin with each formula prefix the exporter escapes.  Tab and
@@ -24,7 +24,7 @@ _TRICKY_NAMES = ["-take2.wav", "@handle_post.txt", "=mc2.wav", "+1_more.wav"]
 
 def _export_then_import(labels, tmp_path, columns=None):
     filepath = tmp_path / "labels.csv"
-    ServerCsvLabelsetExporter().export(
+    ServerCsvResultsExporter().export_labelset(
         {"labels": labels, "selected_columns": columns or ["label", "md5", "origin_name", "filename", "category"]},
         {"filepath": str(filepath)},
     )
@@ -57,7 +57,7 @@ class TestCsvLabelRoundTrip:
     def test_written_csv_still_escapes_for_spreadsheets(self, tmp_path):
         """De-sanitizing on read must not weaken the on-disk escaping."""
         filepath = tmp_path / "labels.csv"
-        ServerCsvLabelsetExporter().export(
+        ServerCsvResultsExporter().export_labelset(
             {
                 "labels": [{"label": "good", "md5": "abc123", "filename": "-take2.wav"}],
                 "selected_columns": ["label", "md5", "filename"],

--- a/tests_lib/io/test_open_url_exporter.py
+++ b/tests_lib/io/test_open_url_exporter.py
@@ -16,7 +16,7 @@ import pytest
 from vtscore import cli_progress
 from vtscore.cli import _run_exporter
 from vtscore.exporters import get_exporter
-from vtscore.exporters.open_url import MAX_URL_LENGTH, OpenUrlLabelsetExporter
+from vtscore.exporters.open_url import MAX_URL_LENGTH, OpenUrlResultsExporter
 
 LABELSET = {
     "labels": [
@@ -58,8 +58,8 @@ def _stub_gui_cli_export(outcome: dict):
 
 
 @pytest.fixture
-def exporter() -> OpenUrlLabelsetExporter:
-    return OpenUrlLabelsetExporter()
+def exporter() -> OpenUrlResultsExporter:
+    return OpenUrlResultsExporter()
 
 
 class TestOpenUrlRegistration:
@@ -78,34 +78,34 @@ class TestOpenUrlRegistration:
 
 class TestUrlFormatting:
     def test_substitutes_ids_from_labelset(self, exporter):
-        out = exporter.export(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
+        out = exporter.export_labelset(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
         assert _ids_param(out["open_url"]) == "aaa1,bbb2,ccc3"
 
     def test_substitutes_ids_from_autodetect_results(self, exporter):
-        out = exporter.export(AUTODETECT_RESULTS, {"url_template": "https://example.com/r?ids={ids}"})
+        out = exporter.export_find_results(AUTODETECT_RESULTS, {"url_template": "https://example.com/r?ids={ids}"})
         assert _ids_param(out["open_url"]) == "aaa1,bbb2"
 
     def test_substitutes_count(self, exporter):
-        out = exporter.export(LABELSET, {"url_template": "https://example.com/r?n={count}"})
+        out = exporter.export_labelset(LABELSET, {"url_template": "https://example.com/r?n={count}"})
         assert _ids_param(out["open_url"], "n") == "3"
 
     def test_id_field_selects_the_identifier(self, exporter):
-        out = exporter.export(
+        out = exporter.export_labelset(
             LABELSET,
             {"url_template": "https://example.com/r?ids={ids}", "id_field": "filename"},
         )
         assert _ids_param(out["open_url"]) == "one.wav,two.wav,three.wav"
 
     def test_falls_back_to_custom_metadata(self, exporter):
-        results = {"labels": [{"md5": "aaa1", "custom_metadata": {"asset_id": "XY-7"}}]}
-        out = exporter.export(
-            results,
+        labelset = {"labels": [{"md5": "aaa1", "custom_metadata": {"asset_id": "XY-7"}}]}
+        out = exporter.export_labelset(
+            labelset,
             {"url_template": "https://example.com/r?ids={ids}", "id_field": "asset_id"},
         )
         assert _ids_param(out["open_url"]) == "XY-7"
 
     def test_separator_is_url_encoded_not_literal(self, exporter):
-        out = exporter.export(
+        out = exporter.export_labelset(
             LABELSET,
             {"url_template": "https://example.com/r?ids={ids}", "separator": "/"},
         )
@@ -114,33 +114,33 @@ class TestUrlFormatting:
         assert _ids_param(out["open_url"]) == "aaa1/bbb2/ccc3"
 
     def test_items_without_the_identifier_are_skipped(self, exporter):
-        results = {"labels": [{"md5": "aaa1"}, {"filename": "no-md5.wav"}]}
-        out = exporter.export(results, {"url_template": "https://example.com/r?ids={ids}"})
+        labelset = {"labels": [{"md5": "aaa1"}, {"filename": "no-md5.wav"}]}
+        out = exporter.export_labelset(labelset, {"url_template": "https://example.com/r?ids={ids}"})
         assert _ids_param(out["open_url"]) == "aaa1"
 
     def test_template_without_placeholders_opens_the_site(self, exporter):
-        out = exporter.export(LABELSET, {"url_template": "https://example.com/review"})
+        out = exporter.export_labelset(LABELSET, {"url_template": "https://example.com/review"})
         assert out["open_url"] == "https://example.com/review"
 
     def test_empty_labelset_yields_an_empty_id_list(self, exporter):
-        out = exporter.export({"labels": []}, {"url_template": "https://example.com/r?ids={ids}"})
+        out = exporter.export_labelset({"labels": []}, {"url_template": "https://example.com/r?ids={ids}"})
         assert out["open_url"] == "https://example.com/r?ids="
         assert out["total_count"] == 0
 
     def test_spaces_from_template_substitution_are_encoded(self, exporter):
         # ``{detector_name}`` is substituted by the framework *before* export()
         # sees the value, and a detector name may contain spaces.
-        out = exporter.export(LABELSET, {"url_template": "https://example.com/r?d=Bird Calls"})
+        out = exporter.export_labelset(LABELSET, {"url_template": "https://example.com/r?d=Bird Calls"})
         assert out["open_url"] == "https://example.com/r?d=Bird%20Calls"
 
     def test_rejects_control_characters(self, exporter):
         with pytest.raises(ValueError, match="control characters"):
-            exporter.export(LABELSET, {"url_template": "https://example.com/r?d=a\nb"})
+            exporter.export_labelset(LABELSET, {"url_template": "https://example.com/r?d=a\nb"})
 
 
 class TestTruncation:
     def test_truncates_to_max_items(self, exporter):
-        out = exporter.export(
+        out = exporter.export_labelset(
             LABELSET,
             {"url_template": "https://example.com/r?ids={ids}", "max_items": "2"},
         )
@@ -149,14 +149,14 @@ class TestTruncation:
         assert out["total_count"] == 3
 
     def test_truncation_is_reported_in_the_message(self, exporter):
-        out = exporter.export(
+        out = exporter.export_labelset(
             LABELSET,
             {"url_template": "https://example.com/r?ids={ids}", "max_items": "2"},
         )
         assert "first 2 of 3" in out["message"]
 
     def test_untruncated_message_omits_the_first_n_phrasing(self, exporter):
-        out = exporter.export(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
+        out = exporter.export_labelset(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
         assert "first" not in out["message"]
         assert out["included_count"] == out["total_count"] == 3
 
@@ -178,30 +178,30 @@ class TestRejection:
     )
     def test_rejects_non_http_schemes(self, exporter, template):
         with pytest.raises(ValueError, match="http or https"):
-            exporter.export(LABELSET, {"url_template": template})
+            exporter.export_labelset(LABELSET, {"url_template": template})
 
     def test_rejects_relative_url(self, exporter):
         with pytest.raises(ValueError, match="http or https"):
-            exporter.export(LABELSET, {"url_template": "/review?ids={ids}"})
+            exporter.export_labelset(LABELSET, {"url_template": "/review?ids={ids}"})
 
     def test_rejects_empty_template(self, exporter):
         with pytest.raises(ValueError, match="required"):
-            exporter.export(LABELSET, {"url_template": "   "})
+            exporter.export_labelset(LABELSET, {"url_template": "   "})
 
     def test_rejects_url_over_the_length_limit(self, exporter):
-        results = {"labels": [{"md5": "x" * 100} for _ in range(100)]}
+        labelset = {"labels": [{"md5": "x" * 100} for _ in range(100)]}
         with pytest.raises(ValueError, match="over the"):
-            exporter.export(results, {"url_template": "https://example.com/r?ids={ids}"})
+            exporter.export_labelset(labelset, {"url_template": "https://example.com/r?ids={ids}"})
 
     def test_length_error_names_the_knob_to_turn(self, exporter):
-        results = {"labels": [{"md5": "x" * 100} for _ in range(100)]}
+        labelset = {"labels": [{"md5": "x" * 100} for _ in range(100)]}
         with pytest.raises(ValueError, match="Max items"):
-            exporter.export(results, {"url_template": "https://example.com/r?ids={ids}"})
+            exporter.export_labelset(labelset, {"url_template": "https://example.com/r?ids={ids}"})
 
     def test_lowering_max_items_brings_it_under_the_limit(self, exporter):
-        results = {"labels": [{"md5": "x" * 100} for _ in range(100)]}
-        out = exporter.export(
-            results,
+        labelset = {"labels": [{"md5": "x" * 100} for _ in range(100)]}
+        out = exporter.export_labelset(
+            labelset,
             {"url_template": "https://example.com/r?ids={ids}", "max_items": "10"},
         )
         assert len(out["open_url"]) <= MAX_URL_LENGTH
@@ -215,18 +215,18 @@ class TestCliExport:
     """
 
     def test_returns_the_url(self, exporter):
-        out = exporter.export_cli(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
-        assert _ids_param(out["open_url"]) == "aaa1,bbb2,ccc3"
+        out = exporter.export_cli(AUTODETECT_RESULTS, {"url_template": "https://example.com/r?ids={ids}"})
+        assert _ids_param(out["open_url"]) == "aaa1,bbb2"
 
     def test_reports_truncation_in_the_message(self, exporter):
         out = exporter.export_cli(
-            LABELSET,
+            AUTODETECT_RESULTS,
             {"url_template": "https://example.com/r?ids={ids}", "max_items": "1"},
         )
-        assert "first 1 of 3" in out["message"]
+        assert "first 1 of 2" in out["message"]
 
     def test_writes_nothing_to_stdout(self, exporter, capsys):
-        exporter.export_cli(LABELSET, {"url_template": "https://example.com/r?ids={ids}"})
+        exporter.export_cli(AUTODETECT_RESULTS, {"url_template": "https://example.com/r?ids={ids}"})
         assert capsys.readouterr().out == ""
 
 
@@ -242,30 +242,30 @@ class TestCliSurfacesOpenUrl:
     TEMPLATE = {"url_template": "https://example.com/r?ids={ids}"}
 
     def test_prints_the_url_under_the_message(self, capsys):
-        _run_exporter("open_url", dict(self.TEMPLATE), LABELSET)
+        _run_exporter("open_url", dict(self.TEMPLATE), AUTODETECT_RESULTS)
         out = capsys.readouterr().out
-        assert "Formatted a URL covering 3 item(s)." in out
-        assert "https://example.com/r?ids=aaa1%2Cbbb2%2Cccc3" in out
+        assert "Formatted a URL covering 2 item(s)." in out
+        assert "https://example.com/r?ids=aaa1%2Cbbb2" in out
 
     def test_carries_the_url_on_the_json_event(self, capsys):
         cli_progress.set_format("json")
-        _run_exporter("open_url", dict(self.TEMPLATE), LABELSET)
+        _run_exporter("open_url", dict(self.TEMPLATE), AUTODETECT_RESULTS)
         lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.strip()]
         assert len(lines) == 1, "the URL must not be printed as prose alongside the NDJSON event"
         event = json.loads(lines[0])
         assert event["event"] == "export_complete"
-        assert _ids_param(event["open_url"]) == "aaa1,bbb2,ccc3"
+        assert _ids_param(event["open_url"]) == "aaa1,bbb2"
 
     def test_exporters_without_a_url_are_unchanged(self, capsys):
         with _stub_gui_cli_export({"message": "Wrote it."}):
-            _run_exporter("gui", {}, LABELSET)
+            _run_exporter("gui", {}, AUTODETECT_RESULTS)
         assert capsys.readouterr().out == "Wrote it.\n"
 
     def test_unusable_url_is_dropped_rather_than_shown(self, capsys):
         """A plugin must not be able to put a ``javascript:`` URL in front of
         the user — but the export itself already ran, so it isn't failed."""
         with _stub_gui_cli_export({"message": "Wrote it.", "open_url": "javascript:alert(1)"}):
-            _run_exporter("gui", {}, LABELSET)
+            _run_exporter("gui", {}, AUTODETECT_RESULTS)
         out = capsys.readouterr().out
         assert "javascript:" not in out
         assert "Wrote it." in out

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -12,6 +12,26 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **Results exporters declare which payload kinds they handle, instead of
+  sniffing the dict shape.** `LabelsetExporter` is now `ResultsExporter`
+  (the old name stays as a permanent module-level alias), and it exposes
+  `export_find_results()` and `export_labelset()` alongside the existing
+  `export_cli_detectors()`. `supported_payloads` is derived from which of
+  those a subclass overrides, so each picker offers an exporter only for the
+  kinds it can actually read and the export route answers 400 - rather than
+  letting an exporter be handed a shape it doesn't understand and deliver an
+  empty export while reporting success. `email_smtp` gained a labelset mode
+  it never had.
+
+  **Existing exporters keep working with no changes.** The default
+  `export_find_results()` / `export_labelset()` both delegate to `export()`,
+  so a plugin written against the single-method contract still runs and still
+  does its own `if "labels" in results` check; it is credited with both
+  payload kinds and logs one line at import pointing at the named methods.
+  Migrating is a mechanical split of that `if` into two methods, and buys
+  accurate picker filtering. See
+  [`vtscore/docs/extending/results-exporters.md`](docs/extending/results-exporters.md).
+
 - **`RemoteUnreachableError` now also covers a retryable HTTP status that
   outlives the retry budget.** `download_file_with_progress` and
   `fetch_text_with_retry` used to end a run of 500/502/503/504/429 responses by

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -538,7 +538,7 @@ def _run_exporter(
     Most exporters consume the scored *results*.  An exporter that instead
     exports the trained classifiers themselves (``needs_trained_detectors``,
     the portable-detector bundle) is handed the *detector_mlps* the pipeline
-    trained, via :meth:`LabelsetExporter.export_cli_detectors`.
+    trained, via :meth:`ResultsExporter.export_cli_detectors`.
 
     An exporter that returns an ``open_url`` gets it surfaced here rather than
     dropped: there is no browser to open it on the command line, so the URL is
@@ -554,7 +554,7 @@ def _run_exporter(
         raise ValueError(f"Unknown exporter: {exporter_name}. Available: {', '.join(available)}")
 
     exporter.validate_cli_field_values(field_values)
-    if getattr(exporter, "needs_trained_detectors", False):
+    if "detector_bundles" in exporter.supported_payloads:
         descriptors = _portable_detector_descriptors(detector_mlps or {})
         result = exporter.export_cli_detectors(descriptors, field_values)
     else:
@@ -598,7 +598,7 @@ def _portable_detector_descriptors(detector_mlps: dict[str, dict[str, Any]]) -> 
     """Serialise each trained detector into a portable-export descriptor.
 
     Turns the pipeline's ``{name: {"mlp", "threshold", ...}}`` map into the
-    list of plain-data dicts :meth:`LabelsetExporter.export_cli_detectors`
+    list of plain-data dicts :meth:`ResultsExporter.export_cli_detectors`
     consumes - the live torch model is reduced to nested-list weights here so
     the exporter itself stays torch-free.
     """

--- a/vtscore/docs/extending/results-exporters.md
+++ b/vtscore/docs/extending/results-exporters.md
@@ -1,4 +1,4 @@
-# Writing a `LabelsetExporter`
+# Writing a `ResultsExporter`
 
 A results exporter sends autodetect output or a label export to a
 destination - a file on the server, a webhook, an email, a queue, an
@@ -6,16 +6,14 @@ S3 object, anything reachable from the Python process. The library
 auto-discovers exporters under `vtscore.exporters` (sentinel
 `EXPORTER`) and walks the `vtscore.exporters` entry-point group so a
 third-party distribution can `pip install` one in. Subclass
-[`LabelsetExporter`](../../exporters/base.py)
+[`ResultsExporter`](../../exporters/base.py)
 ([`vtscore/exporters/base.py`](../../exporters/base.py)), declare
-your `fields`, and implement `export(results, field_values) -> dict`.
+your `fields`, and implement a method per payload kind you support.
 
-The base class is named `LabelsetExporter` for historical reasons; in
-practice it handles both autodetect-results payloads and label
-exports. The `export()` method should detect which is which (label
-payloads carry a top-level `"labels"` key - see
-[`vtscore/exporters/server_json_file/__init__.py`](../../exporters/server_json_file/__init__.py)
-for the pattern).
+The class was called `LabelsetExporter` for historical reasons, which
+described one of the three payloads it has always accepted. It is now
+`ResultsExporter`; `LabelsetExporter` remains a permanent module-level
+alias, so existing imports and subclasses keep working untouched.
 
 **App-side counterpart:** [`docs/EXTENDING-plugins.md § Adding a
 Results Exporter`](../../../docs/EXTENDING-plugins.md#adding-a-results-exporter)
@@ -25,7 +23,7 @@ and third-party packaging.
 ## Contents
 
 - [The contract](#the-contract)
-- [Two payload shapes](#two-payload-shapes)
+- [Payload kinds](#payload-kinds)
 - [Template-variable interpolation](#template-variable-interpolation)
 - [Server-path and URL validation](#server-path-and-url-validation)
 - [Opening a URL in the browser](#opening-a-url-in-the-browser)
@@ -35,7 +33,7 @@ and third-party packaging.
 
 ## The contract
 
-`LabelsetExporter` is a `PluginBase` subclass. Required overrides:
+`ResultsExporter` is a `PluginBase` subclass. Required overrides:
 
 | Member | Type | Purpose |
 |--------|------|---------|
@@ -43,7 +41,7 @@ and third-party packaging.
 | `display_name: str` | class attr | Human-readable label |
 | `description: str` | class attr | One-sentence subtitle |
 | `fields: list[PluginField]` | class attr | User-configurable inputs |
-| `export(results, field_values)` | method | Perform the export; return a dict with at least `"message"` |
+| a payload method | method | At least one of `export_find_results()` / `export_labelset()` / `export_cli_detectors()`; return a dict with at least `"message"` |
 
 Optional overrides:
 
@@ -51,7 +49,8 @@ Optional overrides:
 |--------|---------|---------|
 | `icon: str` | `"📤"` | Emoji rendered in the UI |
 | `opens_url: bool` | `False` | Set `True` when `export()` always returns an `"open_url"` - see [Opening a URL in the browser](#opening-a-url-in-the-browser) |
-| `export_cli(results, field_values)` | delegates to `export()` | Override only when CLI-supplied values need different handling (rare) |
+| `export(results, field_values)` | raises | Legacy single-method form. The named methods delegate here when unoverridden, which keeps pre-existing plugins working; prefer the named methods in new code |
+| `export_cli(results, field_values)` | delegates to `export_find_results()` | Override only when CLI-supplied values need different handling (rare) |
 
 Expose `EXPORTER = YourExporter()` at module level so the registry
 picks it up. The sentinel must be an already-instantiated object, not
@@ -63,9 +62,22 @@ the API response. Two of those keys mean something to the frontend:
 `"display_results"` (rendered in the Auto-Detect Results modal) and
 `"open_url"` (opened in a new browser tab - see below).
 
-## Two payload shapes
+## Payload kinds
 
-Exporters receive one of two dict shapes and should detect which:
+An exporter is a *destination*; what gets sent there is a separate
+axis. There are three payload kinds, each with its own method:
+
+| Kind | Method | What it is |
+|------|--------|------------|
+| `find_results` | `export_find_results()` | a scored run - hit lists, scores, thresholds |
+| `labelset` | `export_labelset()` | a detector's labels - origins and vote provenance |
+| `detector_bundles` | `export_cli_detectors()` | the trained classifiers themselves |
+
+`supported_payloads` is **derived** from which of these you overrode
+(never declared, so there is nothing to forget), and it is what each
+picker filters on: an exporter is only offered for the kinds it claims,
+and the route answers 400 for anything else rather than letting it
+deliver an empty export.
 
 **Autodetect results** (from `/api/auto-detect` or CLI autodetect):
 
@@ -97,19 +109,43 @@ Exporters receive one of two dict shapes and should detect which:
 }
 ```
 
-The standard idiom:
+Note that a scored run carries `negative_hits` alongside `hits`, and
+every built-in exporter ignores it: an export is conventionally the
+items the detector *found*. The key is there if you want the
+below-threshold items.
+
+The standard idiom is one method per kind, sharing whatever delivery
+code they have in common:
 
 ```python
-def export(self, results: dict, field_values: dict) -> dict:
-    if "labels" in results:
-        return self._export_labels(results, field_values)
-    return self._export_autodetect(results, field_values)
+def _deliver(self, payload: dict, field_values: dict) -> dict:
+    ...  # the connection / write / POST, identical either way
+
+def export_find_results(self, results: dict, field_values: dict) -> dict:
+    return self._deliver(results, field_values)
+
+def export_labelset(self, labelset: dict, field_values: dict) -> dict:
+    return self._deliver(labelset, field_values)
 ```
 
 The built-in [`server_json_file`](../../exporters/server_json_file/__init__.py),
 [`server_csv_file`](../../exporters/server_csv_file/), and
 [`webhook`](../../exporters/webhook/__init__.py) exporters all follow
-this pattern.
+this pattern. Implement only one when only one makes sense -
+[`holder`](../../exporters/holder/__init__.py) files items by the label
+a human gave them, so it declares `export_labelset()` alone.
+
+### Legacy single-method exporters
+
+Before the kinds were named, an exporter implemented one `export()` and
+told the two dict shapes apart itself with `if "labels" in results`.
+That still works and is not going away: the default
+`export_find_results()` and `export_labelset()` both delegate to
+`export()`, so an out-of-tree plugin written against the old contract
+needs no changes. Such an exporter is credited with *both* kinds - there
+is no way to know which it handles - and logs a line at import time
+pointing here. Migrating is a mechanical split of the `if` into two
+methods, and buys accurate picker filtering.
 
 ## Template-variable interpolation
 
@@ -161,7 +197,7 @@ normalization](README.md#framework-side-normalization) — the correct
 exporter body just uses the value:
 
 ```python
-def export(self, results: dict, field_values: dict) -> dict:
+def export_find_results(self, results: dict, field_values: dict) -> dict:
     path = Path(field_values["filepath"])   # already stripped, substituted, confined
     requests.post(field_values["url"], json=results, timeout=30, allow_redirects=False)
 ```
@@ -204,15 +240,15 @@ from urllib.parse import quote
 from vtscore.security.url_validation import validate_browser_url
 
 
-class ReviewSiteExporter(LabelsetExporter):
+class ReviewSiteExporter(ResultsExporter):
     name = "review_site"
     display_name = "Review Site"
     description = "Open the labelset in the review site."
     opens_url = True          # lets the button read "Open Labelset in Review Site"
     fields = []
 
-    def export(self, results: dict, field_values: dict) -> dict:
-        ids = ",".join(e["md5"] for e in results.get("labels", []))
+    def export_labelset(self, labelset: dict, field_values: dict) -> dict:
+        ids = ",".join(e["md5"] for e in labelset.get("labels", []))
         url = validate_browser_url(f"https://review.example.com/?ids={quote(ids, safe='')}")
         return {"message": "Opening the labelset in Review Site.", "open_url": url}
 ```
@@ -274,7 +310,7 @@ dependencies = ["vtsearch"]
 my_exporter = "my_pkg.exporter:EXPORTER"
 ```
 
-The value must resolve to an already-instantiated `LabelsetExporter`.
+The value must resolve to an already-instantiated `ResultsExporter`.
 After `pip install`, the exporter appears in `list_exporters()`, the
 `/api/exporters` endpoint, the CLI's `--exporter` flag, and `python
 app.py --list-plugins`.
@@ -295,10 +331,10 @@ from typing import Any
 
 import requests
 
-from vtscore.exporters.base import PluginField, LabelsetExporter
+from vtscore.exporters.base import PluginField, ResultsExporter
 
 
-class SignedWebhookExporter(LabelsetExporter):
+class SignedWebhookExporter(ResultsExporter):
     """POST labels to a webhook with an HMAC-SHA256 signature header."""
 
     name = "signed_webhook"
@@ -322,17 +358,17 @@ class SignedWebhookExporter(LabelsetExporter):
         ),
     ]
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        # Only handle label exports; refuse autodetect-results payloads.
-        if "labels" not in results:
-            raise ValueError("signed_webhook exporter only handles label exports.")
-
+    # Declaring only this method is what makes the exporter labelset-only:
+    # `supported_payloads` is derived from the overrides, so it never appears
+    # in a find-results picker and the route refuses a scored run with a 400.
+    # No hand-written shape check needed.
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
         # Both fields are declared and required, so by this point they are
         # stripped, non-empty, and (for the "url" field type) SSRF-checked.
         url = field_values["url"]
         secret = field_values["hmac_secret"].encode("utf-8")
 
-        body = json.dumps(results, sort_keys=True).encode("utf-8")
+        body = json.dumps(labelset, sort_keys=True).encode("utf-8")
         signature = hmac.new(secret, body, hashlib.sha256).hexdigest()
 
         resp = requests.post(
@@ -347,7 +383,7 @@ class SignedWebhookExporter(LabelsetExporter):
         )
         resp.raise_for_status()
 
-        n = len(results["labels"])
+        n = len(labelset["labels"])
         return {
             "message": f"Posted {n} label(s) to {url} (HTTP {resp.status_code}).",
             "status_code": resp.status_code,

--- a/vtscore/exporters/__init__.py
+++ b/vtscore/exporters/__init__.py
@@ -1,8 +1,8 @@
-"""Labelset-exporter registry with auto-discovery.
+"""Results-exporter registry with auto-discovery.
 
 Any package placed directly under this directory is automatically registered
 if it exposes a module-level ``EXPORTER`` attribute that is a
-:class:`~vtscore.exporters.base.LabelsetExporter` instance.
+:class:`~vtscore.exporters.base.ResultsExporter` instance.
 
 Usage::
 

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -52,11 +52,37 @@ verifies that every imported package is declared there.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Iterator
 
 from vtscore.plugins import PluginBase, PluginField
 
-__all__ = ["LabelsetExporter", "PluginField", "resolve_stream_batch_size"]
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PAYLOAD_KINDS",
+    "LabelsetExporter",
+    "PluginField",
+    "ResultsExporter",
+    "UnsupportedPayloadError",
+    "resolve_stream_batch_size",
+]
+
+#: Every payload kind an exporter can be handed, in the order they are
+#: documented.  ``find_results`` is a scored run (hit lists); ``labelset`` is a
+#: detector's labels (origins and vote provenance); ``detector_bundles`` is the
+#: trained classifiers themselves.  See :class:`ResultsExporter`.
+PAYLOAD_KINDS: tuple[str, ...] = ("find_results", "labelset", "detector_bundles")
+
+
+class UnsupportedPayloadError(ValueError):
+    """Raised when an exporter is handed a payload kind it does not implement.
+
+    A :class:`ValueError` subclass so ``POST /api/exporters/export`` turns it
+    into a 400 through the handler's existing ``except ValueError`` arm rather
+    than a 500: asking a labelset-only exporter for a find-results export is a
+    bad request, not a server fault.
+    """
 
 
 def resolve_stream_batch_size(value: Any, default: int = 500) -> int:
@@ -80,23 +106,94 @@ def resolve_stream_batch_size(value: Any, default: int = 500) -> int:
     return n if n > 0 else default
 
 
-class LabelsetExporter(PluginBase):
+class ResultsExporter(PluginBase):
     """Abstract base class for results exporters.
 
-    Subclass this, set the class-level attributes, implement :meth:`export`,
-    and expose a module-level ``EXPORTER = YourExporter()`` – the registry
-    picks it up automatically.
+    Subclass this, set the class-level attributes, implement the payload
+    method(s) you support, and expose a module-level
+    ``EXPORTER = YourExporter()`` – the registry picks it up automatically.
 
-    The :meth:`export` method receives the full results dict returned by
-    ``/api/auto-detect`` and a flat mapping of field values supplied by the
-    user via the UI.  It should return a dict with at minimum a ``"message"``
-    key describing what happened (shown to the user as confirmation).
+    Payload kinds
+    -------------
+    An exporter is a *destination* (a file, an SMTP server, a webhook, a
+    browser tab).  What gets sent there is a separate axis, and there are three
+    kinds:
 
-    Exporters that can write results incrementally (for the CLI
+    ``find_results``
+        A scored run: hit lists per detector, with scores and thresholds.
+        Implement :meth:`export_find_results`.  Produced by
+        ``POST /api/auto-detect``, the Auto-Find auto-export, and CLI
+        ``--autodetect``.
+
+    ``labelset``
+        A detector's labels: origins, vote provenance, and the metadata that
+        makes the export re-importable.  Implement :meth:`export_labelset`.
+        Produced by the Export modal.
+
+    ``detector_bundles``
+        The trained classifiers themselves, for a portable scoring bundle.
+        Implement :meth:`export_cli_detectors` (CLI/pipeline path only).
+
+    Most destinations can carry more than one kind, and many carry two: a CSV
+    file is a fine home for either a scored run or a labelset.  Implement each
+    kind you actually understand and leave the rest alone – :attr:`supported_payloads`
+    is derived from which methods you overrode, the pickers only offer you for
+    the kinds you claim, and the route rejects anything else with a 400 rather
+    than letting you deliver an empty export.
+
+    Legacy single-method exporters
+    ------------------------------
+    Before the payload kinds were named, an exporter implemented one
+    :meth:`export` method and told the two dict shapes apart itself (typically
+    ``if "labels" in results``).  That still works: the default
+    :meth:`export_find_results` and :meth:`export_labelset` delegate to
+    :meth:`export`, so an existing out-of-tree plugin needs no changes.  Such an
+    exporter is credited with **both** kinds (there is no way to know which it
+    handles), which is exactly the pre-existing behaviour, and it gets a
+    :class:`DeprecationWarning` pointing at the named methods.
+
+    Streaming
+    ---------
+    Exporters that can write a scored run incrementally (for the CLI
     ``--stream-results`` path on a media source larger than RAM) override
     :attr:`supports_streaming` to return ``True`` and implement
-    :meth:`export_cli_streaming`.
+    :meth:`export_cli_streaming`.  Streaming is a ``find_results`` mode only;
+    there is no labelset equivalent.
     """
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # A subclass that overrode only the pre-payload-kinds ``export()`` gets
+        # delegated to and keeps working, but it is credited with every
+        # non-detector payload kind because nothing can tell which it actually
+        # handles - so a picker may hand it one it silently no-ops on.  Say so
+        # once, at import time, rather than leaving the author to discover it
+        # from an empty export.
+        #
+        # Deliberately a log line and not ``warnings.warn(DeprecationWarning)``.
+        # Class bodies are executed inside the registry's import ``try``, so a
+        # caller running under ``-W error`` would turn this advisory into an
+        # ImportError and tombstone the very plugin the delegation exists to
+        # keep working - escalating a compatibility notice into the break it
+        # was written to avoid.  A log line cannot do that, and reaches the
+        # author where they are already looking (the server log at startup),
+        # unlike a DeprecationWarning that Python hides by default anyway.
+        overrides_legacy = cls.export is not ResultsExporter.export
+        overrides_named = (
+            cls.export_find_results is not ResultsExporter.export_find_results
+            or cls.export_labelset is not ResultsExporter.export_labelset
+        )
+        # A detector-bundle exporter legitimately overrides ``export()`` only to
+        # explain why hits are the wrong input; it is not a legacy exporter.
+        exports_bundles = cls.export_cli_detectors is not ResultsExporter.export_cli_detectors
+        if overrides_legacy and not overrides_named and not exports_bundles:
+            logger.warning(
+                "%s implements the legacy ResultsExporter.export(); it still works, but it is offered "
+                "every payload kind because nothing can tell which shapes it handles. Override "
+                "export_find_results() and/or export_labelset() instead - see "
+                "vtscore/docs/extending/results-exporters.md.",
+                cls.__name__,
+            )
 
     #: Emoji or icon string shown next to the display name in the UI.
     icon: str = "📤"
@@ -113,12 +210,171 @@ class LabelsetExporter(PluginBase):
     #: front.  See :meth:`export` for the response contract.
     opens_url: bool = False
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        """Perform the export and return a status dict.
+    @property
+    def supported_payloads(self) -> frozenset[str]:
+        """Which of :data:`PAYLOAD_KINDS` this exporter actually implements.
+
+        Derived from which methods the subclass overrode, never declared.  A
+        declared flag is a second place to forget something, and forgetting is
+        precisely how an exporter ends up in a picker for a payload it cannot
+        read; a derived set cannot drift from the implementation.
+
+        The rules, in order:
+
+        - :attr:`needs_trained_detectors` means "this exporter consumes the
+          trained classifiers, not their output", so it reports
+          ``{"detector_bundles"}`` alone.
+        - Otherwise, overriding :meth:`export_find_results` or
+          :meth:`export_labelset` claims that kind, and overriding the legacy
+          :meth:`export` claims **both** (nothing can tell which dict shapes it
+          handles - see the class docstring).
+        - Overriding :meth:`export_cli_detectors` adds ``detector_bundles``.
+
+        A subclass of a concrete exporter inherits its parent's overrides, and
+        therefore its parent's payload kinds, which is the intended answer.
+        """
+        cls = type(self)
+        if self.needs_trained_detectors:
+            return frozenset({"detector_bundles"})
+
+        kinds: set[str] = set()
+        legacy = cls.export is not ResultsExporter.export
+        if legacy or cls.export_find_results is not ResultsExporter.export_find_results:
+            kinds.add("find_results")
+        if legacy or cls.export_labelset is not ResultsExporter.export_labelset:
+            kinds.add("labelset")
+        if cls.export_cli_detectors is not ResultsExporter.export_cli_detectors:
+            kinds.add("detector_bundles")
+        return frozenset(kinds)
+
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Export a scored run - the hit lists a detector produced.
 
         Args:
-            results: The full auto-detect results dict from ``/api/auto-detect``.
-                     Shape::
+            results: The auto-detect results dict.  Shape::
+
+                         {
+                           "media_type": "audio",
+                           "detectors_run": 2,
+                           "results": {
+                             "<detector_name>": {
+                               "detector_name": "...",
+                               "threshold": 0.5,
+                               "total_hits": 15,      # positives only
+                               "hits": [{...}, ...],
+                               "negative_hits": [{...}, ...],
+                             }
+                           },
+                           "missing_detectors": [...],
+                         }
+
+                     Each hit comes from
+                     :func:`vtscore.utils.hits.build_media_hit`: ``id``,
+                     ``filename``, ``category``, ``score``, plus ``origin`` /
+                     ``origin_name`` / ``md5`` and any clip bounds the media
+                     carries.
+
+                     **``negative_hits`` is conventionally ignored.** Every
+                     built-in exporter writes positives only, because "the
+                     items the detector found" is what an export is for.  The
+                     key is nonetheless always present (the CLI fills it only
+                     under ``--keep-negatives``), so an exporter that wants the
+                     below-threshold items can read it.  ``missing_detectors``
+                     is likewise informational.
+
+            field_values: Mapping of :attr:`PluginField.key` -> value supplied
+                by the user.
+
+        Returns:
+            A status dict; see :meth:`export` for the ``"message"`` /
+            ``"open_url"`` / ``"display_results"`` contract, which is shared by
+            all three payload methods.
+
+        Raises:
+            UnsupportedPayloadError: If this exporter does not handle a scored
+                run (the default, unless the legacy :meth:`export` is
+                overridden).
+        """
+        return self._delegate_to_legacy_export("find_results", results, field_values)
+
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Export a detector's labelset - what it was taught, not what it found.
+
+        Args:
+            labelset: A serialised
+                :class:`~vtscore.datasets.labelset.LabelSet`.  Shape::
+
+                         {
+                           "labels": [{...}, ...],
+                           "selected_columns": ["label", "md5", ...],
+                         }
+
+                     Each entry is a
+                     :class:`~vtscore.datasets.labelset.LabeledElement` dict:
+                     ``md5`` and ``label`` always, plus ``origin`` /
+                     ``origin_name`` / ``filename`` / ``category`` /
+                     ``metadata`` / ``region_box`` where present.  The
+                     ``origin`` is what makes the export re-importable, so
+                     preserve it rather than flattening it to a string.
+
+                     ``selected_columns`` is the user's column choice from the
+                     Export modal.  Honour it for tabular output; a delivery
+                     exporter that sends the whole entry may ignore it.  It is
+                     absent on non-UI call paths.
+
+            field_values: Mapping of :attr:`PluginField.key` -> value supplied
+                by the user.
+
+        Returns:
+            A status dict; see :meth:`export`.
+
+        Raises:
+            UnsupportedPayloadError: If this exporter does not handle a
+                labelset (the default, unless the legacy :meth:`export` is
+                overridden).
+        """
+        return self._delegate_to_legacy_export("labelset", labelset, field_values)
+
+    def _delegate_to_legacy_export(
+        self,
+        kind: str,
+        payload: dict[str, Any],
+        field_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Hand *payload* to a legacy :meth:`export`, or refuse it clearly.
+
+        The compatibility hinge: an exporter written before the payload kinds
+        were named implements :meth:`export` and sniffs the dict shape itself,
+        so the named methods route to it unchanged.  One that implements
+        neither gets an :class:`UnsupportedPayloadError` naming the kind, which
+        the route turns into a 400.
+        """
+        if type(self).export is ResultsExporter.export:
+            raise UnsupportedPayloadError(
+                f"{type(self).__name__} does not export a {kind} payload "
+                f"(supported: {', '.join(sorted(self.supported_payloads)) or 'none'})"
+            )
+        return self.export(payload, field_values)
+
+    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Legacy single-method export; prefer the payload-specific methods.
+
+        Kept working, and not going anywhere, so an out-of-tree exporter written
+        against it needs no changes: :meth:`export_find_results` and
+        :meth:`export_labelset` both delegate here when the subclass hasn't
+        overridden them.  New exporters should implement those instead - an
+        exporter that only implements this one is credited with both payload
+        kinds, so a picker can hand it a shape it doesn't read.
+
+        This method's own contract is unchanged: *results* is whichever payload
+        the caller had, and an implementation tells them apart with
+        ``if "labels" in results``.
+
+        The return contract below is shared by all three payload methods.
+
+        Args:
+            results: The full auto-detect results dict from ``/api/auto-detect``
+                     (or a serialised LabelSet - see above).  Shape::
 
                          {
                            "media_type": "audio",
@@ -175,32 +431,46 @@ class LabelsetExporter(PluginBase):
         raise NotImplementedError(f"{type(self).__name__}.export() is not implemented")
 
     # ------------------------------------------------------------------
+    # Payload-specific export methods
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
     # Serialisation
     # ------------------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise exporter metadata, adding the exporter-only flags.
+        """Serialise exporter metadata, adding the exporter-only fields.
 
         :attr:`opens_url` rides along so ``GET /api/exporters`` tells the
         frontend which exporters end in a new browser tab.  It is declared
         here rather than on :class:`~vtscore.plugins.PluginBase` because no
         other plugin kind has anywhere to open a URL.
+
+        :attr:`supported_payloads` rides along for the same reason: it is what
+        lets each picker offer only the exporters that can read the payload it
+        is about to send, instead of listing the whole registry and finding out
+        afterwards.  Serialised sorted, so the API response is stable.
         """
-        return {**super().to_dict(), "opens_url": self.opens_url}
+        return {
+            **super().to_dict(),
+            "opens_url": self.opens_url,
+            "supported_payloads": sorted(self.supported_payloads),
+        }
 
     # ------------------------------------------------------------------
     # CLI support
     # ------------------------------------------------------------------
 
     def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        """Export results from CLI-provided *field_values*.
+        """Export a scored run from CLI-provided *field_values*.
 
-        The default implementation simply delegates to :meth:`export`, which
-        works for exporters whose ``export()`` only expects plain string values.
+        The CLI autodetect/pipeline path only ever produces find results, so the
+        default delegates to :meth:`export_find_results` (which in turn reaches
+        a legacy :meth:`export`, if that is all the exporter implements).
         Exporters that need different behaviour on the command line (e.g. the
         GUI exporter, which has no browser) should override this method.
         """
-        return self.export(results, field_values)
+        return self.export_find_results(results, field_values)
 
     # ------------------------------------------------------------------
     # Trained-detector CLI support (portable-detector export)
@@ -307,3 +577,12 @@ class LabelsetExporter(PluginBase):
             NotImplementedError: If the exporter does not support streaming.
         """
         raise NotImplementedError(f"{type(self).__name__} does not support streaming export")
+
+
+#: Backwards-compatible alias for the pre-payload-kinds class name.
+#:
+#: ``LabelsetExporter`` described one of the three payloads the class has
+#: always accepted, which is why every guide had to apologise for it.  The
+#: alias is permanent: it costs a line and keeps every out-of-tree ``from
+#: vtscore.exporters.base import LabelsetExporter`` and subclass working.
+LabelsetExporter = ResultsExporter

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -1,29 +1,37 @@
-"""Base classes for Labelset Exporters.
+"""Base classes for Results Exporters.
 
-To add a new exporter, subclass :class:`LabelsetExporter`, define its class
-attributes and :meth:`~LabelsetExporter.export`, then expose a module-level
-``EXPORTER`` instance from a package under this directory.  The registry will
-discover it automatically.
+An exporter is a *destination* - a file, an SMTP server, a webhook, a browser
+tab.  What gets sent there is a separate axis, with three payload kinds
+(:data:`PAYLOAD_KINDS`): a scored run, a detector's labelset, or the trained
+classifiers.  To add a new exporter, subclass :class:`ResultsExporter`, define
+its class attributes and a method per payload kind you support, then expose a
+module-level ``EXPORTER`` instance from a package under this directory.  The
+registry will discover it automatically.
 
-Each exporter also supports CLI usage via :meth:`~LabelsetExporter.add_cli_arguments`
-and :meth:`~LabelsetExporter.export_cli`.  The base class provides default
+:attr:`~ResultsExporter.supported_payloads` is derived from which methods you
+overrode, so each picker offers you only for the kinds you can actually read.
+An exporter written against the older single-:meth:`~ResultsExporter.export`
+contract keeps working unchanged; see that class's docstring.
+
+Each exporter also supports CLI usage via :meth:`~ResultsExporter.add_cli_arguments`
+and :meth:`~ResultsExporter.export_cli`.  The base class provides default
 implementations that derive CLI arguments from the :attr:`fields` list, so most
-exporters work on the command line without any extra code.  Exporters whose
-:meth:`export` expects non-string values should override :meth:`export_cli` to
-handle the CLI-appropriate types.
+exporters work on the command line without any extra code.  Exporters that
+expect non-string values should override :meth:`export_cli` to handle the
+CLI-appropriate types.
 
 For the CLI ``--stream-results`` path (scoring a media source larger than RAM),
 an exporter can write hits incrementally instead of buffering the whole result
-set: set :attr:`~LabelsetExporter.supports_streaming` to ``True`` and implement
-:meth:`~LabelsetExporter.export_cli_streaming`.  See that method's docstring and
+set: set :attr:`~ResultsExporter.supports_streaming` to ``True`` and implement
+:meth:`~ResultsExporter.export_cli_streaming`.  See that method's docstring and
 ``docs/plans/cli-stream-massive-images.md`` for details.
 
 Example – a minimal SFTP exporter skeleton::
 
     # vtsearch/exporters/sftp/__init__.py
-    from vtscore.exporters.base import LabelsetExporter, PluginField
+    from vtscore.exporters.base import PluginField, ResultsExporter
 
-    class SftpLabelsetExporter(LabelsetExporter):
+    class SftpResultsExporter(ResultsExporter):
         name         = "sftp"
         display_name = "SFTP Upload"
         description  = "Upload results JSON to a remote SFTP server."
@@ -36,12 +44,18 @@ Example – a minimal SFTP exporter skeleton::
                           default="/results/autodetect.json"),
         ]
 
-        def export(self, results: dict, field_values: dict) -> dict:
+        def _upload(self, payload: dict, field_values: dict) -> dict:
             import paramiko
             ...  # connect, write JSON, disconnect
             return {"message": f"Uploaded to {field_values['host']}:{field_values['path']}"}
 
-    EXPORTER = SftpLabelsetExporter()
+        def export_find_results(self, results: dict, field_values: dict) -> dict:
+            return self._upload(results, field_values)
+
+        def export_labelset(self, labelset: dict, field_values: dict) -> dict:
+            return self._upload(labelset, field_values)
+
+    EXPORTER = SftpResultsExporter()
 
 If the exporter needs extra packages, add them to
 ``[project.dependencies]`` in the repo's ``pyproject.toml``. They are

--- a/vtscore/exporters/email_smtp/__init__.py
+++ b/vtscore/exporters/email_smtp/__init__.py
@@ -17,7 +17,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any, Iterator
 
-from vtscore.exporters.base import PluginField, LabelsetExporter, resolve_stream_batch_size
+from vtscore.exporters.base import PluginField, ResultsExporter, resolve_stream_batch_size
 
 # Pragmatic address check: a non-empty local part, a single ``@``, and a
 # dotted domain, none of which may contain whitespace.  Not full RFC 5322
@@ -94,6 +94,80 @@ def _default_subject(results: dict[str, Any]) -> str:
     return f"VTSearch Auto-Detect: {total_hits} hit(s) on {media_type} dataset"
 
 
+def _labelset_counts(labels: list[dict[str, Any]]) -> tuple[int, int]:
+    """Return ``(good, bad)`` counts for a labelset's entries."""
+    good = sum(1 for e in labels if e.get("label") == "good")
+    return good, len(labels) - good
+
+
+def _label_row_values(entry: dict[str, Any]) -> tuple[str, str, str]:
+    """Return the ``(label, name, origin)`` cells shown for one label entry.
+
+    ``origin_name`` beats ``filename`` because it is what the item is called
+    inside its source, which is the name a recipient can act on; the origin
+    itself is rendered through :meth:`~vtscore.datasets.origin.Origin.display`
+    so the email says where the item came from rather than dumping a dict.
+    """
+    from vtscore.datasets.origin import Origin
+
+    origin = entry.get("origin")
+    try:
+        origin_str = Origin.from_dict(origin).display() if origin else ""
+    except Exception:  # noqa: BLE001 - a malformed origin must not sink the email
+        origin_str = ""
+    name = entry.get("origin_name") or entry.get("filename") or entry.get("md5", "")
+    return str(entry.get("label", "")), str(name), origin_str
+
+
+def _build_labelset_plain(labelset: dict[str, Any]) -> str:
+    """Render a labelset as a human-readable plain-text listing."""
+    labels = labelset.get("labels", []) or []
+    good, bad = _labelset_counts(labels)
+    lines: list[str] = [
+        "VTSearch Labels",
+        "===============",
+        f"Labels: {len(labels)}  ({good} good, {bad} bad)",
+        "",
+    ]
+    for entry in labels:
+        label, name, origin_str = _label_row_values(entry)
+        lines.append(f"  [{label or '?'}] {name}" + (f"  ({origin_str})" if origin_str else ""))
+    if not labels:
+        lines.append("  No labels in this export.")
+    return "\n".join(lines)
+
+
+def _build_labelset_html(labelset: dict[str, Any]) -> str:
+    """Render a labelset as a minimal HTML table."""
+    from html import escape
+
+    labels = labelset.get("labels", []) or []
+    good, bad = _labelset_counts(labels)
+    rows = ""
+    for entry in labels:
+        label, name, origin_str = _label_row_values(entry)
+        rows += f"<tr><td>{escape(label)}</td><td>{escape(name)}</td><td>{escape(origin_str)}</td></tr>"
+    if not rows:
+        rows = '<tr><td colspan="3"><em>No labels in this export.</em></td></tr>'
+    return (
+        f"<html><body>"
+        f"<h2>VTSearch Labels</h2>"
+        f"<p><strong>Labels:</strong> {len(labels)} "
+        f"({good} good, {bad} bad)</p>"
+        f"<table border='1' cellpadding='4' cellspacing='0'>"
+        f"<tr><th>Label</th><th>Name</th><th>Origin</th></tr>"
+        f"{rows}</table>"
+        f"</body></html>"
+    )
+
+
+def _default_labelset_subject(labelset: dict[str, Any]) -> str:
+    """Auto-generated subject used when the user leaves the field blank."""
+    labels = labelset.get("labels", []) or []
+    good, bad = _labelset_counts(labels)
+    return f"VTSearch Labels: {len(labels)} label(s) ({good} good, {bad} bad)"
+
+
 def _group_batch_by_detector(batch: list[tuple[str, dict[str, Any]]]) -> dict[str, list[dict[str, Any]]]:
     """Group a streamed ``(detector_name, hit)`` batch into ``{detector: [hits]}``."""
     grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -161,8 +235,8 @@ def _resolve_mx(domain: str) -> str:
     return str(best.exchange).rstrip(".")
 
 
-class EmailLabelsetExporter(LabelsetExporter):
-    """Send auto-detect results by e-mail via direct MX delivery.
+class EmailResultsExporter(ResultsExporter):
+    """Send a scored run or a labelset by e-mail via direct MX delivery.
 
     Looks up the recipient domain's MX record and connects directly - no
     SMTP credentials or server configuration required.  The caller must
@@ -172,7 +246,7 @@ class EmailLabelsetExporter(LabelsetExporter):
 
     name = "email_smtp"
     display_name = "Send by Email"
-    description = "Email the results summary to any address."
+    description = "Email the results or labels to any address."
     icon = "📧"
     fields = [
         PluginField(
@@ -217,7 +291,20 @@ class EmailLabelsetExporter(LabelsetExporter):
         ),
     ]
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+    def _send(
+        self,
+        field_values: dict[str, Any],
+        default_subject: str,
+        plain: str,
+        html: str,
+        sent_detail: str,
+    ) -> dict[str, Any]:
+        """Validate the addresses, resolve MX, and deliver one message.
+
+        Shared by both payload kinds: what differs between a scored run and a
+        labelset is only the rendering and the fallback subject, never the
+        delivery.
+        """
         from_addr = field_values["from"]
         to_addr = field_values["to"]
 
@@ -229,19 +316,13 @@ class EmailLabelsetExporter(LabelsetExporter):
         domain = to_addr.rsplit("@", 1)[1]
         mx_host = _resolve_mx(domain)
 
-        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
         # The framework substitutes any {template} vars into ``subject`` at
         # ingress (see vtscore.plugins.normalize); a blank field falls back to
         # the auto-generated summary so existing behaviour is preserved.
-        subject = field_values.get("subject") or _default_subject(results)
-
         msg = MIMEMultipart("alternative")
-        msg["Subject"] = subject
+        msg["Subject"] = field_values.get("subject") or default_subject
         msg["From"] = from_addr
         msg["To"] = to_addr
-
-        plain = _build_plain_text(results)
-        html = _build_html(results)
         msg.attach(MIMEText(plain, "plain", "utf-8"))
         msg.attach(MIMEText(html, "html", "utf-8"))
 
@@ -250,9 +331,36 @@ class EmailLabelsetExporter(LabelsetExporter):
             server.sendmail(from_addr, [to_addr], msg.as_string())
 
         return {
-            "message": (f"Email with {total_hits} hit(s) sent to {to_addr} via {mx_host}."),
+            "message": f"Email with {sent_detail} sent to {to_addr} via {mx_host}.",
             "to": to_addr,
         }
+
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Email a per-detector summary of the scored run."""
+        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
+        return self._send(
+            field_values,
+            _default_subject(results),
+            _build_plain_text(results),
+            _build_html(results),
+            f"{total_hits} hit(s)",
+        )
+
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Email the labelset as a good/bad listing with each item's origin.
+
+        Before this existed the exporter understood only the scored-run shape,
+        so a labelset export from the Export modal mailed an empty body under a
+        "0 hit(s)" subject and still reported success.
+        """
+        labels = labelset.get("labels", []) or []
+        return self._send(
+            field_values,
+            _default_labelset_subject(labelset),
+            _build_labelset_plain(labelset),
+            _build_labelset_html(labelset),
+            f"{len(labels)} label(s)",
+        )
 
     @property
     def supports_streaming(self) -> bool:
@@ -334,4 +442,4 @@ class EmailLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = EmailLabelsetExporter()
+EXPORTER = EmailResultsExporter()

--- a/vtscore/exporters/gui/__init__.py
+++ b/vtscore/exporters/gui/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Iterator
 
-from vtscore.exporters.base import LabelsetExporter
+from vtscore.exporters.base import ResultsExporter
 
 
 def _format_origin(hit: dict[str, Any]) -> str:
@@ -24,7 +24,7 @@ def _format_origin(hit: dict[str, Any]) -> str:
         return str(origin)
 
 
-class DisplayLabelsetExporter(LabelsetExporter):
+class DisplayResultsExporter(ResultsExporter):
     """Display auto-detect results in the browser (GUI) or print to console (CLI).
 
     This is the default exporter: in GUI mode it performs no server-side work
@@ -40,16 +40,28 @@ class DisplayLabelsetExporter(LabelsetExporter):
     hidden_from_picker = True
     fields = []  # no questions to ask
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        # If results come from /api/labels/export (LabelSet format), convert
-        # to the display format expected by displayAutodetectResults().
-        if "labels" in results and "results" not in results:
-            results = self._labelset_to_display(results)
-
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Hand the scored run straight back for the results modal to render."""
         total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
         return {
             "message": (f"Showing {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s)."),
             "display_results": results,
+        }
+
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Render a labelset in the results modal, which speaks hit lists.
+
+        The modal only knows the find-results shape, so the labelset is dressed
+        as one.  The adaptation is display-only and stays local to this
+        exporter: the fabricated ``media_type`` / ``detectors_run`` read fine in
+        a modal header and would read as nonsense in an email subject or a CSV
+        column, which is why there is no framework-level converter.
+        """
+        display = self._labelset_to_display(labelset)
+        total_hits = sum(r.get("total_hits", 0) for r in display.get("results", {}).values())
+        return {
+            "message": f"Showing {total_hits} label(s).",
+            "display_results": display,
         }
 
     @staticmethod
@@ -131,4 +143,4 @@ class DisplayLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = DisplayLabelsetExporter()
+EXPORTER = DisplayResultsExporter()

--- a/vtscore/exporters/holder/__init__.py
+++ b/vtscore/exporters/holder/__init__.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from vtscore.exporters.base import PluginField, LabelsetExporter
+from vtscore.exporters.base import PluginField, ResultsExporter
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +117,7 @@ def _extract_entry_metadata(entry: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-class HolderLabelsetExporter(LabelsetExporter):
+class HolderResultsExporter(ResultsExporter):
     """Export labels to a new Holder package (Good / Bad folders)."""
 
     name = "holder"
@@ -131,10 +131,16 @@ class HolderLabelsetExporter(LabelsetExporter):
         # PluginField(key="holder_url", label="Holder API URL", field_type="text"),
     ]
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        labels = results.get("labels")
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """File each labelled element into the package's Good / Bad folder.
+
+        Labelset-only by design: Holder files items by the label a human gave
+        them, which a scored run does not carry.  Declaring only this method is
+        what keeps the exporter out of the find-results pickers.
+        """
+        labels = labelset.get("labels")
         if not isinstance(labels, list):
-            raise ValueError("Expected labels-format results with a 'labels' key.")
+            raise ValueError("Expected a labelset with a 'labels' key.")
 
         # Create package and folders
         holder_id = _holder_create_package()
@@ -174,4 +180,4 @@ class HolderLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = HolderLabelsetExporter()
+EXPORTER = HolderResultsExporter()

--- a/vtscore/exporters/open_url/__init__.py
+++ b/vtscore/exporters/open_url/__init__.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import quote
 
-from vtscore.exporters.base import LabelsetExporter, PluginField
+from vtscore.exporters.base import PluginField, ResultsExporter
 from vtscore.security.url_validation import validate_browser_url
 
 #: Practical ceiling on a URL the browser will actually follow.  The HTTP spec
@@ -59,7 +59,7 @@ def _encode_unsafe_chars(url: str) -> str:
     return quote(url, safe=_URL_SAFE_CHARS)
 
 
-class OpenUrlLabelsetExporter(LabelsetExporter):
+class OpenUrlResultsExporter(ResultsExporter):
     """Format the labelset into a URL and hand it to the browser to open.
 
     Fills ``{ids}`` (and ``{count}``) in a user-supplied URL template with the
@@ -126,20 +126,18 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_items(results: dict[str, Any]) -> list[dict[str, Any]]:
-        """Return the exported items from either payload shape.
-
-        The Export modal posts a LabelSet (``{"labels": [...]}``); the
-        auto-detect path posts the per-detector results dict.  Both reduce to a
-        flat list of item dicts here.
-        """
-        if "labels" in results:
-            return [e for e in results.get("labels") or [] if isinstance(e, dict)]
+    def _items_from_find_results(results: dict[str, Any]) -> list[dict[str, Any]]:
+        """Flatten a scored run's per-detector hit lists into one item list."""
         items: list[dict[str, Any]] = []
         for det_result in (results.get("results") or {}).values():
             if isinstance(det_result, dict):
                 items.extend(h for h in det_result.get("hits") or [] if isinstance(h, dict))
         return items
+
+    @staticmethod
+    def _items_from_labelset(labelset: dict[str, Any]) -> list[dict[str, Any]]:
+        """Return a labelset's entries as the item list."""
+        return [e for e in labelset.get("labels") or [] if isinstance(e, dict)]
 
     @staticmethod
     def _identifier(item: dict[str, Any], id_field: str) -> str:
@@ -160,8 +158,12 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
             return DEFAULT_MAX_ITEMS
         return n if n > 0 else DEFAULT_MAX_ITEMS
 
-    def _build_url(self, results: dict[str, Any], field_values: dict[str, Any]) -> tuple[str, int, int]:
-        """Return ``(url, included_count, total_count)`` for *results*.
+    def _build_url(self, items: list[dict[str, Any]], field_values: dict[str, Any]) -> tuple[str, int, int]:
+        """Return ``(url, included_count, total_count)`` for *items*.
+
+        Both payload kinds reduce to a flat list of item dicts before they get
+        here, so the URL is built the same way whether the identifiers came
+        from a scored run's hits or a labelset's entries.
 
         Raises:
             ValueError: If the template is empty, the formatted URL fails
@@ -177,7 +179,6 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
         separator = "," if separator is None or separator == "" else str(separator)
         max_items = self._resolve_max_items(field_values.get("max_items"))
 
-        items = self._extract_items(results)
         identifiers = [i for i in (self._identifier(item, id_field) for item in items) if i]
         total = len(identifiers)
         included = identifiers[:max_items]
@@ -199,18 +200,24 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
     # Export
     # ------------------------------------------------------------------
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        url, included, total = self._build_url(results, field_values)
-        if included < total:
-            detail = f"first {included} of {total} item(s)"
-        else:
-            detail = f"{included} item(s)"
+    def _opened(self, items: list[dict[str, Any]], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Build the URL for *items* and describe it as a tab about to open."""
+        url, included, total = self._build_url(items, field_values)
+        detail = f"first {included} of {total} item(s)" if included < total else f"{included} item(s)"
         return {
             "message": f"Opening {detail} in a new tab.",
             "open_url": url,
             "included_count": included,
             "total_count": total,
         }
+
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Format the run's hits into the target site's URL."""
+        return self._opened(self._items_from_find_results(results), field_values)
+
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Format the labelset's entries into the target site's URL."""
+        return self._opened(self._items_from_labelset(labelset), field_values)
 
     def export_cli(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
         """Return the formatted URL — there is no browser here to open it.
@@ -220,7 +227,7 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
         would both duplicate that line and put prose in the middle of the
         NDJSON stream under ``--progress-format json``.
         """
-        url, included, total = self._build_url(results, field_values)
+        url, included, total = self._build_url(self._items_from_find_results(results), field_values)
         detail = f"first {included} of {total} item(s)" if included < total else f"{included} item(s)"
         return {
             "message": f"Formatted a URL covering {detail}.",
@@ -230,4 +237,4 @@ class OpenUrlLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = OpenUrlLabelsetExporter()
+EXPORTER = OpenUrlResultsExporter()

--- a/vtscore/exporters/portable_detector/__init__.py
+++ b/vtscore/exporters/portable_detector/__init__.py
@@ -27,7 +27,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from vtscore.exporters.base import LabelsetExporter, PluginField
+from vtscore.exporters.base import PluginField, ResultsExporter
 from vtscore.io import atomic_write_bytes
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_BUNDLE_PATH = "data/{detector_name}-detector.zip"
 
 
-class PortableDetectorLabelsetExporter(LabelsetExporter):
+class PortableDetectorResultsExporter(ResultsExporter):
     """Write each trained detector as a standalone, portable scoring bundle.
 
     CLI-only: it needs the trained MLP, which only the ``--autodetect`` /
@@ -227,4 +227,4 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-EXPORTER = PortableDetectorLabelsetExporter()
+EXPORTER = PortableDetectorResultsExporter()

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
-from vtscore.exporters.base import PluginField, LabelsetExporter
+from vtscore.exporters.base import PluginField, ResultsExporter
 from vtscore.io import atomic_write_text, sanitize_csv_cell as _sanitize_csv_cell
 
 _DEFAULT_CSV_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.csv"
@@ -39,7 +39,7 @@ def _atomic_write_csv(path: Path, write_rows) -> None:
     atomic_write_text(path, buf.getvalue())
 
 
-class ServerCsvLabelsetExporter(LabelsetExporter):
+class ServerCsvResultsExporter(ResultsExporter):
     """Save auto-detect results as a CSV file on the server filesystem.
 
     Produces one row per hit across all detectors, with columns for the
@@ -72,16 +72,17 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
     #: ``origin`` is always appended as the last column (not listed here).
     _LABEL_BASE_COLUMNS = ["label", "md5", "origin_name", "filename", "category"]
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Write one CSV row per hit, across all detectors."""
         filepath = Path(field_values["filepath"])
         filepath.parent.mkdir(parents=True, exist_ok=True)
-
-        # Labels format (from the export modal UI)
-        if "labels" in results:
-            return self._export_labels(results, filepath)
-
-        # Autodetect results format (from CLI / fill-from-sort)
         return self._export_autodetect(results, filepath)
+
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Write one CSV row per label, in the user's chosen column order."""
+        filepath = Path(field_values["filepath"])
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        return self._export_labels(labelset, filepath)
 
     #: Fixed column order for streamed autodetect exports.  Streaming cannot
     #: pre-scan all hits to detect which optional clip columns are present, so
@@ -287,4 +288,4 @@ class ServerCsvLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = ServerCsvLabelsetExporter()
+EXPORTER = ServerCsvResultsExporter()

--- a/vtscore/exporters/server_json_file/__init__.py
+++ b/vtscore/exporters/server_json_file/__init__.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
-from vtscore.exporters.base import PluginField, LabelsetExporter
+from vtscore.exporters.base import PluginField, ResultsExporter
 from vtscore.io import atomic_write_json
 
 _DEFAULT_JSON_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.json"
@@ -30,7 +30,7 @@ _DEFAULT_JSON_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.json"
 from vtscore.io import atomic_write_text as _atomic_write_text  # noqa: E402, F401
 
 
-class ServerJsonLabelsetExporter(LabelsetExporter):
+class ServerJsonResultsExporter(ResultsExporter):
     """Save auto-detect results as a JSON file on the server filesystem.
 
     The user supplies the destination path (absolute or relative to the
@@ -59,14 +59,9 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
         ),
     ]
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Write the scored run verbatim as JSON."""
         filepath = Path(field_values["filepath"])
-
-        # Labels format (from the export modal UI) - filter to selected columns
-        if "labels" in results:
-            return self._export_labels(results, filepath)
-
-        # Autodetect results format (from CLI / fill-from-sort)
         atomic_write_json(filepath, results)
 
         total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
@@ -137,10 +132,15 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
             "filepath": str(filepath.resolve()),
         }
 
-    def _export_labels(self, results: dict[str, Any], filepath: Path) -> dict[str, Any]:
-        """Export labels, filtering to selected columns when provided."""
-        labels = results.get("labels", [])
-        selected_columns: list[str] | None = results.get("selected_columns")
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """Write the labelset as JSON, filtering to the selected columns.
+
+        Entries keep their ``origin`` as a real nested dict rather than a
+        display string, which is what makes the file re-importable.
+        """
+        filepath = Path(field_values["filepath"])
+        labels = labelset.get("labels", [])
+        selected_columns: list[str] | None = labelset.get("selected_columns")
 
         if selected_columns is not None:
             filtered_labels = []
@@ -164,4 +164,4 @@ class ServerJsonLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = ServerJsonLabelsetExporter()
+EXPORTER = ServerJsonResultsExporter()

--- a/vtscore/exporters/webhook/__init__.py
+++ b/vtscore/exporters/webhook/__init__.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 from typing import Any, Iterator
 
-from vtscore.exporters.base import PluginField, LabelsetExporter, resolve_stream_batch_size
+from vtscore.exporters.base import PluginField, ResultsExporter, resolve_stream_batch_size
 from vtscore.security.url_validation import guarded_session
 
 
-class WebhookLabelsetExporter(LabelsetExporter):
+class WebhookResultsExporter(ResultsExporter):
     """POST the results JSON to a user-specified URL.
 
     Enables integration with automation platforms (Zapier, n8n, Make,
@@ -66,25 +66,36 @@ class WebhookLabelsetExporter(LabelsetExporter):
             headers["Authorization"] = auth_header
         return headers
 
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+    def _post(self, payload: dict[str, Any], field_values: dict[str, Any], detail: str) -> dict[str, Any]:
+        """POST *payload* as JSON and report the outcome with *detail*.
+
+        Both payload kinds go out verbatim - the receiver gets the same dict
+        the exporter was handed, so a labelset arrives with its origins intact
+        and a scored run with its hit lists.
+        """
         url = field_values["url"]
         headers = self._headers(field_values)
 
         with guarded_session() as session:
-            resp = session.post(url, json=results, headers=headers, timeout=30, allow_redirects=False)
+            resp = session.post(url, json=payload, headers=headers, timeout=30, allow_redirects=False)
             resp.raise_for_status()
 
-        if "labels" in results:
-            total_items = len(results.get("labels", []))
-            detail = f"Posted {total_items} label(s)"
-        else:
-            total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
-            detail = f"Posted {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s)"
         return {
             "message": (f"{detail} to {url} (HTTP {resp.status_code})."),
             "status_code": resp.status_code,
             "url": url,
         }
+
+    def export_find_results(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """POST the scored run as a single JSON body."""
+        total_hits = sum(r.get("total_hits", 0) for r in results.get("results", {}).values())
+        detail = f"Posted {total_hits} hit(s) across {results.get('detectors_run', 0)} detector(s)"
+        return self._post(results, field_values, detail)
+
+    def export_labelset(self, labelset: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+        """POST the labelset as a single JSON body."""
+        detail = f"Posted {len(labelset.get('labels', []))} label(s)"
+        return self._post(labelset, field_values, detail)
 
     @property
     def supports_streaming(self) -> bool:
@@ -151,4 +162,4 @@ class WebhookLabelsetExporter(LabelsetExporter):
         }
 
 
-EXPORTER = WebhookLabelsetExporter()
+EXPORTER = WebhookResultsExporter()

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -253,12 +253,15 @@ class PluginField:
 
 #: Class-name suffixes stripped before snake-casing for the default
 #: :attr:`PluginBase.name`.  Order matters; longer / more-specific
-#: suffixes come first so ``HolderLabelsetExporter`` strips
-#: ``LabelsetExporter`` rather than just ``Exporter``.
+#: suffixes come first so ``HolderResultsExporter`` strips
+#: ``ResultsExporter`` rather than just ``Exporter``.  ``LabelsetExporter``
+#: stays listed beside it: it is the results-exporter base class's permanent
+#: alias, so an out-of-tree ``FooLabelsetExporter`` must keep deriving ``foo``.
 _PLUGIN_NAME_SUFFIXES: tuple[str, ...] = (
     "DataSourceImporter",
     "DatasetImporter",
     "LabelsetExporter",
+    "ResultsExporter",
     "LabelImporter",
     "LabelsetSource",
     "SeedImporter",
@@ -288,6 +291,7 @@ _PLUGIN_FAMILY_BASE_NAMES: frozenset[str] = frozenset(
         "DataSourceImporter",
         "DatasetImporter",
         "LabelsetExporter",
+        "ResultsExporter",
         "LabelImporter",
         "LabelsetSource",
         "SeedImporter",
@@ -430,7 +434,7 @@ class PluginBase:
     :meth:`__init_subclass__`:
 
     - :attr:`name`: class name with the trailing family suffix
-      (``DatasetImporter`` / ``LabelsetExporter`` / ``MediaConverter`` /
+      (``DatasetImporter`` / ``ResultsExporter`` / ``MediaConverter`` /
       etc.) stripped and the remainder snake-cased.  E.g.
       ``MyShinyExporter`` → ``"my_shiny"``.
     - :attr:`display_name`: title-cased :attr:`name`.

--- a/vtscore/security/url_validation.py
+++ b/vtscore/security/url_validation.py
@@ -326,7 +326,7 @@ def validate_browser_url(url: str) -> str:
 
     Used for the ``open_url`` an exporter can return so the frontend opens a
     third-party page in a new tab (see
-    :meth:`vtscore.exporters.base.LabelsetExporter.export`).  The fetch is made
+    :meth:`vtscore.exporters.base.ResultsExporter.export`).  The fetch is made
     by the browser, not by us, so this is deliberately *not*
     :func:`validate_url`: resolving the host and refusing private IPs would
     block a perfectly reasonable ``http://localhost:9000/viewer`` companion app

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -1014,12 +1014,24 @@ def _run_autofind_export(response: dict) -> dict | None:
     if exporter is None:
         return {"exporter": exporter_name, "success": False, "error": f"Unknown exporter '{exporter_name}'"}
 
+    if "find_results" not in exporter.supported_payloads:
+        # A saved Auto-Find choice can outlive the exporter's capabilities (a
+        # plugin narrowed, or a labelset-only exporter picked before the
+        # pickers filtered). Report it rather than handing it a shape it can't
+        # read and mailing an empty summary.
+        supported = ", ".join(sorted(exporter.supported_payloads)) or "nothing"
+        return {
+            "exporter": exporter_name,
+            "success": False,
+            "error": f"Exporter '{exporter_name}' cannot export find results (it supports: {supported})",
+        }
+
     field_values = dict(get_autofind_exporter_field_values().get(exporter_name, {}))
     try:
         from vtscore.plugins.normalize import normalize_field_values  # noqa: PLC0415
 
         normalize_field_values(exporter, field_values)
-        outcome = exporter.export(response, field_values) or {}
+        outcome = exporter.export_find_results(response, field_values) or {}
     except Exception as exc:  # noqa: BLE001 - surfaced to the caller, never raised
         logger.exception("Auto-Find export via %s failed", exporter_name)
         return {"exporter": exporter_name, "success": False, "error": str(exc)}

--- a/vtsearch/routes/labels/exporters.py
+++ b/vtsearch/routes/labels/exporters.py
@@ -9,16 +9,21 @@ GET  /api/exporters
     List all registered exporters with their metadata and field definitions.
 
 POST /api/exporters/export
-    Run a specific exporter on auto-detect results supplied in the request
-    body. ``field_values`` is permissive at the schema layer because its
-    inner keys depend on the named exporter; the handler validates it
-    against the selected plugin's :attr:`fields`. Schema-level failures
-    (missing ``exporter_name``) surface as 422; handler-level rejects
-    (unknown exporter, missing plugin field, invalid filepath, plugin
-    error) keep their original HTTP codes (404 / 400 / 500) with the
-    standard ``message`` envelope. An ``open_url`` in the exporter's
-    outcome is re-validated against the browser-URL scheme allowlist
-    before it reaches the frontend; a URL that fails is a 500.
+    Run a specific exporter on the payload supplied in the request body.
+    ``payload_kind`` says whether that payload is a scored run
+    (``find_results``) or a detector's labels (``labelset``); omitting it
+    falls back to inferring from the dict shape, for API clients written
+    before the kinds were named. ``field_values`` is permissive at the
+    schema layer because its inner keys depend on the named exporter; the
+    handler validates it against the selected plugin's :attr:`fields`.
+    Schema-level failures (missing ``exporter_name``, unknown
+    ``payload_kind``) surface as 422; handler-level rejects (unknown
+    exporter, an exporter that doesn't implement the requested kind,
+    missing plugin field, invalid filepath, plugin error) keep their
+    original HTTP codes (404 / 400 / 500) with the standard ``message``
+    envelope. An ``open_url`` in the exporter's outcome is re-validated
+    against the browser-URL scheme allowlist before it reaches the
+    frontend; a URL that fails is a 500.
 """
 
 from __future__ import annotations
@@ -28,6 +33,7 @@ import logging
 from flask_smorest import Blueprint, abort
 
 from vtscore.exporters import get_exporter, list_exporters
+from vtscore.exporters.base import ResultsExporter
 from vtscore.security.url_validation import validate_browser_url
 from vtsearch.routes._shared import validate_exporter_field_values
 from vtsearch.schemas.labels import (
@@ -43,6 +49,26 @@ exporters_bp = Blueprint(
     __name__,
     description="List and run labelset exporters.",
 )
+
+
+def _infer_payload_kind(payload: dict) -> str:
+    """Guess the payload kind for a client that didn't send one.
+
+    The pre-payload-kinds fallback, and the same test every exporter used to
+    run for itself: a serialised LabelSet has a top-level ``labels`` key and a
+    scored run doesn't. Kept only so an API client written against the old body
+    keeps working; the frontend always sends ``payload_kind`` explicitly, which
+    is what lets the capability check below reject a bad pairing instead of
+    guessing at one.
+    """
+    return "labelset" if "labels" in payload else "find_results"
+
+
+def _run(exporter: ResultsExporter, payload_kind: str, payload: dict, field_values: dict) -> dict:
+    """Dispatch to the exporter method for *payload_kind*."""
+    if payload_kind == "labelset":
+        return exporter.export_labelset(payload, field_values)
+    return exporter.export_find_results(payload, field_values)
 
 
 @exporters_bp.route("/api/exporters", methods=["GET"])
@@ -73,13 +99,24 @@ def run_export(body: dict):
 
     field_values = validate_exporter_field_values(exporter, dict(body.get("field_values") or {}))
     results: dict = dict(body.get("results") or {})
+    payload_kind = body.get("payload_kind") or _infer_payload_kind(results)
+
+    if payload_kind not in exporter.supported_payloads:
+        supported = ", ".join(sorted(exporter.supported_payloads)) or "nothing"
+        abort(
+            400,
+            message=(
+                f"Exporter '{exporter_name}' does not export a {payload_kind} payload "
+                f"(it supports: {supported})."
+            ),
+        )
 
     try:
-        outcome = dict(exporter.export(results, field_values) or {})
+        outcome = dict(_run(exporter, payload_kind, results, field_values) or {})
     except ValueError as exc:
         abort(400, message=str(exc))
     except Exception as exc:
-        logger.exception("%s.export() failed: %s", type(exporter).__name__, exc)
+        logger.exception("%s export of a %s payload failed: %s", type(exporter).__name__, payload_kind, exc)
         abort(500, message=str(exc))
 
     if outcome.get("open_url") is not None:

--- a/vtsearch/routes/labels/exporters.py
+++ b/vtsearch/routes/labels/exporters.py
@@ -106,8 +106,7 @@ def run_export(body: dict):
         abort(
             400,
             message=(
-                f"Exporter '{exporter_name}' does not export a {payload_kind} payload "
-                f"(it supports: {supported})."
+                f"Exporter '{exporter_name}' does not export a {payload_kind} payload (it supports: {supported})."
             ),
         )
 

--- a/vtsearch/schemas/labels.py
+++ b/vtsearch/schemas/labels.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 from marshmallow import Schema, fields, validate
 
+from vtscore.exporters.base import PAYLOAD_KINDS
 from vtsearch.schemas.media import OriginSchema
 
 
@@ -229,13 +230,17 @@ class _PluginEntrySchema(Schema):
 class ExporterEntrySchema(_PluginEntrySchema):
     """One entry in ``GET /api/exporters``.
 
-    Adds the exporter-only ``opens_url`` flag (see
-    :attr:`vtscore.exporters.base.LabelsetExporter.opens_url`), which tells the
+    Adds the two exporter-only fields. ``opens_url`` (see
+    :attr:`vtscore.exporters.base.ResultsExporter.opens_url`) tells the
     frontend this exporter ends in a new browser tab so the button can say so
-    before the export runs.
+    before the export runs. ``supported_payloads`` (see
+    :attr:`~vtscore.exporters.base.ResultsExporter.supported_payloads`) lists
+    the payload kinds it implements, so each picker can offer only the
+    exporters that can read what it is about to send.
     """
 
     opens_url = fields.Boolean(required=True)
+    supported_payloads = fields.List(fields.String(), required=True)
 
 
 class RunExportRequestSchema(Schema):
@@ -249,6 +254,20 @@ class RunExportRequestSchema(Schema):
     exporter_name = fields.String(required=True, validate=validate.Length(min=1))
     field_values = fields.Dict(load_default=dict)
     results = fields.Dict(load_default=dict)
+    payload_kind = fields.String(
+        required=False,
+        load_default=None,
+        allow_none=True,
+        validate=validate.OneOf(PAYLOAD_KINDS),
+        metadata={
+            "description": (
+                "Which payload ``results`` carries. Omit and the handler infers it from the dict "
+                "shape, which is what pre-payload-kind API clients get; send it explicitly and the "
+                "handler rejects an exporter that does not implement that kind instead of letting it "
+                "deliver an empty export."
+            )
+        },
+    )
 
 
 class RunExportResponseSchema(Schema):
@@ -259,7 +278,7 @@ class RunExportResponseSchema(Schema):
     are documented optionals. ``display_results`` is the GUI exporter's
     pass-through of the auto-detect results dict (or LabelSet).
     ``open_url`` is an ``http(s)`` URL the frontend opens in a new tab
-    (see :meth:`vtscore.exporters.base.LabelsetExporter.export`); the
+    (see :meth:`vtscore.exporters.base.ResultsExporter.export`); the
     handler has already run it through
     :func:`~vtscore.security.url_validation.validate_browser_url`.
     """


### PR DESCRIPTION
Reworks the results-exporter contract so "which payload an exporter accepts" is a fact the framework knows, rather than something each plugin rediscovers at runtime with a dict-key sniff. Addresses the first paragraph of #3219.

## The bug this makes impossible

`LabelsetExporter` served **three** payload kinds through one `export()`, and the first two were told apart by `if "labels" in results` duplicated inside five plugins. `email_smtp` never sniffed, but both pickers listed the same unfiltered registry — so "Send by Email" was offered for a labelset export, and it mailed `Subject: VTSearch Auto-Detect: 0 hit(s) on unknown dataset` with an empty body, returned success, and the modal toasted "Exported N labels". Nothing tested it. `holder` was the mirror case, labelset-only and held back solely by `hidden_from_picker`.

## What changed

- **Three named payload methods** on `ResultsExporter`: `export_find_results()`, `export_labelset()`, and the existing `export_cli_detectors()`.
- **`supported_payloads` is derived**, never declared — computed from which methods a subclass overrides. A declared flag is a second place to forget, and forgetting is this bug's whole mechanism.
- **The route names the kind.** `payload_kind` on the request body; an exporter that doesn't implement it gets a 400 (`UnsupportedPayloadError` subclasses `ValueError`, so it lands in the handler's existing arm) instead of delivering nothing.
- **Both pickers filter on the capability** — Export modal on `labelset`, Auto-Find settings and the results modal on `find_results`. The Auto-Find autorun path guards too, since a saved choice can outlive what the exporter accepts.
- **`email_smtp` gained a labelset mode**: a good/bad listing with each item's origin, plus the subject that counts labels rather than hits.
- `needs_trained_detectors` retired from the CLI dispatch in favour of `supported_payloads`.

## Backwards compatibility

Extension-facing, so deliberately additive — no out-of-tree exporter needs changes:

- **`export()` stays, and the named methods delegate to it.** A legacy plugin still runs and still does its own shape check; it's credited with both payload kinds (nothing can tell which it handles) and logs one advisory line at import.
- **`LabelsetExporter` remains a permanent alias** for `ResultsExporter`, so existing imports and subclasses resolve. `_PLUGIN_NAME_SUFFIXES` keeps both suffixes so `FooLabelsetExporter` still derives `foo`.
- The advisory is a log line rather than a `DeprecationWarning` on purpose: class bodies execute inside the registry's import `try`, so under `-W error` a warning would tombstone the very plugin the delegation exists to keep working.

`CLAUDE.md`'s backwards-compatibility policy is updated in the same PR to draw the distinction this change turns on: saved data and internal surfaces break freely; extension-facing surfaces (plugin ABCs, registry sentinels, entry-point groups, the public `vtscore` API) don't break casually — prefer additive, keep the cheap aliases, make hard breaks loud, and raise them before committing.

## Also

- `negative_hits` is now documented in the find-results contract. Every exporter ignores it and always has; the behavioural question (should exports carry negatives?) is left open in the plan rather than settled as a rider here.
- Tests: the email regression that was missing, capability derivation (including a legacy `export()`-only exporter and a subclass), route dispatch and the 400, the omitted-kind fallback, the Auto-Find guard, and the two picker filters.
- Docs: the ABC docstring (which documented one of three payloads, and omitted `negative_hits` / `missing_detectors` from that one), both extension guides, and a `vtscore` changelog entry.
- `docs/plans/exporter-payload-contract.md` keeps only what's still owed: the `negative_hits` decision, un-hiding `holder`, per-AutoRun exporter selection (#3219's second paragraph), and why there's no labelset streaming mode.

Full `./run-tests.sh` passes: 8953 passed, 6 skipped, all gates green.

Refs #3219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN6QLiUSReABfE2SYZ6diH