### PR TITLE
Add Documentation as its own Dev2Main release summary category

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ Commit the triage changes on the current branch **before** opening the PR — no
 Run `git fetch origin --prune`, then summarize
 `git log origin/main..origin/dev --no-merges --reverse`.
 
-**Format:** categorized bullets under these headings (collapse any with zero items): **Features**, **Bug fixes**, **Performance**, **Refactors / internals**, **Dev tooling & docs**.
+**Format:** categorized bullets under these headings (collapse any with zero items): **Features**, **Bug fixes**, **Performance**, **Refactors / internals**, **Documentation**, **Dev tooling**.
 
 **Constraints:**
 


### PR DESCRIPTION
## Summary

`docs/RELEASE.md` step 3 (release summary format) previously grouped docs changes into a combined **Dev tooling & docs** heading. This splits it into two separate categories — **Documentation** and **Dev tooling** — so documentation changes get their own bucket in the Dev2Main release summary alongside Features, Bug fixes, Performance, and Refactors / internals.

## Changes

- `docs/RELEASE.md`: split the `**Dev tooling & docs**` heading into `**Documentation**`, `**Dev tooling**`.

## Testing

- `python scripts/check-docs.py` — passes, no drift (single-file prose change, no other references to the old heading text found via repo-wide grep).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7inLdF8VSAgKHWchByz6L)_