### PR TITLE
#3116: an honest reference for the regret decomposition, and the fold-count arm that measures the shipped rule

### DIFF
--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -187,9 +187,10 @@ regret? Both voting modes, since the calibrators differ (VG region voting runs
 the bag-aware calibrator, Caltech binary voting the row-wise one).
 
 `CALIB_FOLD_COUNTS=1,2,3,4,6,8,16` makes every step train `max(counts)` folds
-and emit one `folds_k{K}_xcal` row per count — plus `folds_k{K}_blend`, the
-shipped threshold after the safe-threshold mix-in — each carrying that K's
-regret and its measured `fold_seconds`. This is cheap and **exact** rather than
+and emit one `folds_k{K}_xcal` row per count — plus `folds_k{K}_blend` (the
+retired `cap50` mix-in) and `folds_k{K}_anchored` (production's fold-anchored
+rule, and the only arm in which K moves *both* halves of the threshold) — each
+carrying that K's regret and its measured `fold_seconds`. This is cheap and **exact** rather than
 approximate because the folds are nested: each is an independent stratified draw
 off one `RandomState(42)` at a per-fold size that ignores the count, so the K
 folds a live `calibrate_count=K` run trains are the first K of these. Every K is

--- a/scripts/experiments/calibration/analyze_folds_2897.py
+++ b/scripts/experiments/calibration/analyze_folds_2897.py
@@ -3,8 +3,9 @@
 Consumes ``results/cells/task_*.csv`` from a run launched with
 ``CALIB_FOLD_COUNTS`` set (see ``launch_folds_2897.sh``), where every trainable
 step emits one ``folds_k{K}_xcal`` row per fold count - and, under safe
-thresholds, a ``folds_k{K}_blend`` row - carrying that K's regret and its
-measured ``fold_seconds``.
+thresholds, a ``folds_k{K}_blend`` row and a ``folds_k{K}_anchored`` row (the
+shipped fold-anchored rule, #3116) - carrying that K's regret and its measured
+``fold_seconds``.
 
 **What makes this analysis paired.** The fold arms are nested prefixes of one
 Kmax calibration, so every K in a step re-cuts the *same* votes, the *same*
@@ -25,9 +26,12 @@ Pre-registered deliverables (``docs/experiments/calibration-fold-count/REPORT.md
   the pre-registered :data:`MARGIN`, which is the number the study recommends.
 * **Exchange rate** - regret bought per extra second of calibration, so a
   "significant but tiny" win is visible as such.
-* **Mechanism** - whether K's benefit tracks the pooled calibration-set size and
-  lands on the *rule inefficiency* term (sampling noise in the cut) rather than
-  the calibration->test *shift* term, which K cannot touch.
+* **Mechanism** - ``sd(threshold)`` across seeds per K: does more calibration
+  actually make the shipped cut less variable?  #3116 established that the
+  regret decomposition cannot answer this (``rule_inefficiency`` is a signed
+  cost gap, not a variance, and its reference grows with K), so the dispersion
+  of the threshold is measured directly and the two decomposition terms are
+  reported as arithmetic with a guard flag rather than as a mechanism.
 
 Writes ``results/summary.json``, ``results/agg/*.csv`` and ``results/REPORT.md``.
 
@@ -51,8 +55,8 @@ import pandas as pd  # noqa: E402
 from _cells_io import main_frame_files  # noqa: E402
 from scipy.stats import mannwhitneyu, wilcoxon  # noqa: E402
 
-#: ``folds_k{K}_{xcal,blend}`` - the arms this analyzer owns.
-FOLD_RE = re.compile(r"^folds_k(?P<k>\d+)_(?P<arm>xcal|blend)$")
+#: ``folds_k{K}_{xcal,blend,anchored}`` - the arms this analyzer owns.
+FOLD_RE = re.compile(r"^folds_k(?P<k>\d+)_(?P<arm>xcal|blend|anchored)$")
 
 #: Production's fold count: the baseline every delta is measured against.
 BASELINE_K = 2
@@ -127,12 +131,28 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     return df
 
 
+def _optional(v: pd.DataFrame, col: str) -> pd.Series:
+    """*col* when the run emitted it, else an all-NaN stand-in of the right shape.
+
+    The honest-reference columns (#3116) postdate the #2897 cells, so an
+    analyzer that must still read those runs cannot assume they are there.
+    """
+    return v[col] if col in v.columns else pd.Series(np.nan, index=v.index, dtype=float)
+
+
 def fold_frame(df: pd.DataFrame) -> pd.DataFrame:
     """Just the fold-count arms, with K and arm parsed out and windows assigned."""
     m = df["gmm_variant"].str.extract(FOLD_RE)
     v = df[m["k"].notna()].copy()
     v["k"] = pd.to_numeric(m.loc[v.index, "k"]).astype(int)
     v["arm"] = m.loc[v.index, "arm"]
+    # #3116: `calibration_shift` is measured against the *sample minimum* of the
+    # test cost, which is optimistic, so the term is inflated by however much
+    # that reference overfits.  Carry the cross-fitted version beside it where
+    # the run emitted one; `rule_inefficiency` needs no such twin because it
+    # never references the test oracle.
+    v["calibration_shift_honest"] = _optional(v, "calibration_shift_honest")
+    v["regret_honest"] = _optional(v, "regret_honest")
     edges = [1, *sorted(CHECKPOINTS)]
     v["window"] = pd.cut(v["n_votes"], bins=edges, labels=[f"le_{c}" for c in sorted(CHECKPOINTS)])
     v["window_hi"] = pd.cut(v["n_votes"], bins=edges, labels=sorted(CHECKPOINTS)).astype("Int64")
@@ -155,6 +175,8 @@ def level_table(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
             fnr=("fnr", "mean"),
             rule_inefficiency=("rule_inefficiency", "mean"),
             calibration_shift=("calibration_shift", "mean"),
+            calibration_shift_honest=("calibration_shift_honest", "mean"),
+            regret_honest=("regret_honest", "mean"),
             n_cal_scores=("n_cal_scores", "mean"),
             fold_seconds=("fold_seconds", "mean"),
             cal_share=("cal_share", "mean"),
@@ -166,6 +188,48 @@ def level_table(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
     )
     g.to_csv(agg / "folds_levels.csv", index=False)
     return g
+
+
+def threshold_dispersion(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
+    """``sd(threshold)`` across **seeds**, per (voting, arm, window, K) - issue #3116.
+
+    The quantity H4 was actually reaching for.  #2897 tried to read "did more
+    folds make the cut less noisy" out of the regret decomposition, which cannot
+    answer it: ``rule_inefficiency`` is a signed cost gap between two cuts, not a
+    variance, and its reference moves with K (see :func:`verdicts`).  The
+    dispersion of the shipped threshold itself has no such problem.
+
+    Taken **across seeds at a fixed step**, then averaged over steps - not as one
+    pooled standard deviation.  A pooled sd would mix the variation this study is
+    asking about (same votes, different draw -> different cut) with the variation
+    it is not (the threshold legitimately moving as the trajectory collects
+    votes), and the second is far larger, so the pooled number would be
+    dominated by an effect that has nothing to do with K.
+
+    Steps carrying a single seed contribute nothing (an sd of one observation is
+    undefined, not zero), so a single-seed run yields an empty frame rather than
+    a column of zeros that would read as "perfectly stable".
+    """
+    keys = ["voting", "arm", "window", "k"]
+    cols = [*keys, "sd_threshold", "n_seeds", "n_steps"]
+    per_step = (
+        v.groupby([*keys, "env", "category", "t"], observed=True)["threshold"]
+        .agg(sd="std", n_seeds="count")
+        .reset_index()
+    )
+    per_step = per_step[(per_step["n_seeds"] >= 2) & per_step["sd"].notna()]
+    if per_step.empty:
+        t = pd.DataFrame(columns=cols)
+        t.to_csv(agg / "folds_threshold_sd.csv", index=False)
+        return t
+    t = (
+        per_step.groupby(keys, observed=True)
+        .agg(sd_threshold=("sd", "mean"), n_seeds=("n_seeds", "max"), n_steps=("sd", "size"))
+        .reset_index()
+        .sort_values(keys)
+    )
+    t.to_csv(agg / "folds_threshold_sd.csv", index=False)
+    return t
 
 
 def paired_vs_baseline(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
@@ -186,10 +250,11 @@ def paired_vs_baseline(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
                 continue
             a = a.set_index(STEP_KEYS)
             a = a[~a.index.duplicated()]
+            terms = ["rule_inefficiency", "calibration_shift", "calibration_shift_honest"]
             j = pd.concat(
                 [
-                    a[["regret", "fold_seconds", "window", "rule_inefficiency", "calibration_shift"]].add_suffix("_a"),
-                    base[["regret", "fold_seconds", "rule_inefficiency", "calibration_shift"]].add_suffix("_b"),
+                    a[["regret", "fold_seconds", "window", *terms]].add_suffix("_a"),
+                    base[["regret", "fold_seconds", *terms]].add_suffix("_b"),
                 ],
                 axis=1,
                 join="inner",
@@ -200,9 +265,11 @@ def paired_vs_baseline(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
             j["d_seconds"] = j["fold_seconds_a"] - j["fold_seconds_b"]
             j["d_rule"] = j["rule_inefficiency_a"] - j["rule_inefficiency_b"]
             j["d_shift"] = j["calibration_shift_a"] - j["calibration_shift_b"]
+            j["d_shift_honest"] = j["calibration_shift_honest_a"] - j["calibration_shift_honest_b"]
             j = j.rename(columns={"window_a": "window"})
+            deltas = ["d_regret", "d_seconds", "d_rule", "d_shift", "d_shift_honest"]
             for window, w in j.groupby("window", observed=True):
-                cells = w.groupby(CELL_KEYS, observed=True)[["d_regret", "d_seconds", "d_rule", "d_shift"]].mean()
+                cells = w.groupby(CELL_KEYS, observed=True)[deltas].mean()
                 d = cells["d_regret"].to_numpy()
                 p = float("nan")
                 if len(d) >= 6 and not np.allclose(d, 0):
@@ -219,6 +286,7 @@ def paired_vs_baseline(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
                         "d_regret": float(d.mean()),
                         "d_rule_inefficiency": float(cells["d_rule"].mean()),
                         "d_calibration_shift": float(cells["d_shift"].mean()),
+                        "d_calibration_shift_honest": float(cells["d_shift_honest"].mean()),
                         "d_seconds": d_sec,
                         # Regret bought per extra second of calibration.  A win
                         # that is real but costs 10x the wall clock for 0.001
@@ -244,6 +312,7 @@ def paired_vs_baseline(v: pd.DataFrame, agg: Path) -> pd.DataFrame:
         "d_regret",
         "d_rule_inefficiency",
         "d_calibration_shift",
+        "d_calibration_shift_honest",
         "d_seconds",
         "regret_per_extra_second",
         "win_rate",
@@ -292,7 +361,7 @@ def knee_table(paired: pd.DataFrame, levels: pd.DataFrame, agg: Path) -> pd.Data
     return t
 
 
-def verdicts(paired: pd.DataFrame, knee: pd.DataFrame, levels: pd.DataFrame) -> dict:
+def verdicts(paired: pd.DataFrame, knee: pd.DataFrame, levels: pd.DataFrame, disp: pd.DataFrame) -> dict:
     """Mechanically apply the plan's decision rules.
 
     H1 (benefit): does any K beat K=2 by more than :data:`MARGIN` in the deep
@@ -301,8 +370,29 @@ def verdicts(paired: pd.DataFrame, knee: pd.DataFrame, levels: pd.DataFrame) -> 
     :data:`COST_CEILING_X` of production's?
     H3 (recommendation): the smallest K satisfying both, per voting mode -
     ``2`` (keep production) when H1 fails.
-    H4 (mechanism): does K's benefit land on the rule-inefficiency term rather
-    than the calibration->test shift, as the variance story predicts?
+    H4 (mechanism): **re-posed after #3116.**  It used to ask whether K's benefit
+    lands on ``rule_inefficiency`` rather than on ``calibration_shift``, read as
+    "sampling noise in the cut fell".  That question is not answerable from those
+    two terms, for two independent reasons:
+
+    * ``rule_inefficiency`` is a *signed cost gap between two cuts*, not a
+      variance.  It was negative in every row of #2897 (-0.291 at K=1 ->
+      -0.080 at K=16), i.e. the trained cut beating a calibration-set "oracle"
+      that overfits a handful of scores.  Rising toward zero is not variance
+      falling.
+    * Its reference moves with the arm.  ``c_thr`` is estimated from the pooled
+      calibration set, which grows linearly in K, so as K rises ``c_thr``
+      converges on the test-oracle cut - shrinking ``calibration_shift`` and
+      widening ``rule_inefficiency`` **from one cause, in opposite directions**,
+      with the sum pinned to regret by construction.  The anti-correlation
+      #2897 reported is algebra, not evidence.
+
+    So the arithmetic comparison is still emitted, under a name that describes
+    only the arithmetic (``h4_d_rule_below_d_shift``), together with
+    ``h4_reference_moves_with_k`` recording that its reference is not fixed
+    across the arms.  The mechanism question is answered instead by
+    ``h4_sd_threshold_by_k`` (:func:`threshold_dispersion`), which measures the
+    dispersion of the shipped threshold directly.
     """
     out: dict = {"margin": MARGIN, "cost_ceiling_x": COST_CEILING_X, "baseline_k": BASELINE_K, "by_voting": {}}
     # The shipped threshold is the blended one; fall back to the raw
@@ -316,6 +406,7 @@ def verdicts(paired: pd.DataFrame, knee: pd.DataFrame, levels: pd.DataFrame) -> 
             d_regret=("d_regret", "mean"),
             d_rule=("d_rule_inefficiency", "mean"),
             d_shift=("d_calibration_shift", "mean"),
+            d_shift_honest=("d_calibration_shift_honest", "mean"),
             p=("p_wilcoxon", "max"),
             d_seconds=("d_seconds", "mean"),
         )
@@ -330,6 +421,24 @@ def verdicts(paired: pd.DataFrame, knee: pd.DataFrame, levels: pd.DataFrame) -> 
         recommended = int(min(affordable.index)) if len(affordable) else BASELINE_K
 
         best = agg_k["d_regret"].idxmin() if len(agg_k) else BASELINE_K
+
+        # #3116's guard: the decomposition's reference is estimated from the
+        # calibration set, so if that set's size moves with K the two terms are
+        # not independent readings and must not be reported as if they were.
+        # In this study it always does move - that is what K *is* - so this
+        # flag is expected to be true, and its job is to make the caveat
+        # travel with the number instead of living in someone's memory.
+        n_cal_by_k = lv.groupby("k", observed=True)["n_cal_scores"].mean().dropna()
+        reference_moves = bool(len(n_cal_by_k) > 1 and float(n_cal_by_k.max() - n_cal_by_k.min()) > 0.0)
+
+        # The mechanism question, asked of the threshold directly.
+        sd = disp[(disp["voting"] == voting) & (disp["arm"] == arm)]
+        sd = sd[sd["window"].astype(str).map(_window_hi) >= DEEP_MIN]
+        sd_by_k = sd.groupby("k", observed=True)["sd_threshold"].mean().dropna() if len(sd) else pd.Series(dtype=float)
+        sd_falls = None
+        if BASELINE_K in sd_by_k.index and best in sd_by_k.index and best != BASELINE_K:
+            sd_falls = bool(sd_by_k[best] < sd_by_k[BASELINE_K])
+
         out["by_voting"][voting] = {
             "h1_any_k_beats_baseline": bool(len(beats)),
             "h1_ks_beating_baseline": [int(k) for k in beats.index],
@@ -339,11 +448,15 @@ def verdicts(paired: pd.DataFrame, knee: pd.DataFrame, levels: pd.DataFrame) -> 
             "best_k_ignoring_cost": int(best),
             "best_d_regret": float(agg_k["d_regret"].min()) if len(agg_k) else 0.0,
             "cost_x_at_recommended": float(sec_x.get(recommended, float("nan"))) if sec_x is not None else None,
-            "h4_benefit_is_rule_inefficiency": bool(
-                len(agg_k) and agg_k.loc[best, "d_rule"] <= agg_k.loc[best, "d_shift"]
-            ),
+            # Arithmetic only - see this function's docstring.  The old name for
+            # this key asserted a mechanism the terms cannot carry (#3116).
+            "h4_d_rule_below_d_shift": bool(len(agg_k) and agg_k.loc[best, "d_rule"] <= agg_k.loc[best, "d_shift"]),
+            "h4_reference_moves_with_k": reference_moves,
+            "h4_sd_threshold_by_k": {int(k): float(x) for k, x in sd_by_k.items()},
+            "h4_sd_threshold_falls_at_best_k": sd_falls,
             "d_rule_at_best": float(agg_k.loc[best, "d_rule"]) if len(agg_k) else 0.0,
             "d_shift_at_best": float(agg_k.loc[best, "d_shift"]) if len(agg_k) else 0.0,
+            "d_shift_honest_at_best": float(agg_k.loc[best, "d_shift_honest"]) if len(agg_k) else 0.0,
         }
     out["knee_by_window"] = knee[knee["arm"] == arm].to_dict(orient="records")
     return out
@@ -357,8 +470,16 @@ def _window_hi(label) -> int:
 
 
 def shipped_arm(v: pd.DataFrame) -> str:
-    """The arm the verdict reads: the blended threshold users get, when present."""
-    return "blend" if "blend" in set(v["arm"]) else "xcal"
+    """The arm the verdict reads: the closest thing in the run to what users get.
+
+    ``anchored`` first (#3116): :func:`~vtscore.training.thresholds.fold_anchored_gmm_threshold`
+    has been the shipped path since the 2026-08-05 population-anchored run, and
+    it is the only arm in which K moves *both* halves of the threshold.  ``blend``
+    is the retired ``cap50`` mix-in, kept so pre-#3116 runs still read; ``xcal``
+    is the raw cut, the fallback for a run without safe thresholds.
+    """
+    arms = set(v["arm"])
+    return next((name for name in ("anchored", "blend", "xcal") if name in arms), "xcal")
 
 
 def ab_check(screen: pd.DataFrame, ab_dirs: list[Path], agg: Path) -> pd.DataFrame:
@@ -433,7 +554,7 @@ def _cell_deltas(v: pd.DataFrame, k: int) -> pd.Series:
     return (j["a"] - j["b"]).groupby([j["env"], j["category"], j["seed"]]).mean()
 
 
-def write_report(results: Path, levels, paired, knee, verd, ab) -> None:
+def write_report(results: Path, levels, paired, knee, verd, ab, disp) -> None:
     lines = [
         "# Calibration fold-count study (#2897)",
         "",
@@ -466,6 +587,18 @@ def write_report(results: Path, levels, paired, knee, verd, ab) -> None:
         "",
         _md(knee),
         "",
+        "## Threshold dispersion: sd(threshold) across seeds, per K",
+        "",
+        "The direct form of H4's question (#3116).  `rule_inefficiency` is a",
+        "signed cost gap between two cuts, not a variance, and its reference is",
+        "estimated from a calibration set that grows with K - so the two",
+        "decomposition terms move in opposite directions from one cause and",
+        "cannot answer 'did the cut get less noisy'.  This can: it is the spread",
+        "of the shipped threshold across seeds at a fixed step, averaged over",
+        "steps.",
+        "",
+        _md(disp) if len(disp) else "_No step carries >=2 seeds; dispersion is undefined for this run._",
+        "",
         "## A/B check: does a run that lives at K reproduce the screen?",
         "",
         _md(ab) if len(ab) else "_No A/B run dirs passed; screen only._",
@@ -490,14 +623,17 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     levels = level_table(v, agg)
+    disp = threshold_dispersion(v, agg)
+    if disp.empty:
+        common.log("  sd(threshold): no step carries >=2 seeds; H4's direct instrument is unavailable")
     paired = paired_vs_baseline(v, agg)
     knee = knee_table(paired, levels, agg)
-    verd = verdicts(paired, knee, levels)
+    verd = verdicts(paired, knee, levels, disp)
     ab = ab_check(v, [Path(d) / "results" for d in argv], agg) if argv else pd.DataFrame()
     verd["ab_check"] = ab.to_dict(orient="records") if len(ab) else None
 
     (results / "summary.json").write_text(json.dumps(verd, indent=2))
-    write_report(results, levels, paired, knee, verd, ab)
+    write_report(results, levels, paired, knee, verd, ab, disp)
     common.log(f"wrote {results / 'summary.json'} and {results / 'REPORT.md'}")
     return 0
 

--- a/scripts/experiments/calibration/selftest_analyze_folds_2897.py
+++ b/scripts/experiments/calibration/selftest_analyze_folds_2897.py
@@ -10,8 +10,13 @@ Plants a known answer and checks the analyzer recovers exactly it:
   while still showing up as ``best_k_ignoring_cost``;
 * a **null** binary arm, where no K beats K=2 by more than the margin, so the
   verdict must be "keep production" rather than the argmin of noise;
-* the benefit landing on ``rule_inefficiency`` (H4), not on the
-  calibration->test shift, which more folds cannot touch;
+* the arithmetic comparison of the two decomposition terms, under the name that
+  claims only arithmetic - #3116 established that they cannot carry H4's
+  mechanism claim, because the reference defining the split is estimated from a
+  calibration set that grows with K;
+* H4's **direct** instrument, ``sd(threshold)`` across seeds, planted with a
+  closed-form ``1/sqrt(K)`` shape so the averaging is checked exactly;
+* the guard flag that records the reference moving with the arm;
 * nothing leaking into the shallow windows, where the effect is planted at zero.
 
 The whole point is that a sign error, an off-by-one in the knee scan, or a
@@ -58,6 +63,29 @@ SECONDS_PER_FOLD = 0.4
 OVERHEAD_S = 0.0
 #: The non-calibration part of a step, so ``cal_share`` is a real fraction.
 OTHER_STEP_S = 0.3
+
+#: Planted seed-to-seed spread of the shipped threshold at K=1, shrinking as
+#: ``1/sqrt(K)`` - the textbook shape for an estimator averaging K independent
+#: draws.  With two seeds placed symmetrically about 0.5 the sample sd at fold
+#: count K is exactly ``THRESHOLD_SPREAD / sqrt(2K)``, so
+#: :func:`analyze_folds_2897.threshold_dispersion` has a closed-form answer to
+#: be checked against rather than a "looks about right" bound.
+#:
+#: This is the instrument #3116 asks for: the decomposition terms cannot say
+#: whether the cut got less noisy, and this can.  Planting it here means a
+#: regression in the averaging (pooling across steps instead of across seeds,
+#: say, which would pick up the trajectory's own drift) fails the selftest.
+THRESHOLD_SPREAD = 0.08
+
+
+def _planted_threshold(seed: int, k: int) -> float:
+    """The shipped threshold for one (seed, fold count) - see :data:`THRESHOLD_SPREAD`."""
+    return 0.5 + (seed - 0.5) * THRESHOLD_SPREAD / np.sqrt(k)
+
+
+def _planted_sd(k: int) -> float:
+    """Sample sd of :func:`_planted_threshold` over :data:`SEEDS`, in closed form."""
+    return THRESHOLD_SPREAD / np.sqrt(2.0 * k)
 
 
 def _fabricate(results: Path, rng: np.random.Generator, counts: list[int] | None = None, region=None) -> None:
@@ -110,18 +138,24 @@ def _fabricate(results: Path, rng: np.random.Generator, counts: list[int] | None
                         # inefficiency); the calibration->test shift is a
                         # property of the split, which K cannot move.
                         rule = (regret - 0.05) if deep else 0.08
-                        for arm in ("xcal", "blend"):
+                        for arm in ("xcal", "blend", "anchored"):
                             rows.append(
                                 {
                                     **base,
                                     "gmm_variant": f"folds_k{k}_{arm}",
-                                    "threshold": 0.5,
+                                    "threshold": _planted_threshold(seed, k),
                                     "cost": 0.2 + regret,
                                     "regret": regret,
                                     "fpr": 0.05,
                                     "fnr": 0.12,
                                     "rule_inefficiency": rule,
                                     "calibration_shift": 0.05,
+                                    # #3116's cross-fitted twin.  Planted flat,
+                                    # like its naive sibling: this checks the
+                                    # column reaches the verdict, and asserting
+                                    # a *shape* here would be planting a
+                                    # mechanism nobody has measured.
+                                    "calibration_shift_honest": 0.02,
                                     "fold_count": k,
                                     "fold_seconds": OVERHEAD_S + SECONDS_PER_FOLD * k,
                                     "n_cal_scores": 20 * k,
@@ -158,7 +192,8 @@ def main() -> int:
         assert rc == 0, f"analyze_folds_2897 returned {rc}"
 
         verd = json.loads((results / "summary.json").read_text())
-        assert verd["arm_read"] == "blend", verd  # the shipped threshold, not the raw cut
+        # The shipped rule (#3116), not the retired blend and not the raw cut.
+        assert verd["arm_read"] == "anchored", verd
         region = verd["by_voting"]["region"]
         binary = verd["by_voting"]["binary"]
 
@@ -170,8 +205,26 @@ def main() -> int:
         assert region["h3_kept_production"] is False, region
         assert region["best_k_ignoring_cost"] == 16, region
         assert abs(region["cost_x_at_recommended"] - 1.5) < 1e-6, region
-        assert region["h4_benefit_is_rule_inefficiency"] is True, region
+        assert region["h4_d_rule_below_d_shift"] is True, region
         assert abs(region["d_shift_at_best"]) < 1e-9, region
+        # The honest twin reaches the verdict and is flat, as planted.
+        assert abs(region["d_shift_honest_at_best"]) < 1e-9, region
+
+        # --- #3116: the guard, and H4's direct instrument. ---
+        # `n_cal_scores` is planted as 20*K, so the decomposition's reference
+        # provably moves with the arm and the analyzer must say so.
+        assert region["h4_reference_moves_with_k"] is True, region
+        assert binary["h4_reference_moves_with_k"] is True, binary
+        # sd(threshold) across seeds must come back at the planted closed form
+        # for every K, not merely fall monotonically: an averaging bug that
+        # pooled across steps rather than seeds would still be monotone here.
+        sd_by_k = region["h4_sd_threshold_by_k"]
+        assert sd_by_k, region
+        for k_str, sd in sd_by_k.items():
+            expected = _planted_sd(int(k_str))
+            assert abs(sd - expected) < 1e-9, (k_str, sd, expected)
+        # Best K is 16, baseline 2, and the spread shrinks as 1/sqrt(K).
+        assert region["h4_sd_threshold_falls_at_best_k"] is True, region
 
         # Binary: nothing beats the margin, so production stands.
         assert binary["h1_any_k_beats_baseline"] is False, binary

--- a/scripts/experiments/calibration/status_folds_2897.sh
+++ b/scripts/experiments/calibration/status_folds_2897.sh
@@ -57,7 +57,7 @@ for mode, b in (s.get("by_voting") or {}).items():
     print(f"    {mode}: recommended_k={b.get('h3_recommended_k')} "
           f"kept_production={b.get('h3_kept_production')} "
           f"best_ignoring_cost={b.get('best_k_ignoring_cost')} "
-          f"H4_rule_inefficiency={b.get('h4_benefit_is_rule_inefficiency')}")
+          f"sd_thr_falls={b.get('h4_sd_threshold_falls_at_best_k')}")
 PY
   fi
   echo

--- a/tests_lib/detectors/test_calibration_harness.py
+++ b/tests_lib/detectors/test_calibration_harness.py
@@ -196,6 +196,19 @@ def test_calibration_columns_and_invariants():
         # regret decomposition identity (when the calibration oracle exists)
         if np.isfinite(r["rule_inefficiency"]) and np.isfinite(r["calibration_shift"]):
             assert r["rule_inefficiency"] + r["calibration_shift"] == pytest.approx(r["regret"], abs=1e-5)
+        # #3116: the honest re-decomposition telescopes the same way, off the
+        # cross-fitted reference instead of the sample minimum.
+        if np.isfinite(r["rule_inefficiency"]) and np.isfinite(r["calibration_shift_honest"]):
+            assert r["rule_inefficiency"] + r["calibration_shift_honest"] == pytest.approx(r["regret_honest"], abs=1e-5)
+        # `regret_honest` is the same subtraction off the other reference.
+        # Deliberately NOT asserting `oracle_cost <= oracle_cost_honest` per
+        # row: the cross-fitted rule applies a *different* cut per fold, so it
+        # has freedom the single-threshold sample minimum does not and can beat
+        # it on a given draw.  The bracket is a statement about the population
+        # optimum, not a per-sample ordering, and asserting it here would be a
+        # coin-flip test.
+        if np.isfinite(r["oracle_cost_honest"]):
+            assert r["regret_honest"] == pytest.approx(r["cost"] - r["oracle_cost_honest"], abs=1e-5)
         assert 0.0 <= r["threshold_percentile"] <= 1.0 or np.isnan(r["threshold_percentile"])
     # tree arm pools over many nodes; base n_pool_rows should exceed 1
     assert max(r["n_pool_rows"] for r in rows if r["pool_variant"] == "max") > 1.0

--- a/tests_lib/detectors/test_fold_count_variant_rows.py
+++ b/tests_lib/detectors/test_fold_count_variant_rows.py
@@ -2,9 +2,9 @@
 
 With ``emit_calibration_metrics=True``, a style, and ``fold_count_variants``
 the harness trains ``max(calibrate_count, *variants)`` calibration folds per
-step and emits one ``folds_k{K}_xcal`` row per K - plus a ``folds_k{K}_blend``
-row wherever a safe-threshold fit exists - each carrying that fold count's
-regret and its measured wall clock.
+step and emits one ``folds_k{K}_xcal`` row per K - plus ``folds_k{K}_blend`` and
+``folds_k{K}_anchored`` rows wherever a safe-threshold fit exists - each
+carrying that fold count's regret and its measured wall clock.
 
 The invariants the whole study rests on:
 
@@ -241,6 +241,93 @@ class TestFoldCountBlendArm:
             assert np.isfinite(b["blend_weight"])
             if b["blend_weight"] == 1.0:
                 assert b["threshold"] == xcal[t]["threshold"]
+
+
+class TestFoldCountAnchoredArm:
+    """The arm that measures **production's** threshold rule across K (#3116).
+
+    The other two arms cannot: ``xcal`` is the raw conformal cut, and ``blend``
+    is the retired ``cap50`` mix-in whose GMM half is a single unanchored fit on
+    the sim haystack - K-independent by construction, so only its x-cal half
+    ever moved.  The shipped path fits one *anchored* mixture per fold, so K
+    multiplies the number of mixtures combined.
+    """
+
+    def test_anchored_arm_only_under_safe_thresholds(self):
+        off = _run(fold_counts=_COUNTS, safe=False)
+        assert not any(r["gmm_variant"].endswith("_anchored") for r in off)
+        on = _run(fold_counts=_COUNTS, safe=True)
+        assert any(r["gmm_variant"].endswith("_anchored") for r in on), "no anchored fold-count arm"
+
+    def test_arm_at_live_count_reproduces_the_shipped_threshold(self):
+        """The control that licenses the arm: at K == calibrate_count it *is* production.
+
+        The base row's threshold on a safe-threshold run is
+        ``fold_anchored_gmm_threshold`` over the live folds.  The K=2 anchored
+        arm re-derives it from the Kmax run's own fold prefix, so any drift
+        between the arm and the shipped rule - a mis-sliced prefix, haystacks
+        out of step with their orderings, the wrong inclusion - shows up here as
+        an inequality rather than as a plausible number in a report.
+        """
+        rows = _run(fold_counts=_COUNTS, calibrate_count=2, safe=True)
+        base = _base_rows(rows)
+        live = _arm_rows(rows, "folds_k2_anchored")
+        assert live, "no live-count anchored arm emitted"
+        compared = 0
+        for t, arm in live.items():
+            # Only on steps the shipped rule actually anchored; a step that fell
+            # back to the blend has no fold-anchored threshold to reproduce.
+            if base[t]["threshold_provenance"].startswith("fold_anchored"):
+                assert arm["threshold"] == base[t]["threshold"], t
+                assert arm["threshold_provenance"] == base[t]["threshold_provenance"], t
+                compared += 1
+        assert compared, "no step reached a fold-anchored cut"
+
+    def test_anchored_arm_fits_k_mixtures_at_k(self):
+        """K must actually drive the number of anchored mixtures - the point of the arm.
+
+        Asserted through **provenance** rather than through the threshold.
+        ``fold_anchored_gmm_threshold`` reports ``fold_anchored[a/k]`` naming
+        how many folds it anchored, so a mis-sliced prefix - the live count
+        reused at every K, the haystacks out of step with their orderings -
+        shows up here as the wrong ``k`` and cannot be missed.
+
+        The realized *threshold* is deliberately not the assertion: it is a
+        quantile carried onto the final model's haystack, and this fixture's
+        haystack is small enough that neighbouring quantiles routinely land on
+        the same order statistic.  Two fold counts producing the same float
+        here is therefore an artefact of a 40-media-per-category fixture, not
+        evidence that the fit was reused - which is exactly why the count, not
+        the value, is what this pins.
+        """
+        rows = _run(fold_counts=_COUNTS, calibrate_count=2, safe=True)
+        seen: dict[int, set[str]] = {}
+        for k in _COUNTS:
+            for r in _arm_rows(rows, f"folds_k{k}_anchored").values():
+                seen.setdefault(k, set()).add(r["threshold_provenance"])
+        assert set(seen) == set(_COUNTS), f"missing anchored arms: {set(_COUNTS) - set(seen)}"
+        for k, provs in seen.items():
+            anchored = {p for p in provs if p.startswith("fold_anchored[")}
+            assert anchored, f"K={k} never reached an anchored fit: {provs}"
+            # `[a/k]` - `a` folds anchored of `k` used; `k` is the knob.
+            assert {p.split("/")[1].rstrip("]") for p in anchored} == {str(k)}, (k, anchored)
+
+    def test_extra_haystacks_do_not_perturb_the_live_threshold(self):
+        """Scoring the Kmax fold models must leave the shipped cut byte-identical.
+
+        The extra haystacks ride in ``fold_count_data`` precisely so the live
+        fit keeps using only ``calibrate_count`` of them; this pins that the
+        observer effect is zero.
+        """
+        screened = _base_rows(_run(fold_counts=_COUNTS, calibrate_count=2, safe=True))
+        plain = _base_rows(_run(fold_counts=None, calibrate_count=2, safe=True))
+        compared = 0
+        for t, row in screened.items():
+            if t in plain:
+                assert row["threshold"] == plain[t]["threshold"], t
+                assert row["threshold_provenance"] == plain[t]["threshold_provenance"], t
+                compared += 1
+        assert compared, "no comparable steps"
 
 
 class TestFoldCountBinaryVoting:

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -230,10 +230,14 @@ _CALIBRATION_COLUMNS: tuple[str, ...] = (
     "oracle_fpr",
     "oracle_fnr",
     "regret",
+    "oracle_threshold_honest",
+    "oracle_cost_honest",
+    "regret_honest",
     "cal_oracle_threshold",
     "cal_oracle_cost",
     "rule_inefficiency",
     "calibration_shift",
+    "calibration_shift_honest",
     "n_pool_rows",
     "fold_count",
     "fold_seconds",
@@ -642,6 +646,22 @@ def _safe_threshold_for_step(
         _fids, fscores = _score_sim_set_with_model(model, region_aware, sim_clips, X_all_clips, sim_ids, style_obj)
         fold_haystacks.append(np.asarray(fscores, dtype=np.float64))
 
+    # #3116: the #2897 fold-count arms need a haystack per fold to re-fit the
+    # *shipped* rule at each K, and `details["fold_models"]` is trimmed to the
+    # live `calibrate_count`.  Score the extra Kmax-run folds here, where the
+    # sim set and the scoring machinery are already in hand, and stash them
+    # beside the orderings for :func:`_fold_count_variant_rows`.  Only the
+    # models past the live prefix are scored - the folds are nested, so the
+    # first `n_folds` haystacks are the ones just computed above, and this adds
+    # `Kmax - calibrate_count` scoring passes rather than Kmax of them.
+    fold_data = details.get("fold_count_data")
+    if fold_data is not None and fold_data.get("models"):
+        extended = list(fold_haystacks)
+        for model in fold_data["models"][len(extended) :]:
+            _fids, fscores = _score_sim_set_with_model(model, region_aware, sim_clips, X_all_clips, sim_ids, style_obj)
+            extended.append(np.asarray(fscores, dtype=np.float64))
+        fold_data["haystacks"] = extended
+
     cut = fit_fold_anchored_cut(fold_haystacks, fold_orderings[:n_folds], all_scores) if fold_haystacks else None
     if cut is not None:
         anchored = cut.threshold_at(inclusion)
@@ -740,6 +760,49 @@ def _r(x: float) -> float:
     return round(x, 6) if math.isfinite(x) else x
 
 
+#: Memo for :func:`_honest_oracle`, keyed on a digest of its exact inputs.
+#: Bounded because the only reuse that matters is *within* a step, where every
+#: variant row measures the same ``(base_scores, base_labels)`` at the same
+#: inclusion: a step emits dozens of rows and the cross-fitted oracle is five
+#: sorts, so recomputing it per row would be the dominant cost of the
+#: decomposition.  Across steps the key changes and the old entry is dead, so a
+#: handful of slots is all this ever needs.
+_HONEST_ORACLE_MEMO: "dict[bytes, tuple[float, float]]" = {}
+_HONEST_ORACLE_MEMO_MAX = 8
+
+
+def _honest_oracle(scores: "np.ndarray", labels: "np.ndarray", wf: float, wn: float) -> tuple[float, float]:
+    """Memoized :func:`~vtscore.eval.transfer_rules.honest_test_oracle`.
+
+    Safe to memoize because the estimator is a pure function of its arguments -
+    its own resampling is seeded from a digest of the score array rather than
+    from global RNG state (see :func:`vtscore.eval.transfer_rules._rng`), so two
+    calls on equal inputs return bit-identical results with or without the cache.
+    The key is a digest of both arrays *and* the cost weights, because the same
+    test scores are decomposed at more than one inclusion in a single run.
+    """
+    import hashlib  # noqa: PLC0415
+
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.eval.transfer_rules import honest_test_oracle  # noqa: PLC0415
+
+    s = np.ascontiguousarray(scores, dtype=np.float64)
+    lb = np.ascontiguousarray(labels, dtype=np.float64)
+    h = hashlib.blake2b(s.tobytes(), digest_size=16)
+    h.update(lb.tobytes())
+    h.update(np.asarray([wf, wn], dtype=np.float64).tobytes())
+    key = h.digest()
+    hit = _HONEST_ORACLE_MEMO.get(key)
+    if hit is not None:
+        return hit
+    out = honest_test_oracle(s, lb, wf, wn)
+    if len(_HONEST_ORACLE_MEMO) >= _HONEST_ORACLE_MEMO_MAX:
+        _HONEST_ORACLE_MEMO.clear()
+    _HONEST_ORACLE_MEMO[key] = out
+    return out
+
+
 def _operating_metrics(
     scores: "np.ndarray",
     labels: "np.ndarray",
@@ -762,6 +825,43 @@ def _operating_metrics(
     on calibration vs. best cut on test).  ``cal_scores``/``cal_labels`` are the
     pooled calibration fold orderings under the same pooling; ``None`` skips the
     decomposition (leaves those columns NaN).
+
+    **Two reference points, because the naive one is optimistic** (#3116, #3248).
+    ``oracle_cost`` is the minimum of the empirical cost over the very test
+    sample it is then scored on - :func:`~vtscore.eval.calibration_metrics.oracle_cut`'s
+    own docstring calls it a lower bound on achievable cost rather than a rule -
+    so every gap measured against it is inflated by however much that minimum
+    overfits.  #2883 measured that optimism directly and found it was the *whole*
+    of the sibling ``transfer`` term (+0.041 naive, −0.001 cross-fitted).
+    ``oracle_cost_honest`` is the same quantity cross-fitted
+    (:func:`~vtscore.eval.transfer_rules.honest_test_oracle`: cut chosen on K−1
+    folds, paid on the held-out one), and the pair **brackets** the population
+    optimum rather than pinning it - naive from below, honest from above, since
+    the honest cut sees only ``(K−1)/K`` of the sample.  ``regret`` and
+    ``calibration_shift`` therefore ship beside ``regret_honest`` and
+    ``calibration_shift_honest``; read the two as an interval, and prefer the
+    honest one whenever a *level* rather than a paired contrast is being quoted.
+    ``rule_inefficiency`` is untouched by the choice - it never references the
+    test oracle - so both decompositions telescope exactly:
+
+    * ``rule_inefficiency + calibration_shift        == regret``
+    * ``rule_inefficiency + calibration_shift_honest == regret_honest``
+
+    **The split's reference moves with anything that feeds ``cal_scores``**
+    (#3116).  ``c_thr`` is estimated *from the calibration set*, so a study that
+    sweeps a knob changing that set's size or content - ``calibrate_count`` is
+    the case on record - is moving the yardstick it measures against.  As the
+    calibration set grows, ``c_thr`` converges on the test-oracle cut, which
+    shrinks ``calibration_shift`` and widens ``rule_inefficiency`` **from one
+    cause, in opposite directions**, with their sum pinned to ``regret`` by
+    construction.  #2897 read exactly that anti-correlation as a finding; it is
+    algebra.  Do not report the two terms as independent effects of such a knob
+    without a reference held fixed across the arms - and note that
+    ``rule_inefficiency`` is a signed cost gap between two cuts, **not** a
+    variance: it is routinely negative (the trained cut beating a
+    calibration-set "oracle" that overfits a handful of scores), and a study
+    asking whether the *threshold* got less variable wants ``sd(threshold)``
+    across seeds, which ``analyze_folds_2897.py`` reports.
     """
     import numpy as np  # noqa: PLC0415
 
@@ -781,6 +881,11 @@ def _operating_metrics(
     cost, fpr, fnr = operating_cost(scores, labels, threshold, wf, wn)
     o_thr, o_cost, o_fpr, o_fnr = oracle_cut(scores, labels, wf, wn)
     regret = cost - o_cost
+    # The honest half of the bracket; NaN on a test sample too small or too
+    # one-sided to cross-fit, which leaves the honest columns empty rather than
+    # silently falling back to the optimistic reference they exist to correct.
+    o_cost_honest, o_thr_honest = _honest_oracle(scores, labels, wf, wn)
+    regret_honest = cost - o_cost_honest
 
     nan = float("nan")
     if cal_scores is not None and np.asarray(cal_scores).size > 0:
@@ -790,11 +895,13 @@ def _operating_metrics(
         cal_oracle_cost, _, _ = operating_cost(scores, labels, c_thr, wf, wn)
         rule_inefficiency = cost - cal_oracle_cost
         calibration_shift = cal_oracle_cost - o_cost
+        calibration_shift_honest = cal_oracle_cost - o_cost_honest
     else:
         c_thr = nan
         cal_oracle_cost = nan
         rule_inefficiency = nan
         calibration_shift = nan
+        calibration_shift_honest = nan
 
     return {
         "pool_variant": pool_variant,
@@ -835,10 +942,18 @@ def _operating_metrics(
         "oracle_fpr": _r(o_fpr),
         "oracle_fnr": _r(o_fnr),
         "regret": _r(regret),
+        # The cross-fitted reference and the two terms it re-bases (#3116).
+        # Bracket, not replacement: `oracle_cost` bounds the population optimum
+        # from below and `oracle_cost_honest` from above, so a level quoted from
+        # either alone is one end of an interval.
+        "oracle_threshold_honest": _r(float(o_thr_honest)),
+        "oracle_cost_honest": _r(o_cost_honest),
+        "regret_honest": _r(regret_honest),
         "cal_oracle_threshold": _r(float(c_thr)),
         "cal_oracle_cost": _r(cal_oracle_cost),
         "rule_inefficiency": _r(rule_inefficiency),
         "calibration_shift": _r(calibration_shift),
+        "calibration_shift_honest": _r(calibration_shift_honest),
         "n_pool_rows": _r(float(n_pool_rows)),
     }
 
@@ -1213,16 +1328,33 @@ def _fold_count_variant_rows(
     reproduces this step's own pre-blend conformal cut - the control that
     licenses the rest of the table.
 
-    Two arms per K, because the fold count and the shipped threshold are
+    Three arms per K, because the fold count and the shipped threshold are
     different questions:
 
     * ``folds_k{K}_xcal`` - the raw cross-calibration cut, the thing K is
       actually a knob on.
-    * ``folds_k{K}_blend`` - that cut after the safe-threshold mix-in the user
-      really gets.  The blend weight depends only on the vote counts, so it is
-      identical across K and this arm isolates how much of K's benefit survives
-      being averaged with the GMM cut.  Emitted only when the step has the
-      pooled sim scores the blend fits.
+    * ``folds_k{K}_blend`` - that cut after the ``cap50`` safe-threshold mix-in.
+      The blend weight depends only on the vote counts, so it is identical
+      across K and this arm isolates how much of K's benefit survives being
+      averaged with the GMM cut.  Emitted only when the step has the pooled sim
+      scores the blend fits.
+    * ``folds_k{K}_anchored`` - **production's rule** (#3116).  The blend above
+      was retired by the 2026-08-05 population-anchored run; the shipped path is
+      :func:`~vtscore.training.thresholds.fold_anchored_gmm_threshold`, which
+      fits one anchored mixture *per fold* and combines them in quantile space.
+      K therefore moves the shipped threshold through a path the other two arms
+      do not exercise at all - the blend's GMM half is a single unanchored fit
+      on the sim haystack and is K-independent by construction, so ``blend``
+      varies only in its x-cal half.  Without this arm every conclusion about
+      what ``calibrate_count`` does to the threshold users actually get is
+      partial.  Emitted when the step carries at least K fold haystacks, which
+      :func:`_safe_threshold_for_step` supplies (so: under safe thresholds).
+
+    Note what is *not* a defect here: the unanchored ``fit_gmm_threshold`` is
+    hoisted out of the K loop, and that is correct rather than a frozen
+    reference - it reads only ``sim_pooled_scores``, which no fold count
+    touches, so re-fitting it per K would return the same cut at K times the
+    price.  The gap #3116 identified is the missing arm above, not the hoist.
 
     ``fold_seconds`` is the calibration wall clock this K would have cost: the
     measured fit time of its own folds plus the count-independent overhead of
@@ -1241,6 +1373,7 @@ def _fold_count_variant_rows(
     from vtscore.training.thresholds import (  # noqa: PLC0415
         blend_gmm_threshold,
         fit_gmm_threshold,
+        fold_anchored_gmm_threshold,
         safe_blend_weight,
         threshold_from_fold_orderings,
     )
@@ -1251,6 +1384,7 @@ def _fold_count_variant_rows(
     orderings = fold_data["orderings"]
     seconds = fold_data["seconds"]
     overhead = float(fold_data.get("overhead_seconds") or 0.0)
+    haystacks = fold_data.get("haystacks") or []
     if not orderings:
         return []
 
@@ -1279,6 +1413,10 @@ def _fold_count_variant_rows(
             weight = safe_blend_weight(ctx, schedule)
             blended = blend_gmm_threshold(xcal, gmm_cut, ctx, schedule=schedule, fit=gmm_fit)
             arms.append(("blend", blended, "gmm_blend" if weight < 1.0 else "conformal", weight))
+        # The arm that answers the question for the rule users actually get.
+        if len(haystacks) >= k and sim_pooled_scores:
+            anchored, anchored_prov = fold_anchored_gmm_threshold(haystacks[:k], prefix, sim_pooled_scores, inclusion)
+            arms.append(("anchored", anchored, anchored_prov, float("nan")))
 
         for arm, threshold, provenance, weight in arms:
             row = _operating_metrics(
@@ -2326,6 +2464,11 @@ def _calibrate_with_details(
         if fold_count_variants:
             details["fold_count_data"] = {
                 "orderings": orderings,
+                # The **untrimmed** fold models, so the #3116 anchored arm can
+                # re-fit production's rule at every K.  `details["fold_models"]`
+                # is deliberately cut to the live count so nothing downstream
+                # can accidentally widen the shipped threshold's own fit.
+                "models": list(fold_models),
                 "seconds": fold_seconds,
                 # Everything in the calibration wall clock that is *not* a fold
                 # fit (the pooled conformal rule, the node max-pool): paid once


### PR DESCRIPTION
Closes #3116. Builds directly on #3248's `honest_test_oracle`, as that PR's follow-up 1 recommended ("one fix, not two").

Full `./run-tests.sh` green: **8978 passed, 6 skipped**, plus pyright, pip-audit, npm audit and the Vitest suite all OK.

## The defect

`_operating_metrics` splits regret with a reference cut estimated *from the calibration set*, and that set grows linearly in K. So a study sweeping `calibrate_count` moves the yardstick it measures against: as K rises `c_thr` converges on the test-oracle cut, shrinking `calibration_shift` and widening `rule_inefficiency` **from one cause, in opposite directions**, with the sum pinned to regret by construction. #2897 reported exactly that anti-correlation as a finding. It is algebra.

## What ships

**An honest reference.** `oracle_cost` is the minimum of the empirical cost over the very test sample it is then scored on — `oracle_cut`'s own docstring calls it a lower bound, not a rule. #2883 measured that optimism directly and found it was the *whole* of the sibling `transfer` term (+0.041 naive → −0.001 cross-fitted). `_operating_metrics` now also emits `oracle_cost_honest` / `oracle_threshold_honest` / `regret_honest` / `calibration_shift_honest` via `transfer_rules.honest_test_oracle`.

The pair is a **bracket**, not a replacement: naive bounds the population optimum from below, cross-fitted from above (its cut sees only `(K−1)/K` of the sample). `rule_inefficiency` needs no twin — it never references the test oracle — so both decompositions telescope exactly, and the harness test asserts both identities.

Memoized on a digest of its inputs, because it is constant across a step's dozens of variant rows and is five sorts. Safe because the estimator is a pure function of those inputs: its resampling is seeded from the score array, not from global RNG state.

**`sd(threshold)` across seeds, per K.** The quantity H4 was reaching for, and one the harness did not produce. Taken across seeds *at a fixed step* and then averaged over steps, never pooled — a pooled sd would mix the variation the study asks about with the threshold legitimately moving as votes accumulate, and the second is far larger. The selftest plants a closed-form `1/sqrt(K)` shape, so a regression in the averaging fails rather than merely still looking monotone.

**A guard.** `verdicts()` now emits `h4_reference_moves_with_k` whenever `n_cal_scores` varies across the contrasted arms, and `h4_benefit_is_rule_inefficiency` is renamed `h4_d_rule_below_d_shift` — it describes arithmetic, and the old name asserted a mechanism the terms cannot carry.

## One premise had moved, and the real gap is bigger

The issue's fourth item says `_fold_count_variant_rows` freezes the GMM cut outside the K loop. **That is not a defect:** `fit_gmm_threshold` reads only `sim_pooled_scores`, which no fold count touches, so hoisting it is correct and re-fitting per K would return the same cut at K times the price.

But its *conclusion* — that conclusions about the shipped threshold are partial — holds for a larger reason. The `blend` arm measures `blend_gmm_threshold`, the `cap50` mix-in **retired** by the 2026-08-05 anchored run. Production ships `fold_anchored_gmm_threshold`, which fits one anchored mixture **per fold**. K moves the shipped threshold through a path neither existing arm exercises at all.

So this adds `folds_k{K}_anchored`, re-fitting production's rule over each K-prefix. The extra fold models are scored once past the live prefix (`Kmax − calibrate_count` passes, shared across K by nesting) and ride in `fold_count_data` so the live fit keeps using only `calibrate_count` of them — a test pins that the shipped threshold is byte-identical with the screen on. `shipped_arm()` now reads `anchored` first, falling back to `blend` so pre-existing runs still analyze.

Its control: at `K == calibrate_count` the arm reproduces the step's own shipped threshold exactly. Its K-sensitivity is asserted through **provenance** (`fold_anchored[a/k]`) rather than the realized threshold — the threshold is a quantile carried onto the final haystack, and on a 40-media-per-category fixture neighbouring quantiles routinely land on the same order statistic, so asserting the value would have been a coin flip. That is measured, not assumed: the first draft of that test asserted the value and failed for exactly this reason.

## Deliberately not asserted

`oracle_cost <= oracle_cost_honest` per row. The cross-fitted rule applies a *different* cut per fold, so it has freedom the single-threshold sample minimum does not and can beat it on a given draw. The bracket is a statement about the population optimum, not a per-sample ordering; asserting it would have planted a flaky test.

## Follow-up still owed

`_operating_metrics`' honest columns are emitted but nothing consumes them outside `analyze_folds_2897.py` yet. The other calibration analyzers still read the naive `regret` for their headline, which is right for continuity — changing it silently would move every level in the record — but a study quoting a *level* rather than a paired contrast should read the bracket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnfjRDJEziv4rwxu9xvuPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnfjRDJEziv4rwxu9xvuPP)_