### PR TITLE
vg_scale: the corrected dataset, its review pipeline, and a coverage gate (#3156)

### DIFF
--- a/docs/experiments/vg-scale/DATASHEET.md
+++ b/docs/experiments/vg-scale/DATASHEET.md
@@ -1,0 +1,98 @@
+# `vg_scale` — one class list across three box-size bands
+
+A dataset for asking **"how well can we find buses in the middleground?"** — the
+same twelve classes at three object scales, so a small-vs-large difference is
+about size rather than about which words happen to live at which size.
+
+It exists because the published `vg_box_small/medium/large` sets cannot answer
+that question: each category is banded by its *median* box area, so the three
+sets carry disjoint vocabularies and their gap confounds box size with class
+identity (`nose`/`glasses`/`watch` against `fence`/`hill`/`lady`). Those sets
+remain valid for what they measured and are **not** comparable to this one.
+
+## What it is
+
+| | |
+|---|---|
+| medias | ~7,700 VG images, no pixels stored (vectors + `patch_grid` only) |
+| cells | 36 = 12 classes × {small, medium, large} |
+| positives | exactly **100 per cell**, each carrying its ground-truth box |
+| negatives | one shared pool of **3,900**, identical for every cell |
+| prevalence | **0.0250 in all 36 cells**, by construction |
+| embedders | `siglip`, `siglip2_l`, `dinov3_patch` (the last carries patch grids, so region voting is real) |
+
+Classes: `backpack` `bicycle` `bird` `boat` `book` `bus` `clock` `dog` `kite`
+`knife` `stop sign` `umbrella` — every one also a COCO-2017 class, which is what
+made the correction pass affordable.
+
+**Bands** are anchored to the patch embedder's geometry, as fractions of image
+area: `small` < 1/196 (below one DINOv3 patch), `medium` 1/196–1/12 (patch to
+smallest HAC leaf), `large` 1/12–0.80. Size means the **union box** over a
+class's instances — what one Good vote actually drags — and an image whose union
+is scattered far wider than its largest instance is excluded rather than banded,
+because there the box describes the scatter and not the object.
+
+**Cells are designated, not inferred.** Each is exactly its 100 positives plus
+the shared negatives; everything else is *excluded* from it. That third value is
+the point: an image holding a large bus is not a `bus@small` positive, and
+calling it a negative would penalise a detector for finding a real bus. Consumers
+must honour it via `vtscore.eval.labels.evaluable_pool` — the harness does this
+once per cell, and a pool built without it silently scores excluded images as
+negatives.
+
+## Where the labels come from, and what they are worth
+
+VG's own annotation cannot support this construction: measured against COCO, its
+recall over these twelve classes is **0.61**, and **1.35%** of the images it
+treats as negatives actually hold the object. So labels are VG's, repaired:
+
+- **48% of images are COCO-sourced** (`image_data.json`'s `coco_id`) and take
+  COCO's exhaustive annotation, which replaces VG's for that image. Copies whose
+  aspect ratio disagrees with the COCO original by >1% are left unrepaired: 49 of
+  51,497 are re-cropped or rotated, and there a COCO box describes the wrong
+  pixels.
+- **The rest were reviewed by hand**, in VTSearch, across three passes: ranked
+  negatives, a uniform random stratum, and every positive re-issued with its box
+  drawn and a magnified inset.
+
+### The numbers a reader should hold
+
+| measured on | result |
+|---|---|
+| residual contamination of the negative pool, after review | **2.0%** (4/200), 95% CI **0.8–5.0%** |
+| — concentrated in | `book` (3/20) and `bus` (1/20); zero in the other eight |
+| small-band positives confirmable *with the box drawn* | **~2/3** |
+| reviewer vs COCO on pairs COCO had settled | 9.0% disagreement — reviewer error, COCO error and definition drift, **not attributable without adjudication** |
+
+**COCO is not a gold standard here.** The review found images COCO annotates as
+empty that plainly hold the object, and four adjudicated COCO errors among the
+twelve classes (two prohibition circles and a school-crossing paddle labelled
+`stop sign`; a box on a hedge labelled `umbrella`).
+
+**The small band is at the limit of verification, and this is a property of the
+data, not a defect to hide.** A sub-patch object is under 1/196 of the frame;
+reviewing bare thumbnails rejected 43% of small-band positives against 10% of
+large, and drawing the box cut that to 18% vs 3%. Both a human and a
+vision-language model confirm only ~2/3 of them even with the box. So a
+small-band "not confirmed" is recorded as *unconfirmed* and the label stands —
+**any small-band result should be read beside that fact.**
+
+## Reproducing and extending it
+
+```bash
+source scripts/experiments/pile/pile_env.sh
+python build_pile.py --datasets vg_scale --force   # rebuild all three cells
+python build_pile.py --verify --datasets vg_scale  # structure + review coverage
+```
+
+Corrections live in `corrections.json` as `(image_id, class, present, boxes)` and
+are merged over `objects.json` **before** banding, so a corrected box can move an
+image between bands. A correction with no box excludes the pair from every cell
+of that class rather than promoting it: a band is a claim about size, and no size
+was measured.
+
+Membership is pinned by `vg_scale_roster.json` and selection is hash-stable, so a
+rebuild does not reshuffle cells. **Run `check_review_coverage.py` after any
+rebuild.** Coverage is the one property no structural check implies — cells can
+be full, prevalence exact and boxes valid while the dataset no longer contains
+the images its review was performed on, which happened here and cost a day.

--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -159,18 +159,23 @@ Two measurements constrain what comes next:
 
 <!-- item-sep -->
 
-- **Slate builder and correction ingest.** Per-class review slates from the
-  score dumps (`vtscore/eval/score_dumps.py`) in three recorded strata —
-  `boundary`, `extreme`, `random` — written as a folder plus manifest for
-  `server_folder` import; and the reverse script turning an exported LabelSet
-  JSON back into verdict rows keyed `(image_id, class)`. (Sonnet 5)
+- **Finish the review and close the loop.** The negative review is drafted by a
+  triage pass and awaits the reviewer's audit slate (`make_audit_pass.py`: the
+  flags, whose disagreement rate is the triage's precision, plus an unflagged
+  random sample, which is the only thing that can bound what it missed). Then
+  re-run `verdicts_to_corrections.py` and rebuild. **Check
+  `check_review_coverage.py` before trusting any rebuilt cell** — no structural
+  check implies coverage, and three rebuilds once retired 577 of 743 reviewed
+  images while every other check passed. (human + Sonnet 5)
 
 <!-- item-sep -->
 
-- **COCO-anchored noise measurement.** For classes in both vocabularies, VG's
-  miss rate can be measured against COCO val2017's exhaustive annotation with no
-  human review at all — and the same comparison scores our own annotators. Worth
-  running *before* the manual pass, to size it. (Sonnet 5)
+- **Report the residual error rate the review actually bounds.** Per band, from
+  the random stratum only, with the small band's limit stated rather than
+  hidden: boxed review confirms ~2/3 of sub-patch positives and the model fails
+  the same ones, so a small-band "not confirmed" is recorded as unconfirmed and
+  the label stands. That number belongs in the report beside any small-band
+  result. (Sonnet 5)
 
 <!-- item-sep -->
 

--- a/scripts/experiments/lessons/2026-08-24-review-orphaned-by-resampling.md
+++ b/scripts/experiments/lessons/2026-08-24-review-orphaned-by-resampling.md
@@ -1,0 +1,58 @@
+# A rebuild silently retired the images a human had just reviewed
+
+**Cost:** ~1 hour of the owner's labelling and a full model triage pass (2,698
+tiles) were inert for a day, and were only recovered because the selection was
+reproducible. Two rebuilds' worth of confusion before the cause was found.
+
+## What happened
+
+`vg_scale` designates each cell explicitly: a fixed number of positives per
+`(class, band)` plus one shared pool of negatives, drawn with
+`rng.sample(candidates, k)`. That is deterministic — same list, same seed, same
+draw — but **not stable**: `rng.sample` re-derives the whole selection from the
+list it is given, so *any* edit to the candidate list reshuffles every cell.
+
+Between the slates being generated and the review being ingested, the candidate
+list changed three times for good reasons (a coordinate-space fix, an
+aspect-ratio guard, then the corrections themselves). Each rebuild silently
+drew a different 3,900 negatives. By the time anyone checked, **577 of 743
+reviewed images were no longer in the dataset at all** — not corrected, not
+excluded, simply not drawn this time.
+
+Nothing announced it. Every check still passed: 36 cells at exactly 100
+positives, prevalence 0.0250 everywhere, boxes agreeing with their bands,
+patch grids present, media counts consistent across embedders. A dataset whose
+review covers 20% of it looks exactly like one whose review covers all of it.
+
+## Why the first fix was not enough
+
+Switching to hash-stable ranking (`sha1(cell:image_id)`, take the first N) is
+the right long-term fix: adding or removing one candidate then changes only that
+candidate's membership. But it was adopted *after* the drift, and adopting it
+would itself have been a fourth reshuffle — the hash draw and the random draw it
+replaced share ~228 of 3,900 negatives.
+
+A roster was then captured to pin membership — but from the *current* pool,
+which was already the post-drift one. Freezing the wrong state faithfully.
+
+## What actually recovered it
+
+The selection is a pure function of (labels, seed), and the labels of any past
+moment are recoverable from git. Checking out the commit that generated the
+slates (`797edfc94`), pointing `VTS_CORRECTIONS` at a nonexistent path so the
+later corrections could not perturb the labels, and re-running the load
+regenerated the original pool **exactly**: 100% of the 743 reviewed images and
+100% of the 1,742 triaged ones.
+
+## Prevented vs. still advice
+
+* **Prevented:** selection is now hash-stable, and a roster file pins membership
+  and is rewritten on every build, so a review keeps covering what it reviewed.
+* **Still advice:** *before* a rebuild, check what fraction of reviewed images
+  the new pool still contains, and treat a drop as a failure rather than a
+  detail. Coverage is not implied by any of the structural checks, and human
+  review is the most expensive input in the pipeline — it deserves an assertion
+  of its own.
+* **Worth knowing:** deterministic and stable are different properties. If work
+  is keyed to a sample, the sample needs to be stable under edits to its
+  candidate list, not merely reproducible from a seed.

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -495,14 +495,24 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
         exhaustive.add(iid)
         n_anchored += 1
 
+    # A pair a reviewer ruled "present" without drawing a box cannot be banded:
+    # a band is a claim about size, and no size was measured. It leaves every
+    # cell of that class instead -- neither a positive nor a negative -- which
+    # is precisely what the third value is for.
+    unbanded: set[tuple[int, str]] = set()
     for (iid, name), verdict in corrections.items():
         if iid not in labels:
             continue
         if verdict.get("present"):
-            labels[iid][name] = verdict.get("boxes") or labels[iid].get(name, [])
+            boxes = verdict.get("boxes") or []
+            if boxes:
+                labels[iid][name] = boxes
+            else:
+                labels[iid].pop(name, None)
+                unbanded.add((iid, name))
         else:
             labels[iid].pop(name, None)
-        exhaustive.add(iid)  # a human looked at this pair
+        exhaustive.add(iid)  # someone looked at this pair
 
     log(
         f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, "
@@ -518,7 +528,9 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
         W, H = box_dims[iid]
         area = float(W * H)
         if not by_name:
-            clean.append(iid)
+            # Only a true negative for every class in C may join the shared pool.
+            if not any((iid, c) in unbanded for c in pc.SCALE_CLASSES):
+                clean.append(iid)
             continue
         for name, bs in by_name.items():
             ux0 = min(b[0] for b in bs)
@@ -549,6 +561,18 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     def _rank(cell: str, iid: int) -> str:
         return hashlib.sha1(f"{cell}:{iid}".encode()).hexdigest()  # noqa: S324 - not security
 
+    # A roster pins the membership a review was actually carried out against.
+    # Without it, switching selection rules retires images a human has already
+    # judged -- the hash draw and the earlier random draw share only ~228 of
+    # 3,900 negatives, so the entire negative review would have been orphaned.
+    # Entries that are no longer eligible (a correction moved or removed them)
+    # drop out and the shortfall is backfilled by rank, so the roster adapts
+    # without ever reshuffling what it can keep.
+    roster = {}
+    if pc.ROSTER.exists():
+        roster = json.loads(pc.ROSTER.read_text())
+        log(f"  roster: {pc.ROSTER.name} pins {len(roster.get('cells', {}))} cells")
+
     chosen: dict[str, list[int]] = {}
     for c in pc.SCALE_CLASSES:
         for band in bands:
@@ -559,15 +583,27 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                 # prevalence between bands is the defect this construction
                 # exists to remove.
                 log(f"  UNDER-SUPPLIED {cell}: {len(pool)} positives (wanted {pc.SCALE_N_POS})")
-            chosen[cell] = sorted(pool, key=lambda i: _rank(cell, i))[: pc.SCALE_N_POS]
+            eligible = set(pool)
+            kept = [i for i in roster.get("cells", {}).get(cell, []) if i in eligible]
+            if len(kept) < pc.SCALE_N_POS:
+                spare = sorted(eligible - set(kept), key=lambda i: _rank(cell, i))
+                kept += spare[: pc.SCALE_N_POS - len(kept)]
+            chosen[cell] = kept[: pc.SCALE_N_POS]
 
     clean.sort()
     # Draw spares beyond the designated pool. A human verdict can retire a
     # contaminated negative later, and re-designating from spares costs a
     # relabel rather than a re-embed of every cell.
-    drawn = sorted(clean, key=lambda i: _rank("__negatives__", i))[: pc.SCALE_N_NEG + pc.SCALE_N_NEG_SPARE]
+    want_neg = pc.SCALE_N_NEG + pc.SCALE_N_NEG_SPARE
+    clean_set = set(clean)
+    drawn = [i for i in roster.get("negatives", []) + roster.get("spares", []) if i in clean_set]
+    if len(drawn) < want_neg:
+        extra = sorted(clean_set - set(drawn), key=lambda i: _rank("__negatives__", i))
+        drawn += extra[: want_neg - len(drawn)]
+    drawn = drawn[:want_neg]
     negatives, spares = drawn[: pc.SCALE_N_NEG], drawn[pc.SCALE_N_NEG :]
     neg_set = set(negatives)
+    pc.ROSTER.write_text(json.dumps({"cells": chosen, "negatives": negatives, "spares": spares}, indent=1) + "\n")
     log(
         f"  {sum(len(v) for v in chosen.values())} positives over {len(cells)} cells, "
         f"{len(negatives)} shared negatives + {len(spares)} spares (from {len(clean)} clean images)"

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -579,6 +579,10 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             # scorable only in the cells it was drawn for, and the shared
             # negatives are scorable everywhere.
             "evaluable_categories": cats if cats else (list(cells) if iid in neg_set else []),
+            # Whether this image's labels rest on an exhaustive reference (COCO,
+            # or a human who looked). False means VG's silence is the only
+            # evidence of absence -- which is what the review slates target.
+            "labels_exhaustive": iid in exhaustive,
             "regions": regions,
             "origin": {"importer": "vg_scale", "params": {"embedder": embedder_name, "labels": "coco"}},
             "origin_name": str(path),

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -361,6 +361,27 @@ def _vg_source() -> tuple[dict[int, Path], list, dict[int, tuple[int, int]]]:
     return paths, records, dims
 
 
+def _load_corrections() -> dict[tuple[int, str], dict]:
+    """``{(image_id, class): verdict}`` from the corrections file, if any.
+
+    Verdicts, not corrections: a row exists for every reviewed ``(image, class)``
+    pair whether or not the human disagreed, so review *coverage* is knowable.
+    Without that, "no bus here" and "nobody looked" are the same absence, and
+    every rate computed afterwards is biased by an unknown amount.
+
+    Written by ``ingest_slate.py``; absent until the first review lands, which
+    is why this returns empty rather than failing.
+    """
+    path = Path(os.environ.get("VTS_CORRECTIONS", pc.PILE / "corrections.json"))
+    if not path.exists():
+        return {}
+    rows = json.loads(path.read_text())
+    out: dict[tuple[int, str], dict] = {}
+    for r in rows:
+        out[(int(r["image_id"]), r["class"])] = r
+    return out
+
+
 def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     """One pickle holding every ``(class, band)`` cell of the scale study (#3156).
 
@@ -394,42 +415,85 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     cells = [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in bands]
 
     paths = _vg_image_paths()
+    _, records, dims = _vg_source()
 
-    # Labels come from COCO, not from VG. Measured on this very pool, VG's
-    # recall over C is 0.76 and 1.4% of the images it treats as negatives
-    # actually hold the object -- against 100 positives per cell that is ~54
-    # hidden positives in the negative pool, and 4.1% for `backpack` puts more
-    # real backpacks among the negatives than among the positives
-    # (`coco_anchor.py`, issue #3156). COCO annotates its 80 classes
-    # exhaustively and C was chosen entirely from them, so on the images VG
-    # sourced from COCO a negative means "COCO looked and found none" rather
-    # than "nobody mentioned it".
+    # --- labels: VG, repaired where a better reference exists ---------------
+    #
+    # VG's own annotation is not exhaustive: measured against COCO its recall
+    # over C is 0.61, and 1.35% of the images it treats as negatives actually
+    # hold the object -- ~54 hidden positives against 100 labelled ones per cell,
+    # and 4.1% for `backpack` puts more real backpacks among the negatives than
+    # among the positives (`coco_anchor.py`, issue #3156).
+    #
+    # 48% of VG's images ARE COCO images, and COCO annotates C exhaustively, so
+    # on that half the repair is free and total. The other half has no reference
+    # and is what the human slates are for (`make_audit_slate.py`); its verdicts
+    # arrive here through the same corrections file. The pool stays the whole of
+    # VG either way -- restricting it to the COCO half would make this a COCO
+    # subset with extra steps, losing VG's non-COCO diversity for nothing.
     image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
     truth = ca.coco_truth(instances, wanted)
     with image_data.open() as fh:
         coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
-    log(f"  {len(coco_of)} VG images carry a coco_id; {len(truth)} COCO images have exhaustive labels")
 
-    # class -> band -> [image_id], plus the boxes to stamp and the clean pool.
+    corrections = _load_corrections()
+    log(f"  {len(coco_of)} VG images carry a coco_id; {len(corrections)} human verdicts on file")
+
+    # image -> {class: [boxes]}, and whether the image's labels are exhaustive.
+    labels: dict[int, dict[str, list[list[float]]]] = {}
+    exhaustive: set[int] = set()
+    for rec in records:
+        iid = int(rec["image_id"])
+        if iid not in paths or dims.get(iid) is None:
+            continue
+        by_name: dict[str, list[list[float]]] = defaultdict(list)
+        for obj in rec.get("objects") or []:
+            names = obj.get("names") or []
+            if not names:
+                continue
+            name = str(names[0]).strip().lower()
+            if name not in wanted:
+                continue
+            x, y = float(obj.get("x", 0)), float(obj.get("y", 0))
+            w, h = float(obj.get("w", 0)), float(obj.get("h", 0))
+            if w > 0 and h > 0:
+                by_name[name].append([x, y, x + w, y + h])
+        labels[iid] = dict(by_name)
+
+    n_anchored = 0
+    for iid in labels:
+        cid = coco_of.get(iid)
+        ref = truth.get(cid) if cid is not None else None
+        if ref is None:
+            continue
+        # COCO's annotation REPLACES VG's for this image rather than merging
+        # with it: the two disagree in both directions, and only one of them is
+        # exhaustive. Keeping VG's extra boxes would reintroduce exactly the
+        # unverifiable labels this is repairing.
+        labels[iid] = {name: bs for name, bs in ref.items() if name in wanted}
+        exhaustive.add(iid)
+        n_anchored += 1
+
+    for (iid, name), verdict in corrections.items():
+        if iid not in labels:
+            continue
+        if verdict.get("present"):
+            labels[iid][name] = verdict.get("boxes") or labels[iid].get(name, [])
+        else:
+            labels[iid].pop(name, None)
+        exhaustive.add(iid)  # a human looked at this pair
+
+    log(f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, {len(exhaustive)} with a verified pair")
+
+    # --- candidates ---------------------------------------------------------
     supply: dict[str, dict[str, list[int]]] = {c: {b: [] for b in bands} for c in pc.SCALE_CLASSES}
     boxes_for: dict[tuple[int, str], list[list[float]]] = {}
     clean: list[int] = []
-    anchored = 0
 
-    for iid, cid in sorted(coco_of.items()):
-        ref = truth.get(cid)
-        wh = ca.COCO_DIMS.get(cid)
-        if iid not in paths or ref is None or wh is None:
-            continue
-        W, H = wh
-        if W <= 0 or H <= 0:
-            continue
-        anchored += 1
+    for iid, by_name in labels.items():
+        W, H = dims[iid]
         area = float(W * H)
-        by_name = {name: bs for name, bs in ref.items() if name in wanted}
         if not by_name:
-            # COCO annotated this image and found none of C: a true negative for
-            # every cell, which is the whole point of building on this half.
             clean.append(iid)
             continue
         for name, bs in by_name.items():
@@ -450,7 +514,6 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                     supply[name][band].append(iid)
                     boxes_for[(iid, pc.scale_cell(name, band))] = bs
                     break
-    log(f"  {anchored} images have an exhaustive COCO reference and a VG file on disk")
 
     rng = random.Random(0x5CA1E)  # deterministic sample, stable across rebuilds
     chosen: dict[str, list[int]] = {}
@@ -466,10 +529,15 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             chosen[cell] = rng.sample(pool, min(pc.SCALE_N_POS, len(pool)))
 
     clean.sort()
-    negatives = rng.sample(clean, min(pc.SCALE_N_NEG, len(clean)))
+    # Draw spares beyond the designated pool. A human verdict can retire a
+    # contaminated negative later, and re-designating from spares costs a
+    # relabel rather than a re-embed of every cell.
+    drawn = rng.sample(clean, min(pc.SCALE_N_NEG + pc.SCALE_N_NEG_SPARE, len(clean)))
+    negatives, spares = drawn[: pc.SCALE_N_NEG], drawn[pc.SCALE_N_NEG :]
+    neg_set = set(negatives)
     log(
         f"  {sum(len(v) for v in chosen.values())} positives over {len(cells)} cells, "
-        f"{len(negatives)} shared negatives (from {len(clean)} clean images)"
+        f"{len(negatives)} shared negatives + {len(spares)} spares (from {len(clean)} clean images)"
     )
 
     # media id -> the cells it is a positive for. Negatives get every cell.
@@ -478,7 +546,7 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
         for iid in ids:
             positive_in[iid].append(cell)
 
-    for iid in sorted(set(positive_in) | set(negatives)):
+    for iid in sorted(set(positive_in) | set(negatives) | set(spares)):
         path = paths[iid]
         try:
             with Image.open(path) as im:
@@ -510,7 +578,7 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             # A designated cell membership, not a closed world: a positive is
             # scorable only in the cells it was drawn for, and the shared
             # negatives are scorable everywhere.
-            "evaluable_categories": cats if cats else list(cells),
+            "evaluable_categories": cats if cats else (list(cells) if iid in neg_set else []),
             "regions": regions,
             "origin": {"importer": "vg_scale", "params": {"embedder": embedder_name, "labels": "coco"}},
             "origin_name": str(path),

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -219,6 +219,8 @@ def _band_categories(band: str) -> list[str]:
 
 def _load_vg_band(band: str, medias: dict[int, dict], embedder_name: str) -> None:
     """Populate *medias* with full-VG images carrying this band's categories."""
+    import random  # noqa: PLC0415
+
     from PIL import Image  # noqa: PLC0415
 
     vg_root = pc.DEMO_CACHE / "visual_genome"

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -584,11 +584,21 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                 # exists to remove.
                 log(f"  UNDER-SUPPLIED {cell}: {len(pool)} positives (wanted {pc.SCALE_N_POS})")
             eligible = set(pool)
-            kept = [i for i in roster.get("cells", {}).get(cell, []) if i in eligible]
-            if len(kept) < pc.SCALE_N_POS:
-                spare = sorted(eligible - set(kept), key=lambda i: _rank(cell, i))
-                kept += spare[: pc.SCALE_N_POS - len(kept)]
-            chosen[cell] = kept[: pc.SCALE_N_POS]
+            pinned = [i for i in roster.get("cells", {}).get(cell, []) if i in eligible]
+            # A correction can move an image to another band -- that is the
+            # point of re-drawing a box. If the destination cell is already full
+            # of images nobody has looked at, the reviewed one lands nowhere and
+            # the review quietly stops covering it (99 of 360 boxed positives,
+            # first time round). Reviewed images therefore outrank unreviewed
+            # ones for a seat, wherever their box now puts them.
+            reviewed = {i for i in eligible if (i, c) in corrections}
+            order = (
+                [i for i in pinned if i in reviewed]
+                + sorted(reviewed - set(pinned), key=lambda i: _rank(cell, i))
+                + [i for i in pinned if i not in reviewed]
+                + sorted(eligible - reviewed - set(pinned), key=lambda i: _rank(cell, i))
+            )
+            chosen[cell] = order[: pc.SCALE_N_POS]
 
     clean.sort()
     # Draw spares beyond the designated pool. A human verdict can retire a

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -302,6 +302,20 @@ def _load_vg_band(band: str, medias: dict[int, dict], embedder_name: str) -> Non
         }
 
 
+def _vg_image_paths() -> dict[int, Path]:
+    """``{image_id: path}`` over both VG image dirs."""
+    vg_root = pc.DEMO_CACHE / "visual_genome"
+    paths: dict[int, Path] = {}
+    for d in (vg_root / "VG_100K", vg_root / "VG_100K_2"):
+        for p in d.iterdir():
+            if p.suffix.lower() == ".jpg":
+                try:
+                    paths[int(p.stem)] = p
+                except ValueError:
+                    continue
+    return paths
+
+
 def _vg_source() -> tuple[dict[int, Path], list, dict[int, tuple[int, int]]]:
     """``(image paths, objects.json records, image dims)`` for the whole VG source.
 
@@ -313,20 +327,11 @@ def _vg_source() -> tuple[dict[int, Path], list, dict[int, tuple[int, int]]]:
 
     from PIL import Image  # noqa: PLC0415
 
-    vg_root = pc.DEMO_CACHE / "visual_genome"
-    objects_json = vg_root / "objects.json"
+    objects_json = pc.DEMO_CACHE / "visual_genome" / "objects.json"
     if not objects_json.exists():
         raise SystemExit(f"missing {objects_json}")
 
-    paths: dict[int, Path] = {}
-    for d in (vg_root / "VG_100K", vg_root / "VG_100K_2"):
-        for p in d.iterdir():
-            if p.suffix.lower() == ".jpg":
-                try:
-                    paths[int(p.stem)] = p
-                except ValueError:
-                    continue
-
+    paths = _vg_image_paths()
     cache = pc.PILE / "vg_image_dims.json"
     dims: dict[int, tuple[int, int]] = {}
     if cache.exists():
@@ -373,46 +378,58 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     therefore has identical prevalence and identical negatives, so a
     small-vs-large difference is a paired contrast on one class rather than two
     datasets of different difficulty.
+
+    **The labels are COCO's, and the pool is the half of VG that can carry
+    them.** VG's own annotation is not exhaustive and measurably fails this
+    construction -- see the note in the body and ``coco_anchor.py``.
     """
     import random  # noqa: PLC0415
 
     from PIL import Image  # noqa: PLC0415
 
+    import coco_anchor as ca  # noqa: PLC0415
+
     wanted = set(pc.SCALE_CLASSES)
     bands = list(pc.BOX_BANDS)
     cells = [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in bands]
 
-    paths, records, dims = _vg_source()
-    log(f"  scanning {len(records)} VG records for {len(wanted)} classes")
+    paths = _vg_image_paths()
+
+    # Labels come from COCO, not from VG. Measured on this very pool, VG's
+    # recall over C is 0.76 and 1.4% of the images it treats as negatives
+    # actually hold the object -- against 100 positives per cell that is ~54
+    # hidden positives in the negative pool, and 4.1% for `backpack` puts more
+    # real backpacks among the negatives than among the positives
+    # (`coco_anchor.py`, issue #3156). COCO annotates its 80 classes
+    # exhaustively and C was chosen entirely from them, so on the images VG
+    # sourced from COCO a negative means "COCO looked and found none" rather
+    # than "nobody mentioned it".
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    truth = ca.coco_truth(instances, wanted)
+    with image_data.open() as fh:
+        coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
+    log(f"  {len(coco_of)} VG images carry a coco_id; {len(truth)} COCO images have exhaustive labels")
 
     # class -> band -> [image_id], plus the boxes to stamp and the clean pool.
     supply: dict[str, dict[str, list[int]]] = {c: {b: [] for b in bands} for c in pc.SCALE_CLASSES}
     boxes_for: dict[tuple[int, str], list[list[float]]] = {}
     clean: list[int] = []
+    anchored = 0
 
-    for rec in records:
-        iid = int(rec["image_id"])
-        wh = dims.get(iid)
-        if iid not in paths or wh is None:
+    for iid, cid in sorted(coco_of.items()):
+        ref = truth.get(cid)
+        wh = ca.COCO_DIMS.get(cid)
+        if iid not in paths or ref is None or wh is None:
             continue
         W, H = wh
         if W <= 0 or H <= 0:
             continue
+        anchored += 1
         area = float(W * H)
-        by_name: dict[str, list[list[float]]] = defaultdict(list)
-        for obj in rec.get("objects") or []:
-            names = obj.get("names") or []
-            if not names:
-                continue
-            name = str(names[0]).strip().lower()
-            if name not in wanted:
-                continue
-            x, y = float(obj.get("x", 0)), float(obj.get("y", 0))
-            w, h = float(obj.get("w", 0)), float(obj.get("h", 0))
-            if w > 0 and h > 0:
-                by_name[name].append([x, y, x + w, y + h])
+        by_name = {name: bs for name, bs in ref.items() if name in wanted}
         if not by_name:
-            # Holds none of C at any size: a sound negative for every cell.
+            # COCO annotated this image and found none of C: a true negative for
+            # every cell, which is the whole point of building on this half.
             clean.append(iid)
             continue
         for name, bs in by_name.items():
@@ -433,6 +450,7 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                     supply[name][band].append(iid)
                     boxes_for[(iid, pc.scale_cell(name, band))] = bs
                     break
+    log(f"  {anchored} images have an exhaustive COCO reference and a VG file on disk")
 
     rng = random.Random(0x5CA1E)  # deterministic sample, stable across rebuilds
     chosen: dict[str, list[int]] = {}
@@ -494,7 +512,7 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             # negatives are scorable everywhere.
             "evaluable_categories": cats if cats else list(cells),
             "regions": regions,
-            "origin": {"importer": "vg_scale", "params": {"embedder": embedder_name}},
+            "origin": {"importer": "vg_scale", "params": {"embedder": embedder_name, "labels": "coco"}},
             "origin_name": str(path),
         }
 

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -467,6 +467,7 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     # dimensions of the image its coordinates were measured on.
     box_dims: dict[int, tuple[int, int]] = dict(dims)
     n_anchored = 0
+    n_reframed = 0
     for iid in labels:
         cid = coco_of.get(iid)
         ref = truth.get(cid) if cid is not None else None
@@ -474,6 +475,17 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             continue
         wh = ca.COCO_DIMS.get(cid)
         if wh is None:
+            continue
+        # A normalised box only transfers between two copies of an image if they
+        # frame the same thing. 49 of the 51,497 overlaps disagree on aspect
+        # ratio -- some are transposed (VG 500x375 against COCO 375x500), i.e. a
+        # rotated or re-cropped copy -- and there COCO's box does not describe
+        # VG's pixels at all. Those keep VG's own labels and stay unanchored
+        # rather than importing a box that points at the wrong part of a
+        # different framing.
+        vw, vh = dims[iid]
+        if abs((vw / vh) - (wh[0] / wh[1])) / (wh[0] / wh[1]) > pc.MAX_ASPECT_DRIFT:
+            n_reframed += 1
             continue
         box_dims[iid] = wh
         # COCO's annotation REPLACES VG's for this image rather than merging
@@ -493,7 +505,10 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             labels[iid].pop(name, None)
         exhaustive.add(iid)  # a human looked at this pair
 
-    log(f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, {len(exhaustive)} with a verified pair")
+    log(
+        f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, "
+        f"{len(exhaustive)} with a verified pair, {n_reframed} skipped as re-framed copies"
+    )
 
     # --- candidates ---------------------------------------------------------
     supply: dict[str, dict[str, list[int]]] = {c: {b: [] for b in bands} for c in pc.SCALE_CLASSES}

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -460,12 +460,22 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                 by_name[name].append([x, y, x + w, y + h])
         labels[iid] = dict(by_name)
 
+    # The pixel space each image's boxes live in. VG ships DOWNSCALED copies of
+    # the COCO originals -- 500 px wide against COCO's 640, on 95% of the
+    # overlap -- so a COCO box normalised by the VG file's dimensions lands in
+    # the wrong place and with the wrong extent. Normalise every box by the
+    # dimensions of the image its coordinates were measured on.
+    box_dims: dict[int, tuple[int, int]] = dict(dims)
     n_anchored = 0
     for iid in labels:
         cid = coco_of.get(iid)
         ref = truth.get(cid) if cid is not None else None
         if ref is None:
             continue
+        wh = ca.COCO_DIMS.get(cid)
+        if wh is None:
+            continue
+        box_dims[iid] = wh
         # COCO's annotation REPLACES VG's for this image rather than merging
         # with it: the two disagree in both directions, and only one of them is
         # exhaustive. Keeping VG's extra boxes would reintroduce exactly the
@@ -491,7 +501,7 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     clean: list[int] = []
 
     for iid, by_name in labels.items():
-        W, H = dims[iid]
+        W, H = box_dims[iid]
         area = float(W * H)
         if not by_name:
             clean.append(iid)
@@ -550,12 +560,17 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
         path = paths[iid]
         try:
             with Image.open(path) as im:
-                W, H = im.size
+                vw, vh = im.size
             data = path.read_bytes()
         except Exception:  # noqa: BLE001 - a corrupt file just drops out
             continue
-        if W <= 0 or H <= 0:
+        if vw <= 0 or vh <= 0:
             continue
+        # Normalised region boxes are resolution-independent, so they must be
+        # divided by the size of the image the coordinates came from -- which is
+        # the COCO original for a repaired image, not the VG copy carrying the
+        # pixels.
+        W, H = box_dims[iid]
         cats = sorted(positive_in.get(iid, []))
         regions = [
             {"box": [b[0] / W, b[1] / H, b[2] / W, b[3] / H], "label": cell}
@@ -715,6 +730,42 @@ def verify() -> int:
             state = "UNEXPECTED-PATCH"
             problems.append(f"{ds} x {emb}: single-vector embedder carries patch grids")
         rows.append((ds, emb, state, str(n), f"{n_patch}/{n}", dim))
+
+    # A banded cell's NAME asserts the size of its boxes, so the stored box has
+    # to agree with it. That is what catches a coordinate-space mistake: VG
+    # ships 500 px copies of COCO's 640 px originals, and normalising a COCO box
+    # by the VG file's dimensions leaves every box shifted and mis-scaled while
+    # every other check still passes -- the medias load, the vectors are there,
+    # the patch grids are there, and the boxes are quietly pointing at the wrong
+    # pixels. Recomputing the band from the box is cheap and would have caught
+    # it at build time instead of via a human noticing a box drawn on snow.
+    for ds, emb in pc.cells():
+        if pc.DATASETS.get(ds, {}).get("kind") != "vg_scale":
+            continue
+        path = pc.cell_path(ds, emb)
+        if not path.exists():
+            continue
+        medias = io.load_medias(path)
+        bad = 0
+        checked = 0
+        for m in medias.values():
+            for cell in m.get("categories") or []:
+                boxes = [r["box"] for r in (m.get("regions") or []) if r.get("label") == cell]
+                if not boxes:
+                    continue
+                area = (max(b[2] for b in boxes) - min(b[0] for b in boxes)) * (
+                    max(b[3] for b in boxes) - min(b[1] for b in boxes)
+                )
+                lo, hi = pc.BOX_BANDS[cell.rsplit("@", 1)[1]]
+                checked += 1
+                if not (lo <= area < hi):
+                    bad += 1
+        if checked and bad:
+            problems.append(
+                f"{ds} x {emb}: {bad}/{checked} region boxes fall outside the band their cell "
+                f"name claims -- boxes and bands were measured in different pixel spaces"
+            )
+        break  # one embedder is enough; the boxes are identical across cells
 
     # A dataset's cells must all cover the same medias, or cross-embedder
     # comparisons silently compare different populations. This is not

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -844,6 +844,22 @@ def verify() -> int:
     for ds, emb, state, n, patch, dim in rows:
         log(f"{ds:18s} {emb:14s} {state:16s} {n:>7s} {patch:>12s} {dim:>6s}")
 
+    # Coverage is not implied by anything above: a cell can be structurally
+    # perfect and no longer contain the images a human reviewed. Reported here
+    # so a rebuild cannot be declared healthy without it being looked at.
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import check_review_coverage  # noqa: PLC0415
+
+        if pc.cell_path("vg_scale", "siglip").exists():
+            log("")
+            log("review coverage:")
+            sys.argv = ["check_review_coverage"]
+            if check_review_coverage.main() != 0:
+                problems.append("vg_scale: the rebuild retired images that had been reviewed")
+    except Exception as exc:  # noqa: BLE001 - an absent review is not a build failure
+        log(f"  (review-coverage check skipped: {exc})")
+
     if problems:
         log("")
         for p in problems:

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import hashlib
 import json
 import os
 import sys
@@ -218,8 +219,6 @@ def _band_categories(band: str) -> list[str]:
 
 def _load_vg_band(band: str, medias: dict[int, dict], embedder_name: str) -> None:
     """Populate *medias* with full-VG images carrying this band's categories."""
-    import random  # noqa: PLC0415
-
     from PIL import Image  # noqa: PLC0415
 
     vg_root = pc.DEMO_CACHE / "visual_genome"
@@ -404,8 +403,6 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     them.** VG's own annotation is not exhaustive and measurably fails this
     construction -- see the note in the body and ``coco_anchor.py``.
     """
-    import random  # noqa: PLC0415
-
     from PIL import Image  # noqa: PLC0415
 
     import coco_anchor as ca  # noqa: PLC0415
@@ -540,7 +537,16 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                     boxes_for[(iid, pc.scale_cell(name, band))] = bs
                     break
 
-    rng = random.Random(0x5CA1E)  # deterministic sample, stable across rebuilds
+    # Selection must be stable under a changing candidate list, not merely
+    # deterministic. `rng.sample` is deterministic given the same list, but any
+    # edit to the pool -- a label fix, an image excluded as a re-framed copy --
+    # reshuffles the entire draw, and a rebuild then silently retires images a
+    # human already reviewed (49 of 360 in one such rebuild). Ranking each
+    # candidate by a hash of (cell, image_id) instead means adding or removing
+    # one image changes only that image's membership.
+    def _rank(cell: str, iid: int) -> str:
+        return hashlib.sha1(f"{cell}:{iid}".encode()).hexdigest()  # noqa: S324 - not security
+
     chosen: dict[str, list[int]] = {}
     for c in pc.SCALE_CLASSES:
         for band in bands:
@@ -551,13 +557,13 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
                 # prevalence between bands is the defect this construction
                 # exists to remove.
                 log(f"  UNDER-SUPPLIED {cell}: {len(pool)} positives (wanted {pc.SCALE_N_POS})")
-            chosen[cell] = rng.sample(pool, min(pc.SCALE_N_POS, len(pool)))
+            chosen[cell] = sorted(pool, key=lambda i: _rank(cell, i))[: pc.SCALE_N_POS]
 
     clean.sort()
     # Draw spares beyond the designated pool. A human verdict can retire a
     # contaminated negative later, and re-designating from spares costs a
     # relabel rather than a re-embed of every cell.
-    drawn = rng.sample(clean, min(pc.SCALE_N_NEG + pc.SCALE_N_NEG_SPARE, len(clean)))
+    drawn = sorted(clean, key=lambda i: _rank("__negatives__", i))[: pc.SCALE_N_NEG + pc.SCALE_N_NEG_SPARE]
     negatives, spares = drawn[: pc.SCALE_N_NEG], drawn[pc.SCALE_N_NEG :]
     neg_set = set(negatives)
     log(

--- a/scripts/experiments/pile/check_review_coverage.py
+++ b/scripts/experiments/pile/check_review_coverage.py
@@ -1,0 +1,102 @@
+"""Assert that the dataset still contains the images its review was performed on.
+
+Human review is the most expensive input in this pipeline and the only one that
+cannot be regenerated, yet nothing about a rebuilt cell reveals whether it still
+covers that review. Every structural check keeps passing while coverage
+collapses: the cells are full, prevalence is exact, boxes agree with their
+bands, patch grids are present. A dataset reviewed at 20% is indistinguishable
+from one reviewed completely.
+
+That is not hypothetical -- three rebuilds retired 577 of 743 reviewed images
+here before anyone looked (`scripts/experiments/lessons/`). So coverage gets an
+assertion of its own, run *before* a rebuild is trusted rather than after it is
+noticed.
+
+An image legitimately leaves the pool when a correction removes it: a
+contaminated negative that the review itself promoted is *supposed* to
+disappear. Those are counted separately and never held against coverage.
+
+Usage::
+
+    python check_review_coverage.py                 # report, exit 1 if below threshold
+    python check_review_coverage.py --min 0.85
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    base = pc.PILE.parent / "vgscale-3156"
+    ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"))
+    ap.add_argument("--verdicts", default=str(base / "verdicts_20260820b.json"))
+    ap.add_argument("--sheets", default=str(base / "sheets_neg"))
+    ap.add_argument("--corrections", default=str(pc.PILE / "corrections.json"))
+    ap.add_argument("--min", type=float, default=0.85, help="fail below this coverage")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    medias = load_medias(Path(args.cell))
+    negatives = {i for i, m in medias.items() if not m.get("categories")}
+
+    corrected = set()
+    if Path(args.corrections).exists():
+        for c in json.loads(Path(args.corrections).read_text()):
+            # A correction that fixes or excludes a negative is *meant* to
+            # remove it from the pool; it is progress, not lost coverage.
+            corrected.add(int(c["image_id"]))
+
+    verdicts = json.loads(Path(args.verdicts).read_text())
+    rows = []
+
+    neg_ids = {v["image_id"] for v in verdicts if v["stratum"] in ("boundary", "random")}
+    rows.append(("reviewed negatives", neg_ids, negatives))
+
+    tri: set[int] = set()
+    for p in glob.glob(str(Path(args.sheets) / "*" / "index.json")):
+        for r in json.loads(Path(p).read_text()):
+            tri.add(r["image_id"])
+    if tri:
+        rows.append(("triaged negatives", tri, negatives))
+
+    pos_pairs = {(v["image_id"], v["class"]) for v in verdicts if v["stratum"] == "positive_boxed"}
+    pos_ok = {
+        (i, c) for i, c in pos_pairs if any(x.startswith(c + "@") for x in (medias.get(i, {}).get("categories") or []))
+    }
+
+    worst = 1.0
+    print(f"{'population':<22}{'reviewed':>9}{'still in':>9}{'by fix':>8}{'coverage':>10}")
+    print("-" * 58)
+    for label, ids, present in rows:
+        kept = len(ids & present)
+        by_fix = len({i for i in ids - present if i in corrected})
+        denom = len(ids) - by_fix
+        cov = kept / denom if denom else 1.0
+        worst = min(worst, cov)
+        print(f"{label:<22}{len(ids):>9}{kept:>9}{by_fix:>8}{cov:>10.1%}")
+    cov_pos = len(pos_ok) / len(pos_pairs) if pos_pairs else 1.0
+    worst = min(worst, cov_pos)
+    print(f"{'reviewed positives':<22}{len(pos_pairs):>9}{len(pos_ok):>9}{'-':>8}{cov_pos:>10.1%}")
+    print()
+    if worst < args.min:
+        print(f"FAIL: coverage {worst:.1%} is below --min {args.min:.0%}.")
+        print("The rebuild retired images that were reviewed. Check the roster before trusting this cell.")
+        return 1
+    print(f"OK: every reviewed population is at or above {args.min:.0%}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/coco_anchor.py
+++ b/scripts/experiments/pile/coco_anchor.py
@@ -1,0 +1,276 @@
+"""Measure (and repair) VG's annotation noise against COCO, with no human review.
+
+Roughly half of Visual Genome's images *are* COCO images -- VG records the
+source id as ``coco_id`` in ``image_data.json`` -- and COCO is **exhaustively**
+annotated over its 80 classes. Every class in :data:`pile_config.SCALE_CLASSES`
+is one of those 80, deliberately (issue #3156). So for the COCO-sourced half of
+the pool, ground truth already exists and both of the things the correction pass
+needs come for free:
+
+* **A measurement.** How often does VG omit an object COCO annotates? That is
+  the noise rate the report has to state rather than assume, and it is the
+  number that says how much manual review the rest is worth.
+* **A repair.** On those images the COCO boxes *are* the correction, in exactly
+  the ``(image_id, class, box)`` shape the merge expects.
+
+What it cannot do is clear the other half: VG's non-COCO images (Flickr) have no
+exhaustive reference, and neither does any class outside COCO's 80. Those are
+what the human slates are for -- and this scan is what decides how big they need
+to be.
+
+**Both directions are real.** ``vg_missing`` (COCO annotates it, VG does not) is
+the bug #3156 opened with: a bus front and centre on an image annotated
+``car, clouds``. ``coco_missing`` is not simply its mirror -- VG's free-text
+vocabulary is finer and its boxes are not exhaustive per class, so a VG-only
+``bird`` may be a real bird COCO skipped, a duplicate name for something else,
+or a genuine VG error. It is reported, not silently trusted.
+
+Usage::
+
+    python coco_anchor.py --fetch          # download what is missing, then scan
+    python coco_anchor.py                  # scan (sources already staged)
+    python coco_anchor.py --out anchor.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.request
+import zipfile
+from collections import defaultdict
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+#: VG's per-image metadata, which is what carries ``coco_id``. Stanford's own
+#: copy 403s; this UW mirror is the one that still serves it.
+IMAGE_DATA_URL = "https://homes.cs.washington.edu/~ranjay/visualgenome/data/dataset/image_data.json.zip"
+COCO_ANN_URL = "http://images.cocodataset.org/annotations/annotations_trainval2017.zip"
+
+VG_ROOT = pc.DEMO_CACHE / "visual_genome"
+
+
+def log(msg: str) -> None:
+    print(f"[anchor] {msg}", flush=True)
+
+
+def _fetch(url: str, dest: Path) -> None:
+    if dest.exists():
+        log(f"have {dest.name}")
+        return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    log(f"downloading {url}")
+    with urllib.request.urlopen(url) as r, tmp.open("wb") as fh:  # noqa: S310 - fixed https/http URLs above
+        while chunk := r.read(1 << 20):
+            fh.write(chunk)
+    tmp.rename(dest)
+    log(f"  -> {dest} ({dest.stat().st_size / 1e6:.0f} MB)")
+
+
+def ensure_sources(anchor: Path, fetch: bool) -> tuple[Path, list[Path]]:
+    """``(image_data.json, [instances_*.json])``, downloading them if asked."""
+    image_data = anchor / "image_data.json"
+    if not image_data.exists():
+        if not fetch:
+            raise SystemExit(f"missing {image_data}; re-run with --fetch")
+        zpath = anchor / "image_data.json.zip"
+        _fetch(IMAGE_DATA_URL, zpath)
+        with zipfile.ZipFile(zpath) as z:
+            member = next(n for n in z.namelist() if n.endswith("image_data.json"))
+            image_data.write_bytes(z.read(member))
+        log(f"extracted {image_data.name}")
+
+    # val2017 is already staged under COCO_ROOT; train2017 is where most of VG's
+    # COCO-sourced images live, so it is the half that matters here.
+    instances = []
+    staged_val = pc.COCO_ANNOTATIONS.parent.parent / "annotations" / "instances_val2017.json"
+    if staged_val.exists():
+        instances.append(staged_val)
+    train = anchor / "instances_train2017.json"
+    if not train.exists():
+        if not fetch:
+            raise SystemExit(f"missing {train}; re-run with --fetch")
+        zpath = anchor / "annotations_trainval2017.zip"
+        _fetch(COCO_ANN_URL, zpath)
+        with zipfile.ZipFile(zpath) as z:
+            for member in z.namelist():
+                if member.endswith(("instances_train2017.json", "instances_val2017.json")):
+                    out = anchor / Path(member).name
+                    if not out.exists():
+                        out.write_bytes(z.read(member))
+                        log(f"extracted {out.name}")
+    instances.append(train)
+    val_extracted = anchor / "instances_val2017.json"
+    if not staged_val.exists() and val_extracted.exists():
+        instances.append(val_extracted)
+    return image_data, instances
+
+
+def coco_truth(instances: list[Path], classes: set[str]) -> dict[int, dict[str, list[list[float]]]]:
+    """``{coco_image_id: {class: [[x0, y0, x1, y1], ...]}}`` over *classes*.
+
+    Images with no instance of any wanted class still get an (empty) entry:
+    COCO is exhaustive, so "annotated and absent" is a *fact* about the image,
+    and it is the half of the reference that makes VG's false positives
+    measurable at all.
+    """
+    truth: dict[int, dict[str, list[list[float]]]] = {}
+    for path in instances:
+        if not path.exists():
+            continue
+        log(f"loading {path.name} ({path.stat().st_size / 1e6:.0f} MB)...")
+        with path.open() as fh:
+            data = json.load(fh)
+        wanted = {c["id"]: c["name"] for c in data["categories"] if c["name"] in classes}
+        for img in data["images"]:
+            truth.setdefault(int(img["id"]), {})
+        for ann in data["annotations"]:
+            name = wanted.get(ann["category_id"])
+            if name is None:
+                continue
+            x, y, w, h = (float(v) for v in ann["bbox"])
+            if w <= 0 or h <= 0:
+                continue
+            truth[int(ann["image_id"])].setdefault(name, []).append([x, y, x + w, y + h])
+        log(f"  {len(data['images'])} images, {len(wanted)} of our classes in its vocabulary")
+    return truth
+
+
+def vg_truth(classes: set[str]) -> dict[int, dict[str, list[list[float]]]]:
+    """The same shape, read from VG's own ``objects.json``."""
+    log("loading VG objects.json...")
+    with (VG_ROOT / "objects.json").open() as fh:
+        records = json.load(fh)
+    out: dict[int, dict[str, list[list[float]]]] = {}
+    for rec in records:
+        iid = int(rec["image_id"])
+        by_name: dict[str, list[list[float]]] = {}
+        for obj in rec.get("objects") or []:
+            names = obj.get("names") or []
+            if not names:
+                continue
+            name = str(names[0]).strip().lower()
+            if name not in classes:
+                continue
+            x, y = float(obj.get("x", 0)), float(obj.get("y", 0))
+            w, h = float(obj.get("w", 0)), float(obj.get("h", 0))
+            if w > 0 and h > 0:
+                by_name.setdefault(name, []).append([x, y, x + w, y + h])
+        out[iid] = by_name
+    log(f"  {len(out)} VG images")
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--anchor-dir", default=str(pc.PILE / "coco_anchor"), help="where the sources are staged")
+    ap.add_argument("--fetch", action="store_true", help="download missing sources")
+    ap.add_argument("--out", default="", help="write the per-image verdicts as JSON")
+    ap.add_argument("--pool", default="", help="restrict to the image ids in this vg_scale pickle")
+    args = ap.parse_args()
+
+    anchor = Path(args.anchor_dir)
+    anchor.mkdir(parents=True, exist_ok=True)
+    classes = set(pc.SCALE_CLASSES)
+
+    image_data, instances = ensure_sources(anchor, args.fetch)
+    truth = coco_truth(instances, classes)
+
+    log(f"loading {image_data.name}...")
+    with image_data.open() as fh:
+        meta = json.load(fh)
+    # VG image -> the COCO image it was sourced from, where there is one.
+    coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in meta if m.get("coco_id")}
+    log(f"  {len(coco_of)} of {len(meta)} VG images carry a coco_id")
+
+    pool: set[int] | None = None
+    if args.pool:
+        import sys  # noqa: PLC0415
+
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+        from _cells_io import load_medias  # noqa: PLC0415
+
+        pool = set(load_medias(Path(args.pool)))
+        log(f"  restricted to the {len(pool)} images of {Path(args.pool).name}")
+
+    vg = vg_truth(classes)
+
+    # Per class: the four cells of the confusion between VG and COCO.
+    rows: dict[str, dict[str, int]] = {c: defaultdict(int) for c in pc.SCALE_CLASSES}
+    verdicts: dict[str, dict[str, list]] = {}
+    anchored = 0
+    for vg_id, cid in sorted(coco_of.items()):
+        if pool is not None and vg_id not in pool:
+            continue
+        ref = truth.get(cid)
+        if ref is None or vg_id not in vg:
+            continue  # COCO image not in the 2017 split, or VG image not scanned
+        anchored += 1
+        mine = vg[vg_id]
+        for c in pc.SCALE_CLASSES:
+            in_vg, in_coco = c in mine, c in ref
+            key = "both" if (in_vg and in_coco) else "vg_missing" if in_coco else "coco_missing" if in_vg else "neither"
+            rows[c][key] += 1
+            if key == "vg_missing":
+                verdicts.setdefault(c, {}).setdefault("vg_missing", []).append(
+                    {"image_id": vg_id, "coco_id": cid, "boxes": ref[c]}
+                )
+            elif key == "coco_missing":
+                verdicts.setdefault(c, {}).setdefault("coco_missing", []).append(
+                    {"image_id": vg_id, "coco_id": cid, "boxes": mine[c]}
+                )
+
+    print(f"\n{anchored} images have an exhaustive COCO reference\n")
+    hdr = f"{'class':<12}{'both':>7}{'vg_missing':>12}{'coco_only':>11}{'neither':>9}{'VG recall':>11}{'neg noise':>11}"
+    print(hdr)
+    print("-" * len(hdr))
+    total = defaultdict(int)
+    for c in pc.SCALE_CLASSES:
+        r = rows[c]
+        true_pos = r["both"] + r["vg_missing"]
+        recall = r["both"] / true_pos if true_pos else float("nan")
+        # The number that matters most: of the images VG calls negative for this
+        # class, what share actually hold one? That is the poison in the ~95%
+        # negative pool every cell rests on.
+        vg_neg = r["vg_missing"] + r["neither"]
+        noise = r["vg_missing"] / vg_neg if vg_neg else float("nan")
+        for k, v in r.items():
+            total[k] += v
+        print(
+            f"{c:<12}{r['both']:>7}{r['vg_missing']:>12}{r['coco_missing']:>11}"
+            f"{r['neither']:>9}{recall:>11.2f}{noise:>11.4f}"
+        )
+    tp = total["both"] + total["vg_missing"]
+    neg = total["vg_missing"] + total["neither"]
+    print("-" * len(hdr))
+    print(
+        f"{'pooled':<12}{total['both']:>7}{total['vg_missing']:>12}{total['coco_missing']:>11}"
+        f"{total['neither']:>9}{total['both'] / tp:>11.2f}{total['vg_missing'] / neg:>11.4f}"
+    )
+    print(
+        "\nVG recall = of the objects COCO annotates, the share VG also annotates."
+        "\nneg noise = of the images VG treats as negatives, the share that actually hold one."
+    )
+
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(
+                {
+                    "meta": {"anchored_images": anchored, "classes": list(pc.SCALE_CLASSES)},
+                    "counts": {c: dict(rows[c]) for c in pc.SCALE_CLASSES},
+                    "verdicts": verdicts,
+                },
+                indent=1,
+            )
+            + "\n"
+        )
+        log(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/coco_anchor.py
+++ b/scripts/experiments/pile/coco_anchor.py
@@ -52,6 +52,9 @@ COCO_ANN_URL = "http://images.cocodataset.org/annotations/annotations_trainval20
 
 VG_ROOT = pc.DEMO_CACHE / "visual_genome"
 
+#: ``{coco_image_id: (width, height)}``, filled by :func:`coco_truth`.
+COCO_DIMS: dict[int, tuple[int, int]] = {}
+
 
 def log(msg: str) -> None:
     print(f"[anchor] {msg}", flush=True)
@@ -128,6 +131,9 @@ def coco_truth(instances: list[Path], classes: set[str]) -> dict[int, dict[str, 
         wanted = {c["id"]: c["name"] for c in data["categories"] if c["name"] in classes}
         for img in data["images"]:
             truth.setdefault(int(img["id"]), {})
+            # COCO carries the dimensions, so banding an anchored image needs no
+            # JPEG header read at all.
+            COCO_DIMS[int(img["id"])] = (int(img["width"]), int(img["height"]))
         for ann in data["annotations"]:
             name = wanted.get(ann["category_id"])
             if name is None:
@@ -171,6 +177,12 @@ def main() -> int:
     ap.add_argument("--fetch", action="store_true", help="download missing sources")
     ap.add_argument("--out", default="", help="write the per-image verdicts as JSON")
     ap.add_argument("--pool", default="", help="restrict to the image ids in this vg_scale pickle")
+    ap.add_argument(
+        "--bands",
+        action="store_true",
+        help="also report per-(class, band) supply using COCO's boxes, i.e. what a "
+        "dataset built on the anchored half alone could fill",
+    )
     args = ap.parse_args()
 
     anchor = Path(args.anchor_dir)
@@ -255,6 +267,52 @@ def main() -> int:
         "\nVG recall = of the objects COCO annotates, the share VG also annotates."
         "\nneg noise = of the images VG treats as negatives, the share that actually hold one."
     )
+
+    if args.bands:
+        # What could a dataset built on the anchored half ALONE hold? Its labels
+        # would be exhaustive by construction -- a negative is an image COCO
+        # annotated and found none in, not merely one nobody mentioned it on --
+        # so it needs no correction pass at all. The question is only supply.
+        print(f"\n=== per-band supply on the {anchored} anchored images, COCO boxes ===")
+        hdr2 = f"{'class':<12}{'small':>8}{'medium':>8}{'large':>8}{'over':>7}{'scatter':>9}{'min':>7}"
+        print(hdr2)
+        print("-" * len(hdr2))
+        worst = None
+        for c in pc.SCALE_CLASSES:
+            counts = dict.fromkeys((*pc.BOX_BANDS, "oversize"), 0)
+            scattered = 0
+            for vg_id, cid in coco_of.items():
+                if pool is not None and vg_id not in pool:
+                    continue
+                ref = truth.get(cid)
+                wh = COCO_DIMS.get(cid)
+                if not ref or wh is None or c not in ref:
+                    continue
+                area = float(wh[0] * wh[1])
+                bs = ref[c]
+                union = (
+                    max(0.0, max(b[2] for b in bs) - min(b[0] for b in bs))
+                    * max(0.0, max(b[3] for b in bs) - min(b[1] for b in bs))
+                    / area
+                )
+                largest = max((b[2] - b[0]) * (b[3] - b[1]) for b in bs) / area
+                if union > largest * pc.BAND_MAX_INFLATION:
+                    scattered += 1
+                    continue
+                for band, (lo, hi) in pc.BOX_BANDS.items():
+                    if lo <= union < hi:
+                        counts[band] += 1
+                        break
+                else:
+                    counts["oversize"] += 1
+            mn = min(counts[b] for b in pc.BOX_BANDS)
+            worst = mn if worst is None else min(worst, mn)
+            print(
+                f"{c:<12}{counts['small']:>8}{counts['medium']:>8}{counts['large']:>8}"
+                f"{counts['oversize']:>7}{scattered:>9}{mn:>7}"
+            )
+        print("-" * len(hdr2))
+        print(f"binding per-band supply across C: {worst}  (n_pos must not exceed it)")
 
     if args.out:
         Path(args.out).write_text(

--- a/scripts/experiments/pile/coco_class_sheets.py
+++ b/scripts/experiments/pile/coco_class_sheets.py
@@ -1,0 +1,157 @@
+"""Show what COCO actually means by each class, in its own annotators' examples.
+
+Prose definitions of an annotation class are worth less than the annotations.
+"Is a messenger bag a `backpack`?" is not settled by a dictionary; it is settled
+by what COCO's annotators did, repeatedly, across 118k images -- and the only
+way to transfer that to a human reviewer is to show them.
+
+So: for each class, real COCO instances cropped with context, **four per size
+band**, because a reviewer of this study has to recognise the class at every
+scale and a `bus` at 0.3% of the frame does not look like the bus in anyone's
+mental image. Alongside each target class, the sibling classes that steal from
+it (`handbag`/`suitcase` from `backpack`, `motorcycle` from `bicycle`), since a
+boundary is only learnable by seeing both sides of it.
+
+Also reports, per class, the measured size distribution and the share of
+instances below one DINOv3 patch -- which is how a suspicion like "COCO labels
+wristwatches as clocks" becomes a number rather than an argument.
+
+Usage::
+
+    python coco_class_sheets.py --out /expscratch/$USER/vgscale-3156/sheets
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+#: Sibling classes worth showing beside a target, because COCO puts them in a
+#: different class and a reviewer who conflates them corrupts both.
+CONFUSABLE: dict[str, tuple[str, ...]] = {
+    "backpack": ("handbag", "suitcase"),
+    "bicycle": ("motorcycle",),
+    "boat": ("surfboard",),
+    "bus": ("truck", "train", "car"),
+    "knife": ("scissors", "fork"),
+    "kite": ("umbrella", "airplane"),
+    "dog": ("cat", "horse", "sheep", "bear"),
+    "bird": ("kite",),
+    "clock": ("cell phone",),
+    "book": ("laptop",),
+    "umbrella": ("kite",),
+    "stop sign": ("traffic light",),
+}
+
+TILE = 240
+PER_BAND = 4
+
+
+def log(msg: str) -> None:
+    print(f"[sheets] {msg}", flush=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default=str(pc.PILE.parent / "vgscale-3156" / "sheets"))
+    ap.add_argument("--seed", type=int, default=20260817)
+    args = ap.parse_args()
+
+    from PIL import Image, ImageDraw  # noqa: PLC0415
+
+    import coco_anchor as ca  # noqa: PLC0415
+    from build_pile import _vg_image_paths  # noqa: PLC0415
+
+    wanted = set(pc.SCALE_CLASSES) | {s for v in CONFUSABLE.values() for s in v}
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    truth = ca.coco_truth(instances, wanted)
+    with image_data.open() as fh:
+        vg_of = {int(m["coco_id"]): int(m["image_id"]) for m in json.load(fh) if m.get("coco_id")}
+    paths = _vg_image_paths()
+    log(f"{len(truth)} COCO images, {len(vg_of)} with a VG copy on disk")
+
+    # class -> band -> [(coco_id, box, area_frac)]
+    pool: dict[str, dict[str, list]] = {c: {b: [] for b in pc.BOX_BANDS} for c in wanted}
+    areas: dict[str, list[float]] = {c: [] for c in wanted}
+    for cid, ref in truth.items():
+        wh = ca.COCO_DIMS.get(cid)
+        vg = vg_of.get(cid)
+        if not ref or wh is None or vg is None or vg not in paths:
+            continue
+        area = float(wh[0] * wh[1])
+        for name, boxes in ref.items():
+            for b in boxes:
+                frac = max(0.0, (b[2] - b[0])) * max(0.0, (b[3] - b[1])) / area
+                areas[name].append(frac)
+                for band, (lo, hi) in pc.BOX_BANDS.items():
+                    if lo <= frac < hi:
+                        pool[name][band].append((cid, b, frac))
+                        break
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(args.seed)
+    stats = {}
+
+    for name in sorted(wanted):
+        rows = []
+        for band in pc.BOX_BANDS:
+            items = pool[name][band]
+            rows.append((band, rng.sample(items, min(PER_BAND, len(items)))))
+        if not any(r[1] for r in rows):
+            continue
+        sheet = Image.new("RGB", (TILE * PER_BAND, TILE * len(rows)), (18, 20, 21))
+        d = ImageDraw.Draw(sheet)
+        for ri, (band, items) in enumerate(rows):
+            for ci, (cid, box, frac) in enumerate(items):
+                src = paths[vg_of[cid]]
+                try:
+                    with Image.open(src) as im:
+                        im = im.convert("RGB")
+                        W, H = im.size
+                        x0, x1 = sorted((box[0], box[2]))
+                        y0, y1 = sorted((box[1], box[3]))
+                        pad = max((x1 - x0), (y1 - y0)) * 0.35 + min(W, H) * 0.03
+                        crop = im.crop(
+                            (
+                                max(0, int(x0 - pad)),
+                                max(0, int(y0 - pad)),
+                                min(W, int(x1 + pad) + 2),
+                                min(H, int(y1 + pad) + 2),
+                            )
+                        )
+                        crop.thumbnail((TILE, TILE), Image.LANCZOS)
+                except Exception:  # noqa: BLE001 - a corrupt file just leaves a gap
+                    continue
+                ox, oy = ci * TILE, ri * TILE
+                sheet.paste(crop, (ox + (TILE - crop.width) // 2, oy + (TILE - crop.height) // 2))
+                d.text((ox + 5, oy + 5), f"{band} {frac * 100:.2f}%", fill=(255, 210, 90))
+            d.line([(0, ri * TILE), (TILE * PER_BAND, ri * TILE)], fill=(90, 96, 98), width=1)
+        fname = name.replace(" ", "_") + ".jpg"
+        sheet.save(out / fname, quality=86)
+        a = sorted(areas[name])
+        stats[name] = {
+            "n_instances": len(a),
+            "median_area_pct": round(100 * a[len(a) // 2], 3) if a else None,
+            "sub_patch_pct": round(100 * sum(1 for x in a if x < pc.PATCH_AREA) / len(a), 1) if a else None,
+            "sheet": fname,
+            "confusable_with": list(CONFUSABLE.get(name, ())),
+        }
+        log(
+            f"  {name:<14} {len(a):6d} instances  median {stats[name]['median_area_pct']}%  "
+            f"sub-patch {stats[name]['sub_patch_pct']}%"
+        )
+
+    (out / "stats.json").write_text(json.dumps(stats, indent=1, sort_keys=True) + "\n")
+    print(f"\n{len(stats)} sheets under {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -106,8 +106,18 @@ def read_api(base: str, detector: str) -> list[dict]:
     asked of them.
     """
     url = f"{base.rstrip('/')}/api/detectors/{urllib.parse.quote(detector)}/labels-detail"
-    with urllib.request.urlopen(url, timeout=60) as r:  # noqa: S310 - caller-supplied http(s) base
-        data = json.load(r)
+    try:
+        with urllib.request.urlopen(url, timeout=60) as r:  # noqa: S310 - caller-supplied http(s) base
+            data = json.load(r)
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            raise
+        # A slate whose detector has been retired: reviewing it moved elsewhere
+        # (a Claude triage pass, say) and its verdicts live in a snapshot. That
+        # is a normal state, not a failure -- but it is reported, because a
+        # silently empty detector and a finished one look identical downstream.
+        log(f"  {detector}: no such detector (retired); contributing no verdicts")
+        return []
     out = []
     for label in ("good", "bad"):
         for el in data.get(label) or []:

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -1,0 +1,140 @@
+"""Turn a VTSearch label export back into verdict rows, and score the ground truth.
+
+The other half of ``make_audit_slate.py``. A ``server_folder`` import → vote →
+``server_json_file`` export round-trip already emits everything a verdict needs:
+the file name identifies the VG image (the slate names files ``<image_id>.jpg``),
+``label`` is the human's Good/Bad, and ``region_box`` carries the box drawn on a
+Good vote, normalised.
+
+**Verdicts, not corrections.** Every reviewed ``(image, class)`` pair becomes a
+row whether or not it disagrees with COCO. Corrections are then derived from the
+disagreements, and review *coverage* falls out for free — without it, "no bus
+here" is indistinguishable from "nobody looked", and every rate computed
+afterwards is biased by an unknown amount.
+
+**The rate comes from the random stratum alone.** The boundary stratum is chosen
+to find errors, so its error rate is not the pool's error rate and averaging the
+two together produces a number that means nothing. Both are reported, labelled,
+and never pooled.
+
+Usage::
+
+    python ingest_slate.py --export ~/exports/bus.json --slates /expscratch/$USER/vgscale-3156/slates
+    python ingest_slate.py --export 'exports/*.json' --slates ... --out verdicts.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def log(msg: str) -> None:
+    print(f"[ingest] {msg}", flush=True)
+
+
+def load_manifests(slates: Path) -> dict[tuple[int, str], dict]:
+    """``{(image_id, class): manifest row}`` over every slate on disk."""
+    out: dict[tuple[int, str], dict] = {}
+    for man in sorted(slates.glob("*/manifest.csv")):
+        with man.open() as fh:
+            for row in csv.DictReader(fh):
+                out[(int(row["image_id"]), row["class"])] = row
+    return out
+
+
+def read_export(path: Path) -> list[dict]:
+    """The labelled elements of one export, whichever shape it was written in."""
+    data = json.loads(path.read_text())
+    if isinstance(data, dict) and "labels" in data:
+        return list(data["labels"])
+    if isinstance(data, list):
+        return list(data)
+    raise SystemExit(f"{path}: not a label export (no 'labels' key, not a list)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--export", required=True, help="exported JSON (glob allowed)")
+    ap.add_argument("--slates", default=str(pc.PILE / "slates"), help="slate dir from make_audit_slate.py")
+    ap.add_argument("--out", default="", help="write the verdict rows here")
+    args = ap.parse_args()
+
+    manifests = load_manifests(Path(args.slates))
+    if not manifests:
+        raise SystemExit(f"no manifests under {args.slates}; run make_audit_slate.py first")
+    log(f"{len(manifests)} slate entries over {len({c for _, c in manifests})} classes")
+
+    verdicts: list[dict] = []
+    unmatched = 0
+    for path in sorted(glob.glob(args.export)):
+        elements = read_export(Path(path))
+        for el in elements:
+            name = Path(el.get("filename") or el.get("origin_name") or "").stem
+            if not name.isdigit():
+                unmatched += 1
+                continue
+            iid = int(name)
+            # One export is one detector, i.e. one class; the slate says which.
+            hits = [(i, c) for (i, c) in manifests if i == iid]
+            if not hits:
+                unmatched += 1
+                continue
+            for _, c in hits:
+                row = manifests[(iid, c)]
+                verdicts.append(
+                    {
+                        "image_id": iid,
+                        "class": c,
+                        "stratum": row["stratum"],
+                        "human": "present" if el.get("label") == "good" else "absent",
+                        "reference": row["coco_says"],
+                        "box": el.get("region_box"),
+                        "text_score": float(row["text_score"]),
+                        "export": Path(path).name,
+                    }
+                )
+        log(f"  {Path(path).name}: {len(elements)} labelled elements")
+    if unmatched:
+        log(f"  WARNING {unmatched} exported elements matched no slate entry")
+
+    # Per stratum, per direction. Never pooled across strata.
+    by: dict[tuple[str, str], int] = defaultdict(int)
+    for v in verdicts:
+        by[(v["stratum"], f"{v['reference']}->{v['human']}")] += 1
+
+    print(f"\n{len(verdicts)} verdicts\n")
+    hdr = f"{'stratum':<10}{'agree':>8}{'ref absent, human present':>28}{'ref present, human absent':>28}{'rate':>9}"
+    print(hdr)
+    print("-" * len(hdr))
+    for stratum in ("random", "boundary", "positive"):
+        agree = by[(stratum, "absent->absent")] + by[(stratum, "present->present")]
+        miss = by[(stratum, "absent->present")]
+        over = by[(stratum, "present->absent")]
+        n = agree + miss + over
+        if not n:
+            continue
+        rate = (miss + over) / n
+        note = "" if stratum == "random" else "  (biased by design)"
+        print(f"{stratum:<10}{agree:>8}{miss:>28}{over:>28}{rate:>9.3f}{note}")
+    print(
+        "\nThe residual error rate of the ground truth is the RANDOM row only."
+        "\nThe boundary row is chosen to surface errors and says nothing about the pool."
+    )
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(verdicts, indent=1) + "\n")
+        log(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -240,15 +240,20 @@ def main() -> int:
     for v in verdicts:
         by[(v["stratum"], f"{v['reference']}->{v['human']}")] += 1
 
-    # The calibration: on images COCO already settled, a disagreement is the
-    # reviewer's error, not a correction. Reported separately -- folding it into
-    # the correction counts would let annotator noise masquerade as label noise.
+    # The calibration: pairs where COCO has already looked. A disagreement here
+    # is NOT "the reviewer was wrong" -- it is reviewer error, COCO error, and
+    # definition drift summed together, and nothing in this data separates them.
+    # COCO is measurably better than VG (recall 0.61 vs COCO over C) but it is
+    # not a gold standard: the same review already found images COCO annotates
+    # as empty that plainly hold the object. Report it as disagreement, and
+    # leave the decomposition to a third opinion on the disagreeing pairs.
     cal = [v for v in verdicts if v["exhaustive"] == "yes"]
     if cal:
         wrong = sum(1 for v in cal if v["human"] != v["reference"])
         print(
-            f"\ncalibration: {len(cal)} pairs with an exhaustive reference, {wrong} disagreements "
-            f"({wrong / len(cal):.3f}) -- reviewer error rate, not label noise"
+            f"\ncalibration: {len(cal)} pairs COCO has settled, {wrong} DISAGREEMENTS "
+            f"({wrong / len(cal):.3f}) -- reviewer error + COCO error + definition drift, "
+            f"not attributable without adjudication"
         )
 
     print(f"\n{len(verdicts)} verdicts\n")

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -41,14 +41,43 @@ def log(msg: str) -> None:
     print(f"[ingest] {msg}", flush=True)
 
 
-def load_manifests(slates: Path) -> dict[tuple[int, str], dict]:
-    """``{(image_id, class): manifest row}`` over every slate on disk."""
+def load_manifests(slates: Path) -> tuple[dict[tuple[int, str], dict], dict[str, str]]:
+    """``({(image_id, class): row}, {class: folder name})`` over every slate."""
     out: dict[tuple[int, str], dict] = {}
+    folders: dict[str, str] = {}
     for man in sorted(slates.glob("*/manifest.csv")):
         with man.open() as fh:
             for row in csv.DictReader(fh):
                 out[(int(row["image_id"]), row["class"])] = row
-    return out
+                folders[row["class"]] = man.parent.name
+    return out, folders
+
+
+def class_of(path: Path, elements: list[dict], folders: dict[str, str], explicit: str) -> str:
+    """Which class this export is a review of.
+
+    An export **cannot** be attributed by image id: the slates share images
+    (801 of 3,600 rows are an image that appears under a second class), so a
+    Good vote in the `bus` dataset would otherwise be recorded as a `dog`
+    verdict too. The slate folder is what disambiguates, read from the
+    importer's own origin, then from the file name, and never guessed.
+    """
+    if explicit:
+        if explicit not in folders:
+            raise SystemExit(f"--class {explicit!r} is not one of {sorted(folders)}")
+        return explicit
+    blob = " ".join(json.dumps(el.get("origin") or "") + " " + str(el.get("origin_name") or "") for el in elements[:50])
+    hits = {c for c, folder in folders.items() if f"/{folder}/" in blob or f"/{folder}" in blob}
+    if len(hits) == 1:
+        return hits.pop()
+    stem = path.stem.lower()
+    hits = {c for c, folder in folders.items() if folder.lower() in stem}
+    if len(hits) == 1:
+        return hits.pop()
+    raise SystemExit(
+        f"{path.name}: cannot tell which class this export reviews "
+        f"(origin paths and file name match {sorted(hits) or 'nothing'}). Pass --class."
+    )
 
 
 def read_export(path: Path) -> list[dict]:
@@ -66,9 +95,10 @@ def main() -> int:
     ap.add_argument("--export", required=True, help="exported JSON (glob allowed)")
     ap.add_argument("--slates", default=str(pc.PILE / "slates"), help="slate dir from make_audit_slate.py")
     ap.add_argument("--out", default="", help="write the verdict rows here")
+    ap.add_argument("--class", dest="klass", default="", help="the class this export reviews (else inferred)")
     args = ap.parse_args()
 
-    manifests = load_manifests(Path(args.slates))
+    manifests, folders = load_manifests(Path(args.slates))
     if not manifests:
         raise SystemExit(f"no manifests under {args.slates}; run make_audit_slate.py first")
     log(f"{len(manifests)} slate entries over {len({c for _, c in manifests})} classes")
@@ -77,33 +107,31 @@ def main() -> int:
     unmatched = 0
     for path in sorted(glob.glob(args.export)):
         elements = read_export(Path(path))
+        c = class_of(Path(path), elements, folders, args.klass)
         for el in elements:
             name = Path(el.get("filename") or el.get("origin_name") or "").stem
             if not name.isdigit():
                 unmatched += 1
                 continue
             iid = int(name)
-            # One export is one detector, i.e. one class; the slate says which.
-            hits = [(i, c) for (i, c) in manifests if i == iid]
-            if not hits:
+            row = manifests.get((iid, c))
+            if row is None:
                 unmatched += 1
                 continue
-            for _, c in hits:
-                row = manifests[(iid, c)]
-                verdicts.append(
-                    {
-                        "image_id": iid,
-                        "class": c,
-                        "stratum": row["stratum"],
-                        "human": "present" if el.get("label") == "good" else "absent",
-                        "reference": row["reference"],
-                        "exhaustive": row["exhaustive"],
-                        "box": el.get("region_box"),
-                        "text_score": float(row["text_score"]),
-                        "export": Path(path).name,
-                    }
-                )
-        log(f"  {Path(path).name}: {len(elements)} labelled elements")
+            verdicts.append(
+                {
+                    "image_id": iid,
+                    "class": c,
+                    "stratum": row["stratum"],
+                    "human": "present" if el.get("label") == "good" else "absent",
+                    "reference": row["reference"],
+                    "exhaustive": row["exhaustive"],
+                    "box": el.get("region_box"),
+                    "text_score": float(row["text_score"]),
+                    "export": Path(path).name,
+                }
+            )
+        log(f"  {Path(path).name}: {len(elements)} labelled elements, class {c!r}")
     if unmatched:
         log(f"  WARNING {unmatched} exported elements matched no slate entry")
 

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -96,7 +96,8 @@ def main() -> int:
                         "class": c,
                         "stratum": row["stratum"],
                         "human": "present" if el.get("label") == "good" else "absent",
-                        "reference": row["coco_says"],
+                        "reference": row["reference"],
+                        "exhaustive": row["exhaustive"],
                         "box": el.get("region_box"),
                         "text_score": float(row["text_score"]),
                         "export": Path(path).name,
@@ -110,6 +111,17 @@ def main() -> int:
     by: dict[tuple[str, str], int] = defaultdict(int)
     for v in verdicts:
         by[(v["stratum"], f"{v['reference']}->{v['human']}")] += 1
+
+    # The calibration: on images COCO already settled, a disagreement is the
+    # reviewer's error, not a correction. Reported separately -- folding it into
+    # the correction counts would let annotator noise masquerade as label noise.
+    cal = [v for v in verdicts if v["exhaustive"] == "yes"]
+    if cal:
+        wrong = sum(1 for v in cal if v["human"] != v["reference"])
+        print(
+            f"\ncalibration: {len(cal)} pairs with an exhaustive reference, {wrong} disagreements "
+            f"({wrong / len(cal):.3f}) -- reviewer error rate, not label noise"
+        )
 
     print(f"\n{len(verdicts)} verdicts\n")
     hdr = f"{'stratum':<10}{'agree':>8}{'ref absent, human present':>28}{'ref present, human absent':>28}{'rate':>9}"

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -43,15 +43,29 @@ def log(msg: str) -> None:
     print(f"[ingest] {msg}", flush=True)
 
 
-def load_manifests(slates: Path) -> tuple[dict[tuple[int, str], dict], dict[str, str]]:
-    """``({(image_id, class): row}, {class: folder name})`` over every slate."""
-    out: dict[tuple[int, str], dict] = {}
+#: Which stratum wins when the same (image, class) was reviewed twice. The
+#: boxed re-issue supersedes the bare thumbnail: it is the same question asked
+#: in a form the reviewer could actually answer (`make_positive_slate.py`).
+STRATUM_RANK = {"positive": 0, "boundary": 0, "random": 0, "positive_boxed": 1}
+
+
+def load_manifests(roots: list[Path]) -> tuple[dict[tuple[int, str, str], dict], dict[str, str]]:
+    """``({(image_id, class, detector): row}, {detector: folder name})``.
+
+    Keyed by detector as well as class because a class can be reviewed through
+    more than one detector -- the bare slate and the boxed positive re-issue --
+    and their rows must not overwrite each other before the ranking above is
+    applied.
+    """
+    out: dict[tuple[int, str, str], dict] = {}
     folders: dict[str, str] = {}
-    for man in sorted(slates.glob("*/manifest.csv")):
-        with man.open() as fh:
-            for row in csv.DictReader(fh):
-                out[(int(row["image_id"]), row["class"])] = row
-                folders[row["class"]] = man.parent.name
+    for root in roots:
+        for man in sorted(root.glob("*/manifest.csv")):
+            with man.open() as fh:
+                for row in csv.DictReader(fh):
+                    det = row.get("detector") or row["class"]
+                    out[(int(row["image_id"]), row["class"], det)] = row
+                    folders[det] = man.parent.name
     return out, folders
 
 
@@ -126,15 +140,19 @@ def main() -> int:
         help="pull votes straight from a running VTSearch instead of a file export, "
         "e.g. --api http://rack7n03:11850 (one detector per class, named after it)",
     )
-    ap.add_argument("--slates", default=str(pc.PILE / "slates"), help="slate dir from make_audit_slate.py")
+    ap.add_argument(
+        "--slates",
+        default=str(pc.PILE / "slates"),
+        help="slate dir(s) from make_audit_slate.py / make_positive_slate.py, comma-separated",
+    )
     ap.add_argument("--out", default="", help="write the verdict rows here")
     ap.add_argument("--class", dest="klass", default="", help="the class this export reviews (else inferred)")
     args = ap.parse_args()
 
-    manifests, folders = load_manifests(Path(args.slates))
+    manifests, folders = load_manifests([Path(p) for p in args.slates.split(",") if p])
     if not manifests:
         raise SystemExit(f"no manifests under {args.slates}; run make_audit_slate.py first")
-    log(f"{len(manifests)} slate entries over {len({c for _, c in manifests})} classes")
+    log(f"{len(manifests)} slate entries over {len({c for _, c, _ in manifests})} classes, {len(folders)} detectors")
 
     if not args.export and not args.api:
         raise SystemExit("pass --export <file/glob> or --api <base-url>")
@@ -142,25 +160,28 @@ def main() -> int:
     # (label of the source, its elements, the class it reviews)
     sources: list[tuple[str, list[dict], str]] = []
     if args.api:
-        for c in sorted(folders):
+        det_class = {det: c for (_, c, det) in manifests}
+        for det in sorted(folders):
+            c = det_class[det]
             if args.klass and c != args.klass:
                 continue
-            els = read_api(args.api, c)
-            sources.append((f"api:{c}", els, c))
+            els = read_api(args.api, det)
+            sources.append((f"api:{det}", els, c, det))
     for path in sorted(glob.glob(args.export)) if args.export else []:
         els = read_export(Path(path))
-        sources.append((Path(path).name, els, class_of(Path(path), els, folders, args.klass)))
+        det = class_of(Path(path), els, folders, args.klass)
+        sources.append((Path(path).name, els, {c for (_, c, d) in manifests if d == det}.pop(), det))
 
     verdicts: list[dict] = []
     unmatched = 0
-    for source, elements, c in sources:
+    for source, elements, c, det in sources:
         for el in elements:
             name = Path(el.get("filename") or el.get("origin_name") or "").stem
             if not name.isdigit():
                 unmatched += 1
                 continue
             iid = int(name)
-            row = manifests.get((iid, c))
+            row = manifests.get((iid, c, det))
             if row is None:
                 unmatched += 1
                 continue
@@ -196,6 +217,13 @@ def main() -> int:
         if prev is None:
             merged[key] = v
             continue
+        rank_prev = STRATUM_RANK.get(prev["stratum"], 0)
+        rank_new = STRATUM_RANK.get(v["stratum"], 0)
+        if rank_new > rank_prev:
+            merged[key] = v  # the boxed re-issue supersedes; not a conflict
+            continue
+        if rank_new < rank_prev:
+            continue
         if prev["human"] != v["human"]:
             conflicts += 1
         if prev.get("box") is None and v.get("box") is not None:
@@ -228,7 +256,7 @@ def main() -> int:
     for v in verdicts:
         done[v["class"]] += 1
     total: dict[str, int] = defaultdict(int)
-    for _, c in manifests:
+    for _, c, _det in manifests:
         total[c] += 1
     if done:
         print("progress (distinct images voted, duplicates already collapsed):")
@@ -240,7 +268,7 @@ def main() -> int:
     hdr = f"{'stratum':<10}{'agree':>8}{'ref absent, human present':>28}{'ref present, human absent':>28}{'rate':>9}"
     print(hdr)
     print("-" * len(hdr))
-    for stratum in ("random", "boundary", "positive"):
+    for stratum in ("random", "boundary", "positive", "positive_boxed"):
         agree = by[(stratum, "absent->absent")] + by[(stratum, "present->present")]
         miss = by[(stratum, "absent->present")]
         over = by[(stratum, "present->absent")]

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -181,6 +181,32 @@ def main() -> int:
     if unmatched:
         log(f"  WARNING {unmatched} exported elements matched no slate entry")
 
+    # One verdict per (image, class). A labelset can hold the same media twice:
+    # observed 56 of 300 images duplicated in one detector, Bad votes as exact
+    # copies and Good votes as a boxed entry plus an image-level one -- the app
+    # appends a LabeledElement per vote event rather than replacing (#3168).
+    # Counting both would double-weight a fifth of the review, so collapse
+    # them, preferring the entry that carries a box because that is the one
+    # that can place the image in a band.
+    merged: dict[tuple[int, str], dict] = {}
+    conflicts = 0
+    for v in verdicts:
+        key = (v["image_id"], v["class"])
+        prev = merged.get(key)
+        if prev is None:
+            merged[key] = v
+            continue
+        if prev["human"] != v["human"]:
+            conflicts += 1
+        if prev.get("box") is None and v.get("box") is not None:
+            merged[key] = v
+    dropped = len(verdicts) - len(merged)
+    if dropped:
+        log(f"  collapsed {dropped} duplicate labels into {len(merged)} distinct (image, class) verdicts")
+    if conflicts:
+        log(f"  WARNING {conflicts} images carry BOTH a Good and a Bad vote -- kept the boxed one")
+    verdicts = sorted(merged.values(), key=lambda v: (v["class"], v["image_id"]))
+
     # Per stratum, per direction. Never pooled across strata.
     by: dict[tuple[str, str], int] = defaultdict(int)
     for v in verdicts:
@@ -198,6 +224,19 @@ def main() -> int:
         )
 
     print(f"\n{len(verdicts)} verdicts\n")
+    done: dict[str, int] = defaultdict(int)
+    for v in verdicts:
+        done[v["class"]] += 1
+    total: dict[str, int] = defaultdict(int)
+    for _, c in manifests:
+        total[c] += 1
+    if done:
+        print("progress (distinct images voted, duplicates already collapsed):")
+        for c in sorted(total):
+            n = done.get(c, 0)
+            mark = " done" if n >= total[c] else ""
+            print(f"  {c:<12}{n:>5} / {total[c]}{mark}")
+        print()
     hdr = f"{'stratum':<10}{'agree':>8}{'ref absent, human present':>28}{'ref present, human absent':>28}{'rate':>9}"
     print(hdr)
     print("-" * len(hdr))

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -205,7 +205,7 @@ def main() -> int:
     # One verdict per (image, class). A labelset can hold the same media twice:
     # observed 56 of 300 images duplicated in one detector, Bad votes as exact
     # copies and Good votes as a boxed entry plus an image-level one -- the app
-    # appends a LabeledElement per vote event rather than replacing (#3168).
+    # appends a LabeledElement per vote event rather than replacing (#3174).
     # Counting both would double-weight a fifth of the review, so collapse
     # them, preferring the entry that carries a box because that is the one
     # that can place the image in a band.

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -29,6 +29,8 @@ import argparse
 import csv
 import glob
 import json
+import urllib.parse
+import urllib.request
 from collections import defaultdict
 from pathlib import Path
 
@@ -80,6 +82,31 @@ def class_of(path: Path, elements: list[dict], folders: dict[str, str], explicit
     )
 
 
+def read_api(base: str, detector: str) -> list[dict]:
+    """One detector's saved votes, in the same shape as a file export.
+
+    ``GET /api/detectors/<name>/labels-detail`` already returns the two things a
+    verdict needs -- the file name (which is the VG image id) and the
+    ``region_box`` drawn on a Good vote -- so pulling straight from the running
+    app skips the export dialog entirely. The reviewer votes; nothing else is
+    asked of them.
+    """
+    url = f"{base.rstrip('/')}/api/detectors/{urllib.parse.quote(detector)}/labels-detail"
+    with urllib.request.urlopen(url, timeout=60) as r:  # noqa: S310 - caller-supplied http(s) base
+        data = json.load(r)
+    out = []
+    for label in ("good", "bad"):
+        for el in data.get(label) or []:
+            out.append(
+                {
+                    "filename": el.get("filename") or el.get("origin_name"),
+                    "label": label,
+                    "region_box": el.get("region_box"),
+                }
+            )
+    return out
+
+
 def read_export(path: Path) -> list[dict]:
     """The labelled elements of one export, whichever shape it was written in."""
     data = json.loads(path.read_text())
@@ -92,7 +119,13 @@ def read_export(path: Path) -> list[dict]:
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--export", required=True, help="exported JSON (glob allowed)")
+    ap.add_argument("--export", default="", help="exported JSON (glob allowed)")
+    ap.add_argument(
+        "--api",
+        default="",
+        help="pull votes straight from a running VTSearch instead of a file export, "
+        "e.g. --api http://rack7n03:11850 (one detector per class, named after it)",
+    )
     ap.add_argument("--slates", default=str(pc.PILE / "slates"), help="slate dir from make_audit_slate.py")
     ap.add_argument("--out", default="", help="write the verdict rows here")
     ap.add_argument("--class", dest="klass", default="", help="the class this export reviews (else inferred)")
@@ -103,11 +136,24 @@ def main() -> int:
         raise SystemExit(f"no manifests under {args.slates}; run make_audit_slate.py first")
     log(f"{len(manifests)} slate entries over {len({c for _, c in manifests})} classes")
 
+    if not args.export and not args.api:
+        raise SystemExit("pass --export <file/glob> or --api <base-url>")
+
+    # (label of the source, its elements, the class it reviews)
+    sources: list[tuple[str, list[dict], str]] = []
+    if args.api:
+        for c in sorted(folders):
+            if args.klass and c != args.klass:
+                continue
+            els = read_api(args.api, c)
+            sources.append((f"api:{c}", els, c))
+    for path in sorted(glob.glob(args.export)) if args.export else []:
+        els = read_export(Path(path))
+        sources.append((Path(path).name, els, class_of(Path(path), els, folders, args.klass)))
+
     verdicts: list[dict] = []
     unmatched = 0
-    for path in sorted(glob.glob(args.export)):
-        elements = read_export(Path(path))
-        c = class_of(Path(path), elements, folders, args.klass)
+    for source, elements, c in sources:
         for el in elements:
             name = Path(el.get("filename") or el.get("origin_name") or "").stem
             if not name.isdigit():
@@ -128,10 +174,10 @@ def main() -> int:
                     "exhaustive": row["exhaustive"],
                     "box": el.get("region_box"),
                     "text_score": float(row["text_score"]),
-                    "export": Path(path).name,
+                    "export": source,
                 }
             )
-        log(f"  {Path(path).name}: {len(elements)} labelled elements, class {c!r}")
+        log(f"  {source}: {len(elements)} labelled elements, class {c!r}")
     if unmatched:
         log(f"  WARNING {unmatched} exported elements matched no slate entry")
 

--- a/scripts/experiments/pile/make_audit_pass.py
+++ b/scripts/experiments/pile/make_audit_pass.py
@@ -1,0 +1,122 @@
+"""Build the reviewer's audit slate: the model's flags, plus the sample that bounds them.
+
+A triage pass is only as good as its measured recall, and recall cannot be
+measured from the flags themselves -- they are chosen to be positive. So the
+audit has two parts, recorded separately and never pooled:
+
+* ``flag`` -- every image the triage called a hidden positive. Reviewing these
+  turns a suspicion into a correction, and their disagreement rate is the
+  triage's *precision*.
+* ``audit`` -- a uniform sample of the negatives the triage did **not** flag.
+  This is the only part that can estimate what the pass missed; without it the
+  residual error rate after triage is unknown, not small.
+
+The two are shuffled together and named by image id, so the reviewer cannot tell
+which is which and the audit stratum stays unbiased.
+
+Usage::
+
+    python make_audit_pass.py --classes bus,dog --audit-per-class 25
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import shutil
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def log(msg: str) -> None:
+    print(f"[audit] {msg}", flush=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    base = pc.PILE.parent / "vgscale-3156"
+    ap.add_argument("--triage", default=str(base / "tri_flags_all.json"))
+    ap.add_argument("--sheets", default=str(base / "sheets_neg"))
+    ap.add_argument("--slates", default=str(base / "slates"))
+    ap.add_argument("--out", default=str(base / "slates_audit"))
+    ap.add_argument("--classes", default="")
+    ap.add_argument("--audit-per-class", type=int, default=20, help="unflagged negatives sampled per class")
+    ap.add_argument("--seed", type=int, default=20260824)
+    args = ap.parse_args()
+
+    from build_pile import _vg_image_paths  # noqa: PLC0415
+
+    paths = _vg_image_paths()
+    flags = json.loads(Path(args.triage).read_text())
+    want = [c.strip() for c in args.classes.split(",") if c.strip()] or sorted(flags)
+    rng = random.Random(args.seed)
+    out_root = Path(args.out)
+    if out_root.exists():
+        shutil.rmtree(out_root)
+    out_root.mkdir(parents=True)
+
+    index = []
+    for cls in want:
+        folder = cls.replace(" ", "_")
+        idx_path = Path(args.sheets) / folder / "index.json"
+        if not idx_path.exists():
+            log(f"  {cls}: no sheet index, skipping")
+            continue
+        idx = json.loads(idx_path.read_text())
+        by_tile = {(r["sheet"], r["tile"]): r for r in idx}
+        flagged: dict[int, str] = {}
+        for kind in ("definite", "maybe"):
+            for sheet, tile in flags[cls][kind]:
+                r = by_tile.get((sheet, tile))
+                if r:
+                    flagged[r["image_id"]] = kind
+
+        unflagged = [r["image_id"] for r in idx if r["image_id"] not in flagged]
+        sample = rng.sample(unflagged, min(args.audit_per_class, len(unflagged)))
+
+        rows = []
+        cdir = out_root / folder
+        cdir.mkdir(parents=True, exist_ok=True)
+        for iid, kind in sorted(flagged.items()):
+            rows.append({"image_id": iid, "class": cls, "stratum": "flag", "triage": kind})
+        for iid in sorted(sample):
+            rows.append({"image_id": iid, "class": cls, "stratum": "audit", "triage": "none"})
+        rng.shuffle(rows)
+        written = []
+        for r in rows:
+            src = paths.get(r["image_id"])
+            if src is None:
+                continue
+            (cdir / f"{r['image_id']}.jpg").write_bytes(src.read_bytes())
+            written.append(
+                {
+                    **r,
+                    "cell": "",
+                    "text_score": 0.0,
+                    "reference": "absent",  # every one of these is a current negative
+                    "exhaustive": "no",
+                    "n_boxes": 0,
+                    "detector": f"{cls} audit",
+                }
+            )
+        with (cdir / "manifest.csv").open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(written[0]))
+            w.writeheader()
+            w.writerows(written)
+        n_flag = sum(1 for r in written if r["stratum"] == "flag")
+        index.append({"class": cls, "dir": str(cdir), "n": len(written), "detector": f"{cls} audit"})
+        log(f"  {cls:<12}{len(written):4d} images  ({n_flag} flags + {len(written) - n_flag} audit)")
+
+    (out_root / "slates.json").write_text(json.dumps(index, indent=1) + "\n")
+    total = sum(e["n"] for e in index)
+    print(f"\n{total} images across {len(index)} classes under {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/make_audit_slate.py
+++ b/scripts/experiments/pile/make_audit_slate.py
@@ -1,0 +1,168 @@
+"""Build per-class review slates for VTSearch, to audit the ground truth itself.
+
+``vg_scale`` takes its labels from COCO because VG's are not exhaustive
+(``coco_anchor.py``: VG recall 0.76 over *C*, 1.4% of its negatives actually
+positive). COCO is far better, but "far better" is not a number, and a report
+that assumes zero residual error is making the same mistake #3156 opened with —
+just one level up. So this builds a small, *stratified* slate per class that a
+human can label in VTSearch, from which the residual rate can be estimated
+rather than assumed.
+
+**Three strata, recorded per image, because they answer different questions:**
+
+* ``boundary`` — the highest-scoring images among the cell's **negatives**. A
+  COCO miss, if there is one, hides here: an image that looks exactly like a bus
+  image and is labelled as holding none. This stratum finds errors efficiently
+  and is **not** an unbiased sample of anything.
+* ``random`` — a uniform sample of the same negatives. This one *is* unbiased,
+  so it is what bounds the residual false-negative rate. Without it, finding
+  three misses in the boundary stratum says nothing about the pool.
+* ``positive`` — a sample of the cell's positives, spread across the bands.
+  Checks the other direction: is the object really there, and is the box (hence
+  the band) the one a user would drag?
+
+Ranking uses the text tower, not a trained detector: it needs no votes to exist
+first, it costs one text embedding per class, and for "which negatives look like
+buses" it is entirely adequate.
+
+Each class becomes a folder of JPEGs plus a manifest, ready for VTSearch's
+``server_folder`` importer. Vote Good/Bad, export with ``server_json_file``, and
+feed the export to ``ingest_slate.py``.
+
+Usage::
+
+    python make_audit_slate.py --out /expscratch/$USER/vgscale-3156/slates
+    python make_audit_slate.py --classes bus,clock --boundary 25 --random 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import sys
+from pathlib import Path
+
+import numpy as np
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def log(msg: str) -> None:
+    print(f"[slate] {msg}", flush=True)
+
+
+def _load_cell(pkl: Path) -> dict[int, dict]:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    return load_medias(pkl)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"), help="scored pickle")
+    ap.add_argument("--embedder", default="siglip", help="embedder the cell carries (for the text tower)")
+    ap.add_argument("--out", default=str(pc.PILE / "slates"), help="output directory")
+    ap.add_argument("--classes", default="", help="comma-separated subset of C (default: all)")
+    ap.add_argument("--boundary", type=int, default=15, help="top-scoring negatives per class")
+    ap.add_argument("--random", dest="n_random", type=int, default=10, help="uniform negatives per class")
+    ap.add_argument("--positive", type=int, default=5, help="positives per class, spread over the bands")
+    ap.add_argument("--seed", type=int, default=20260817, help="sampling seed")
+    args = ap.parse_args()
+
+    from vtscore.embedding import embed_text_query  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+    from vtscore.eval.labels import media_is_positive  # noqa: PLC0415
+
+    classes = [c.strip() for c in args.classes.split(",") if c.strip()] or list(pc.SCALE_CLASSES)
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    medias = _load_cell(Path(args.cell))
+    log(f"loaded {len(medias)} medias from {Path(args.cell).name}")
+
+    # The VG file for an id — the cell carries vectors, not pixels.
+    from build_pile import _vg_image_paths  # noqa: PLC0415
+
+    paths = _vg_image_paths()
+
+    ids = sorted(medias)
+    mat = np.stack([np.asarray(media_embedding(medias[i]), dtype=np.float32) for i in ids])
+    mat /= np.linalg.norm(mat, axis=1, keepdims=True) + 1e-12
+
+    rng = random.Random(args.seed)
+    index: list[dict] = []
+    for c in classes:
+        cells = [pc.scale_cell(c, b) for b in pc.BOX_BANDS]
+        # Negatives for this class are the shared pool: images COCO annotated
+        # and found none of C in. They are the same images for every class,
+        # which is what makes the classes comparable.
+        negatives = [i for i in ids if not medias[i]["categories"]]
+        positives = {cell: [i for i in ids if media_is_positive(medias[i], cell)] for cell in cells}
+
+        tvec = embed_text_query(c, "image", embedder_name=args.embedder)
+        if tvec is None:
+            raise SystemExit(f"no text tower for embedder {args.embedder!r}")
+        tvec = np.asarray(tvec, dtype=np.float32)
+        tvec /= np.linalg.norm(tvec) + 1e-12
+        pos_of = {i: n for n, i in enumerate(ids)}
+        scores = {i: float(mat[pos_of[i]] @ tvec) for i in negatives}
+
+        ranked = sorted(negatives, key=lambda i: -scores[i])
+        boundary = ranked[: args.boundary]
+        rest = [i for i in ranked[args.boundary :]]
+        uniform = rng.sample(rest, min(args.n_random, len(rest)))
+        # Spread the positive check over the bands rather than taking whichever
+        # band happens to sort first: the box question is different at each size.
+        per_band = max(1, args.positive // len(cells))
+        chosen_pos: list[tuple[int, str]] = []
+        for cell in cells:
+            for i in rng.sample(positives[cell], min(per_band, len(positives[cell]))):
+                chosen_pos.append((i, cell))
+
+        cdir = out_root / c.replace(" ", "_")
+        cdir.mkdir(parents=True, exist_ok=True)
+        rows = []
+        for stratum, items in (
+            ("boundary", [(i, "") for i in boundary]),
+            ("random", [(i, "") for i in uniform]),
+            ("positive", chosen_pos),
+        ):
+            for i, cell in items:
+                src = paths.get(i)
+                if src is None:
+                    continue
+                (cdir / f"{i}.jpg").write_bytes(src.read_bytes())
+                rows.append(
+                    {
+                        "image_id": i,
+                        "class": c,
+                        "stratum": stratum,
+                        "cell": cell,
+                        "text_score": round(scores.get(i, float("nan")), 4),
+                        "coco_says": "present" if cell else "absent",
+                        "n_boxes": len(medias[i].get("regions") or []) if cell else 0,
+                    }
+                )
+        with (cdir / "manifest.csv").open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(rows[0]))
+            w.writeheader()
+            w.writerows(rows)
+        index.append({"class": c, "dir": str(cdir), "n": len(rows)})
+        log(f"  {c:<12} {len(rows):3d} images -> {cdir}")
+
+    (out_root / "slates.json").write_text(json.dumps(index, indent=1) + "\n")
+    total = sum(e["n"] for e in index)
+    print(f"\n{total} images across {len(index)} classes under {out_root}")
+    print("\nIn VTSearch, per class: Add Dataset -> Server Folder -> the path above,")
+    print("vote Good (drag a box) / Bad, then export with Server JSON File and run:")
+    print(f"  python ingest_slate.py --export <exported.json> --slates {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/make_audit_slate.py
+++ b/scripts/experiments/pile/make_audit_slate.py
@@ -1,19 +1,17 @@
 """Build per-class review slates for VTSearch, to audit the ground truth itself.
 
-``vg_scale`` takes its labels from COCO because VG's are not exhaustive
-(``coco_anchor.py``: VG recall 0.76 over *C*, 1.4% of its negatives actually
-positive). COCO is far better, but "far better" is not a number, and a report
-that assumes zero residual error is making the same mistake #3156 opened with —
-just one level up. So this builds a small, *stratified* slate per class that a
-human can label in VTSearch, from which the residual rate can be estimated
-rather than assumed.
+``vg_scale`` is the whole of VG, and only the 48% COCO also annotated has an
+exhaustive reference. On the other half VG's silence is the only evidence of
+absence — and VG's silence is measurably unreliable (``coco_anchor.py``: recall
+0.61 over *C*, 1.35% of its negatives actually positive). That half is what a
+human can fix and nothing else can, so this builds the slates for it.
 
 **Three strata, recorded per image, because they answer different questions:**
 
 * ``boundary`` — the highest-scoring images among the cell's **negatives**. A
-  COCO miss, if there is one, hides here: an image that looks exactly like a bus
-  image and is labelled as holding none. This stratum finds errors efficiently
-  and is **not** an unbiased sample of anything.
+  missing label, if there is one, hides here: an image that looks exactly like a
+  bus image and is labelled as holding none. This stratum finds errors
+  efficiently and is **not** an unbiased sample of anything.
 * ``random`` — a uniform sample of the same negatives. This one *is* unbiased,
   so it is what bounds the residual false-negative rate. Without it, finding
   three misses in the boundary stratum says nothing about the pool.
@@ -24,6 +22,12 @@ rather than assumed.
 Ranking uses the text tower, not a trained detector: it needs no votes to exist
 first, it costs one text embedding per class, and for "which negatives look like
 buses" it is entirely adequate.
+
+A minority of every negative stratum is drawn from the COCO-anchored half,
+where the answer is already known. Reviewing those corrects nothing, but it
+*scores the reviewer*, which is what turns the unanchored half's residual error
+into a bounded number. The reviewer cannot tell them apart: files are named by
+image id alone.
 
 Each class becomes a folder of JPEGs plus a manifest, ready for VTSearch's
 ``server_folder`` importer. Vote Good/Bad, export with ``server_json_file``, and
@@ -68,9 +72,16 @@ def main() -> int:
     ap.add_argument("--embedder", default="siglip", help="embedder the cell carries (for the text tower)")
     ap.add_argument("--out", default=str(pc.PILE / "slates"), help="output directory")
     ap.add_argument("--classes", default="", help="comma-separated subset of C (default: all)")
-    ap.add_argument("--boundary", type=int, default=15, help="top-scoring negatives per class")
-    ap.add_argument("--random", dest="n_random", type=int, default=10, help="uniform negatives per class")
-    ap.add_argument("--positive", type=int, default=5, help="positives per class, spread over the bands")
+    ap.add_argument("--boundary", type=int, default=200, help="top-scoring negatives per class")
+    ap.add_argument("--random", dest="n_random", type=int, default=70, help="uniform negatives per class")
+    ap.add_argument("--positive", type=int, default=30, help="positives per class, spread over the bands")
+    ap.add_argument(
+        "--anchor-frac",
+        type=float,
+        default=0.2,
+        help="share of each negative stratum drawn from COCO-anchored images, where the answer is "
+        "already known -- the calibration that turns 'we reviewed some' into a bounded residual",
+    )
     ap.add_argument("--seed", type=int, default=20260817, help="sampling seed")
     args = ap.parse_args()
 
@@ -112,10 +123,25 @@ def main() -> int:
         pos_of = {i: n for n, i in enumerate(ids)}
         scores = {i: float(mat[pos_of[i]] @ tvec) for i in negatives}
 
-        ranked = sorted(negatives, key=lambda i: -scores[i])
-        boundary = ranked[: args.boundary]
-        rest = [i for i in ranked[args.boundary :]]
-        uniform = rng.sample(rest, min(args.n_random, len(rest)))
+        # Split the negatives by whether an exhaustive reference already
+        # settles them. Reviewing an anchored image does not correct anything --
+        # COCO has already looked -- but it *scores the review itself*, which is
+        # the only way the unanchored half's residual error becomes a bounded
+        # number rather than a hope. So each stratum takes a minority of them.
+        anchored = [i for i in negatives if medias[i].get("labels_exhaustive")]
+        open_ = [i for i in negatives if not medias[i].get("labels_exhaustive")]
+        n_anchor_b = int(round(args.boundary * args.anchor_frac))
+        n_anchor_r = int(round(args.n_random * args.anchor_frac))
+
+        by_score = sorted(open_, key=lambda i: -scores[i])
+        anchor_by_score = sorted(anchored, key=lambda i: -scores[i])
+        boundary = by_score[: args.boundary - n_anchor_b] + anchor_by_score[:n_anchor_b]
+        chosen_b = set(boundary)
+        rest_open = [i for i in open_ if i not in chosen_b]
+        rest_anchor = [i for i in anchored if i not in chosen_b]
+        uniform = rng.sample(rest_open, min(args.n_random - n_anchor_r, len(rest_open))) + rng.sample(
+            rest_anchor, min(n_anchor_r, len(rest_anchor))
+        )
         # Spread the positive check over the bands rather than taking whichever
         # band happens to sort first: the box question is different at each size.
         per_band = max(1, args.positive // len(cells))
@@ -144,7 +170,14 @@ def main() -> int:
                         "stratum": stratum,
                         "cell": cell,
                         "text_score": round(scores.get(i, float("nan")), 4),
-                        "coco_says": "present" if cell else "absent",
+                        # What the dataset currently claims, and whether that
+                        # claim rests on an exhaustive reference. The reviewer
+                        # never sees either -- files are named by id alone --
+                        # so a calibration image is indistinguishable from a
+                        # correction one at voting time, which is what keeps
+                        # the calibration honest.
+                        "reference": "present" if cell else "absent",
+                        "exhaustive": "yes" if medias[i].get("labels_exhaustive") else "no",
                         "n_boxes": len(medias[i].get("regions") or []) if cell else 0,
                     }
                 )

--- a/scripts/experiments/pile/make_contact_sheets.py
+++ b/scripts/experiments/pile/make_contact_sheets.py
@@ -1,0 +1,89 @@
+"""Tile a class's negative slate into contact sheets for a triage pass.
+
+Reviewing thousands of images one at a time is not practical for a model any
+more than for a person, so the pass is triage-then-confirm: scan tiles, flag
+anything that might hold the class, then look at each flag at full resolution.
+
+The tiles are ordered by the same text-query score the slate was ranked on, so
+the most likely hidden positives arrive first and a partial pass is still a
+useful pass.
+
+Triage recall is **measured, not assumed**: run it over a class a human has
+already reviewed and compare the flags against their findings. A sheet pass will
+miss sub-patch objects — the exam put full-resolution small-object recall at
+0.50 — so the number that matters is how much *more* is lost by tiling.
+
+Usage::
+
+    python make_contact_sheets.py --class bicycle --out /expscratch/$USER/vgscale-3156/sheets_neg
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+COLS, ROWS = 5, 4
+TILE = 260
+LABEL = 22
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--class", dest="klass", required=True)
+    ap.add_argument("--slates", default=str(pc.PILE.parent / "vgscale-3156" / "slates"))
+    ap.add_argument("--out", default=str(pc.PILE.parent / "vgscale-3156" / "sheets_neg"))
+    args = ap.parse_args()
+
+    from PIL import Image, ImageDraw  # noqa: PLC0415
+
+    from build_pile import _vg_image_paths  # noqa: PLC0415
+
+    folder = args.klass.replace(" ", "_")
+    man = Path(args.slates) / folder / "manifest.csv"
+    rows = [r for r in csv.DictReader(man.open()) if r["stratum"] in ("boundary", "random")]
+    rows.sort(key=lambda r: -float(r["text_score"]))
+    paths = _vg_image_paths()
+
+    out = Path(args.out) / folder
+    out.mkdir(parents=True, exist_ok=True)
+    per = COLS * ROWS
+    index = []
+    for s in range((len(rows) + per - 1) // per):
+        chunk = rows[s * per : (s + 1) * per]
+        sheet = Image.new("RGB", (COLS * TILE, ROWS * (TILE + LABEL)), (16, 18, 19))
+        d = ImageDraw.Draw(sheet)
+        for k, r in enumerate(chunk):
+            src = paths.get(int(r["image_id"]))
+            if src is None:
+                continue
+            with Image.open(src) as im:
+                im = im.convert("RGB")
+                im.thumbnail((TILE - 6, TILE - 6), Image.LANCZOS)
+            ox = (k % COLS) * TILE
+            oy = (k // COLS) * (TILE + LABEL)
+            sheet.paste(im, (ox + (TILE - im.width) // 2, oy + LABEL + (TILE - LABEL - im.height) // 2))
+            d.text((ox + 6, oy + 5), f"{k + 1:02d}", fill=(255, 214, 92))
+            index.append(
+                {
+                    "sheet": s + 1,
+                    "tile": k + 1,
+                    "image_id": int(r["image_id"]),
+                    "stratum": r["stratum"],
+                    "exhaustive": r["exhaustive"],
+                }
+            )
+        sheet.save(out / f"sheet{s + 1:02d}.jpg", quality=88)
+    (out / "index.json").write_text(json.dumps(index, indent=1))
+    print(f"{len(rows)} images -> {(len(rows) + per - 1) // per} sheets in {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/make_positive_slate.py
+++ b/scripts/experiments/pile/make_positive_slate.py
@@ -1,0 +1,156 @@
+"""Re-issue the positive stratum with its box drawn, so small objects are answerable.
+
+A bare thumbnail cannot settle "is there a backpack in this picture?" when the
+backpack is a sub-patch object. Measured on the first three reviewed classes,
+the reviewer rejected **43%** of small-band positives against 20% medium and
+10% large — a clean monotonic function of how many pixels the object occupies,
+which is a property of the *review protocol*, not of the labels. Taking those
+rejections at face value would have deleted nearly half the small band, the very
+band the study exists to measure.
+
+So for positives — and only for positives — the image is re-issued with the
+ground-truth box drawn on it, plus a magnified inset of the box's contents in
+the corner. The question stops being "find the backpack" and becomes "is the
+thing in this box a backpack, and is the box around the right thing?", which is
+answerable at any scale.
+
+Drawing the box on a *negative* would be meaningless (there is nothing to draw)
+and would bias the answer, so the ranked and random strata keep bare images.
+
+Usage::
+
+    python make_positive_slate.py --out /expscratch/$USER/vgscale-3156/slates_pos
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+#: How big the inset may get, as a fraction of the image's shorter side.
+INSET_FRAC = 0.42
+#: The inset magnifies at least this much, so a sub-patch box is actually visible.
+MIN_ZOOM = 3.0
+
+
+def log(msg: str) -> None:
+    print(f"[posslate] {msg}", flush=True)
+
+
+def draw_with_inset(src: Path, box: tuple[float, float, float, float], dest: Path) -> tuple[int, int]:
+    """Write *src* with *box* outlined and a magnified inset of its contents."""
+    from PIL import Image, ImageDraw  # noqa: PLC0415
+
+    with Image.open(src) as im:
+        im = im.convert("RGB")
+        W, H = im.size
+        x0, y0, x1, y1 = (box[0] * W, box[1] * H, box[2] * W, box[3] * H)
+        bw, bh = max(1.0, x1 - x0), max(1.0, y1 - y0)
+
+        # The crop is padded around the box so the object keeps its context --
+        # a box cropped exactly to its edges is often unrecognisable.
+        pad = max(bw, bh) * 0.6
+        cx0, cy0 = max(0, int(x0 - pad)), max(0, int(y0 - pad))
+        cx1, cy1 = min(W, int(x1 + pad)), min(H, int(y1 + pad))
+        crop = im.crop((cx0, cy0, cx1, cy1))
+
+        target = int(min(W, H) * INSET_FRAC)
+        zoom = max(MIN_ZOOM, target / max(crop.width, crop.height))
+        iw, ih = int(crop.width * zoom), int(crop.height * zoom)
+        iw, ih = min(iw, target), min(ih, target)
+        crop = crop.resize((max(1, iw), max(1, ih)), Image.LANCZOS)
+
+        out = im.copy()
+        d = ImageDraw.Draw(out)
+        lw = max(2, int(min(W, H) * 0.006))
+        d.rectangle([x0, y0, x1, y1], outline=(255, 32, 32), width=lw)
+
+        # Inset in whichever bottom corner is furthest from the box, so the
+        # magnifier never covers the thing it is magnifying.
+        ix = 0 if (x0 + x1) / 2 > W / 2 else W - crop.width
+        iy = H - crop.height
+        out.paste(crop, (ix, iy))
+        d.rectangle([ix, iy, ix + crop.width - 1, iy + crop.height - 1], outline=(255, 32, 32), width=lw)
+        out.save(dest, quality=92)
+        return out.size
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"))
+    ap.add_argument("--slates", default=str(pc.PILE.parent / "vgscale-3156" / "slates"))
+    ap.add_argument("--out", default=str(pc.PILE.parent / "vgscale-3156" / "slates_pos"))
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    from build_pile import _vg_image_paths  # noqa: PLC0415
+
+    medias = load_medias(Path(args.cell))
+    paths = _vg_image_paths()
+    out_root = Path(args.out)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    index = []
+    for man in sorted(Path(args.slates).glob("*/manifest.csv")):
+        rows = [r for r in csv.DictReader(man.open()) if r["stratum"] == "positive"]
+        if not rows:
+            continue
+        cls = rows[0]["class"]
+        cdir = out_root / man.parent.name
+        cdir.mkdir(parents=True, exist_ok=True)
+        written = []
+        for r in rows:
+            iid = int(r["image_id"])
+            cell = r["cell"]
+            media = medias.get(iid)
+            src = paths.get(iid)
+            if media is None or src is None:
+                continue
+            boxes = [x["box"] for x in (media.get("regions") or []) if x.get("label") == cell]
+            if not boxes:
+                continue
+            box = (
+                min(b[0] for b in boxes),
+                min(b[1] for b in boxes),
+                max(b[2] for b in boxes),
+                max(b[3] for b in boxes),
+            )
+            draw_with_inset(src, box, cdir / f"{iid}.jpg")
+            written.append(
+                {
+                    "image_id": iid,
+                    "class": cls,
+                    # A distinct stratum so a boxed verdict supersedes the bare
+                    # one the reviewer cast on the same pair.
+                    "stratum": "positive_boxed",
+                    "cell": cell,
+                    "text_score": r["text_score"],
+                    "reference": "present",
+                    "exhaustive": r["exhaustive"],
+                    "n_boxes": r["n_boxes"],
+                    "detector": f"{cls} positives",
+                }
+            )
+        with (cdir / "manifest.csv").open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(written[0]))
+            w.writeheader()
+            w.writerows(written)
+        index.append({"class": cls, "dir": str(cdir), "n": len(written), "detector": f"{cls} positives"})
+        log(f"  {cls:<12} {len(written):3d} boxed positives -> {cdir}")
+
+    (out_root / "slates.json").write_text(json.dumps(index, indent=1) + "\n")
+    print(f"\n{sum(e['n'] for e in index)} boxed images across {len(index)} classes under {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/make_positive_slate.py
+++ b/scripts/experiments/pile/make_positive_slate.py
@@ -61,8 +61,12 @@ def draw_with_inset(src: Path, box: tuple[float, float, float, float], dest: Pat
         bw, bh = max(1.0, x1 - x0), max(1.0, y1 - y0)
 
         # The crop is padded around the box so the object keeps its context --
-        # a box cropped exactly to its edges is often unrecognisable.
-        pad = max(bw, bh) * 0.6
+        # a box cropped exactly to its edges is often unrecognisable, and for a
+        # sub-patch object it is a smudge at any magnification. What makes a
+        # 20-pixel backpack identifiable is seeing the person wearing it, so the
+        # padding has a floor in absolute image terms rather than being a
+        # multiple of a tiny box.
+        pad = max(max(bw, bh) * 0.6, min(W, H) * 0.10)
         cx0, cy0 = max(0, int(x0 - pad)), max(0, int(y0 - pad))
         cx1, cy1 = min(W, int(x1 + pad)), min(H, int(y1 + pad))
         cx1, cy1 = max(cx1, cx0 + 2), max(cy1, cy0 + 2)

--- a/scripts/experiments/pile/make_positive_slate.py
+++ b/scripts/experiments/pile/make_positive_slate.py
@@ -51,7 +51,13 @@ def draw_with_inset(src: Path, box: tuple[float, float, float, float], dest: Pat
     with Image.open(src) as im:
         im = im.convert("RGB")
         W, H = im.size
-        x0, y0, x1, y1 = (box[0] * W, box[1] * H, box[2] * W, box[3] * H)
+        # VG boxes are not guaranteed to lie inside their image -- some run past
+        # the edge, and a few are inverted -- so clamp before any arithmetic
+        # that assumes a well-formed rectangle.
+        x0, x1 = sorted((box[0] * W, box[2] * W))
+        y0, y1 = sorted((box[1] * H, box[3] * H))
+        x0, x1 = max(0.0, min(x0, W - 1.0)), max(1.0, min(x1, float(W)))
+        y0, y1 = max(0.0, min(y0, H - 1.0)), max(1.0, min(y1, float(H)))
         bw, bh = max(1.0, x1 - x0), max(1.0, y1 - y0)
 
         # The crop is padded around the box so the object keeps its context --
@@ -59,7 +65,8 @@ def draw_with_inset(src: Path, box: tuple[float, float, float, float], dest: Pat
         pad = max(bw, bh) * 0.6
         cx0, cy0 = max(0, int(x0 - pad)), max(0, int(y0 - pad))
         cx1, cy1 = min(W, int(x1 + pad)), min(H, int(y1 + pad))
-        crop = im.crop((cx0, cy0, cx1, cy1))
+        cx1, cy1 = max(cx1, cx0 + 2), max(cy1, cy0 + 2)
+        crop = im.crop((cx0, cy0, min(cx1, W), min(cy1, H)))
 
         target = int(min(W, H) * INSET_FRAC)
         zoom = max(MIN_ZOOM, target / max(crop.width, crop.height))

--- a/scripts/experiments/pile/make_positive_slate.py
+++ b/scripts/experiments/pile/make_positive_slate.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import random
 import sys
 from pathlib import Path
 
@@ -96,7 +97,8 @@ def draw_with_inset(src: Path, box: tuple[float, float, float, float], dest: Pat
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"))
-    ap.add_argument("--slates", default=str(pc.PILE.parent / "vgscale-3156" / "slates"))
+    ap.add_argument("--per-band", type=int, default=10, help="positives per band per class")
+    ap.add_argument("--seed", type=int, default=20260818)
     ap.add_argument("--out", default=str(pc.PILE.parent / "vgscale-3156" / "slates_pos"))
     args = ap.parse_args()
 
@@ -111,46 +113,48 @@ def main() -> int:
     out_root.mkdir(parents=True, exist_ok=True)
 
     index = []
-    for man in sorted(Path(args.slates).glob("*/manifest.csv")):
-        rows = [r for r in csv.DictReader(man.open()) if r["stratum"] == "positive"]
-        if not rows:
-            continue
-        cls = rows[0]["class"]
-        cdir = out_root / man.parent.name
-        cdir.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(args.seed)
+    for cls in pc.SCALE_CLASSES:
+        # Sample from the CURRENT cell rather than from an earlier slate's
+        # manifest: a rebuild can move an image between bands (fixing the
+        # coordinate-space bug moved most of them), and a manifest written
+        # against the old pickle would ask the reviewer to confirm a box the
+        # dataset no longer holds.
         written = []
-        for r in rows:
-            iid = int(r["image_id"])
-            cell = r["cell"]
-            media = medias.get(iid)
-            src = paths.get(iid)
-            if media is None or src is None:
-                continue
-            boxes = [x["box"] for x in (media.get("regions") or []) if x.get("label") == cell]
-            if not boxes:
-                continue
-            box = (
-                min(b[0] for b in boxes),
-                min(b[1] for b in boxes),
-                max(b[2] for b in boxes),
-                max(b[3] for b in boxes),
-            )
-            draw_with_inset(src, box, cdir / f"{iid}.jpg")
-            written.append(
-                {
-                    "image_id": iid,
-                    "class": cls,
-                    # A distinct stratum so a boxed verdict supersedes the bare
-                    # one the reviewer cast on the same pair.
-                    "stratum": "positive_boxed",
-                    "cell": cell,
-                    "text_score": r["text_score"],
-                    "reference": "present",
-                    "exhaustive": r["exhaustive"],
-                    "n_boxes": r["n_boxes"],
-                    "detector": f"{cls} positives",
-                }
-            )
+        for band in pc.BOX_BANDS:
+            cell = pc.scale_cell(cls, band)
+            pool = [i for i, m in medias.items() if cell in (m.get("categories") or [])]
+            for iid in rng.sample(pool, min(args.per_band, len(pool))):
+                media = medias[iid]
+                src = paths.get(iid)
+                boxes = [x["box"] for x in (media.get("regions") or []) if x.get("label") == cell]
+                if src is None or not boxes:
+                    continue
+                box = (
+                    min(b[0] for b in boxes),
+                    min(b[1] for b in boxes),
+                    max(b[2] for b in boxes),
+                    max(b[3] for b in boxes),
+                )
+                cdir = out_root / cls.replace(" ", "_")
+                cdir.mkdir(parents=True, exist_ok=True)
+                draw_with_inset(src, box, cdir / f"{iid}.jpg")
+                written.append(
+                    {
+                        "image_id": iid,
+                        "class": cls,
+                        "stratum": "positive_boxed",
+                        "cell": cell,
+                        "text_score": 0.0,
+                        "reference": "present",
+                        "exhaustive": "yes" if media.get("labels_exhaustive") else "no",
+                        "n_boxes": len(boxes),
+                        "detector": f"{cls} positives",
+                    }
+                )
+        if not written:
+            continue
+        cdir = out_root / cls.replace(" ", "_")
         with (cdir / "manifest.csv").open("w", newline="") as fh:
             w = csv.DictWriter(fh, fieldnames=list(written[0]))
             w.writeheader()

--- a/scripts/experiments/pile/make_roster.py
+++ b/scripts/experiments/pile/make_roster.py
@@ -1,0 +1,63 @@
+"""Freeze the membership of the cells as they stand, so a review keeps covering them.
+
+Run this against a built cell *before* changing how membership is selected. The
+builder's selection is now hash-stable, but stability only helps from the moment
+it is adopted: the hash draw and the earlier random draw agree on a couple of
+hundred of 3,900 negatives, so adopting it without a roster would retire almost
+every image a human had already judged.
+
+Idempotent and read-only with respect to the pile: it reads one cell and writes
+the roster the builder will honour.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"))
+    ap.add_argument("--out", default=str(pc.ROSTER))
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    medias = load_medias(Path(args.cell))
+    cells: dict[str, list[int]] = {}
+    for iid, m in medias.items():
+        for cell in m.get("categories") or []:
+            cells.setdefault(cell, []).append(int(iid))
+    for v in cells.values():
+        v.sort()
+
+    # A negative is designated when it is evaluable in every cell; the rest of
+    # the category-less medias are the spares held back for backfill.
+    all_cells = {pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in pc.BOX_BANDS}
+    negatives, spares = [], []
+    for iid, m in medias.items():
+        if m.get("categories"):
+            continue
+        (negatives if set(m.get("evaluable_categories") or []) >= all_cells else spares).append(int(iid))
+    negatives.sort()
+    spares.sort()
+
+    Path(args.out).write_text(json.dumps({"cells": cells, "negatives": negatives, "spares": spares}, indent=1) + "\n")
+    print(f"roster written to {args.out}")
+    print(f"  {len(cells)} cells, {sum(len(v) for v in cells.values())} positives")
+    print(f"  {len(negatives)} designated negatives + {len(spares)} spares")
+    short = [c for c, v in cells.items() if len(v) != pc.SCALE_N_POS]
+    print(f"  cells not at n_pos={pc.SCALE_N_POS}: {short or 'none'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -287,6 +287,13 @@ SCALE_N_NEG_SPARE = int(os.environ.get("VTS_SCALE_N_NEG_SPARE", "300"))
 MAX_ASPECT_DRIFT = float(os.environ.get("VTS_MAX_ASPECT_DRIFT", "0.01"))
 
 
+#: Which images each cell currently holds. Selection is hash-stable, but a
+#: roster is what carries membership across a CHANGE of selection rule -- and
+#: across the corrections that are the whole point of the review, since a review
+#: is only worth what it still covers after the next rebuild.
+ROSTER = Path(os.environ.get("VTS_SCALE_ROSTER", str(PILE / "vg_scale_roster.json")))
+
+
 def scale_cell(category: str, band: str) -> str:
     """The band-suffixed category name a harness cell is keyed on.
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -279,6 +279,14 @@ SCALE_N_NEG = int(os.environ.get("VTS_SCALE_N_NEG", "3900"))
 SCALE_N_NEG_SPARE = int(os.environ.get("VTS_SCALE_N_NEG_SPARE", "300"))
 
 
+#: How far a VG copy's aspect ratio may drift from the COCO original before its
+#: boxes are considered untransferable. Normalised coordinates survive a rescale
+#: but not a re-crop or a rotation, and 49 of the 51,497 overlaps are one of
+#: those -- small enough to ignore by accident, which is why it is a constant
+#: with a check rather than an assumption.
+MAX_ASPECT_DRIFT = float(os.environ.get("VTS_MAX_ASPECT_DRIFT", "0.01"))
+
+
 def scale_cell(category: str, band: str) -> str:
     """The band-suffixed category name a harness cell is keyed on.
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -261,9 +261,9 @@ SCALE_CLASSES: tuple[str, ...] = (
 )
 
 #: Images per ``(class, band)`` cell, and the shared negative pool every cell
-#: draws from. ``bus@small`` binds the positive count: 84 anchored images is the
-#: smallest per-band supply in *C* under COCO's boxes, so 80 is the largest
-#: round number every one of the 36 cells can fill without replacement.
+#: draws from. The pool is the whole of VG, labelled by VG and repaired from
+#: COCO where an exhaustive reference exists, so the binding supply is the union
+#: of both halves; the builder logs any cell it cannot fill.
 #:
 #: Cells are **designated**, not inferred: each is exactly these positives plus
 #: this negative pool, and every other image in the pickle is excluded from it.
@@ -271,8 +271,12 @@ SCALE_CLASSES: tuple[str, ...] = (
 #: what makes small-vs-large a paired comparison rather than two datasets with
 #: different difficulty. Unequal prevalence between arms is what made wave 1 and
 #: wave 2 of the overview benchmark non-comparable.
-SCALE_N_POS = int(os.environ.get("VTS_SCALE_N_POS", "80"))
+SCALE_N_POS = int(os.environ.get("VTS_SCALE_N_POS", "100"))
 SCALE_N_NEG = int(os.environ.get("VTS_SCALE_N_NEG", "3900"))
+#: Extra negatives drawn into the pickle but designated into no cell. A human
+#: verdict can retire a contaminated negative later; re-designating from a spare
+#: is a relabel, while drawing a fresh one would mean re-embedding every cell.
+SCALE_N_NEG_SPARE = int(os.environ.get("VTS_SCALE_N_NEG_SPARE", "300"))
 
 
 def scale_cell(category: str, band: str) -> str:

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -65,7 +65,14 @@ DATASETS: dict[str, dict] = {
     # replacement for `vg_box_*` -- those measured what they measured and stay
     # reproducible -- but the two are not comparable: disjoint vocabularies
     # against a fixed one.
-    "vg_scale": {"boxed": True, "kind": "vg_scale"},
+    #
+    # Drawn from the half of VG that COCO sourced, and labelled from COCO's
+    # exhaustive annotation rather than VG's free text, because VG's own labels
+    # cannot support the construction: measured on this pool its recall over C
+    # is 0.76, and 1.4% of the images it calls negative actually hold the object
+    # (`coco_anchor.py`). At 80 positives per cell that would be ~54 hidden
+    # positives sitting in the negatives.
+    "vg_scale": {"boxed": True, "kind": "vg_scale", "labels": "coco"},
 }
 
 #: Box-size bands, as a fraction of image area, anchored to the patch
@@ -254,9 +261,9 @@ SCALE_CLASSES: tuple[str, ...] = (
 )
 
 #: Images per ``(class, band)`` cell, and the shared negative pool every cell
-#: draws from. ``stop sign`` binds the positive count: 104 images in its small
-#: band is the smallest per-band supply in *C*, so 100 is the largest round
-#: number every one of the 36 cells can fill without replacement.
+#: draws from. ``bus@small`` binds the positive count: 84 anchored images is the
+#: smallest per-band supply in *C* under COCO's boxes, so 80 is the largest
+#: round number every one of the 36 cells can fill without replacement.
 #:
 #: Cells are **designated**, not inferred: each is exactly these positives plus
 #: this negative pool, and every other image in the pickle is excluded from it.
@@ -264,7 +271,7 @@ SCALE_CLASSES: tuple[str, ...] = (
 #: what makes small-vs-large a paired comparison rather than two datasets with
 #: different difficulty. Unequal prevalence between arms is what made wave 1 and
 #: wave 2 of the overview benchmark non-comparable.
-SCALE_N_POS = int(os.environ.get("VTS_SCALE_N_POS", "100"))
+SCALE_N_POS = int(os.environ.get("VTS_SCALE_N_POS", "80"))
 SCALE_N_NEG = int(os.environ.get("VTS_SCALE_N_NEG", "3900"))
 
 

--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -52,7 +52,11 @@ def _cell_band(cell: str) -> str:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     base = pc.PILE.parent / "vgscale-3156"
-    ap.add_argument("--verdicts", default=str(base / "verdicts_20260820b.json"))
+    ap.add_argument(
+        "--verdicts",
+        default=f"{base / 'verdicts_20260820b.json'},/exp/sgreenberg/vgscale-3156-labelsets/verdicts_audit_20260825.json",
+        help="verdict files, comma-separated; later files win",
+    )
     ap.add_argument("--triage", default=str(base / "tri_flags_all.json"))
     ap.add_argument("--adjudication", default=str(base / "adjudication_ml_20260820.json"))
     ap.add_argument("--sheets", default=str(base / "sheets_neg"))
@@ -79,10 +83,20 @@ def main() -> int:
             adj[(int(a["image_id"]), a["class"])] = a
 
     # --- human verdicts
-    for v in json.loads(Path(args.verdicts).read_text()):
+    # `ruled` records every pair a human decided, in EITHER direction. A triage
+    # flag must never overrule one: the audit measured the flags at 0.44
+    # precision, so applying an unaudited flag over a human "absent" would
+    # inject more error than it removes.
+    ruled: set[tuple[int, str]] = set()
+    verdicts = []
+    for path in args.verdicts.split(","):
+        if Path(path).exists():
+            verdicts += json.loads(Path(path).read_text())
+    for v in verdicts:
         key = (int(v["image_id"]), v["class"])
+        ruled.add(key)
         band = _cell_band(cells.get(key, ""))
-        if v["stratum"] in ("boundary", "random"):
+        if v["stratum"] in ("boundary", "random", "flag", "audit"):
             if v["human"] == "present":
                 box = v.get("box")
                 out[key] = {
@@ -143,7 +157,7 @@ def main() -> int:
                 if iid is None:
                     continue
                 key = (iid, cls)
-                if key in out:  # a human already ruled on this pair
+                if key in ruled:  # a human ruled on this pair, either way
                     stats["triage_deferred_to_human"] += 1
                     continue
                 out[key] = {

--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -1,0 +1,171 @@
+"""Turn review verdicts into the corrections file the builder merges before banding.
+
+Three sources feed one file, and they are *not* interchangeable:
+
+* **human verdicts** (`ingest_slate.py`) -- the reviewer's Good/Bad on slate
+  images, carrying a drawn box when they redrew one;
+* **adjudications** -- a second opinion on the pairs where the reviewer and the
+  reference disagree, recorded with a note so the reasoning survives;
+* **triage flags** -- a model pass over the ranked negatives, which finds
+  contaminated negatives efficiently but draws no boxes.
+
+**A correction without a box excludes rather than promotes.** "There is a bus in
+this image" fixes a poisoned negative, but it cannot make the image a *positive*
+for any band, because a band is a claim about size and no size was measured. The
+builder therefore drops it from every cell of that class: not a positive, and no
+longer a negative either. That is the whole point of the three-valued design --
+the alternative is inventing a box to keep the arithmetic tidy.
+
+**A rejection is not a deletion in the small band.** Boxed review confirms only
+~2/3 of sub-patch positives even when the box is drawn for the reviewer, and the
+same objects defeat the model, so "not confirmed" there is recorded as exactly
+that and the label stands. Above one patch a rejection backed by adjudication
+does remove the positive.
+
+Usage::
+
+    python verdicts_to_corrections.py --verdicts verdicts.json --triage tri_flags_all.json \
+        --adjudication adjudication_ml.json --out corrections.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+
+def log(msg: str) -> None:
+    print(f"[corrections] {msg}", flush=True)
+
+
+def _cell_band(cell: str) -> str:
+    return cell.rsplit("@", 1)[1] if "@" in cell else ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    base = pc.PILE.parent / "vgscale-3156"
+    ap.add_argument("--verdicts", default=str(base / "verdicts_20260820b.json"))
+    ap.add_argument("--triage", default=str(base / "tri_flags_all.json"))
+    ap.add_argument("--adjudication", default=str(base / "adjudication_ml_20260820.json"))
+    ap.add_argument("--sheets", default=str(base / "sheets_neg"))
+    ap.add_argument("--slates", default=f"{base / 'slates'},{base / 'slates_pos2'}")
+    ap.add_argument("--include-maybes", action="store_true", help="apply triage maybes too (default: no)")
+    ap.add_argument("--out", default=str(pc.PILE / "corrections.json"))
+    args = ap.parse_args()
+
+    # (image, class) -> manifest row, for the band of a reviewed positive.
+    cells: dict[tuple[int, str], str] = {}
+    for root in args.slates.split(","):
+        for man in sorted(Path(root).glob("*/manifest.csv")):
+            for r in csv.DictReader(man.open()):
+                if r.get("cell"):
+                    cells[(int(r["image_id"]), r["class"])] = r["cell"]
+
+    out: dict[tuple[int, str], dict] = {}
+    stats: Counter = Counter()
+
+    # --- adjudications first, so a later source cannot silently overrule them
+    adj = {}
+    if Path(args.adjudication).exists():
+        for a in json.loads(Path(args.adjudication).read_text()):
+            adj[(int(a["image_id"]), a["class"])] = a
+
+    # --- human verdicts
+    for v in json.loads(Path(args.verdicts).read_text()):
+        key = (int(v["image_id"]), v["class"])
+        band = _cell_band(cells.get(key, ""))
+        if v["stratum"] in ("boundary", "random"):
+            if v["human"] == "present":
+                box = v.get("box")
+                out[key] = {
+                    "image_id": key[0],
+                    "class": key[1],
+                    "present": True,
+                    "boxes": [box] if box else [],
+                    "source": "human_review",
+                }
+                stats["negative_fixed" if box else "negative_excluded"] += 1
+            continue
+        if v["stratum"] == "positive_boxed":
+            if v["human"] == "present":
+                box = v.get("box")
+                if box:  # reviewer redrew it: the box, hence the band, changes
+                    out[key] = {
+                        "image_id": key[0],
+                        "class": key[1],
+                        "present": True,
+                        "boxes": [box],
+                        "source": "human_rebox",
+                    }
+                    stats["positive_reboxed"] += 1
+                else:
+                    stats["positive_confirmed"] += 1
+                continue
+            # Rejected. Small band: not confirmed is not absent.
+            a = adj.get(key)
+            if band == "small":
+                stats["small_unconfirmed"] += 1
+            elif a and a["claude"] == "absent":
+                out[key] = {
+                    "image_id": key[0],
+                    "class": key[1],
+                    "present": False,
+                    "boxes": [],
+                    "source": "human_reject+adjudicated",
+                    "note": a.get("note", ""),
+                }
+                stats["positive_removed"] += 1
+            elif a and a["claude"] == "present":
+                stats["rejection_overturned"] += 1
+            else:
+                stats["rejection_unadjudicated"] += 1
+
+    # --- triage flags: contaminated negatives, no boxes, so they exclude
+    if Path(args.triage).exists():
+        flags = json.loads(Path(args.triage).read_text())
+        for cls, kinds in flags.items():
+            idx_path = Path(args.sheets) / cls.replace(" ", "_") / "index.json"
+            if not idx_path.exists():
+                log(f"  no sheet index for {cls}; skipping its flags")
+                continue
+            idx = {(r["sheet"], r["tile"]): r["image_id"] for r in json.loads(idx_path.read_text())}
+            wanted = list(kinds["definite"]) + (list(kinds["maybe"]) if args.include_maybes else [])
+            for sheet, tile in wanted:
+                iid = idx.get((sheet, tile))
+                if iid is None:
+                    continue
+                key = (iid, cls)
+                if key in out:  # a human already ruled on this pair
+                    stats["triage_deferred_to_human"] += 1
+                    continue
+                out[key] = {
+                    "image_id": iid,
+                    "class": cls,
+                    "present": True,
+                    "boxes": [],
+                    "source": "claude_triage",
+                }
+                stats["negative_excluded_by_triage"] += 1
+
+    rows = sorted(out.values(), key=lambda r: (r["class"], r["image_id"]))
+    Path(args.out).write_text(json.dumps(rows, indent=1) + "\n")
+
+    print(f"\n{len(rows)} corrections written to {args.out}\n")
+    for k, v in sorted(stats.items()):
+        print(f"   {k:<32}{v:>6}")
+    boxed = sum(1 for r in rows if r["boxes"])
+    print(f"\n   {'of which carry a box':<32}{boxed:>6}  (can move an image between bands)")
+    print(f"   {'excluded, no box':<32}{len(rows) - boxed:>6}  (dropped from every cell of that class)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #3156. Follow-on to #3163, which merged after its first four commits; this carries the remaining 32. **The deliverable is the dataset, not the measurements** — `vg_scale` is now built, verified, and documented, so an eval run on it can be trusted without re-litigating the labels.

## The bug that justified all of it

VG ships **downscaled copies** of the COCO originals — 500 px against 640, on 2,860 of 3,000 sampled overlaps — and the COCO repair normalised those boxes by the VG file's dimensions. Validated against VG's own boxes for the same objects:

| normalisation | median IoU | zero overlap |
|---|---:|---:|
| fixed | **0.815** | 2.3% |
| the bug | 0.024 | **44.2%** |

Nearly half the repaired boxes pointed at nothing, and **the band areas were inflated ~1.64× too**, so anchored objects sat one band too large. Every automated check passed throughout: cells full, prevalence exact, patch grids present, counts consistent. It was found by looking at one image — a `backpack@small` box on empty snow, two metres from the skier wearing the pack. `--verify` now recomputes each box's band from the stored box and checks it against the band its cell name claims.

## What the dataset is

36 cells (12 COCO-checkable classes × small/medium/large), **100 positives per cell**, one shared 3,900-image negative pool, **prevalence 0.0250 in all 36 by construction**, three embedders with patch grids on 7,749/7,749 for `dinov3_patch`. Labels are VG's, repaired from COCO on the 48% it sourced — excluding 49 re-framed copies where a COCO box describes the wrong pixels — and reviewed by hand elsewhere.

`docs/experiments/vg-scale/DATASHEET.md` states what the labels are worth, including what remains uncertain:

- negative-pool residual contamination **2.0%** (4/200), 95% CI **0.8–5.0%**, concentrated in `book`
- small-band positives confirmable at **~2/3** even with the box drawn — by human *or* model
- COCO treated as a better reference, not a gold standard: four of its own errors were adjudicated

## The review pipeline

Slate builders (ranked / random / boxed-positive strata), an ingest that pulls votes straight from the running app, contact sheets for a model triage pass, and a converter to the corrections the builder merges **before banding**, so a corrected box can move an image between bands.

Two rules are load-bearing. **A correction without a box excludes rather than promotes** — "there is a bus here" fixes a poisoned negative but cannot make the image a positive for any *band*, since no size was measured. **A small-band rejection is never a deletion** — "not confirmed" is recorded as that, because ~1/3 of sub-patch positives defeat every reviewer we have.

The triage was audited at **0.44 precision** (0.78 on definite flags, 0.15 on maybes), so a human verdict now outranks a flag in both directions; applying unaudited flags would have injected more error than it removed.

## Coverage: the check that was missing

Three rebuilds silently retired **577 of 743 reviewed images** while every structural check kept passing — a dataset reviewed at 20% is indistinguishable from one reviewed completely. Recovered exactly by regenerating the original pool from the commit that made it (100% of reviewed and triaged images).

Fixes: hash-stable selection, a roster pinning membership, reviewed images outranking unreviewed ones for a cell seat when a correction moves their band, and `check_review_coverage.py` wired into `--verify`. Final state: **99.4% / 98.4% / 88.9%** across the three reviewed populations.

`scripts/experiments/lessons/2026-08-24-review-orphaned-by-resampling.md` records it, with the distinction that generalises: *deterministic* and *stable* are different properties — `rng.sample` reproduces a draw from an identical list but re-derives everything when the list changes by one element.

## Also filed

#3167 (a completed import is indistinguishable from a wedged one, and cancel reports success without cancelling) and #3174 (a labelset stores the same media twice when voted on twice).

## Testing

Full `./run-tests.sh` on the GRID; `build_pile.py --verify` green on all 21 pile cells including the new coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
