### PR TITLE
Add the DocMarks corpus builder for scanned-document mark retrieval

### DIFF
--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -64,6 +64,40 @@ reorders what was previously planned here.
 
 <!-- item-sep -->
 
+- **DocMarks — finish the scanned-document corpus and run it.** The builder is in
+  `scripts/experiments/docmarks/` (see its README): SPODS + StaVer + Tobacco800
+  as real-GT anchor classes, UCSF IDL as haystack and weakly-labelled letterhead
+  classes, LogoDet-3K artwork on held-out scans as a sweepable synthetic
+  stratum, in one manifest with nested 5k/50k/200k tiers. It exists because the
+  2026-07-13 result — the first configuration where structural search beats the
+  deep embedder on a real corpus — rests on two corpora of 259 and 1,088 pages
+  with as few as 9 instances per class, which cannot separate a good ranker from
+  a lucky one. Owed:
+  - **Run it.** `build_corpus.py --probe`, then tier `s`, then
+    `embed_corpus.py`. Nothing here has touched the real archives yet: the
+    parsers are tested against fixtures built from each source's documented
+    layout, and SPODS's layout is confirmed from its RAR headers, but StaVer's
+    and Tobacco800's Kaggle mirrors are unverified until a token is present.
+  - **The eval side of the contamination rule.** `classes.json` records each
+    class's `eligible_distractor_sources` and *nothing consumes it yet*. Until a
+    scoring path restricts each class's candidate pool to its eligible sources,
+    a Tobacco800 query scored over the whole corpus is being marked wrong for
+    retrieving real matches out of UCSF's tobacco archive. This is the one item
+    that makes the rest of the design load-bearing rather than decorative.
+  - **The three human passes**, in value order: `letterhead` (does the weak UCSF
+    label hold? the whole haystack layer's usability is downstream of this
+    number), `cluster` (are the derived SPODS/StaVer identities real?),
+    `distinctive` (which marks are instances rather than shapes?).
+  - **Set `--min-instances` from the real survival curve**, which the build
+    prints. The default of 10 is a placeholder chosen without data.
+  - **More artwork and more haystack, if the first run justifies it**: the ICDAR
+    2023 ReST seal set (10,000 real seals, behind an RRC registration, so it
+    needs a manual fetch into `--synth-pool-dir`), full RVL-CDIP rather than the
+    100-per-class sample the downloader currently wires, and DocILE (~932k real
+    invoices grouped into vendor layout clusters, behind a research access form).
+
+<!-- item-sep -->
+
 - **3-DoF geometry as a per-media-profile default.** `scale_translation`
   (isotropic scale + translation, no rotation) is implemented in
   `vtscore/media/structural_geometry.py` and is a **free precision win** on flat

--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -74,6 +74,7 @@ correct union of the two branches with no judgement involved.
 |---|---|---|
 | 2026-08-24 | [a cost re-evaluated at a rounded threshold is a different cost](lessons/2026-08-24-a-cost-recomputed-at-a-rounded-threshold.md) | #2883 |
 | 2026-08-24 | [a login-node timing nearly cut a whole arm from a study](lessons/2026-08-24-a-login-node-timing-nearly-cut-an-arm.md) | #2883 |
+| 2026-08-24 | [a rebuild silently retired the images a human had just reviewed](lessons/2026-08-24-review-orphaned-by-resampling.md) | — |
 | 2026-08-21 | [a launcher pinned a head that stopped being production](lessons/2026-08-21-a-launcher-pinned-a-head-that-stopped.md) | #2865 |
 | 2026-08-21 | [a pooled number over an axis that rescales the metric is that axis's endpoints](lessons/2026-08-21-a-pooled-number-over-an-axis-that-rescales.md) | #2865 |
 | 2026-08-20 | [the rebuild fixed one axis and silently moved another](lessons/2026-08-20-the-rebuild-reproduced-the-pin-and-moved-the-card.md) | #3160 |

--- a/scripts/experiments/docmarks/README.md
+++ b/scripts/experiments/docmarks/README.md
@@ -1,0 +1,191 @@
+# DocMarks — stamps and logos in scanned documents
+
+One instance-retrieval corpus, assembled from four sources in three strata, with
+nested size tiers. Built for structural-search experiments: the 2026-07-13
+screenshot/scanned-document study found the **first configuration where
+structural search beats the deep embedder on a real corpus**
+(SuperPoint+LightGlue, AP 0.395/0.481 vs SigLIP's 0.204/0.235), and then could
+not push on that result because the two document corpora it used are far too
+small — 259 and 1,088 pages, with as few as 9 instances per class.
+
+```bash
+python build_corpus.py --probe                        # can I reach every source?
+python build_corpus.py --sources spods --limit 40     # small real build
+python build_corpus.py --survival                     # class counts vs threshold
+python build_corpus.py                                # the whole thing
+
+python make_audit_slate.py --task cluster             # the human passes
+python audit_to_corrections.py --task cluster --apply
+
+source ../pile/pile_env.sh
+python embed_corpus.py --tier s --embedders sift_vlad,siglip
+```
+
+## The three strata
+
+| stratum | source | what it gives | what it costs |
+|---|---|---|---|
+| anchor | SPODS, StaVer, Tobacco800 | real marks, real scans, real boxes | small; ~2,700 pages, and two of the three ship no identities |
+| haystack | UCSF Industry Documents Library | millions of real scanned pages; weak letterhead classes at 10⁵ instances | labels are metadata-derived and unverified |
+| synth | LogoDet-3K artwork on held-out real scans | exact ground truth, sweepable size/rotation/count | pasted marks are not printed marks |
+
+The rule that comes with the third one: **synthetic numbers quantify a
+mechanism, real numbers size the effect.** A finding that appears only in
+`synth` is a hypothesis about the pipeline, not a claim about documents.
+
+## What each source actually ships
+
+**SPODS** — 1,088 scanned pseudo-official pages, direct download, no
+registration. Confirmed by walking the RAR headers:
+
+```
+SPODS_Dataset/image (1..1088).png
+Ground truth (GT1)/{logo,signature,stamp,text}/image (1..1088).png
+```
+
+Four **binary pixel masks per page**, one per category. Note what is *not*
+there: any notion of *which* logo. A previous study reported "64 logo/stamp
+classes" for SPODS with names like `logo_14` — those identities were derived by
+that study, not read off the dataset, and nothing verified them. Since class
+identity is the entire ground truth of an instance benchmark, that inventory was
+a hypothesis with unmeasured error bars. Here the derivation is explicit
+(`cluster_marks.py`), flagged (`provenance="clustered"`), and audited.
+
+SPODS is **not offline**, despite having been recorded that way. Its own page
+still advertises `www.facweb.iitkgp.ernet.in`, a decommissioned host that 503s;
+`facweb.iitkgp.ac.in` serves the same 2.94 GB file. The authors' Scanned
+Document Degradation Tool is beside it (`sddt.zip`, 689 MB).
+
+**StaVer** — 400 scanned dummy bills with pixel-accurate stamp GT plus per-file
+`info` text (stamp count, colour, overlap, signature presence). Kaggle mirror;
+the DFKI original was unreachable when this was written. Again: locations, no
+identities. The recorded stamp count is used as an independent check on the mask
+decomposition — a page the dataset says has one stamp that decomposes to four
+means the merge gap is wrong, which is otherwise invisible.
+
+**Tobacco800** — 1,290 real scanned business documents, 412 carrying a logo,
+GEDI XML ground truth from UMD's LAMP. The published logo protocol keeps the 21
+categories with **≥2 occurrences**, which cannot support a train-and-search
+eval: at two instances, using one as the query leaves one thing to retrieve. Use
+`--min-instances` and read the survival curve.
+
+**UCSF IDL** — an open Solr index. Measured live on 2026-08-25:
+
+| query | count |
+|---|---:|
+| tobacco, 1–2 pages, has `collection` | 13,216,456 |
+| tobacco, 1 page, `type:letter` | 1,802,100 |
+| `author:"RJR"` 1-page letters | 162,197 |
+| `author:"PHILIP MORRIS"` | 73,320 |
+| `author:"LOR, LORILLARD"` | 21,120 |
+
+Prefer `author` over `collection`. `collection` is provenance — whose filing
+cabinet the page sat in — so a letter *in* the Philip Morris collection is about
+as likely to be incoming mail on someone else's letterhead.
+
+## Contamination is prevented by construction, not by annotation
+
+The trap: RVL-CDIP, Tobacco800 and UCSF's Tobacco industry all descend from
+IIT-CDIP. An American Tobacco letterhead is *certain* to appear in an RVL-CDIP
+"distractor" pool. Unlabelled positives in a distractor set do not make a
+benchmark slightly noisy — they make a correct retrieval count as a false
+positive, so the metric punishes the model for being right.
+
+No amount of hand annotation fixes that at 200k pages. `CONTAMINATES` in
+`docmarks_config.py` encodes which sources may serve as distractors for which
+classes, `classes.json` records the resolved list per class, and eval code must
+score a class against its `eligible_distractor_sources` rather than the whole
+corpus. Tobacco800 classes therefore get UCSF's *non-tobacco* industries; SPODS
+and StaVer, whose marks exist nowhere else, get everything.
+
+Note one residual: companies span industries (Philip Morris reaches Food through
+Kraft), so industry exclusion is a strong filter, not a proof.
+
+## Tiers
+
+`s`=5k, `m`=50k, `l`=200k pages, **nested**: every page in `s` is in `m` is in
+`l`, and all three share class ids, so a result on one is comparable to a result
+on another. Positives are in every tier — a tier keeping 3 of a class's 30
+instances measures a different and much harder problem, not the same one more
+cheaply. Distractors get a stable hash rank and tiers are prefixes of it.
+
+Two stability promises are on offer and they genuinely conflict:
+
+* **within a build** (default): exact budgets, nested. Run on `s`, then on `l`,
+  no rebuild.
+* **across builds** (`--pin-tiers <earlier build_report.json>`): membership fixed
+  by absolute rank cutoff, so a grown source pool cannot evict a page from a
+  tier it was already in. Budgets drift instead.
+
+Without pinning, a build over a different page set is a **new corpus version**
+and should be named as one. `tests_lib/datasets/test_docmarks_corpus.py` pins
+both behaviours, including the negative one.
+
+## The three human passes — and the one that isn't
+
+Each exists because a specific number is otherwise *unknowable*, not merely
+unverified. In value order:
+
+1. **`letterhead`** — sample ~100 pages per weak-label author and count how many
+   really carry the mark. This is the single highest-value check in the corpus:
+   at 90% the UCSF stratum is usable with a noise model, at 40% it is not usable
+   at all, and nothing except looking can tell you which. Everything else in the
+   haystack layer is downstream of this number.
+2. **`cluster`** — confirm the derived SPODS/StaVer classes. One contact sheet
+   per class, all instances; single linkage's failure mode (two classes bridged
+   by one ambiguous crop) is obvious on sight. Verdicts: `ok`, `split`,
+   `merge_into:<id>`, `drop`.
+3. **`distinctive`** — one sheet of every class's exemplar, marked `distinctive`
+   or `generic`. A plain warning triangle or a ruled box is a *shape*, not an
+   *instance*: "find this rectangle" is not a well-posed retrieval query. The
+   prior study's worst classes (`warning_diamond` at 17 keypoints,
+   `hospital_cross`) are exactly this, and averaging them into a headline AP
+   measures the dataset's junk. Generic classes are **kept and labelled**, never
+   deleted, so both numbers stay reportable.
+
+Query crops are generated automatically from each class's largest boxed instance
+(the prior study measured a 2.2× AP advantage for a clean query over a small
+in-scene crop). Weak-label classes have no box, so they are listed in
+`build_report.json` under `needs_hand_crop` — one hand-drawn crop each.
+
+**Not a pass:** exhaustively checking the distractor pool for unlabelled
+positives. Unfixable by hand at this scale; prevented by construction above.
+What *is* worth doing after a run is adjudicating the top-k false positives per
+query — a few hundred thumbnails that separate a model error from a missing
+label, which no aggregate can do.
+
+## Output
+
+```
+corpus.jsonl        one record per page: path, size, marks, provenance, tier
+classes.json        class inventory: instances, median px, eligible distractors, audit slots
+queries/            one query crop per admitted class
+cluster_report.json what the identity clustering did
+build_report.json   counts, survival curve, tier cutoffs, rejections with reasons, warnings
+```
+
+Every mark carries a `provenance`: `gt` (shipped by the source), `clustered`
+(derived here, audit pending), `weak` (metadata-implied, unverified) or
+`synthetic` (true by construction). Do not aggregate across them without saying
+so.
+
+## Embedding cells
+
+`embed_corpus.py` writes `docmarks_<tier>__<embedder>.pkl` into the shared
+pile's `embeddings/` dir, in the pile's own format, via the pile's own pickle
+IO. It is deliberately *not* a `pile_config.DATASETS` entry: the pile builds the
+full dataset × embedder cross-product, so adding DocMarks and `sift_vlad` there
+would silently schedule `sift_vlad` cells for all six existing datasets — a
+dozen-odd cells nobody asked for, on a mount the playbook already calls
+chronically full.
+
+## Before running this on the grid
+
+`python build_corpus.py --probe` first. Every source fails differently — a
+decommissioned hostname, a missing Kaggle token, an absent RAR extractor — and
+finding out which costs seconds now and a queue slot later. SPODS needs one of
+`bsdtar` / `7z` / `unar` / `unrar`; StaVer and Tobacco800 need a Kaggle token at
+`~/.kaggle/kaggle.json` or in `KAGGLE_USERNAME`/`KAGGLE_KEY`.
+
+Then `bash ../preflight.sh` as usual, and size from a real cell rather than a
+guess: build tier `s` first and read its actual seconds.

--- a/scripts/experiments/docmarks/audit_to_corrections.py
+++ b/scripts/experiments/docmarks/audit_to_corrections.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""Fold filled-in audit verdicts back into the corpus.
+
+    python audit_to_corrections.py --task cluster --apply
+    python audit_to_corrections.py --task distinctive --apply
+    python audit_to_corrections.py --task letterhead          # dry run (default)
+
+Without ``--apply`` it prints what it would change and touches nothing.
+
+Verdicts are additive and idempotent: they are recorded in ``classes.json``
+under each class's ``audit`` block, and re-running with the same verdict file is
+a no-op.  Nothing is ever deleted — a class judged ``generic`` keeps all its
+instances and simply stops being part of the headline stratum, so both numbers
+stay available and the decision stays visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import docmarks_config as cfg  # noqa: E402
+from sources._common import Mark, Page, read_manifest, write_manifest  # noqa: E402
+
+
+def load_verdicts(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise SystemExit(f"no verdict file at {path} — run make_audit_slate.py first")
+    out = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                row = json.loads(line)
+                if str(row.get("verdict", "")).strip():
+                    out.append(row)
+    return out
+
+
+def apply_cluster(
+    pages: list[Page], classes: dict[str, Any], verdicts: list[dict[str, Any]]
+) -> tuple[list[str], list[str]]:
+    """``ok`` / ``split`` / ``merge_into:<id>`` / ``drop`` on derived classes."""
+    changes: list[str] = []
+    problems: list[str] = []
+
+    for row in verdicts:
+        class_id = row["class_id"]
+        verdict = str(row["verdict"]).strip()
+        meta = classes.get(class_id)
+        if meta is None:
+            problems.append(f"{class_id}: not in classes.json")
+            continue
+
+        if verdict == "ok":
+            meta["audit"]["cluster_ok"] = True
+            changes.append(f"{class_id}: confirmed")
+        elif verdict == "split":
+            # A split needs per-instance labels, which a contact sheet cannot
+            # express.  Mark it unusable rather than guessing a partition: a
+            # silently wrong split is worse than a missing class.
+            meta["audit"]["cluster_ok"] = False
+            meta["audit"]["notes"] = (row.get("notes") or "flagged for split; excluded pending re-cluster").strip()
+            changes.append(f"{class_id}: flagged as over-merged (excluded)")
+        elif verdict.startswith("merge_into:"):
+            target = verdict.split(":", 1)[1].strip()
+            if target not in classes:
+                problems.append(f"{class_id}: merge target {target!r} does not exist")
+                continue
+            for page in pages:
+                for i, mark in enumerate(page.marks):
+                    if mark.class_id == class_id:
+                        page.marks[i] = Mark(mark.kind, mark.box, target, mark.provenance)
+            classes[target]["n_instances"] += meta["n_instances"]
+            classes[target]["page_ids"] = sorted(set(classes[target]["page_ids"]) | set(meta["page_ids"]))
+            classes[target]["audit"]["cluster_ok"] = True
+            classes.pop(class_id)
+            changes.append(f"{class_id}: merged into {target}")
+        elif verdict == "drop":
+            for page in pages:
+                page.marks = [m for m in page.marks if m.class_id != class_id]
+            classes.pop(class_id)
+            changes.append(f"{class_id}: dropped")
+        else:
+            problems.append(f"{class_id}: unrecognised verdict {verdict!r}")
+
+    return changes, problems
+
+
+def apply_distinctive(classes: dict[str, Any], verdicts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    changes: list[str] = []
+    problems: list[str] = []
+    for row in verdicts:
+        class_id = row["class_id"]
+        verdict = str(row["verdict"]).strip().lower()
+        meta = classes.get(class_id)
+        if meta is None:
+            problems.append(f"{class_id}: not in classes.json")
+            continue
+        if verdict not in ("distinctive", "generic"):
+            problems.append(f"{class_id}: unrecognised verdict {verdict!r}")
+            continue
+        meta["audit"]["distinctive"] = verdict == "distinctive"
+        changes.append(f"{class_id}: {verdict}")
+    return changes, problems
+
+
+def apply_letterhead(classes: dict[str, Any], verdicts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    changes: list[str] = []
+    problems: list[str] = []
+    for row in verdicts:
+        class_id = row["class_id"]
+        meta = classes.get(class_id)
+        if meta is None:
+            problems.append(f"{class_id}: not in classes.json")
+            continue
+        try:
+            hits = int(str(row["verdict"]).strip())
+        except ValueError:
+            problems.append(f"{class_id}: verdict must be the count of pages carrying the mark")
+            continue
+        sampled = int(row.get("sampled", 0)) or 1
+        precision = hits / sampled
+        meta["audit"]["letterhead_precision"] = round(precision, 3)
+        meta["audit"]["letterhead_sampled"] = sampled
+        flag = "" if precision >= 0.8 else "  <- below 0.8, treat this class as noisy"
+        changes.append(f"{class_id}: label precision {precision:.2f} ({hits}/{sampled}){flag}")
+    return changes, problems
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--task", required=True, choices=("cluster", "distinctive", "letterhead"))
+    ap.add_argument("--corpus", type=Path, default=cfg.OUT)
+    ap.add_argument("--apply", action="store_true", help="write the changes (default is a dry run)")
+    args = ap.parse_args(argv)
+
+    classes_path = args.corpus / "classes.json"
+    manifest_path = args.corpus / "corpus.jsonl"
+    classes = json.loads(classes_path.read_text(encoding="utf-8"))
+    verdicts = load_verdicts(args.corpus / "audit" / args.task / "verdicts.jsonl")
+
+    pages = list(read_manifest(manifest_path)) if args.task == "cluster" else []
+
+    if args.task == "cluster":
+        changes, problems = apply_cluster(pages, classes, verdicts)
+    elif args.task == "distinctive":
+        changes, problems = apply_distinctive(classes, verdicts)
+    else:
+        changes, problems = apply_letterhead(classes, verdicts)
+
+    for c in changes:
+        print(f"  {c}")
+    for p in problems:
+        print(f"  PROBLEM: {p}")
+    print(f"\n{len(changes)} change(s), {len(problems)} problem(s) from {len(verdicts)} filled verdict(s)")
+
+    if not args.apply:
+        print("dry run — pass --apply to write")
+        return 1 if problems else 0
+
+    classes_path.write_text(json.dumps(classes, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.task == "cluster":
+        write_manifest(pages, manifest_path)
+    print(f"wrote {classes_path}" + (f" and {manifest_path}" if args.task == "cluster" else ""))
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/docmarks/build_corpus.py
+++ b/scripts/experiments/docmarks/build_corpus.py
@@ -34,7 +34,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import docmarks_config as cfg  # noqa: E402
 from sources import _common  # noqa: E402
-from sources._common import Mark, Page  # noqa: E402
+from sources._common import Page  # noqa: E402
 
 ALL_SOURCES = ("spods", "staver", "tobacco800", "ucsf", "synth")
 
@@ -124,9 +124,7 @@ def admit_classes(
             "median_mark_px": median_px,
             "provenance": sorted(provenances),
             "page_ids": sorted(pages[pi].page_id for pi, _ in refs),
-            "eligible_distractor_sources": sorted(
-                s for s in ALL_SOURCES if cfg.eligible_distractor(source, s)
-            ),
+            "eligible_distractor_sources": sorted(s for s in ALL_SOURCES if cfg.eligible_distractor(source, s)),
             # Filled by the human passes; see make_audit_slate.py.
             "audit": {"distinctive": None, "cluster_ok": None, "letterhead_precision": None, "notes": ""},
         }
@@ -397,7 +395,9 @@ def probe(raw: Path) -> int:
 
 def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--sources", default=",".join(ALL_SOURCES), help="comma-separated subset of " + ",".join(ALL_SOURCES))
+    ap.add_argument(
+        "--sources", default=",".join(ALL_SOURCES), help="comma-separated subset of " + ",".join(ALL_SOURCES)
+    )
     ap.add_argument("--raw", type=Path, default=cfg.RAW)
     ap.add_argument("--out", type=Path, default=cfg.OUT)
     ap.add_argument("--limit", type=int, default=None, help="cap pages per anchor source (smoke builds)")
@@ -513,9 +513,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
             print(f"synth: {len(synth_pages)} page(s) over {len(pool)} class(es); {len(used)} background(s) held out")
             inventory = class_inventory(pages)
 
-    admitted, rejected = admit_classes(
-        pages, inventory, min_instances=args.min_instances, min_mark_px=args.min_mark_px
-    )
+    admitted, rejected = admit_classes(pages, inventory, min_instances=args.min_instances, min_mark_px=args.min_mark_px)
     print(f"\nadmitted {len(admitted)} class(es); rejected {len(rejected)}")
 
     needs_hand_crop = write_query_crops(pages, inventory, admitted, args.out / "queries")
@@ -580,7 +578,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
     (args.out / "build_report.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     print(f"\nwrote {n} page(s) to {args.out / 'corpus.jsonl'}")
-    print(f"  tiers (cumulative): " + ", ".join(f"{t}={cumulative[t]}" for t in cfg.TIER_ORDER))
+    print("  tiers (cumulative): " + ", ".join(f"{t}={cumulative[t]}" for t in cfg.TIER_ORDER))
     if dropped:
         print(f"  {dropped} page(s) dropped: past the largest tier's budget")
     for w in warnings:

--- a/scripts/experiments/docmarks/build_corpus.py
+++ b/scripts/experiments/docmarks/build_corpus.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python
+"""Assemble the DocMarks corpus: stamps and logos in scanned documents.
+
+    python build_corpus.py --probe                      # what can I reach?
+    python build_corpus.py --sources spods --limit 40   # small real build
+    python build_corpus.py --survival                   # class counts vs threshold
+    python build_corpus.py                              # the whole thing
+
+Outputs, under ``docmarks_config.OUT``:
+
+    corpus.jsonl      one record per page: path, size, marks, provenance, tier
+    classes.json      the class inventory, with eligibility and audit slots
+    queries/          one query crop per admitted class
+    build_report.json counts, warnings, the survival curve, what was dropped
+
+The three strata (anchor / haystack / synth) live in one manifest with **nested
+tiers**, so ``docmarks_s`` and ``docmarks_l`` share class ids and a result on
+one is comparable to a result on the other.
+
+Read ``README.md`` before changing the contamination rules; they are the part of
+this script that is easy to "simplify" and expensive to get wrong.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import docmarks_config as cfg  # noqa: E402
+from sources import _common  # noqa: E402
+from sources._common import Mark, Page  # noqa: E402
+
+ALL_SOURCES = ("spods", "staver", "tobacco800", "ucsf", "synth")
+
+#: Mark kinds that may become query classes.  Signatures are excluded on
+#: purpose: a handwritten signature is a different mark every time it is made,
+#: so it is not an instance in the sense structural search means.  They stay in
+#: the manifest as a documented negative control.
+QUERYABLE_KINDS = ("logo", "stamp")
+
+
+# --------------------------------------------------------------------------
+# Class inventory
+# --------------------------------------------------------------------------
+
+
+def class_inventory(pages: Sequence[Page]) -> dict[str, list[tuple[int, int]]]:
+    """``{class_id: [(page index, mark index), ...]}`` over every labelled mark."""
+    inv: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    for pi, page in enumerate(pages):
+        for mi, mark in enumerate(page.marks):
+            if mark.class_id:
+                inv[mark.class_id].append((pi, mi))
+    return dict(inv)
+
+
+def survival_curve(inventory: dict[str, list[tuple[int, int]]], thresholds: Iterable[int]) -> dict[int, int]:
+    """How many classes survive each ``min-instances`` bar.
+
+    Printed on every build because the bar is the single most consequential
+    knob in the corpus and the right value is a property of the data, not a
+    preference.  Tobacco800's published protocol uses >=2, which cannot support
+    a train-and-search eval at all.
+    """
+    sizes = [len(v) for v in inventory.values()]
+    return {t: sum(1 for s in sizes if s >= t) for t in thresholds}
+
+
+def admit_classes(
+    pages: Sequence[Page],
+    inventory: dict[str, list[tuple[int, int]]],
+    *,
+    min_instances: int,
+    min_mark_px: int,
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    """Split the inventory into admitted query classes and rejects-with-reasons.
+
+    A class is admitted when it has enough instances *and* its typical instance
+    is big enough to be findable.  The size bar matters as much as the count
+    bar: the 2026-07-13 study measured a hard floor near 32 px below which no
+    structural pipeline recovers anything, so a class built from sub-floor marks
+    measures the floor rather than the method, and averaging it in with the rest
+    drags every aggregate toward zero for a reason that has nothing to do with
+    what is being compared.
+    """
+    admitted: dict[str, dict[str, Any]] = {}
+    rejected: dict[str, str] = {}
+
+    for class_id, refs in sorted(inventory.items()):
+        marks = [pages[pi].marks[mi] for pi, mi in refs]
+        kinds = {m.kind for m in marks}
+        if not kinds & set(QUERYABLE_KINDS):
+            rejected[class_id] = f"kind {sorted(kinds)} is not queryable"
+            continue
+        if len(refs) < min_instances:
+            rejected[class_id] = f"{len(refs)} instance(s) < min_instances={min_instances}"
+            continue
+
+        boxed = [m for m in marks if m.area() > 0]
+        provenances = {m.provenance for m in marks}
+        median_px: Optional[int] = None
+        if boxed:
+            sides = sorted(m.longest_side() for m in boxed)
+            median_px = sides[len(sides) // 2]
+            if median_px < min_mark_px:
+                rejected[class_id] = f"median mark {median_px}px < min_mark_px={min_mark_px}"
+                continue
+        elif provenances != {"weak"}:
+            rejected[class_id] = "no boxed instances and not a weak-label class"
+            continue
+
+        source = class_id.split("/", 1)[0]
+        admitted[class_id] = {
+            "class_id": class_id,
+            "source": source,
+            "kind": sorted(kinds)[0],
+            "n_instances": len(refs),
+            "median_mark_px": median_px,
+            "provenance": sorted(provenances),
+            "page_ids": sorted(pages[pi].page_id for pi, _ in refs),
+            "eligible_distractor_sources": sorted(
+                s for s in ALL_SOURCES if cfg.eligible_distractor(source, s)
+            ),
+            # Filled by the human passes; see make_audit_slate.py.
+            "audit": {"distinctive": None, "cluster_ok": None, "letterhead_precision": None, "notes": ""},
+        }
+    return admitted, rejected
+
+
+# --------------------------------------------------------------------------
+# Tiers
+# --------------------------------------------------------------------------
+
+
+def assign_tiers(
+    pages: Sequence[Page],
+    admitted: dict[str, dict[str, Any]],
+    *,
+    tiers: dict[str, int],
+    tier_order: Sequence[str],
+    salt: str,
+    pinned_cutoffs: Optional[dict[str, float]] = None,
+) -> tuple[dict[str, str], dict[str, float]]:
+    """``({page_id: smallest tier containing it}, {tier: rank cutoff})``.
+
+    Pages carrying an admitted class are in every tier: a tier that keeps 3 of a
+    class's 30 instances does not measure that class more cheaply, it measures a
+    different and much harder problem.  Distractors get a stable hash rank in
+    ``[0, 1)`` and tiers are prefixes of that order, so ``s`` is always a subset
+    of ``m`` is always a subset of ``l``.
+
+    Two different stability promises are on offer here, and they genuinely
+    conflict — you cannot both hit an exact page budget and keep membership
+    fixed when the source pool changes size:
+
+    * **Within a build** (the default): tiers hit their budgets exactly and are
+      nested.  This is what makes "run it on ``s`` first, then on ``l``" work
+      without a rebuild.
+    * **Across builds** (``pinned_cutoffs``): tier membership is defined by an
+      absolute rank threshold carried over from an earlier build, so adding
+      pages to the source pool cannot evict a page from a tier it was already
+      in.  Budgets then drift with the pool, which is the price.
+
+    Every build records the cutoffs it used in ``build_report.json``; pass them
+    back with ``--pin-tiers`` when a later build must stay comparable to an
+    earlier one.  Without that, a build over a different page set is a new
+    corpus version and should be named as one.
+    """
+    positive_pages: set[str] = set()
+    for meta in admitted.values():
+        positive_pages.update(meta["page_ids"])
+
+    ranked = sorted(
+        ((_common.stable_rank(p.page_id, salt), p.page_id) for p in pages if p.page_id not in positive_pages),
+    )
+
+    out: dict[str, str] = {pid: tier_order[0] for pid in positive_pages}
+    cutoffs: dict[str, float] = {}
+    n_positive = len(positive_pages)
+
+    for tier in tier_order:
+        if pinned_cutoffs and tier in pinned_cutoffs:
+            cutoff = pinned_cutoffs[tier]
+            selected = [pid for rank, pid in ranked if rank < cutoff]
+        else:
+            budget = max(0, tiers[tier] - n_positive)
+            selected = [pid for _rank, pid in ranked[:budget]]
+            # The cutoff sits just past the last selected rank, so replaying it
+            # on this same pool reproduces this same selection exactly.
+            cutoff = ranked[budget - 1][0] + 1e-12 if 0 < budget <= len(ranked) else 1.0
+        cutoffs[tier] = cutoff
+        for pid in selected:
+            out.setdefault(pid, tier)
+
+    # Anything past the largest tier is excluded from the corpus entirely.
+    return out, cutoffs
+
+
+# --------------------------------------------------------------------------
+# Query crops
+# --------------------------------------------------------------------------
+
+
+def write_query_crops(
+    pages: Sequence[Page],
+    inventory: dict[str, list[tuple[int, int]]],
+    admitted: dict[str, dict[str, Any]],
+    out_dir: Path,
+) -> list[str]:
+    """One query crop per admitted class: its largest boxed instance.
+
+    Largest, because the prior study measured a 2.2x AP advantage for a clean
+    canonical query over a crop of a small in-scene instance — the query is the
+    one place where more pixels are free.
+
+    Weak-label classes have no box and therefore get no crop; they are returned
+    as the list of classes still owing a hand-drawn query.
+    """
+    from PIL import Image
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    needs_hand_crop: list[str] = []
+
+    for class_id, meta in sorted(admitted.items()):
+        refs = inventory[class_id]
+        boxed = [(pi, mi) for pi, mi in refs if pages[pi].marks[mi].area() > 0]
+        if not boxed:
+            needs_hand_crop.append(class_id)
+            continue
+        pi, mi = max(boxed, key=lambda r: pages[r[0]].marks[r[1]].area())
+        mark = pages[pi].marks[mi]
+        x, y, w, h = mark.box
+        dest = out_dir / f"{class_id.replace('/', '__')}.png"
+        if not dest.exists():
+            with Image.open(pages[pi].path) as im:
+                im.convert("RGB").crop((x, y, x + w, y + h)).save(dest)
+        meta["query_crop"] = str(dest)
+        meta["query_page_id"] = pages[pi].page_id
+    return needs_hand_crop
+
+
+# --------------------------------------------------------------------------
+# Source loading
+# --------------------------------------------------------------------------
+
+
+def load_anchor_sources(
+    selected: Sequence[str],
+    raw: Path,
+    *,
+    limit: Optional[int],
+    warnings: list[str],
+) -> list[Page]:
+    """Fetch and parse the real-ground-truth sources."""
+    pages: list[Page] = []
+
+    if "spods" in selected:
+        from sources import spods
+
+        unpacked = spods.fetch(raw)
+        pages.extend(spods.build_pages(unpacked, min_area_frac=cfg.MIN_MARK_AREA_FRAC, limit=limit))
+
+    if "staver" in selected:
+        from sources import staver
+
+        unpacked = staver.fetch(raw)
+        got, warns = staver.build_pages(unpacked, min_area_frac=cfg.MIN_MARK_AREA_FRAC, limit=limit)
+        pages.extend(got)
+        warnings.extend(warns)
+
+    if "tobacco800" in selected:
+        from sources import tobacco800
+
+        unpacked = tobacco800.fetch(raw)
+        got, warns = tobacco800.build_pages(unpacked, limit=limit)
+        pages.extend(got)
+        warnings.extend(warns)
+
+    return pages
+
+
+def load_ucsf(
+    raw: Path,
+    out_images: Path,
+    *,
+    distractor_budget: int,
+    letterhead_per_author: int,
+    split_by_decade: bool,
+    warnings: list[str],
+) -> list[Page]:
+    """Pull the haystack and the weakly-labelled letterhead classes."""
+    from sources import ucsf
+
+    failures: list[str] = []
+
+    def note(doc_id: str, exc: Exception) -> None:
+        failures.append(f"{doc_id}: {type(exc).__name__}")
+
+    pages: list[Page] = []
+
+    for author in cfg.UCSF_LETTERHEAD_AUTHORS:
+        if letterhead_per_author <= 0:
+            break
+        query = ucsf.build_query(author=author, doc_type="letter", max_pages=1)
+        docs = list(ucsf.solr_docs(query, limit=letterhead_per_author))
+        if not docs:
+            warnings.append(f"ucsf: author {author!r} returned no documents")
+            continue
+        pages.extend(
+            ucsf.fetch_and_render(
+                docs,
+                raw,
+                out_images / "ucsf",
+                letterhead_author=author,
+                split_by_decade=split_by_decade,
+                on_error=note,
+            )
+        )
+
+    per_industry = max(1, distractor_budget // max(1, len(cfg.UCSF_INDUSTRIES)))
+    for industry in cfg.UCSF_INDUSTRIES:
+        query = ucsf.build_query(industry=industry, doc_type=None, max_pages=1)
+        docs = list(ucsf.solr_docs(query, limit=per_industry))
+        pages.extend(ucsf.fetch_and_render(docs, raw, out_images / "ucsf", on_error=note))
+
+    if failures:
+        warnings.append(f"ucsf: skipped {len(failures)} document(s) that failed to download or render")
+    return pages
+
+
+# --------------------------------------------------------------------------
+# Probe
+# --------------------------------------------------------------------------
+
+
+def probe(raw: Path) -> int:
+    """Report what each source can currently be reached and unpacked from.
+
+    Run this before a grid job.  Every source here has a different failure mode
+    — a decommissioned hostname, a missing Kaggle token, an absent RAR extractor
+    — and finding out which one applies costs seconds now and an overnight queue
+    slot later.
+    """
+    import requests
+
+    from sources import spods, staver, tobacco800, ucsf
+
+    ok = True
+    print("DocMarks source probe\n")
+
+    try:
+        head = requests.head(spods.SPODS_URL, timeout=30, allow_redirects=True)
+        size = int(head.headers.get("content-length", 0))
+        status = "OK" if head.status_code == 200 else f"HTTP {head.status_code}"
+        print(f"  spods       {status:<12} {size / 1e9:.2f} GB  {spods.SPODS_URL}")
+        ok &= head.status_code == 200
+    except Exception as exc:  # noqa: BLE001 - a probe reports, it does not raise
+        print(f"  spods       UNREACHABLE  {type(exc).__name__}: {exc}")
+        ok = False
+
+    for name, slug in (("staver", staver.KAGGLE_SLUG), ("tobacco800", tobacco800.KAGGLE_SLUG)):
+        try:
+            _common.kaggle_download(slug, raw / f"_probe_{name}")
+            print(f"  {name:<11} OK           kaggle:{slug}")
+        except _common.FetchError as exc:
+            print(f"  {name:<11} BLOCKED      {exc}")
+            ok = False
+
+    try:
+        n = ucsf.count(ucsf.build_query(industry="Tobacco", doc_type="letter", max_pages=1))
+        print(f"  ucsf        OK           {n:,} single-page tobacco letters")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ucsf        UNREACHABLE  {type(exc).__name__}: {exc}")
+        ok = False
+
+    print("\n  rar extractor:", end=" ")
+    import shutil
+
+    found = [t for t in ("bsdtar", "7z", "unar", "unrar") if shutil.which(t)]
+    print(", ".join(found) if found else "NONE FOUND (needed for SPODS)")
+    ok &= bool(found)
+
+    print("\n" + ("probe passed" if ok else "probe FAILED — see above"))
+    return 0 if ok else 1
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sources", default=",".join(ALL_SOURCES), help="comma-separated subset of " + ",".join(ALL_SOURCES))
+    ap.add_argument("--raw", type=Path, default=cfg.RAW)
+    ap.add_argument("--out", type=Path, default=cfg.OUT)
+    ap.add_argument("--limit", type=int, default=None, help="cap pages per anchor source (smoke builds)")
+    ap.add_argument("--min-instances", type=int, default=cfg.MIN_INSTANCES)
+    ap.add_argument("--min-mark-px", type=int, default=cfg.MIN_MARK_PX)
+    ap.add_argument("--cluster-backend", default=cfg.CLUSTER_BACKEND, choices=("phash", "siglip"))
+    ap.add_argument("--cluster-threshold", type=float, default=cfg.CLUSTER_THRESHOLD)
+    ap.add_argument("--ucsf-distractors", type=int, default=0, help="total UCSF distractor pages to pull")
+    ap.add_argument("--ucsf-letterhead-per-author", type=int, default=0)
+    ap.add_argument("--split-letterhead-by-decade", action="store_true")
+    ap.add_argument("--synth-per-class", type=int, default=cfg.SYNTH_INSTANCES_PER_CLASS)
+    ap.add_argument("--synth-pool-dir", type=Path, default=None, help="local artwork dir (else LogoDet-3K via Kaggle)")
+    ap.add_argument("--synth-max-classes", type=int, default=200)
+    ap.add_argument(
+        "--pin-tiers",
+        type=Path,
+        default=None,
+        help="an earlier build_report.json; reuse its tier cutoffs so this build stays comparable to it",
+    )
+    ap.add_argument("--probe", action="store_true", help="check every source is reachable, then exit")
+    ap.add_argument("--survival", action="store_true", help="print the class survival curve and exit")
+    args = ap.parse_args(argv)
+
+    if args.probe:
+        return probe(args.raw)
+
+    selected = [s.strip() for s in args.sources.split(",") if s.strip()]
+    unknown = set(selected) - set(ALL_SOURCES)
+    if unknown:
+        ap.error(f"unknown source(s): {sorted(unknown)}")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    images_dir = args.out / "images"
+    warnings: list[str] = []
+
+    pages = load_anchor_sources(selected, args.raw, limit=args.limit, warnings=warnings)
+    print(f"anchor sources: {len(pages)} page(s)")
+
+    # Identity clustering, for the sources that ship location without identity.
+    from cluster_marks import cluster_source, write_cluster_report
+
+    summaries = []
+    for source in ("spods", "staver"):
+        if source in selected:
+            summary = cluster_source(
+                pages,
+                source,
+                backend=args.cluster_backend,
+                threshold=args.cluster_threshold,
+            )
+            summaries.append(summary)
+            print(
+                f"  {source}: {summary['marks']} mark(s) -> {summary['classes']} candidate class(es) "
+                f"({summary.get('singletons', 0)} singleton) via {summary['backend']}"
+            )
+    if summaries:
+        write_cluster_report(summaries, args.out / "cluster_report.json")
+
+    if "ucsf" in selected and (args.ucsf_distractors or args.ucsf_letterhead_per_author):
+        ucsf_pages = load_ucsf(
+            args.raw,
+            images_dir,
+            distractor_budget=args.ucsf_distractors,
+            letterhead_per_author=args.ucsf_letterhead_per_author,
+            split_by_decade=args.split_letterhead_by_decade,
+            warnings=warnings,
+        )
+        pages.extend(ucsf_pages)
+        print(f"ucsf: {len(ucsf_pages)} page(s)")
+
+    inventory = class_inventory(pages)
+    curve = survival_curve(inventory, (2, 5, 10, 15, 20, 30, 50))
+    print("\nclass survival curve (min instances -> classes):")
+    for t, n in sorted(curve.items()):
+        marker = "  <- selected" if t == args.min_instances else ""
+        print(f"  >={t:<3} {n:>5}{marker}")
+
+    if args.survival:
+        return 0
+
+    # Synthesis last: it needs held-out backgrounds, which means it needs to know
+    # which pages already carry a real mark.
+    if "synth" in selected:
+        from synth_compose import build_synthetic_pages
+        from sources import artwork
+
+        marked = {p.page_id for p in pages if p.marks}
+        backgrounds = [Path(p.path) for p in pages if p.page_id not in marked]
+        if not backgrounds:
+            warnings.append("synth: no unmarked pages available as backgrounds — skipped")
+        else:
+            if args.synth_pool_dir:
+                pool = artwork.load_pool_dir(args.synth_pool_dir, limit=args.synth_max_classes)
+            else:
+                root = artwork.fetch_logodet3k(args.raw)
+                pool = artwork.build_pool_from_logodet(
+                    root, args.raw / "artwork_pool", max_classes=args.synth_max_classes
+                )
+            synth_pages = build_synthetic_pages(
+                backgrounds,
+                pool,
+                images_dir / "synth",
+                instances_per_class=args.synth_per_class,
+                size_px=cfg.SYNTH_SIZE_PX,
+                rotation_deg=cfg.SYNTH_ROTATION_DEG,
+                seed=cfg.SYNTH_SEED,
+            )
+            used = {str(p) for page in synth_pages for p in [Path(page.meta["background"])]}
+            # Hold the backgrounds out: a page must not be both a synthetic
+            # canvas and a distractor scored against its own pasted mark.
+            pages = [p for p in pages if p.path not in used]
+            pages.extend(synth_pages)
+            print(f"synth: {len(synth_pages)} page(s) over {len(pool)} class(es); {len(used)} background(s) held out")
+            inventory = class_inventory(pages)
+
+    admitted, rejected = admit_classes(
+        pages, inventory, min_instances=args.min_instances, min_mark_px=args.min_mark_px
+    )
+    print(f"\nadmitted {len(admitted)} class(es); rejected {len(rejected)}")
+
+    needs_hand_crop = write_query_crops(pages, inventory, admitted, args.out / "queries")
+    if needs_hand_crop:
+        print(f"  {len(needs_hand_crop)} weak-label class(es) need a hand-drawn query crop")
+
+    pinned: Optional[dict[str, float]] = None
+    if args.pin_tiers:
+        pinned = json.loads(args.pin_tiers.read_text(encoding="utf-8")).get("tier_cutoffs")
+        print(f"\npinning tier cutoffs from {args.pin_tiers}: {pinned}")
+
+    tier_of, tier_cutoffs = assign_tiers(
+        pages,
+        admitted,
+        tiers=cfg.TIERS,
+        tier_order=cfg.TIER_ORDER,
+        salt=cfg.TIER_SALT,
+        pinned_cutoffs=pinned,
+    )
+    kept = []
+    for page in pages:
+        tier = tier_of.get(page.page_id)
+        if tier is None:
+            continue
+        page.meta["tier"] = tier
+        kept.append(page)
+    dropped = len(pages) - len(kept)
+
+    n = _common.write_manifest(kept, args.out / "corpus.jsonl")
+    (args.out / "classes.json").write_text(json.dumps(admitted, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    tier_counts = {t: sum(1 for p in kept if p.meta.get("tier") == t) for t in cfg.TIER_ORDER}
+    cumulative = {}
+    running = 0
+    for t in cfg.TIER_ORDER:
+        running += tier_counts[t]
+        cumulative[t] = running
+
+    report = {
+        "pages_written": n,
+        "pages_dropped_over_budget": dropped,
+        "tier_counts": tier_counts,
+        "tier_cumulative": cumulative,
+        # Feed these back with --pin-tiers to keep a later, larger build's tier
+        # membership comparable to this one.
+        "tier_cutoffs": tier_cutoffs,
+        "classes_admitted": len(admitted),
+        "classes_rejected": len(rejected),
+        "rejection_reasons": rejected,
+        "survival_curve": {str(k): v for k, v in curve.items()},
+        "needs_hand_crop": needs_hand_crop,
+        "warnings": warnings,
+        "settings": {
+            "sources": selected,
+            "min_instances": args.min_instances,
+            "min_mark_px": args.min_mark_px,
+            "cluster_backend": args.cluster_backend,
+            "cluster_threshold": args.cluster_threshold,
+            "tier_salt": cfg.TIER_SALT,
+        },
+    }
+    (args.out / "build_report.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"\nwrote {n} page(s) to {args.out / 'corpus.jsonl'}")
+    print(f"  tiers (cumulative): " + ", ".join(f"{t}={cumulative[t]}" for t in cfg.TIER_ORDER))
+    if dropped:
+        print(f"  {dropped} page(s) dropped: past the largest tier's budget")
+    for w in warnings:
+        print(f"  warning: {w}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/docmarks/cluster_marks.py
+++ b/scripts/experiments/docmarks/cluster_marks.py
@@ -1,0 +1,290 @@
+"""Turn located marks into identity classes — and be honest that it's a guess.
+
+SPODS and StaVer both ship *where* every logo and stamp is, and neither ships
+*which* one it is.  A previous VTSearch study reported "64 logo/stamp classes"
+for SPODS with names like ``logo_14``; those identities were derived, not read
+off the dataset, and nothing verified them.  Since class identity is the entire
+ground truth of an instance-retrieval benchmark, a derived clustering that
+nobody checked is not a benchmark — it is a hypothesis with error bars nobody
+measured.
+
+So this module does three things in order:
+
+1. crop every mark and describe it (``phash`` by default, ``siglip`` when the
+   pile's models are available);
+2. single-linkage agglomerate under a distance threshold into candidate classes;
+3. emit the material a human needs to confirm or correct the result, and mark
+   every derived ``class_id`` with ``provenance="clustered"`` so downstream code
+   can tell a verified identity from a guessed one.
+
+Single linkage is chosen deliberately over a centroid method: instances of one
+stamp vary continuously with ink coverage and scan quality, so a chain of near
+neighbours is the right shape, and the failure mode it does have — two classes
+bridged by one ambiguous crop — is exactly what a human reviewing the largest
+clusters will spot immediately.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+import numpy as np
+
+from sources._common import Mark, Page
+
+#: Side length the crop is normalised to before hashing.
+PHASH_RESIZE = 32
+#: Low-frequency DCT block kept.  64 coefficients -> a 64-bit hash.
+PHASH_BLOCK = 8
+
+
+@dataclass(frozen=True)
+class MarkRef:
+    """A pointer to one mark inside the page list, plus its crop descriptor."""
+
+    page_index: int
+    mark_index: int
+    page_id: str
+    kind: str
+    box: tuple[int, int, int, int]
+
+
+# --------------------------------------------------------------------------
+# Descriptors
+# --------------------------------------------------------------------------
+
+
+def _dct2(block: np.ndarray) -> np.ndarray:
+    """2-D DCT-II via matrix multiply.
+
+    Written out rather than pulled from scipy so the clustering pass has the
+    same dependency footprint as the rest of the builder (numpy + Pillow) and
+    runs identically on a login node and a compute node.
+    """
+    n = block.shape[0]
+    k = np.arange(n)
+    basis = np.cos(np.pi * (2 * k[:, None] + 1) * k[None, :] / (2 * n))
+    basis[0, :] = basis[0, :] / np.sqrt(2)
+    return basis @ block @ basis.T
+
+
+def phash(image: Any) -> np.ndarray:
+    """A 64-bit perceptual hash of *image*, as a boolean vector.
+
+    Scale-invariant by construction (everything is resized to a fixed square),
+    which is what we want: the same stamp appears at whatever size the scanner
+    and the page layout produced.  Aspect ratio is deliberately discarded here
+    and reintroduced as a separate gate in :func:`distance_matrix`, because two
+    marks with very different aspect ratios are not the same mark however
+    similar their normalised pixels look.
+    """
+    grey = image.convert("L").resize((PHASH_RESIZE, PHASH_RESIZE))
+    arr = np.asarray(grey, dtype=np.float64)
+    coeffs = _dct2(arr)[:PHASH_BLOCK, :PHASH_BLOCK]
+    flat = coeffs.flatten()
+    # Drop the DC term before taking the median: it encodes overall brightness,
+    # which on a scan is the paper, not the mark.
+    median = np.median(flat[1:])
+    return flat > median
+
+
+def crop_mark(page_image: Any, box: tuple[int, int, int, int], *, pad_frac: float = 0.04) -> Any:
+    """Crop *box* out of *page_image* with a little context padding."""
+    x, y, w, h = box
+    pad = int(round(max(w, h) * pad_frac))
+    left = max(0, x - pad)
+    top = max(0, y - pad)
+    right = min(page_image.width, x + w + pad)
+    bottom = min(page_image.height, y + h + pad)
+    return page_image.crop((left, top, right, bottom))
+
+
+def describe_marks(
+    pages: Sequence[Page],
+    refs: Sequence[MarkRef],
+    *,
+    backend: str = "phash",
+) -> np.ndarray:
+    """Descriptor matrix for *refs*, one row per mark.
+
+    ``phash`` returns a boolean matrix compared by normalised Hamming distance;
+    ``siglip`` returns L2-normalised float vectors compared by cosine distance.
+    """
+    from PIL import Image
+
+    if backend == "phash":
+        rows = []
+        cache: dict[str, Any] = {}
+        for ref in refs:
+            page = pages[ref.page_index]
+            if page.path not in cache:
+                cache.clear()  # one page open at a time; pages are large
+                cache[page.path] = Image.open(page.path).convert("L")
+            rows.append(phash(crop_mark(cache[page.path], ref.box)))
+        return np.array(rows, dtype=bool)
+
+    if backend == "siglip":
+        from vtscore.media.image.embedder_siglip import SiglipEmbedder  # noqa: PLC0415
+
+        embedder = SiglipEmbedder()
+        crops = []
+        cache_path: Optional[str] = None
+        cache_img: Any = None
+        for ref in refs:
+            page = pages[ref.page_index]
+            if page.path != cache_path:
+                cache_path, cache_img = page.path, Image.open(page.path).convert("RGB")
+            crops.append(crop_mark(cache_img, ref.box))
+        vecs = np.asarray(embedder.embed_images(crops), dtype=np.float32)
+        norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+        return vecs / np.clip(norms, 1e-8, None)
+
+    raise ValueError(f"unknown cluster backend {backend!r} (expected 'phash' or 'siglip')")
+
+
+def distance_matrix(
+    desc: np.ndarray,
+    refs: Sequence[MarkRef],
+    *,
+    backend: str = "phash",
+    max_aspect_ratio: float = 2.0,
+) -> np.ndarray:
+    """Pairwise distances, with mismatched aspect ratios forced apart.
+
+    The aspect gate is what stops a round rubber stamp and a wide letterhead
+    banner from merging just because both are dark ink on white paper at 32x32.
+    """
+    if backend == "phash":
+        bits = desc.astype(np.uint8)
+        # Hamming distance via matrix algebra: |a XOR b| = a.(1-b) + (1-a).b
+        inv = 1 - bits
+        dist = (bits @ inv.T + inv @ bits.T).astype(np.float64) / desc.shape[1]
+    else:
+        dist = 1.0 - (desc @ desc.T)
+
+    aspects = np.array([max(b.box[2], 1) / max(b.box[3], 1) for b in refs], dtype=np.float64)
+    ratio = np.maximum(aspects[:, None] / aspects[None, :], aspects[None, :] / aspects[:, None])
+    dist = np.where(ratio > max_aspect_ratio, 1.0, dist)
+
+    np.fill_diagonal(dist, 0.0)
+    return dist
+
+
+# --------------------------------------------------------------------------
+# Clustering
+# --------------------------------------------------------------------------
+
+
+def single_linkage(dist: np.ndarray, threshold: float) -> list[int]:
+    """Union-find single-linkage clustering.  Returns a label per row."""
+    n = dist.shape[0]
+    parent = list(range(n))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            if dist[i, j] <= threshold:
+                ri, rj = find(i), find(j)
+                if ri != rj:
+                    parent[max(ri, rj)] = min(ri, rj)
+
+    # Relabel roots to dense 0..k-1 in first-appearance order, so the labelling
+    # is a pure function of the distance matrix and not of dict iteration.
+    remap: dict[int, int] = {}
+    labels = []
+    for i in range(n):
+        root = find(i)
+        if root not in remap:
+            remap[root] = len(remap)
+        labels.append(remap[root])
+    return labels
+
+
+def assign_class_ids(
+    pages: list[Page],
+    refs: Sequence[MarkRef],
+    labels: Sequence[int],
+    *,
+    source: str,
+) -> dict[str, list[MarkRef]]:
+    """Write clustered ``class_id``\\ s back onto the pages' marks.
+
+    Class ids are derived from the cluster's *smallest page id*, not from its
+    index, so adding pages to the corpus cannot silently renumber existing
+    classes and invalidate a previous run's audit verdicts.
+    """
+    members: dict[int, list[MarkRef]] = {}
+    for ref, label in zip(refs, labels):
+        members.setdefault(label, []).append(ref)
+
+    out: dict[str, list[MarkRef]] = {}
+    for label, group in members.items():
+        anchor = min(group, key=lambda r: (r.page_id, r.mark_index))
+        kind = group[0].kind
+        class_id = f"{source}/{kind}_{anchor.page_id.split('/')[-1]}_{anchor.mark_index}"
+        out[class_id] = group
+        for ref in group:
+            mark = pages[ref.page_index].marks[ref.mark_index]
+            pages[ref.page_index].marks[ref.mark_index] = Mark(
+                kind=mark.kind,
+                box=mark.box,
+                class_id=class_id,
+                provenance="clustered",
+            )
+    return out
+
+
+def collect_refs(pages: Sequence[Page], *, kinds: Iterable[str], source: str) -> list[MarkRef]:
+    """Every unlabelled mark of the given *kinds* from *source*'s pages."""
+    wanted = set(kinds)
+    refs = []
+    for pi, page in enumerate(pages):
+        if page.source != source:
+            continue
+        for mi, mark in enumerate(page.marks):
+            if mark.kind in wanted and mark.class_id is None:
+                refs.append(MarkRef(pi, mi, page.page_id, mark.kind, mark.box))
+    return refs
+
+
+def cluster_source(
+    pages: list[Page],
+    source: str,
+    *,
+    kinds: Iterable[str] = ("logo", "stamp"),
+    backend: str = "phash",
+    threshold: float = 0.18,
+) -> dict[str, Any]:
+    """Cluster one source's marks in place.  Returns a summary for the report."""
+    refs = collect_refs(pages, kinds=kinds, source=source)
+    if not refs:
+        return {"source": source, "marks": 0, "classes": 0, "backend": backend, "threshold": threshold}
+
+    desc = describe_marks(pages, refs, backend=backend)
+    dist = distance_matrix(desc, refs, backend=backend)
+    labels = single_linkage(dist, threshold)
+    classes = assign_class_ids(pages, refs, labels, source=source)
+
+    sizes = sorted((len(v) for v in classes.values()), reverse=True)
+    return {
+        "source": source,
+        "marks": len(refs),
+        "classes": len(classes),
+        "backend": backend,
+        "threshold": threshold,
+        "largest_clusters": sizes[:10],
+        "singletons": sum(1 for s in sizes if s == 1),
+    }
+
+
+def write_cluster_report(summaries: list[dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summaries, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/experiments/docmarks/docmarks_config.py
+++ b/scripts/experiments/docmarks/docmarks_config.py
@@ -34,7 +34,9 @@ RAW = Path(os.environ.get("VTS_DOCMARKS_RAW", "/expscratch/{u}/docmarks/raw".for
 
 #: Where the assembled corpus lands: ``images/``, ``queries/``, ``corpus.jsonl``,
 #: ``classes.json``.  This is what a study reads and what the pile embeds.
-OUT = Path(os.environ.get("VTS_DOCMARKS_OUT", "/expscratch/{u}/docmarks/corpus".format(u=os.environ.get("USER", "user"))))
+OUT = Path(
+    os.environ.get("VTS_DOCMARKS_OUT", "/expscratch/{u}/docmarks/corpus".format(u=os.environ.get("USER", "user")))
+)
 
 # --------------------------------------------------------------------------
 # Tiers — nested by construction

--- a/scripts/experiments/docmarks/docmarks_config.py
+++ b/scripts/experiments/docmarks/docmarks_config.py
@@ -1,0 +1,185 @@
+"""Configuration for the DocMarks corpus — stamps and logos in scanned documents.
+
+DocMarks is one corpus assembled from several sources, in three strata:
+
+* **anchor** — real ground truth from SPODS, StaVer and Tobacco800.  These carry
+  per-mark boxes; SPODS and StaVer need an identity-clustering pass on top (see
+  :mod:`cluster_marks`) because neither ships instance labels.
+* **haystack** — real scanned pages with no marks of interest, pulled from the
+  UCSF Industry Documents Library.  Distractors, plus (optionally) weakly
+  labelled letterhead classes keyed on the document's ``author`` field.
+* **synth** — real mark artwork pasted onto held-out real scans at known
+  ``(x, y, scale, rotation)``.  Instance ground truth by construction; used for
+  statistical power, never quoted on its own.
+
+The corpus is emitted as one manifest with **nested tiers**, so a 5k experiment
+and a 200k experiment read the same file and the same class ids.
+
+Every knob here is overridable by environment variable so a GRID job can be
+re-pointed without editing the tree.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Paths
+# --------------------------------------------------------------------------
+
+#: Where source archives are downloaded and unpacked.  Big; keep it off the
+#: 50G mount (see scripts/experiments/GRID-PLAYBOOK.md).
+RAW = Path(os.environ.get("VTS_DOCMARKS_RAW", "/expscratch/{u}/docmarks/raw".format(u=os.environ.get("USER", "user"))))
+
+#: Where the assembled corpus lands: ``images/``, ``queries/``, ``corpus.jsonl``,
+#: ``classes.json``.  This is what a study reads and what the pile embeds.
+OUT = Path(os.environ.get("VTS_DOCMARKS_OUT", "/expscratch/{u}/docmarks/corpus".format(u=os.environ.get("USER", "user"))))
+
+# --------------------------------------------------------------------------
+# Tiers — nested by construction
+# --------------------------------------------------------------------------
+
+#: ``tier -> total page budget``.  Tiers are *nested*: every page in ``s`` is in
+#: ``m``, every page in ``m`` is in ``l``.  Positives are in every tier (a class
+#: with 30 instances is useless if a tier keeps 3 of them); only distractors are
+#: subsampled, by a stable seeded rank on the page id, so growing a tier never
+#: reshuffles the smaller one.
+TIERS: dict[str, int] = {
+    "s": int(os.environ.get("VTS_DOCMARKS_TIER_S", "5000")),
+    "m": int(os.environ.get("VTS_DOCMARKS_TIER_M", "50000")),
+    "l": int(os.environ.get("VTS_DOCMARKS_TIER_L", "200000")),
+}
+
+#: Ordered smallest-to-largest.  Used for the nesting invariant.
+TIER_ORDER: tuple[str, ...] = ("s", "m", "l")
+
+#: Salt for the deterministic distractor rank.  Change it and every tier
+#: membership is reshuffled — so don't, unless you mean to.
+TIER_SALT = os.environ.get("VTS_DOCMARKS_TIER_SALT", "docmarks-v1")
+
+# --------------------------------------------------------------------------
+# Class admission
+# --------------------------------------------------------------------------
+
+#: A class needs at least this many instances to be admitted as a *query* class.
+#: Tobacco800's published "21 logo classes" uses a >=2 bar, which cannot support
+#: a train-and-search eval: with two instances there is nothing left to retrieve
+#: once one is the query.  ``build_corpus.py`` prints the survival curve over
+#: every threshold so this can be set from data rather than taste.
+MIN_INSTANCES = int(os.environ.get("VTS_DOCMARKS_MIN_INSTANCES", "10"))
+
+#: Marks smaller than this (longest side, px, at the page's native scan
+#: resolution) are recorded but never promoted to a query class.  The
+#: 2026-07-13 study found a hard floor around 32 px below which no structural
+#: pipeline recovers anything; a class made of sub-floor instances measures the
+#: floor, not the method.
+MIN_MARK_PX = int(os.environ.get("VTS_DOCMARKS_MIN_MARK_PX", "32"))
+
+#: Connected components smaller than this fraction of the page are dropped as
+#: mask speckle rather than treated as marks.
+MIN_MARK_AREA_FRAC = float(os.environ.get("VTS_DOCMARKS_MIN_MARK_AREA_FRAC", "0.0002"))
+
+# --------------------------------------------------------------------------
+# Contamination — which sources may serve as distractors for which classes
+# --------------------------------------------------------------------------
+#
+# The trap this exists to avoid: RVL-CDIP and Tobacco800 are both drawn from
+# IIT-CDIP, so an American Tobacco letterhead is *certain* to appear in an
+# RVL-CDIP "distractor" pool.  Unlabelled positives in the distractor set do not
+# make the benchmark slightly noisy, they make a correct retrieval count as a
+# false positive — the metric punishes the model for being right.  No amount of
+# hand annotation fixes that at 200k pages, so it is fixed by construction here.
+#
+# Read as: "a class from source K may be scored against distractors from any
+# source NOT listed in CONTAMINATES[K]".
+
+CONTAMINATES: dict[str, frozenset[str]] = {
+    # Indian pseudo-official documents authored for the dataset.  Their marks
+    # exist nowhere else on earth, so every other source is a safe distractor.
+    "spods": frozenset({"spods"}),
+    # Stamps on European scanned invoices.  Likewise self-contained.
+    "staver": frozenset({"staver"}),
+    # IIT-CDIP tobacco litigation documents.  UCSF's Tobacco industry is the
+    # *same underlying archive*, so it is excluded; the other UCSF industries
+    # are different companies and are admitted.
+    "tobacco800": frozenset({"tobacco800", "ucsf:Tobacco"}),
+    # Weakly-labelled UCSF letterhead classes contaminate all of UCSF: the same
+    # company's letterhead recurs across industries (Philip Morris reaches Food
+    # through Kraft), and the label is metadata-derived rather than observed.
+    "ucsf": frozenset({"ucsf"}),
+    # Synthetic pastes contaminate only their own backgrounds, which
+    # build_corpus.py holds out of every other stratum.
+    "synth": frozenset({"synth"}),
+}
+
+#: UCSF industries pulled for the distractor pool.  Tobacco is deliberately
+#: *first* and deliberately excluded from Tobacco800's eligible distractors by
+#: ``CONTAMINATES`` above — it is pulled because it is the richest source of
+#: scanned letterhead for the weakly-labelled classes, not despite the clash.
+UCSF_INDUSTRIES: tuple[str, ...] = ("Tobacco", "Opioids", "Chemical", "Fossil Fuel", "Drug", "Food")
+
+#: Companies whose single-page letters form the weakly-labelled letterhead
+#: classes.  ``author`` (who wrote it), not ``collection`` (whose files it sat
+#: in): a letter *in* the Philip Morris collection is as likely to be incoming
+#: mail on a law firm's letterhead.  Live counts of single-page ``type:letter``
+#: documents per author, measured 2026-08-25, are in the README.
+UCSF_LETTERHEAD_AUTHORS: tuple[str, ...] = (
+    "PHILIP MORRIS",
+    "RJR",
+    "LOR, LORILLARD",
+    "AMERICAN TOBACCO",
+    "BROWN & WILLIAMSON",
+    "BATCO",
+    "COUNCIL FOR TOBACCO RESEARCH",
+    "TOBACCO INSTITUTE",
+)
+
+# --------------------------------------------------------------------------
+# Identity clustering
+# --------------------------------------------------------------------------
+
+#: Default backend for turning per-mark crops into identity classes.  ``phash``
+#: is cheap, deterministic and runs with no models — good enough to build the
+#: audit slate a human then corrects.  ``siglip`` is the quality option and
+#: needs the pile's models dir.
+CLUSTER_BACKEND = os.environ.get("VTS_DOCMARKS_CLUSTER_BACKEND", "phash")
+
+#: Agglomerative merge threshold, in the backend's own distance units
+#: (normalised Hamming for ``phash``, cosine distance for ``siglip``).
+CLUSTER_THRESHOLD = float(os.environ.get("VTS_DOCMARKS_CLUSTER_THRESHOLD", "0.18"))
+
+# --------------------------------------------------------------------------
+# Synthesis (layer 3)
+# --------------------------------------------------------------------------
+
+#: Instances generated per synthetic class.
+SYNTH_INSTANCES_PER_CLASS = int(os.environ.get("VTS_DOCMARKS_SYNTH_PER_CLASS", "30"))
+
+#: Longest-side pixel sizes the pasted mark is drawn from, log-uniformly.  The
+#: band spans the 2026-07-13 study's measured cliff (nothing works below ~32 px;
+#: 128-256 px is where SIFT recovers) so a sweep can locate it rather than
+#: straddle it.
+SYNTH_SIZE_PX = (24, 320)
+
+#: Rotation range in degrees.  Scanned marks are near-upright but not exactly:
+#: a rubber stamp is applied by hand, a letterhead is not.
+SYNTH_ROTATION_DEG = (-8.0, 8.0)
+
+#: Seed for every random choice in synthesis.  One seed, one corpus.
+SYNTH_SEED = int(os.environ.get("VTS_DOCMARKS_SYNTH_SEED", "20260825"))
+
+
+def eligible_distractor(class_source: str, page_source: str, page_industry: str | None = None) -> bool:
+    """Is *page_source* safe to score as a distractor for a *class_source* class?
+
+    ``page_industry`` qualifies UCSF pages, so that Tobacco800 classes can use
+    UCSF's non-tobacco industries while excluding the tobacco archive they
+    overlap with.
+    """
+    banned = CONTAMINATES.get(class_source, frozenset())
+    if page_source in banned:
+        return False
+    if page_source == "ucsf" and page_industry and f"ucsf:{page_industry}" in banned:
+        return False
+    return True

--- a/scripts/experiments/docmarks/embed_corpus.py
+++ b/scripts/experiments/docmarks/embed_corpus.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+"""Embed a built DocMarks corpus into pile-format cells, on the GRID.
+
+    source scripts/experiments/pile/pile_env.sh
+    python embed_corpus.py --list
+    python embed_corpus.py --tier s --embedders sift_vlad,siglip
+    python embed_corpus.py --verify
+
+One cell = one ``docmarks_<tier>__<embedder>.pkl`` of media dicts carrying
+vectors (plus ``local_features`` for structural embedders) and **no pixels**,
+written into the shared pile's ``embeddings/`` directory so studies read it the
+same way they read every other cell.
+
+Why this is not just a new entry in ``pile_config.DATASETS``: the pile builds
+the full ``dataset x embedder`` cross-product, so adding DocMarks *and*
+``sift_vlad`` there would silently schedule ``sift_vlad`` cells for all six
+existing datasets and three deep-embedder cells for each DocMarks tier — a
+dozen-odd cells nobody asked for, on a mount the playbook already describes as
+chronically full.  This script reuses the pile's *format*, *location* and
+*pickle IO* while keeping the cell list explicit.
+
+Tiers are nested, so build them small-first: ``--tier s`` produces a 5k cell you
+can iterate against in minutes, and ``l`` is the same corpus with more
+distractors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import docmarks_config as cfg  # noqa: E402
+from sources._common import Page, read_manifest  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[3]
+_PILE_DIR = _REPO / "scripts" / "experiments" / "pile"
+_CALIB_DIR = _REPO / "scripts" / "experiments" / "calibration"
+
+#: Embedders worth caching for this corpus.  ``sift_vlad`` is the shipped
+#: structural embedder and the reason the corpus exists; the deep embedders are
+#: the baseline every structural result is quoted against, and the hybrid arm
+#: needs both in the same media dicts.
+EMBEDDERS: dict[str, dict[str, Any]] = {
+    "sift_vlad": {"batch": None, "structural": True},
+    "siglip": {"batch": 128, "structural": False},
+    "siglip2_l": {"batch": 32, "structural": False},
+}
+
+
+def _load_by_path(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _cells_io() -> Any:
+    """The calibration harness's pickle IO — drops bytes, keeps vectors."""
+    return _load_by_path("_docmarks_cells_io", _CALIB_DIR / "_cells_io.py")
+
+
+def _pile_config() -> Any:
+    return _load_by_path("_docmarks_pile_config", _PILE_DIR / "pile_config.py")
+
+
+def cell_name(tier: str, embedder: str) -> str:
+    return f"docmarks_{tier}__{embedder}.pkl"
+
+
+def cell_path(tier: str, embedder: str) -> Path:
+    return _pile_config().EMBEDDINGS / cell_name(tier, embedder)
+
+
+@contextmanager
+def _batch_size(embedder: str) -> Iterator[None]:
+    """Apply this embedder's batch size for the embed pass.
+
+    An explicitly-set environment variable always wins: whoever set it is
+    tuning for the card in front of them, and a table in this file cannot know
+    what that card is.
+    """
+    want = EMBEDDERS.get(embedder, {}).get("batch")
+    if want is None or os.environ.get("VTSEARCH_EMBED_BATCH_SIZE", "").strip():
+        yield
+        return
+    previous = os.environ.get("VTSEARCH_EMBED_BATCH_SIZE")
+    os.environ["VTSEARCH_EMBED_BATCH_SIZE"] = str(want)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("VTSEARCH_EMBED_BATCH_SIZE", None)
+        else:
+            os.environ["VTSEARCH_EMBED_BATCH_SIZE"] = previous
+
+
+def tiers_up_to(tier: str) -> set[str]:
+    """Tier *tier* and every smaller one — tiers nest, so a cell is cumulative."""
+    order = list(cfg.TIER_ORDER)
+    return set(order[: order.index(tier) + 1])
+
+
+def pages_for_tier(corpus: Path, tier: str) -> list[Page]:
+    wanted = tiers_up_to(tier)
+    return [p for p in read_manifest(corpus / "corpus.jsonl") if p.meta.get("tier") in wanted]
+
+
+def load_medias(pages: Sequence[Page], classes: dict[str, Any], embedder: str) -> dict[int, dict]:
+    """Turn manifest pages into the media dicts the embedding stage expects.
+
+    ``regions`` carries every ground-truth mark, so a region-voting arm can drag
+    the real box rather than the whole page.  Weak (boxless) marks are recorded
+    in ``categories`` but contribute no region — a zero-area box would be
+    indistinguishable from a real one downstream, which is exactly the
+    distinction the corpus is built to preserve.
+    """
+    medias: dict[int, dict] = {}
+    for index, page in enumerate(sorted(pages, key=lambda p: p.page_id)):
+        regions = []
+        categories = []
+        for mark in page.marks:
+            if not mark.class_id:
+                continue
+            categories.append(mark.class_id)
+            if mark.area() > 0:
+                x, y, w, h = mark.box
+                regions.append(
+                    {
+                        "label": mark.class_id,
+                        "x": x,
+                        "y": y,
+                        "width": w,
+                        "height": h,
+                        "provenance": mark.provenance,
+                    }
+                )
+        ordered = sorted(dict.fromkeys(categories))
+        medias[index] = {
+            "id": index,
+            "media_type": "image",
+            "embedder": embedder,
+            "duration": 0,
+            "file_size": 0,
+            "md5": "",
+            "embeddings": {},
+            "media_bytes": Path(page.path).read_bytes(),
+            "media_string": None,
+            "filename": Path(page.path).name,
+            "category": ordered[0] if ordered else "",
+            "categories": ordered,
+            "regions": regions,
+            "origin": {"importer": "docmarks", "params": {"embedder": embedder, "page_id": page.page_id}},
+            "origin_name": page.page_id,
+            # Carried through so a study can filter without re-reading the
+            # manifest: which stratum, which tier, and how trustworthy the
+            # labels on this page are.
+            "docmarks": {
+                "source": page.source,
+                "tier": page.meta.get("tier"),
+                "provenances": sorted({m.provenance for m in page.marks}),
+                "industry": page.meta.get("industry"),
+                "decade": page.meta.get("decade"),
+            },
+        }
+    return medias
+
+
+def build_cell(corpus: Path, tier: str, embedder: str, *, force: bool = False) -> dict[str, Any]:
+    from vtscore.datasets.stages.embedding import embed_missing  # noqa: PLC0415
+
+    out = cell_path(tier, embedder)
+    if out.exists() and not force:
+        print(f"skip docmarks_{tier} x {embedder} (exists: {out.name})")
+        return {"tier": tier, "embedder": embedder, "status": "exists"}
+
+    classes_path = corpus / "classes.json"
+    classes = json.loads(classes_path.read_text(encoding="utf-8")) if classes_path.exists() else {}
+
+    t0 = time.time()
+    pages = pages_for_tier(corpus, tier)
+    if not pages:
+        raise SystemExit(f"no pages at tier {tier!r} in {corpus} — was the corpus built with this tier?")
+    medias = load_medias(pages, classes, embedder)
+    print(f"=== docmarks_{tier} x {embedder}: {len(medias)} page(s) loaded in {time.time() - t0:.0f}s")
+
+    t1 = time.time()
+    with _batch_size(embedder):
+        embed_missing(medias, embedder)
+    embed_s = time.time() - t1
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    nbytes = _cells_io().dump_medias(medias, out)
+    n_local = sum(1 for m in medias.values() if m.get("local_features") is not None)
+    print(
+        f"  wrote {out.name}: {nbytes / 1e6:.0f} MB, {len(medias)} medias, "
+        f"local_features {n_local}/{len(medias)}, embed {embed_s:.0f}s"
+    )
+    return {
+        "tier": tier,
+        "embedder": embedder,
+        "status": "built",
+        "n_medias": len(medias),
+        "n_local_features": n_local,
+        "megabytes": round(nbytes / 1e6, 1),
+        "embed_seconds": round(embed_s, 1),
+    }
+
+
+def verify(corpus: Path) -> int:
+    """Load every present cell and check it is usable.  Returns an exit code."""
+    io = _cells_io()
+    bad = 0
+    for tier in cfg.TIER_ORDER:
+        for embedder in EMBEDDERS:
+            path = cell_path(tier, embedder)
+            if not path.exists():
+                continue
+            try:
+                medias = io.load_medias(path)
+            except Exception as exc:  # noqa: BLE001 - verify reports, never raises
+                print(f"  BROKEN {path.name}: {type(exc).__name__}: {exc}")
+                bad += 1
+                continue
+            vectors = sum(1 for m in medias.values() if m.get("embeddings"))
+            labelled = sum(1 for m in medias.values() if m.get("categories"))
+            status = "ok" if vectors == len(medias) else f"MISSING {len(medias) - vectors} vector(s)"
+            print(f"  {path.name}: {len(medias)} medias, {labelled} labelled, {status}")
+            bad += status != "ok"
+    return 1 if bad else 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--corpus", type=Path, default=cfg.OUT)
+    ap.add_argument("--tier", default="s", choices=cfg.TIER_ORDER)
+    ap.add_argument("--embedders", default="sift_vlad,siglip")
+    ap.add_argument("--force", action="store_true")
+    ap.add_argument("--list", action="store_true", help="show which cells exist, then exit")
+    ap.add_argument("--verify", action="store_true", help="load every present cell and check it, then exit")
+    args = ap.parse_args(argv)
+
+    if args.list:
+        for tier in cfg.TIER_ORDER:
+            for embedder in EMBEDDERS:
+                path = cell_path(tier, embedder)
+                mark = f"{path.stat().st_size / 1e6:>8.0f} MB" if path.exists() else "        --"
+                print(f"  {mark}  {path.name}")
+        return 0
+
+    if args.verify:
+        return verify(args.corpus)
+
+    requested = [e.strip() for e in args.embedders.split(",") if e.strip()]
+    unknown = set(requested) - set(EMBEDDERS)
+    if unknown:
+        ap.error(f"unknown embedder(s): {sorted(unknown)}; known: {sorted(EMBEDDERS)}")
+
+    summaries = [build_cell(args.corpus, args.tier, e, force=args.force) for e in requested]
+    built = [s for s in summaries if s["status"] == "built"]
+    print(f"\n{len(built)} cell(s) built, {len(summaries) - len(built)} already present")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/docmarks/make_audit_slate.py
+++ b/scripts/experiments/docmarks/make_audit_slate.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+"""Render the contact sheets for the DocMarks human passes.
+
+    python make_audit_slate.py --task cluster      # are the derived classes real?
+    python make_audit_slate.py --task distinctive  # is this mark an instance at all?
+    python make_audit_slate.py --task letterhead   # does the weak label hold?
+
+Each task writes PNG sheets plus a ``verdicts.jsonl`` template into
+``<out>/audit/<task>/``.  Fill in the verdict field, then fold the answers back
+with ``audit_to_corrections.py``.
+
+**These are the only three annotation passes the corpus asks for**, and each one
+exists because a specific number is otherwise unknowable rather than merely
+unverified:
+
+``cluster``
+    SPODS and StaVer ship mark locations without identities, so their class
+    inventory is derived by :mod:`cluster_marks` and is currently a hypothesis.
+    A previous study published per-class results on exactly this kind of derived
+    inventory without checking it.  Reviewing the largest clusters catches the
+    single-linkage failure mode (two classes bridged by one ambiguous crop) in
+    about a minute per class.
+
+``distinctive``
+    A plain warning triangle or a ruled box is a *shape*, not an *instance*: no
+    amount of geometry makes "find this rectangle" a well-posed retrieval query.
+    The prior study's worst SPODS/StaVer classes (``warning_diamond`` at 17
+    keypoints, ``hospital_cross``) are this failure, and averaging them into a
+    headline AP measures the dataset's junk rather than the method.  Splitting
+    them out as a labelled stratum — not deleting them — lets both numbers be
+    reported.
+
+``letterhead``
+    The UCSF stratum's labels come from metadata: ``author:"PHILIP MORRIS"``
+    implies a Philip Morris letterhead.  Nobody has measured how often that is
+    true.  If it is 90% the stratum is usable with a noise model; if it is 40%
+    it is not usable at all.  ~100 sampled pages per author settles it, and
+    nothing else can.
+
+Deliberately **not** an annotation pass: exhaustively checking the distractor
+pool for unlabelled positives.  That is unfixable by hand at 200k pages and is
+instead prevented by construction — see ``CONTAMINATES`` in
+``docmarks_config.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import docmarks_config as cfg  # noqa: E402
+from sources._common import Page, read_manifest  # noqa: E402
+
+THUMB = 180
+COLS = 8
+PAD = 6
+
+
+def _sheet(images: Sequence[Any], title: str, out_path: Path, captions: Optional[Sequence[str]] = None) -> None:
+    from PIL import Image, ImageDraw
+
+    rows = (len(images) + COLS - 1) // COLS
+    cap_h = 14 if captions else 0
+    width = COLS * (THUMB + PAD) + PAD
+    height = rows * (THUMB + PAD + cap_h) + PAD + 24
+    sheet = Image.new("RGB", (width, height), "white")
+    draw = ImageDraw.Draw(sheet)
+    draw.text((PAD, 6), title, fill="black")
+
+    for i, im in enumerate(images):
+        r, c = divmod(i, COLS)
+        thumb = im.convert("RGB").copy()
+        thumb.thumbnail((THUMB, THUMB))
+        x = PAD + c * (THUMB + PAD)
+        y = 24 + PAD + r * (THUMB + PAD + cap_h)
+        sheet.paste(thumb, (x, y))
+        draw.rectangle([x, y, x + thumb.width, y + thumb.height], outline="#cccccc")
+        if captions:
+            draw.text((x, y + thumb.height + 2), captions[i][:28], fill="#444444")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(out_path)
+
+
+def _crop(page: Page, box: tuple[int, int, int, int], pad_frac: float = 0.08) -> Any:
+    from PIL import Image
+
+    x, y, w, h = box
+    pad = int(round(max(w, h) * pad_frac))
+    with Image.open(page.path) as im:
+        return im.convert("RGB").crop(
+            (max(0, x - pad), max(0, y - pad), min(im.width, x + w + pad), min(im.height, y + h + pad))
+        )
+
+
+def task_cluster(pages: list[Page], classes: dict[str, Any], out: Path, *, max_per_class: int = 24) -> list[dict]:
+    """One sheet per derived class: every instance, so a bad merge is obvious."""
+    by_id = {p.page_id: p for p in pages}
+    verdicts = []
+    derived = {k: v for k, v in classes.items() if "clustered" in v.get("provenance", [])}
+
+    for class_id, meta in sorted(derived.items(), key=lambda kv: -kv[1]["n_instances"]):
+        crops, caps = [], []
+        for page_id in meta["page_ids"][:max_per_class]:
+            page = by_id.get(page_id)
+            if page is None:
+                continue
+            for mark in page.marks:
+                if mark.class_id == class_id:
+                    crops.append(_crop(page, mark.box))
+                    caps.append(page_id.split("/")[-1])
+                    break
+        if not crops:
+            continue
+        name = class_id.replace("/", "__")
+        _sheet(crops, f"{class_id}  —  {meta['n_instances']} instances  —  all one mark?", out / f"{name}.png", caps)
+        verdicts.append(
+            {
+                "task": "cluster",
+                "class_id": class_id,
+                "n_instances": meta["n_instances"],
+                "sheet": f"{name}.png",
+                # one of: ok | split | merge_into:<class_id> | drop
+                "verdict": "",
+                "notes": "",
+            }
+        )
+    return verdicts
+
+
+def task_distinctive(pages: list[Page], classes: dict[str, Any], out: Path) -> list[dict]:
+    """One sheet of every class's exemplar: is this an instance or a shape?"""
+    from PIL import Image
+
+    exemplars, caps, verdicts = [], [], []
+    for class_id, meta in sorted(classes.items()):
+        crop_path = meta.get("query_crop")
+        if not crop_path or not Path(crop_path).exists():
+            continue
+        exemplars.append(Image.open(crop_path))
+        caps.append(class_id.split("/")[-1])
+        verdicts.append(
+            {
+                "task": "distinctive",
+                "class_id": class_id,
+                # one of: distinctive | generic
+                # "generic" = a shape anyone could draw (plain box, warning
+                # triangle, ruled line). Kept in the corpus, excluded from the
+                # headline stratum.
+                "verdict": "",
+                "notes": "",
+            }
+        )
+
+    for start in range(0, len(exemplars), COLS * 6):
+        chunk = exemplars[start : start + COLS * 6]
+        _sheet(
+            chunk,
+            f"distinctive vs generic — classes {start}..{start + len(chunk) - 1}",
+            out / f"exemplars_{start // (COLS * 6):03d}.png",
+            caps[start : start + COLS * 6],
+        )
+    return verdicts
+
+
+def task_letterhead(pages: list[Page], out: Path, *, sample_per_author: int = 100, seed: int = 7) -> list[dict]:
+    """Sampled full pages per weak-label author: does the letterhead exist?"""
+    from PIL import Image
+
+    rng = random.Random(seed)
+    by_class: dict[str, list[Page]] = {}
+    for page in pages:
+        for mark in page.marks:
+            if mark.provenance == "weak" and mark.class_id:
+                by_class.setdefault(mark.class_id, []).append(page)
+
+    verdicts = []
+    for class_id, group in sorted(by_class.items()):
+        sample = rng.sample(group, min(sample_per_author, len(group)))
+        name = class_id.replace("/", "__")
+        thumbs = []
+        for page in sample:
+            with Image.open(page.path) as im:
+                # Only the top third: a letterhead lives at the top of the page,
+                # and a full-page thumbnail at this size shows nothing useful.
+                thumbs.append(im.convert("RGB").crop((0, 0, im.width, im.height // 3)))
+        for start in range(0, len(thumbs), COLS * 5):
+            _sheet(
+                thumbs[start : start + COLS * 5],
+                f"{class_id} — page tops — which carry the letterhead?",
+                out / f"{name}_{start // (COLS * 5):03d}.png",
+            )
+        verdicts.append(
+            {
+                "task": "letterhead",
+                "class_id": class_id,
+                "sampled": len(sample),
+                "population": len(group),
+                # Fill in the count of sampled pages that DO carry the mark.
+                # That count divided by `sampled` is the stratum's label
+                # precision, which is the number the whole layer hangs on.
+                "verdict": "",
+                "notes": "",
+            }
+        )
+    return verdicts
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--task", required=True, choices=("cluster", "distinctive", "letterhead"))
+    ap.add_argument("--corpus", type=Path, default=cfg.OUT)
+    ap.add_argument("--sample-per-author", type=int, default=100)
+    args = ap.parse_args(argv)
+
+    pages = list(read_manifest(args.corpus / "corpus.jsonl"))
+    classes_path = args.corpus / "classes.json"
+    classes = json.loads(classes_path.read_text(encoding="utf-8")) if classes_path.exists() else {}
+
+    out = args.corpus / "audit" / args.task
+    out.mkdir(parents=True, exist_ok=True)
+
+    if args.task == "cluster":
+        verdicts = task_cluster(pages, classes, out)
+    elif args.task == "distinctive":
+        verdicts = task_distinctive(pages, classes, out)
+    else:
+        verdicts = task_letterhead(pages, out, sample_per_author=args.sample_per_author)
+
+    path = out / "verdicts.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for v in verdicts:
+            fh.write(json.dumps(v, sort_keys=True) + "\n")
+
+    print(f"{args.task}: {len(verdicts)} item(s) to review")
+    print(f"  sheets   {out}")
+    print(f"  verdicts {path}  (fill in the 'verdict' field, then run audit_to_corrections.py)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/docmarks/sources/__init__.py
+++ b/scripts/experiments/docmarks/sources/__init__.py
@@ -1,0 +1,10 @@
+"""Per-source adapters for the DocMarks corpus.
+
+Each module exposes the same two-part shape:
+
+* ``fetch(raw_root) -> Path`` — network and filesystem; not unit tested.
+* pure parsers over what ``fetch`` left on disk — unit tested against fixtures.
+
+That split is what lets the builder be developed and verified somewhere that
+cannot reach Kaggle or hold a 3 GB archive, and run unchanged on the cluster.
+"""

--- a/scripts/experiments/docmarks/sources/_common.py
+++ b/scripts/experiments/docmarks/sources/_common.py
@@ -1,0 +1,310 @@
+"""Shared record types and pure helpers for the DocMarks source adapters.
+
+Every adapter splits the same way:
+
+* ``fetch_*`` touches the network and the filesystem.  Not unit-tested; it is
+  exercised for real on the GRID and guarded by ``--probe``.
+* everything else is a pure function of bytes already on disk, and *is* unit
+  tested against small fixtures.
+
+That split is the reason the corpus builder can be developed and verified in an
+environment that cannot reach Kaggle or hold a 3 GB archive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import zipfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+# --------------------------------------------------------------------------
+# Records
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Mark:
+    """One ground-truth mark on one page.
+
+    ``class_id`` is ``None`` until the identity-clustering pass runs: SPODS and
+    StaVer ship *where* a mark is without shipping *which* mark it is.
+    """
+
+    kind: str  # "logo" | "stamp" | "signature" | "text" | "icon"
+    box: tuple[int, int, int, int]  # x, y, w, h in page pixels
+    class_id: Optional[str] = None
+    #: "gt" (shipped by the source), "clustered" (derived, needs audit),
+    #: "weak" (metadata-implied, unverified) or "synthetic" (true by construction).
+    provenance: str = "gt"
+
+    def area(self) -> int:
+        return self.box[2] * self.box[3]
+
+    def longest_side(self) -> int:
+        return max(self.box[2], self.box[3])
+
+
+@dataclass
+class Page:
+    """One page image plus everything known about it."""
+
+    page_id: str  # globally unique, "<source>/<local id>"
+    source: str  # spods | staver | tobacco800 | ucsf | synth
+    path: str  # relative to the corpus root
+    width: int
+    height: int
+    marks: list[Mark] = field(default_factory=list)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["marks"] = [{**asdict(m), "box": list(m.box)} for m in self.marks]
+        return d
+
+    @staticmethod
+    def from_json(d: dict[str, Any]) -> "Page":
+        marks = [
+            Mark(
+                kind=m["kind"],
+                box=tuple(m["box"]),  # type: ignore[arg-type]
+                class_id=m.get("class_id"),
+                provenance=m.get("provenance", "gt"),
+            )
+            for m in d.get("marks", [])
+        ]
+        return Page(
+            page_id=d["page_id"],
+            source=d["source"],
+            path=d["path"],
+            width=d["width"],
+            height=d["height"],
+            marks=marks,
+            meta=d.get("meta", {}),
+        )
+
+
+def write_manifest(pages: Iterable[Page], path: Path) -> int:
+    """Write ``corpus.jsonl``.  Returns the number of records written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    n = 0
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for page in pages:
+            fh.write(json.dumps(page.to_json(), sort_keys=True) + "\n")
+            n += 1
+    tmp.replace(path)
+    return n
+
+
+def read_manifest(path: Path) -> Iterator[Page]:
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield Page.from_json(json.loads(line))
+
+
+# --------------------------------------------------------------------------
+# Deterministic sampling
+# --------------------------------------------------------------------------
+
+
+def stable_rank(key: str, salt: str) -> float:
+    """A stable pseudo-random rank in ``[0, 1)`` for *key*.
+
+    Used to pick which distractors land in which tier.  It must be a pure
+    function of the id, never of iteration order or of how many pages happened
+    to be fetched — otherwise a tier reshuffles every time the corpus grows, and
+    two studies that both say "tier s" are not comparable.
+    """
+    h = hashlib.sha256(f"{salt}\x00{key}".encode()).digest()
+    return int.from_bytes(h[:8], "big") / float(1 << 64)
+
+
+# --------------------------------------------------------------------------
+# Masks -> boxes
+# --------------------------------------------------------------------------
+
+
+def mask_to_boxes(mask: Any, min_area_frac: float = 0.0002) -> list[tuple[int, int, int, int]]:
+    """Connected components of a binary *mask* as ``(x, y, w, h)`` boxes.
+
+    SPODS and StaVer both ship per-category pixel masks rather than boxes, so
+    this is the first step for either.  Components below *min_area_frac* of the
+    page are dropped as scanning speckle.
+
+    *mask* is a 2-D numpy array; anything non-zero is foreground.
+    """
+    import numpy as np
+
+    arr = np.asarray(mask)
+    if arr.ndim == 3:  # RGB(A) mask -> any channel lit
+        arr = arr[..., :3].max(axis=2)
+    binary = (arr > 0).astype("uint8")
+    if not binary.any():
+        return []
+
+    page_area = float(binary.shape[0] * binary.shape[1])
+    min_area = max(1.0, min_area_frac * page_area)
+
+    boxes: list[tuple[int, int, int, int]] = []
+    try:
+        import cv2
+
+        n, _labels, stats, _centroids = cv2.connectedComponentsWithStats(binary, connectivity=8)
+        for i in range(1, n):  # 0 is background
+            x, y, w, h, area = (int(v) for v in stats[i])
+            if area >= min_area:
+                boxes.append((x, y, w, h))
+    except ImportError:
+        from scipy import ndimage  # type: ignore[import-untyped]
+
+        labels, n = ndimage.label(binary)
+        for i, sl in enumerate(ndimage.find_objects(labels), start=1):
+            if sl is None:
+                continue
+            ys, xs = sl
+            area = int((labels[sl] == i).sum())
+            if area >= min_area:
+                boxes.append((int(xs.start), int(ys.start), int(xs.stop - xs.start), int(ys.stop - ys.start)))
+
+    boxes.sort(key=lambda b: (b[1], b[0]))
+    return boxes
+
+
+def merge_overlapping(boxes: list[tuple[int, int, int, int]], gap: int = 6) -> list[tuple[int, int, int, int]]:
+    """Merge boxes that touch or nearly touch, within *gap* pixels.
+
+    A rubber stamp's mask usually breaks into a dozen components — the ring, the
+    text inside it, a broken arc where the ink did not take.  Left unmerged,
+    every fragment becomes its own "mark" and the class inventory is nonsense.
+    """
+    remaining = list(boxes)
+    out: list[tuple[int, int, int, int]] = []
+    while remaining:
+        x, y, w, h = remaining.pop()
+        changed = True
+        while changed:
+            changed = False
+            for other in list(remaining):
+                ox, oy, ow, oh = other
+                if x - gap < ox + ow and ox - gap < x + w and y - gap < oy + oh and oy - gap < y + h:
+                    nx, ny = min(x, ox), min(y, oy)
+                    x, y, w, h = nx, ny, max(x + w, ox + ow) - nx, max(y + h, oy + oh) - ny
+                    remaining.remove(other)
+                    changed = True
+        out.append((x, y, w, h))
+    out.sort(key=lambda b: (b[1], b[0]))
+    return out
+
+
+# --------------------------------------------------------------------------
+# Fetch helpers
+# --------------------------------------------------------------------------
+
+
+class FetchError(RuntimeError):
+    """A source could not be fetched, with an actionable reason."""
+
+
+def kaggle_download(slug: str, dest: Path, *, unzip: bool = True) -> Path:
+    """Download a Kaggle dataset *slug* (``owner/name``) into *dest*.
+
+    Uses the Kaggle CLI, which reads ``~/.kaggle/kaggle.json`` or the
+    ``KAGGLE_USERNAME`` / ``KAGGLE_KEY`` environment pair.  Raises
+    :class:`FetchError` with the setup instruction when no credential is
+    present, rather than failing halfway through a grid job with a 403.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    if any(dest.iterdir()):
+        return dest
+
+    has_env = bool(os.environ.get("KAGGLE_USERNAME") and os.environ.get("KAGGLE_KEY"))
+    has_file = (Path.home() / ".kaggle" / "kaggle.json").exists()
+    if not (has_env or has_file):
+        raise FetchError(
+            f"Kaggle credentials not found, needed for '{slug}'. "
+            "Put a token at ~/.kaggle/kaggle.json (Kaggle > Settings > Create New Token), "
+            "or export KAGGLE_USERNAME and KAGGLE_KEY."
+        )
+
+    cmd = ["kaggle", "datasets", "download", "-d", slug, "-p", str(dest)]
+    if unzip:
+        cmd.append("--unzip")
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)  # noqa: S603
+    except FileNotFoundError as exc:
+        raise FetchError("The 'kaggle' CLI is not installed (pip install kaggle).") from exc
+    except subprocess.CalledProcessError as exc:
+        raise FetchError(f"kaggle download of '{slug}' failed: {exc.stderr.strip()[:400]}") from exc
+    return dest
+
+
+def http_download(url: str, dest: Path, *, chunk: int = 1 << 20) -> Path:
+    """Stream *url* to *dest*, resuming a partial file and writing atomically."""
+    import requests
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest
+
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    have = tmp.stat().st_size if tmp.exists() else 0
+    headers = {"Range": f"bytes={have}-"} if have else {}
+    with requests.get(url, headers=headers, stream=True, timeout=(20, 120)) as resp:
+        if resp.status_code not in (200, 206):
+            raise FetchError(f"{url} returned HTTP {resp.status_code}")
+        mode = "ab" if have and resp.status_code == 206 else "wb"
+        with tmp.open(mode) as fh:
+            for block in resp.iter_content(chunk_size=chunk):
+                fh.write(block)
+    tmp.replace(dest)
+    return dest
+
+
+def extract_rar(archive: Path, dest: Path) -> Path:
+    """Unpack a RAR archive, trying the tools most likely to exist on a cluster.
+
+    SPODS ships as RAR4, which Python cannot read from the standard library.
+    ``bsdtar`` (libarchive) handles it and is far more commonly installed on a
+    compute node than ``unrar`` is.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    if any(dest.iterdir()):
+        return dest
+
+    for cmd in (
+        ["bsdtar", "-x", "-f", str(archive), "-C", str(dest)],
+        ["7z", "x", f"-o{dest}", "-y", str(archive)],
+        ["unar", "-o", str(dest), str(archive)],
+        ["unrar", "x", "-y", str(archive), str(dest) + "/"],
+    ):
+        try:
+            subprocess.run(cmd, check=True, capture_output=True, text=True)  # noqa: S603
+            return dest
+        except FileNotFoundError:
+            continue
+        except subprocess.CalledProcessError as exc:
+            raise FetchError(f"{cmd[0]} failed on {archive.name}: {exc.stderr.strip()[:300]}") from exc
+    raise FetchError(
+        f"No RAR extractor found for {archive.name}. Install one of: bsdtar (libarchive), 7z (p7zip), unar, unrar."
+    )
+
+
+def extract_zip(archive: Path, dest: Path) -> Path:
+    dest.mkdir(parents=True, exist_ok=True)
+    if any(dest.iterdir()):
+        return dest
+    with zipfile.ZipFile(archive) as zf:
+        for member in zf.infolist():
+            # Reject absolute paths and traversal before writing anything.
+            name = Path(member.filename)
+            if name.is_absolute() or ".." in name.parts:
+                raise FetchError(f"unsafe path in {archive.name}: {member.filename}")
+        zf.extractall(dest)  # noqa: S202 - paths validated above
+    return dest

--- a/scripts/experiments/docmarks/sources/artwork.py
+++ b/scripts/experiments/docmarks/sources/artwork.py
@@ -1,0 +1,142 @@
+"""Artwork pools for the synthetic stratum — the marks that get pasted.
+
+Synthesis needs a supply of *distinct, real* marks.  Two pools are supported:
+
+* **LogoDet-3K** — 3,000 logo categories, 158,652 images, ~200k boxed logo
+  instances, Pascal-VOC XML annotations.  The upstream GitHub is reachable only
+  from China; the Kaggle mirror is the practical route.  Cropping one clean
+  instance per category yields a pool in the thousands, each a genuine logo
+  rather than a synthetic glyph.
+* **a local directory** — any PNGs, ideally with alpha.  This is the escape
+  hatch for pools that need a manual download (the ICDAR 2023 ReST seal set,
+  10,000 real Chinese official seals, is the obvious one: it sits behind an RRC
+  competition registration, so it cannot be fetched unattended).
+
+Whatever the pool, the contract is the same: RGBA images with the mark's ink in
+the colour channels and everything else transparent.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET  # noqa: S405 - local dataset annotations
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from . import _common
+
+KAGGLE_SLUG_LOGODET3K = "lyly99/logodet3k"
+
+_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".bmp"}
+
+
+def fetch_logodet3k(raw_root: Path) -> Path:
+    dest = raw_root / "logodet3k"
+    _common.kaggle_download(KAGGLE_SLUG_LOGODET3K, dest)
+    return dest
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", text.strip().lower()).strip("_")
+
+
+def parse_voc(xml_text: str) -> list[tuple[str, tuple[int, int, int, int]]]:
+    """Pascal-VOC XML -> ``[(class name, (x, y, w, h)), ...]``."""
+    root = ET.fromstring(xml_text)  # noqa: S314 - local dataset annotation file
+    out: list[tuple[str, tuple[int, int, int, int]]] = []
+    for obj in root.iter("object"):
+        name_el = obj.find("name")
+        box_el = obj.find("bndbox")
+        if name_el is None or box_el is None or not name_el.text:
+            continue
+        try:
+            xmin = int(round(float(box_el.findtext("xmin", ""))))
+            ymin = int(round(float(box_el.findtext("ymin", ""))))
+            xmax = int(round(float(box_el.findtext("xmax", ""))))
+            ymax = int(round(float(box_el.findtext("ymax", ""))))
+        except (TypeError, ValueError):
+            continue
+        if xmax <= xmin or ymax <= ymin:
+            continue
+        out.append((name_el.text.strip(), (xmin, ymin, xmax - xmin, ymax - ymin)))
+    return out
+
+
+def iter_logodet_instances(root: Path) -> Iterator[tuple[str, Path, tuple[int, int, int, int]]]:
+    """Yield ``(class name, image path, box)`` for every annotated logo."""
+    for xml_path in sorted(root.rglob("*.xml")):
+        image_path = next(
+            (xml_path.with_suffix(s) for s in (".jpg", ".jpeg", ".png") if xml_path.with_suffix(s).exists()),
+            None,
+        )
+        if image_path is None:
+            continue
+        try:
+            for name, box in parse_voc(xml_path.read_text(encoding="utf-8", errors="replace")):
+                yield name, image_path, box
+        except ET.ParseError:
+            continue
+
+
+def build_pool_from_logodet(
+    root: Path,
+    out_dir: Path,
+    *,
+    max_classes: int = 200,
+    min_side_px: int = 64,
+) -> dict[str, Path]:
+    """Crop one clean instance per LogoDet-3K category into *out_dir*.
+
+    "Clean" means the largest annotated instance of that category, since a big
+    crop degrades gracefully to a small paste and the reverse does not.
+    """
+    from PIL import Image
+
+    best: dict[str, tuple[int, Path, tuple[int, int, int, int]]] = {}
+    for name, image_path, box in iter_logodet_instances(root):
+        area = box[2] * box[3]
+        if min(box[2], box[3]) < min_side_px:
+            continue
+        key = _slug(name)
+        if key and (key not in best or area > best[key][0]):
+            best[key] = (area, image_path, box)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pool: dict[str, Path] = {}
+    for key, (_area, image_path, box) in sorted(best.items())[:max_classes]:
+        dest = out_dir / f"{key}.png"
+        if not dest.exists():
+            with Image.open(image_path) as im:
+                x, y, w, h = box
+                im.convert("RGBA").crop((x, y, x + w, y + h)).save(dest)
+        pool[key] = dest
+    return pool
+
+
+def load_pool_dir(directory: Path, *, limit: Optional[int] = None) -> dict[str, Path]:
+    """Every image in *directory* as a ``{class name: path}`` artwork pool."""
+    files = sorted(p for p in directory.rglob("*") if p.suffix.lower() in _IMAGE_SUFFIXES)
+    if limit is not None:
+        files = files[:limit]
+    return {_slug(p.stem): p for p in files}
+
+
+def to_rgba_mark(image: Any, *, white_threshold: int = 245) -> Any:
+    """Coerce artwork to RGBA with the paper knocked out.
+
+    A LogoDet crop is a photo region with an opaque white-ish background; pasted
+    as-is it lands on the page as a conspicuous white rectangle that any matcher
+    could find from the rectangle alone.  Knocking out near-white pixels leaves
+    the ink, which is what a real mark contributes.
+    """
+    import numpy as np
+
+    rgba = image.convert("RGBA")
+    arr = np.array(rgba)
+    if arr[..., 3].min() < 255:
+        return rgba  # already has real alpha; trust it
+    near_white = (arr[..., :3] >= white_threshold).all(axis=2)
+    arr[..., 3] = np.where(near_white, 0, 255)
+    from PIL import Image as _Image
+
+    return _Image.fromarray(arr, mode="RGBA")

--- a/scripts/experiments/docmarks/sources/spods.py
+++ b/scripts/experiments/docmarks/sources/spods.py
@@ -1,0 +1,141 @@
+"""SPODS — 1,088 scanned pseudo-official document pages with per-category masks.
+
+Nandedkar, Mukhopadhyay & Sural, ICVGIP 2016.  The authors authored realistic
+official documents, printed them, applied logos/stamps/signatures and scanned
+the result — so the marks are real ink on real paper, but the documents are not
+anyone's real correspondence, which is why they could publish them at all.
+
+**What SPODS actually ships** (confirmed by walking the RAR's headers, since the
+paper does not say):
+
+    SPODS_Dataset/image (1..1088).png                        <- the pages
+    Ground truth (GT1)/logo/image (1..1088).png              <- binary masks
+    Ground truth (GT1)/stamp/image (1..1088).png
+    Ground truth (GT1)/signature/image (1..1088).png
+    Ground truth (GT1)/text/image (1..1088).png
+
+Note what is **not** there: any notion of *which* logo.  The ground truth is
+four binary masks per page, one per category.  A previous VTSearch study
+(2026-07-13) reported "64 logo/stamp classes" for SPODS with class names like
+``logo_14`` — those class identities were derived by that study, not read off
+the dataset, and nothing verified them.  This adapter therefore emits marks with
+``class_id=None`` and leaves identity to :mod:`cluster_marks`, whose output is
+explicitly flagged ``provenance="clustered"`` and routed through a human audit.
+
+Signature and text masks are parsed and recorded but never promoted to query
+classes: a handwritten signature is a different mark every time it is made, so
+it is not an *instance* in the sense structural search means, and the text mask
+is the page body.  Keeping them costs nothing and gives the study a documented
+negative control.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from . import _common
+from ._common import Mark, Page
+
+#: Direct download, no registration.  The dataset's own page still advertises
+#: the ``www.facweb.iitkgp.ernet.in`` host, which has been decommissioned and
+#: 503s; ``facweb.iitkgp.ac.in`` serves the same file.  A previous study
+#: recorded SPODS as "offline" on the strength of the dead hostname.
+SPODS_URL = "https://facweb.iitkgp.ac.in/~jay/spods/spods.rar"
+SPODS_SIZE_BYTES = 2_937_772_915
+
+PAGES_DIR = "SPODS_Dataset"
+GT_DIR = "Ground truth (GT1)"
+
+#: Categories that become query classes, and those kept only as context.
+MARK_CATEGORIES = ("logo", "stamp")
+CONTEXT_CATEGORIES = ("signature", "text")
+
+_IMAGE_RE = re.compile(r"image\s*\((\d+)\)\.png$", re.IGNORECASE)
+
+
+def fetch(raw_root: Path) -> Path:
+    """Download and unpack SPODS.  Returns the directory holding both trees."""
+    archive = raw_root / "spods" / "spods.rar"
+    unpacked = raw_root / "spods" / "unpacked"
+    _common.http_download(SPODS_URL, archive)
+    _common.extract_rar(archive, unpacked)
+    return unpacked
+
+
+def page_number(path: Path) -> Optional[int]:
+    """``image (417).png`` -> ``417``; ``None`` for anything else."""
+    m = _IMAGE_RE.search(path.name)
+    return int(m.group(1)) if m else None
+
+
+def find_tree(unpacked: Path) -> tuple[Path, Path]:
+    """Locate the pages dir and the GT dir under *unpacked*.
+
+    Extractors disagree about whether to create a top-level wrapper directory,
+    so this searches rather than assuming a depth.
+    """
+    pages = next((p for p in unpacked.rglob(PAGES_DIR) if p.is_dir()), None)
+    gt = next((p for p in unpacked.rglob(GT_DIR) if p.is_dir()), None)
+    if pages is None or gt is None:
+        raise _common.FetchError(
+            f"SPODS layout not recognised under {unpacked}: "
+            f"expected '{PAGES_DIR}/' and '{GT_DIR}/' directories "
+            f"(found: {sorted(p.name for p in unpacked.iterdir())[:8]})"
+        )
+    return pages, gt
+
+
+def marks_for_page(gt_dir: Path, page_no: int, *, min_area_frac: float, merge_gap: int = 6) -> list[Mark]:
+    """Every mark on one page, from that page's four category masks.
+
+    Each mask is reduced to connected components, and components within
+    *merge_gap* pixels are merged: a stamp's mask is typically a ring plus the
+    text inside it plus a broken arc where the ink did not take, and treating
+    those as three marks would poison the class inventory.
+    """
+    from PIL import Image
+
+    marks: list[Mark] = []
+    for kind in (*MARK_CATEGORIES, *CONTEXT_CATEGORIES):
+        mask_path = gt_dir / kind / f"image ({page_no}).png"
+        if not mask_path.exists():
+            continue
+        with Image.open(mask_path) as im:
+            boxes = _common.mask_to_boxes(im.convert("L"), min_area_frac=min_area_frac)
+        # Text masks are per-word and must not be merged into one page-sized blob.
+        if kind != "text":
+            boxes = _common.merge_overlapping(boxes, gap=merge_gap)
+        marks.extend(Mark(kind=kind, box=b, class_id=None, provenance="gt") for b in boxes)
+    return marks
+
+
+def build_pages(unpacked: Path, *, min_area_frac: float, limit: int | None = None) -> list[Page]:
+    """Every SPODS page as a :class:`Page`, marks attached, identities unset."""
+    from PIL import Image
+
+    pages_dir, gt_dir = find_tree(unpacked)
+    numbered = sorted(
+        ((n, p) for p in pages_dir.glob("*.png") if (n := page_number(p)) is not None),
+        key=lambda t: t[0],
+    )
+    if limit is not None:
+        numbered = numbered[:limit]
+
+    out: list[Page] = []
+    for page_no, path in numbered:
+        with Image.open(path) as im:
+            width, height = im.size
+        out.append(
+            Page(
+                page_id=f"spods/{page_no:05d}",
+                source="spods",
+                path=str(path),
+                width=width,
+                height=height,
+                marks=marks_for_page(gt_dir, page_no, min_area_frac=min_area_frac),
+                meta={"page_no": page_no},
+            )
+        )
+    return out

--- a/scripts/experiments/docmarks/sources/staver.py
+++ b/scripts/experiments/docmarks/sources/staver.py
@@ -1,0 +1,177 @@
+"""StaVer — scanned dummy bills carrying rubber stamps, with pixel-accurate GT.
+
+Originally published by DFKI (``madm.dfki.de/downloads-ds-staver``); that host
+was unreachable when this adapter was written, so the Kaggle mirror is the
+default route and DFKI is kept as a documented fallback.
+
+The published dataset is **400 document images** with pixel-accurate ground
+truth plus per-file ``info`` text describing how many stamps are present,
+whether they overlap printed text, whether a signature is present, and whether
+the stamp is black or coloured.  A previous VTSearch study used 259 pages and 36
+multi-instance classes, i.e. a filtered subset; this adapter takes the whole
+published set and lets ``build_corpus.py`` do the filtering, so the threshold is
+a visible parameter rather than a number baked into a corpus.
+
+Like SPODS, StaVer ships *where* the stamps are, not *which* stamp each one is.
+Identity comes from :mod:`cluster_marks` and is flagged ``clustered``.
+
+The ``info`` files are worth parsing for one reason beyond metadata: the
+recorded stamp count is an independent check on the mask decomposition.  If the
+connected-component pass yields four marks on a page the dataset says has one
+stamp, the merge gap is wrong — and that is a bug that would otherwise show up
+only as a mysteriously bad class inventory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+from . import _common
+from ._common import Mark, Page
+
+KAGGLE_SLUG = "rtatman/stamp-verification-staver-dataset"
+DFKI_PAGE = "https://madm.dfki.de/downloads-ds-staver"
+
+#: Directory names the mirror is known to use, lowercased for matching.
+_SCAN_DIR_HINTS = ("scans", "images", "documents", "scan")
+_MASK_DIR_HINTS = ("ground-truth-pixel", "ground_truth_pixel", "groundtruth", "ground-truth")
+_INFO_DIR_HINTS = ("info", "infos")
+
+_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp"}
+
+
+def fetch(raw_root: Path) -> Path:
+    """Download StaVer from Kaggle.  Returns the unpacked directory."""
+    dest = raw_root / "staver"
+    _common.kaggle_download(KAGGLE_SLUG, dest)
+    return dest
+
+
+def _find_dir(root: Path, hints: tuple[str, ...]) -> Optional[Path]:
+    """First directory under *root* whose name matches one of *hints*.
+
+    Mirrors reshuffle nesting depth, so this searches rather than assuming.
+    """
+    for path in sorted(root.rglob("*")):
+        if path.is_dir() and path.name.lower().replace(" ", "-") in hints:
+            return path
+    return None
+
+
+def find_tree(unpacked: Path) -> tuple[Path, Path, Optional[Path]]:
+    """Locate ``(scans, masks, info)``.  *info* is optional; the others are not."""
+    masks = _find_dir(unpacked, _MASK_DIR_HINTS)
+    scans = _find_dir(unpacked, _SCAN_DIR_HINTS)
+    info = _find_dir(unpacked, _INFO_DIR_HINTS)
+
+    # Some mirrors drop the scans at the archive root beside the GT directory.
+    if scans is None and masks is not None:
+        siblings = [p for p in masks.parent.iterdir() if p.is_dir() and p != masks and p != info]
+        scans = siblings[0] if len(siblings) == 1 else None
+
+    if scans is None or masks is None:
+        found = sorted({p.name for p in unpacked.rglob("*") if p.is_dir()})[:12]
+        raise _common.FetchError(
+            f"StaVer layout not recognised under {unpacked}: need a scans dir and a "
+            f"ground-truth-pixel dir (found dirs: {found}). "
+            f"If the Kaggle mirror changed, the original is at {DFKI_PAGE}."
+        )
+    return scans, masks, info
+
+
+def parse_info(text: str) -> dict[str, Any]:
+    """Parse one StaVer ``info`` file into a dict.
+
+    The files are loose ``key: value`` lines with inconsistent casing and
+    spacing between releases, so this normalises keys and pulls out the one
+    field used as a check (``stamps``) as an int when it looks like one.
+    """
+    out: dict[str, Any] = {}
+    for line in text.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = re.sub(r"[^a-z0-9]+", "_", key.strip().lower()).strip("_")
+        value = value.strip()
+        if not key:
+            continue
+        if re.fullmatch(r"\d+", value):
+            out[key] = int(value)
+        elif value.lower() in ("yes", "true"):
+            out[key] = True
+        elif value.lower() in ("no", "false"):
+            out[key] = False
+        else:
+            out[key] = value
+    return out
+
+
+def expected_stamp_count(info: dict[str, Any]) -> Optional[int]:
+    """The stamp count StaVer records for a page, if it records one."""
+    for key in ("number_of_stamps", "stamps", "num_stamps", "no_of_stamps", "stamp_count"):
+        value = info.get(key)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def build_pages(
+    unpacked: Path,
+    *,
+    min_area_frac: float,
+    merge_gap: int = 10,
+    limit: int | None = None,
+) -> tuple[list[Page], list[str]]:
+    """Every StaVer page as a :class:`Page`.
+
+    Returns ``(pages, warnings)``; *warnings* names pages where the number of
+    merged components disagrees with the count the dataset records, which is the
+    signal that the merge gap needs tuning rather than that the data is wrong.
+    """
+    from PIL import Image
+
+    scans_dir, masks_dir, info_dir = find_tree(unpacked)
+    masks_by_stem = {p.stem.lower(): p for p in masks_dir.rglob("*") if p.suffix.lower() in _IMAGE_SUFFIXES}
+    info_by_stem = {p.stem.lower(): p for p in (info_dir.rglob("*") if info_dir else []) if p.is_file()}
+
+    scans = sorted(p for p in scans_dir.rglob("*") if p.suffix.lower() in _IMAGE_SUFFIXES)
+    if limit is not None:
+        scans = scans[:limit]
+
+    pages: list[Page] = []
+    warnings: list[str] = []
+    for scan in scans:
+        stem = scan.stem.lower()
+        mask_path = masks_by_stem.get(stem)
+        if mask_path is None:
+            warnings.append(f"staver/{stem}: no ground-truth mask")
+            continue
+
+        with Image.open(scan) as im:
+            width, height = im.size
+        with Image.open(mask_path) as im:
+            boxes = _common.mask_to_boxes(im.convert("L"), min_area_frac=min_area_frac)
+        boxes = _common.merge_overlapping(boxes, gap=merge_gap)
+
+        meta: dict[str, Any] = {}
+        info_path = info_by_stem.get(stem)
+        if info_path is not None:
+            meta = parse_info(info_path.read_text(encoding="utf-8", errors="replace"))
+            expected = expected_stamp_count(meta)
+            if expected is not None and expected != len(boxes):
+                warnings.append(f"staver/{stem}: info says {expected} stamp(s), mask decomposed to {len(boxes)}")
+
+        pages.append(
+            Page(
+                page_id=f"staver/{stem}",
+                source="staver",
+                path=str(scan),
+                width=width,
+                height=height,
+                marks=[Mark(kind="stamp", box=b, class_id=None, provenance="gt") for b in boxes],
+                meta=meta,
+            )
+        )
+    return pages, warnings

--- a/scripts/experiments/docmarks/sources/tobacco800.py
+++ b/scripts/experiments/docmarks/sources/tobacco800.py
@@ -1,0 +1,180 @@
+"""Tobacco800 — 1,290 real scanned business documents with logo and signature GT.
+
+A public subset of the IIT-CDIP tobacco-litigation collection, ground-truthed by
+the University of Maryland's Language and Media Processing lab in GEDI XML.  Of
+the 1,290 pages, 412 carry a logo.  The published logo-matching protocol keeps
+the 21 logo categories with **two or more** occurrences, which is a fine bar for
+a matching paper and a useless one for a train-and-search eval: at two
+instances, using one as the query leaves exactly one thing to retrieve.
+``build_corpus.py`` applies its own ``--min-instances`` and prints the survival
+curve so the bar is chosen from the data.
+
+Two things to know about the ground truth:
+
+* The v2.0 XML carries **the true identity of each signature instance**, which
+  is what makes Tobacco800 a signature-authorship benchmark.  It is much less
+  clear that logo zones carry an identity attribute — the literature describes
+  the 21 logo categories as something researchers derived.  This adapter
+  therefore reads any identity-looking attribute it finds and falls back to
+  clustering when there is none, rather than assuming either way.
+* Tobacco800 is drawn from IIT-CDIP, the same archive behind RVL-CDIP and UCSF's
+  Tobacco industry.  Any of those used as a "distractor" pool is certain to
+  contain more instances of these same letterheads.  ``docmarks_config`` encodes
+  that as a contamination rule; do not work around it.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET  # noqa: S405 - local trusted GT files, see parse_gedi
+from pathlib import Path
+from typing import Any, Optional
+
+from . import _common
+from ._common import Mark, Page
+
+#: The official TC-11 host (``tc11.cvc.uab.es/datasets/Tobacco800_1``) did not
+#: resolve when this was written; the Kaggle mirror bundles images and GT.
+KAGGLE_SLUG = "kaiquanmah/tobacco800-with-ground-truth"
+TC11_PAGE = "https://tc11.cvc.uab.es/datasets/Tobacco800_1"
+
+#: GEDI zone types that are marks we care about.
+_ZONE_KINDS = {
+    "dllogo": "logo",
+    "dlsignature": "signature",
+}
+
+#: Attributes that have carried an instance identity in some GEDI releases,
+#: most-specific first.  ``id`` is deliberately absent: it is a per-zone serial
+#: number, not an identity, and treating it as one would give every mark its own
+#: singleton class.
+_IDENTITY_ATTRS = ("logoid", "logo_id", "authorid", "author_id", "name", "label", "companyname")
+
+_IMAGE_SUFFIXES = {".tif", ".tiff", ".png", ".jpg", ".jpeg"}
+
+
+def fetch(raw_root: Path) -> Path:
+    dest = raw_root / "tobacco800"
+    _common.kaggle_download(KAGGLE_SLUG, dest)
+    return dest
+
+
+def _lower_attrs(elem: ET.Element) -> dict[str, str]:
+    return {k.lower(): v for k, v in elem.attrib.items()}
+
+
+def _int_attr(attrs: dict[str, str], *names: str) -> Optional[int]:
+    for n in names:
+        v = attrs.get(n)
+        if v is None:
+            continue
+        try:
+            return int(round(float(v)))
+        except ValueError:
+            continue
+    return None
+
+
+def parse_gedi(xml_text: str) -> dict[str, list[Mark]]:
+    """Parse one GEDI XML file into ``{page image stem: [Mark, ...]}``.
+
+    These are local ground-truth files shipped with the dataset, not remote
+    input, so stdlib XML parsing is appropriate; there is no entity expansion in
+    GEDI and nothing here is fetched at parse time.
+    """
+    root = ET.fromstring(xml_text)  # noqa: S314 - local trusted GT file
+    out: dict[str, list[Mark]] = {}
+
+    for page in root.iter():
+        if not page.tag.lower().endswith("dl_page"):
+            continue
+        pattrs = _lower_attrs(page)
+        src = pattrs.get("src") or pattrs.get("filename") or ""
+        stem = Path(src).stem.lower()
+        if not stem:
+            continue
+        marks = out.setdefault(stem, [])
+
+        for zone in page.iter():
+            if not zone.tag.lower().endswith("dl_zone"):
+                continue
+            zattrs = _lower_attrs(zone)
+            kind = _ZONE_KINDS.get(str(zattrs.get("gedi_type", "")).lower())
+            if kind is None:
+                continue
+            x = _int_attr(zattrs, "col", "x", "left")
+            y = _int_attr(zattrs, "row", "y", "top")
+            w = _int_attr(zattrs, "width", "w")
+            h = _int_attr(zattrs, "height", "h")
+            if None in (x, y, w, h) or w <= 0 or h <= 0:  # type: ignore[operator]
+                continue
+
+            identity = next((zattrs[a] for a in _IDENTITY_ATTRS if zattrs.get(a)), None)
+            class_id = None
+            if identity:
+                slug = re.sub(r"[^a-z0-9]+", "_", identity.strip().lower()).strip("_")
+                if slug:
+                    class_id = f"tobacco800/{kind}_{slug}"
+
+            marks.append(
+                Mark(
+                    kind=kind,
+                    box=(x, y, w, h),  # type: ignore[arg-type]
+                    class_id=class_id,
+                    provenance="gt" if class_id else "gt",
+                )
+            )
+    return out
+
+
+def build_pages(unpacked: Path, *, limit: int | None = None) -> tuple[list[Page], list[str]]:
+    """Every Tobacco800 page as a :class:`Page`.
+
+    Pages with no logo and no signature are kept: they are the dataset's own
+    in-domain negatives, and they are the only distractors guaranteed *not* to
+    be contaminated by the same collection's unlabelled letterheads.
+    """
+    from PIL import Image
+
+    xml_marks: dict[str, list[Mark]] = {}
+    for xml_path in sorted(unpacked.rglob("*.xml")):
+        try:
+            for stem, marks in parse_gedi(xml_path.read_text(encoding="utf-8", errors="replace")).items():
+                xml_marks.setdefault(stem, []).extend(marks)
+        except ET.ParseError:
+            continue
+
+    images = sorted(p for p in unpacked.rglob("*") if p.suffix.lower() in _IMAGE_SUFFIXES)
+    if limit is not None:
+        images = images[:limit]
+
+    warnings: list[str] = []
+    if not xml_marks:
+        warnings.append(f"tobacco800: no GEDI XML parsed under {unpacked} — is this the ground-truth mirror?")
+
+    pages: list[Page] = []
+    matched_stems: set[str] = set()
+    for img in images:
+        stem = img.stem.lower()
+        with Image.open(img) as im:
+            width, height = im.size
+        marks = xml_marks.get(stem, [])
+        if marks:
+            matched_stems.add(stem)
+        meta: dict[str, Any] = {"stem": stem}
+        pages.append(
+            Page(
+                page_id=f"tobacco800/{stem}",
+                source="tobacco800",
+                path=str(img),
+                width=width,
+                height=height,
+                marks=marks,
+                meta=meta,
+            )
+        )
+
+    unmatched = set(xml_marks) - matched_stems
+    if unmatched:
+        warnings.append(f"tobacco800: {len(unmatched)} GT page(s) had no matching image, e.g. {sorted(unmatched)[:3]}")
+    return pages, warnings

--- a/scripts/experiments/docmarks/sources/ucsf.py
+++ b/scripts/experiments/docmarks/sources/ucsf.py
@@ -1,0 +1,273 @@
+"""UCSF Industry Documents Library — the haystack, and weak letterhead classes.
+
+Two jobs, from one open Solr index (no registration, no token):
+
+**Distractors.** Real scanned corporate pages in the millions.  This is what
+makes a retrieval number mean something: StaVer's own 259 pages cannot separate
+a good ranker from a lucky one, and the shipped SPODS/StaVer/Tobacco800 sets
+together are ~2,700 pages.
+
+**Weakly-labelled letterhead classes.** Single-page documents of ``type:letter``
+written by a given company are, in the overwhelming majority, that company's
+letterhead — so the ``author`` field is an instance label for the letterhead
+logo, at a scale no hand annotation reaches.  Measured 2026-08-25 against the
+live index, single-page ``type:letter`` counts per author:
+
+    RJR                          162,197
+    PHILIP MORRIS                 73,320
+    LOR, LORILLARD                21,120
+
+with 1,802,100 single-page tobacco letters in total and 13,216,456 short
+tobacco documents carrying a ``collection``.
+
+**The label is weak and this module never pretends otherwise.**  Marks it emits
+carry ``provenance="weak"`` and no box: the metadata says the page is *from*
+Philip Morris, not *where* on the page the logo is, nor even that a logo was
+printed at all.  Two things must happen before this stratum is quoted:
+
+1. a human spot-check of sampled pages per author, to estimate what fraction
+   really carry the letterhead (``make_audit_slate.py --task letterhead``), and
+2. one hand-drawn query crop per class, since there is no box to crop from.
+
+Prefer ``author`` over ``collection``.  ``collection`` is provenance — whose
+filing cabinet the page sat in — so a letter *in* the Philip Morris collection
+is about as likely to be incoming mail on a law firm's letterhead.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from . import _common
+from ._common import Mark, Page
+
+API_URL = "https://metadata.idl.ucsf.edu/solr/ltdl3/query"
+DOWNLOAD_URL = "https://download.industrydocuments.ucsf.edu"
+
+#: Fields worth carrying into the manifest.  ``documentdate`` earns its place:
+#: a corporate logo is redesigned every decade or so, and a class that silently
+#: spans two designs will look like a method failure rather than what it is.
+FIELDS = "id,collection,collectioncode,author,industry,type,documentdate,pages,title,brand"
+
+#: The endpoint ignores ``rows`` and returns up to this many docs per request.
+PAGE_SIZE = 1000
+
+
+def _slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", text.strip().lower()).strip("_")
+
+
+def build_query(
+    *,
+    industry: Optional[str] = None,
+    author: Optional[str] = None,
+    doc_type: Optional[str] = "letter",
+    max_pages: int = 1,
+) -> str:
+    """Assemble a Solr ``q``.  Multi-word values are quoted."""
+
+    def q(value: str) -> str:
+        return f'"{value}"' if " " in value or "," in value else value
+
+    clauses = [f"pages:[1 TO {max_pages}]" if max_pages > 1 else "pages:1"]
+    if industry:
+        clauses.append(f"industry:{q(industry)}")
+    if author:
+        clauses.append(f"author:{q(author)}")
+    if doc_type:
+        clauses.append(f"type:{q(doc_type)}")
+    return " AND ".join(clauses)
+
+
+def solr_docs(query: str, *, limit: int, session: Any = None, pause_s: float = 0.0) -> Iterator[dict[str, Any]]:
+    """Yield up to *limit* Solr documents for *query*, deep-paged by cursorMark.
+
+    ``start``-based paging breaks down past a few thousand rows on this index;
+    ``cursorMark`` with a deterministic ``sort`` is the supported deep-paging
+    route and is stable across requests, so a resumed job sees the same order.
+    """
+    import requests
+
+    session = session or requests.Session()
+    cursor = "*"
+    seen = 0
+    while seen < limit:
+        params = {
+            "q": query,
+            "rows": str(min(PAGE_SIZE, limit - seen)),
+            "wt": "json",
+            "fl": FIELDS,
+            "sort": "id asc",
+            "cursorMark": cursor,
+        }
+        resp = session.get(API_URL, params=params, timeout=(20, 120))
+        resp.raise_for_status()
+        payload = resp.json()
+        docs = payload.get("response", {}).get("docs", [])
+        if not docs:
+            return
+        for doc in docs:
+            yield doc
+            seen += 1
+            if seen >= limit:
+                return
+        next_cursor = payload.get("nextCursorMark")
+        if not next_cursor or next_cursor == cursor:
+            return
+        cursor = next_cursor
+        if pause_s:
+            time.sleep(pause_s)
+
+
+def count(query: str, session: Any = None) -> int:
+    """``numFound`` for *query* — used to size a pull before making it."""
+    import requests
+
+    session = session or requests.Session()
+    resp = session.get(
+        API_URL,
+        params={"q": query, "rows": "0", "wt": "json"},
+        timeout=(20, 60),
+    )
+    resp.raise_for_status()
+    return int(resp.json()["response"]["numFound"])
+
+
+def pdf_url(doc_id: str) -> str:
+    """UCSF's split-character path scheme: ``ffbb0019`` -> ``f/f/b/b/ffbb0019``."""
+    if len(doc_id) < 4:
+        raise ValueError(f"document id too short for the UCSF URL scheme: {doc_id!r}")
+    a, b, c, d = doc_id[0], doc_id[1], doc_id[2], doc_id[3]
+    return f"{DOWNLOAD_URL}/{a}/{b}/{c}/{d}/{doc_id}/{doc_id}.pdf"
+
+
+def first_value(doc: dict[str, Any], key: str) -> Optional[str]:
+    """Solr multi-valued fields come back as lists; take the first."""
+    value = doc.get(key)
+    if isinstance(value, list):
+        return str(value[0]) if value else None
+    return str(value) if value is not None else None
+
+
+def decade(documentdate: Optional[str]) -> Optional[str]:
+    """``"1996 January 24"`` -> ``"1990s"``.
+
+    Used to optionally split a letterhead class by era.  A 1965 Philip Morris
+    mark and a 1995 one may be different artwork; whether structural search
+    should treat them as one class is a *finding*, not a nuisance, so the corpus
+    records the decade and lets the study decide.
+    """
+    if not documentdate:
+        return None
+    m = re.search(r"\b(1[89]\d{2}|20\d{2})\b", documentdate)
+    if not m:
+        return None
+    return f"{int(m.group(1)) // 10 * 10}s"
+
+
+def doc_to_page(
+    doc: dict[str, Any],
+    image_path: str,
+    width: int,
+    height: int,
+    *,
+    page_index: int = 0,
+    letterhead_author: Optional[str] = None,
+    split_by_decade: bool = False,
+) -> Page:
+    """One rendered page image plus its Solr metadata as a :class:`Page`.
+
+    When *letterhead_author* is given the page gets a boxless ``weak`` mark for
+    that author's letterhead class.  No box is invented: a fabricated box would
+    be indistinguishable downstream from a real one, and the whole point of the
+    ``provenance`` field is that the difference stays visible.
+    """
+    doc_id = str(doc["id"])
+    industry = first_value(doc, "industry")
+    era = decade(first_value(doc, "documentdate"))
+
+    marks: list[Mark] = []
+    if letterhead_author:
+        class_id = f"ucsf/letterhead_{_slug(letterhead_author)}"
+        if split_by_decade and era:
+            class_id = f"{class_id}_{era}"
+        marks.append(Mark(kind="logo", box=(0, 0, 0, 0), class_id=class_id, provenance="weak"))
+
+    return Page(
+        page_id=f"ucsf/{doc_id}#{page_index}",
+        source="ucsf",
+        path=image_path,
+        width=width,
+        height=height,
+        marks=marks,
+        meta={
+            "doc_id": doc_id,
+            "industry": industry,
+            "collection": first_value(doc, "collection"),
+            "author": first_value(doc, "author"),
+            "type": first_value(doc, "type"),
+            "documentdate": first_value(doc, "documentdate"),
+            "decade": era,
+            "title": first_value(doc, "title"),
+        },
+    )
+
+
+def fetch_and_render(
+    docs: list[dict[str, Any]],
+    raw_root: Path,
+    out_images: Path,
+    *,
+    dpi: int = 150,
+    letterhead_author: Optional[str] = None,
+    split_by_decade: bool = False,
+    max_pages_per_doc: int = 1,
+    on_error: Optional[Any] = None,
+) -> list[Page]:
+    """Download each doc's PDF, render its pages to PNG, return :class:`Page`\\ s.
+
+    Failures are skipped rather than fatal: at 200k documents a handful of dead
+    ids or malformed PDFs is expected, and an aborted pull is far more expensive
+    than a slightly short one.  Every skip is reported through *on_error* so the
+    count is visible instead of silent.
+    """
+    from vtscore.datasets.pdf import render_pdf_pages
+
+    pdf_dir = raw_root / "ucsf" / "pdf"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    out_images.mkdir(parents=True, exist_ok=True)
+
+    pages: list[Page] = []
+    for doc in docs:
+        doc_id = str(doc.get("id", ""))
+        if len(doc_id) < 4:
+            continue
+        pdf_path = pdf_dir / f"{doc_id}.pdf"
+        try:
+            _common.http_download(pdf_url(doc_id), pdf_path)
+            rendered = render_pdf_pages(pdf_path, dpi=dpi)
+        except Exception as exc:  # noqa: BLE001 - a dead id must not kill a 200k pull
+            if on_error:
+                on_error(doc_id, exc)
+            pdf_path.unlink(missing_ok=True)
+            continue
+
+        for idx, (_name, image) in enumerate(rendered[:max_pages_per_doc]):
+            image_path = out_images / f"{doc_id}_{idx}.png"
+            if not image_path.exists():
+                image.save(image_path)
+            pages.append(
+                doc_to_page(
+                    doc,
+                    str(image_path),
+                    image.width,
+                    image.height,
+                    page_index=idx,
+                    letterhead_author=letterhead_author,
+                    split_by_decade=split_by_decade,
+                )
+            )
+    return pages

--- a/scripts/experiments/docmarks/synth_compose.py
+++ b/scripts/experiments/docmarks/synth_compose.py
@@ -1,0 +1,246 @@
+"""Layer 3 — paste real mark artwork onto real scanned pages at known geometry.
+
+Why bother, when layers 1 and 2 are real?  Because the real strata cannot be
+*swept*.  The 2026-07-13 study's most actionable findings were all about where a
+threshold sits — the ~32 px floor below which nothing verifies, the inlier floor
+near 24 for SuperPoint+LightGlue, the 2.2x advantage of a canonical-artwork
+query over a crop of an in-scene instance — and a found dataset only samples the
+sizes its own scanner and layout happened to produce.  Here size, rotation,
+count and placement are inputs, so a sweep can locate a cliff instead of
+straddling it.
+
+What it costs: pasted marks are not printed marks.  The prior report already
+flagged this as a limitation of its ``synth`` corpus, and nothing here fixes it
+— the degradation pipeline narrows the gap and does not close it.  So the rule
+that comes with this module is: **synthetic numbers quantify a mechanism, real
+numbers size the effect.**  A finding that appears only in ``synth`` is a
+hypothesis about the pipeline, not a claim about documents.
+
+Backgrounds are held out.  A page used as a synthetic canvas is removed from
+every other stratum by ``build_corpus.py``, so a synthetic class can never be
+scored against a page that also carries a real mark of some other class.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from sources._common import Mark, Page
+
+
+@dataclass(frozen=True)
+class Placement:
+    """Where one mark went, in page pixels.  This *is* the ground truth."""
+
+    class_id: str
+    box: tuple[int, int, int, int]
+    scale_px: int
+    rotation_deg: float
+
+
+def _rand_log_uniform(rng: random.Random, lo: float, hi: float) -> float:
+    return math.exp(rng.uniform(math.log(lo), math.log(hi)))
+
+
+def degrade_mark(mark: Any, rng: random.Random, *, ink_jitter: float = 0.18) -> Any:
+    """Make a clean logo crop look like ink that went through a scanner.
+
+    Three effects, in the order the physical process applies them: the ink is
+    laid down unevenly (alpha jitter + a slight blur at the edge), the paper
+    absorbs it (a small dilation, so thin strokes thicken), and the scanner
+    quantises it (contrast loss).  Each is small; together they are the
+    difference between a mark that SIFT finds trivially and one it has to work
+    for.
+    """
+    import numpy as np
+    from PIL import Image, ImageEnhance, ImageFilter
+
+    rgba = mark.convert("RGBA")
+
+    # Uneven ink coverage: scale alpha by a smooth random field.
+    arr = np.array(rgba).astype(np.float32)
+    h, w = arr.shape[:2]
+    coarse = rng.random()
+    field = np.random.default_rng(int(coarse * 2**32)).random((max(2, h // 16), max(2, w // 16)))
+    field = np.array(Image.fromarray((field * 255).astype("uint8")).resize((w, h), Image.BILINEAR)) / 255.0
+    arr[..., 3] *= 1.0 - ink_jitter * field
+    rgba = Image.fromarray(arr.clip(0, 255).astype("uint8"), mode="RGBA")
+
+    # Ink bleed: widen the alpha slightly, then soften the edge.
+    if rng.random() < 0.7:
+        alpha = rgba.getchannel("A").filter(ImageFilter.MaxFilter(3))
+        rgba.putalpha(alpha)
+    rgba = rgba.filter(ImageFilter.GaussianBlur(rng.uniform(0.2, 0.9)))
+
+    # Scanner contrast loss.
+    return ImageEnhance.Contrast(rgba).enhance(rng.uniform(0.75, 1.0))
+
+
+def paste_mark(
+    page: Any,
+    mark: Any,
+    *,
+    target_px: int,
+    rotation_deg: float,
+    position: tuple[float, float],
+) -> tuple[int, int, int, int]:
+    """Composite *mark* onto *page* in place.  Returns the tight box it occupies.
+
+    The box is computed from the rotated mark's **alpha bounding box**, not from
+    the paste rectangle: a rotated logo's paste rectangle includes transparent
+    corners, and a ground-truth box that is 30% empty would quietly make every
+    query crop worse than it needed to be.
+    """
+    scale = target_px / max(mark.width, mark.height)
+    sized = mark.resize(
+        (max(1, int(round(mark.width * scale))), max(1, int(round(mark.height * scale)))),
+        _resample_bicubic(),
+    )
+    rotated = sized.rotate(rotation_deg, expand=True, resample=_resample_bicubic())
+
+    max_x = max(1, page.width - rotated.width)
+    max_y = max(1, page.height - rotated.height)
+    x = int(round(position[0] * max_x))
+    y = int(round(position[1] * max_y))
+
+    page.alpha_composite(rotated, (x, y))
+
+    bbox = rotated.getchannel("A").point(lambda v: 255 if v > 8 else 0).getbbox()
+    if bbox is None:
+        return (x, y, rotated.width, rotated.height)
+    bx0, by0, bx1, by1 = bbox
+    return (x + bx0, y + by0, bx1 - bx0, by1 - by0)
+
+
+def _resample_bicubic() -> int:
+    from PIL import Image
+
+    return Image.BICUBIC
+
+
+def compose_page(
+    background_path: Path,
+    artwork: Sequence[tuple[str, Any]],
+    out_path: Path,
+    rng: random.Random,
+    *,
+    size_px: tuple[int, int],
+    rotation_deg: tuple[float, float],
+    jpeg_quality: Optional[int] = None,
+) -> list[Placement]:
+    """Compose one synthetic page and write it.  Returns the placements.
+
+    *artwork* is a list of ``(class_id, RGBA image)``.  Marks are placed in
+    non-overlapping quadrant-ish positions so that two pasted marks on one page
+    do not occlude each other, which would make the ground-truth box a lie.
+    """
+    from PIL import Image
+
+    page = Image.open(background_path).convert("RGBA")
+    placements: list[Placement] = []
+
+    slots = [(0.15, 0.10), (0.72, 0.12), (0.18, 0.70), (0.70, 0.74), (0.45, 0.42)]
+    rng.shuffle(slots)
+
+    for i, (class_id, art) in enumerate(artwork):
+        if i >= len(slots):
+            break
+        target = int(round(_rand_log_uniform(rng, size_px[0], size_px[1])))
+        angle = rng.uniform(*rotation_deg)
+        jitter = (slots[i][0] + rng.uniform(-0.06, 0.06), slots[i][1] + rng.uniform(-0.06, 0.06))
+        position = (min(max(jitter[0], 0.0), 1.0), min(max(jitter[1], 0.0), 1.0))
+        box = paste_mark(
+            page,
+            degrade_mark(art, rng),
+            target_px=target,
+            rotation_deg=angle,
+            position=position,
+        )
+        placements.append(Placement(class_id=class_id, box=box, scale_px=target, rotation_deg=angle))
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rgb = page.convert("RGB")
+    if jpeg_quality is not None:
+        rgb.save(out_path, quality=jpeg_quality)
+    else:
+        rgb.save(out_path)
+    return placements
+
+
+def build_synthetic_pages(
+    backgrounds: Sequence[Path],
+    pool: dict[str, Path],
+    out_images: Path,
+    *,
+    instances_per_class: int,
+    size_px: tuple[int, int],
+    rotation_deg: tuple[float, float],
+    seed: int,
+    marks_per_page: int = 1,
+) -> list[Page]:
+    """Generate the whole synthetic stratum.
+
+    Each class gets *instances_per_class* placements spread across distinct
+    background pages.  Backgrounds are consumed round-robin so no single scan
+    carries a disproportionate share of the ground truth — a corpus where one
+    page holds 40 marks would let a matcher "win" by recognising that page.
+    """
+    from PIL import Image
+
+    if not backgrounds:
+        raise ValueError("synthetic composition needs at least one background page")
+    if not pool:
+        raise ValueError("synthetic composition needs a non-empty artwork pool")
+
+    from sources.artwork import to_rgba_mark
+
+    rng = random.Random(seed)
+    art_cache = {name: to_rgba_mark(Image.open(path)) for name, path in sorted(pool.items())}
+
+    jobs: list[tuple[str, Any]] = []
+    for name in sorted(art_cache):
+        jobs.extend((f"synth/{name}", art_cache[name]) for _ in range(instances_per_class))
+    rng.shuffle(jobs)
+
+    pages: list[Page] = []
+    bg_index = 0
+    for start in range(0, len(jobs), marks_per_page):
+        batch = jobs[start : start + marks_per_page]
+        background = backgrounds[bg_index % len(backgrounds)]
+        bg_index += 1
+        page_id = f"synth/{bg_index:06d}"
+        out_path = out_images / f"{bg_index:06d}.png"
+        placements = compose_page(
+            background,
+            batch,
+            out_path,
+            rng,
+            size_px=size_px,
+            rotation_deg=rotation_deg,
+        )
+        with Image.open(out_path) as im:
+            width, height = im.size
+        pages.append(
+            Page(
+                page_id=page_id,
+                source="synth",
+                path=str(out_path),
+                width=width,
+                height=height,
+                marks=[
+                    Mark(kind="logo", box=p.box, class_id=p.class_id, provenance="synthetic") for p in placements
+                ],
+                meta={
+                    "background": str(background),
+                    "placements": [
+                        {"class_id": p.class_id, "scale_px": p.scale_px, "rotation_deg": round(p.rotation_deg, 2)}
+                        for p in placements
+                    ],
+                },
+            )
+        )
+    return pages

--- a/scripts/experiments/docmarks/synth_compose.py
+++ b/scripts/experiments/docmarks/synth_compose.py
@@ -231,9 +231,7 @@ def build_synthetic_pages(
                 path=str(out_path),
                 width=width,
                 height=height,
-                marks=[
-                    Mark(kind="logo", box=p.box, class_id=p.class_id, provenance="synthetic") for p in placements
-                ],
+                marks=[Mark(kind="logo", box=p.box, class_id=p.class_id, provenance="synthetic") for p in placements],
                 meta={
                     "background": str(background),
                     "placements": [

--- a/scripts/experiments/lessons/2026-08-24-review-orphaned-by-resampling.md
+++ b/scripts/experiments/lessons/2026-08-24-review-orphaned-by-resampling.md
@@ -1,4 +1,4 @@
-# A rebuild silently retired the images a human had just reviewed
+# 2026-08-24 — a rebuild silently retired the images a human had just reviewed
 
 **Cost:** ~1 hour of the owner's labelling and a full model triage pass (2,698
 tiles) were inert for a day, and were only recovered because the selection was

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -247,9 +247,7 @@ class TestUcsf:
 
     def test_decade_split_makes_separate_classes(self, mods):
         doc = {"id": "ffbb0019", "documentdate": "1965 May 3"}
-        page = mods["ucsf"].doc_to_page(
-            doc, "/tmp/x.png", 10, 10, letterhead_author="RJR", split_by_decade=True
-        )
+        page = mods["ucsf"].doc_to_page(doc, "/tmp/x.png", 10, 10, letterhead_author="RJR", split_by_decade=True)
         assert page.marks[0].class_id == "ucsf/letterhead_rjr_1960s"
 
     def test_a_page_with_no_author_carries_no_marks(self, mods):
@@ -505,9 +503,7 @@ class TestSynthesis:
         from PIL import Image
 
         page = Image.new("RGBA", (800, 1000), (255, 255, 255, 255))
-        box = mods["synth"].paste_mark(
-            page, self._artwork(), target_px=200, rotation_deg=30.0, position=(0.5, 0.5)
-        )
+        box = mods["synth"].paste_mark(page, self._artwork(), target_px=200, rotation_deg=30.0, position=(0.5, 0.5))
         x, y, w, h = box
         # A 30-degree rotation expands the paste rectangle well beyond the mark.
         # The recorded box must follow the ink, not the rectangle.
@@ -522,9 +518,7 @@ class TestSynthesis:
 
         page = Image.new("RGBA", (600, 800), (255, 255, 255, 255))
         for pos in ((0.0, 0.0), (1.0, 1.0), (0.5, 0.5)):
-            x, y, w, h = mods["synth"].paste_mark(
-                page, self._artwork(), target_px=120, rotation_deg=0.0, position=pos
-            )
+            x, y, w, h = mods["synth"].paste_mark(page, self._artwork(), target_px=120, rotation_deg=0.0, position=pos)
             assert 0 <= x and 0 <= y and x + w <= page.width and y + h <= page.height
 
     def test_build_synthetic_pages_records_exact_ground_truth(self, mods, tmp_path):
@@ -570,8 +564,13 @@ class TestSynthesis:
     def test_empty_pool_is_an_error_not_an_empty_corpus(self, mods, tmp_path):
         with pytest.raises(ValueError, match="artwork pool"):
             mods["synth"].build_synthetic_pages(
-                [tmp_path / "bg.png"], {}, tmp_path, instances_per_class=1, size_px=(64, 128),
-                rotation_deg=(0, 0), seed=1
+                [tmp_path / "bg.png"],
+                {},
+                tmp_path,
+                instances_per_class=1,
+                size_px=(64, 128),
+                rotation_deg=(0, 0),
+                seed=1,
             )
 
 
@@ -660,6 +659,4 @@ class TestEmbedCells:
 
         forward = mods["embed"].load_medias(pages, {}, "siglip")
         reverse = mods["embed"].load_medias(list(reversed(pages)), {}, "siglip")
-        assert {i: m["origin_name"] for i, m in forward.items()} == {
-            i: m["origin_name"] for i, m in reverse.items()
-        }
+        assert {i: m["origin_name"] for i, m in forward.items()} == {i: m["origin_name"] for i, m in reverse.items()}

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -1,0 +1,665 @@
+"""Tests for the DocMarks corpus builder (``scripts/experiments/docmarks/``).
+
+The builder assembles one instance-retrieval corpus out of four document
+sources.  Everything network-touching lives behind ``fetch_*`` and is not
+exercised here; everything that decides *what the corpus means* is pure and is
+pinned below.
+
+Three of these tests guard properties that a plausible-looking refactor would
+quietly break, and whose breakage would not show up as a crash — only as
+numbers that are wrong in a direction nobody notices:
+
+* **tier nesting** — a study on ``docmarks_s`` and one on ``docmarks_l`` are
+  only comparable if the small tier is a subset of the large one.  Sampling
+  distractors with anything order-dependent silently breaks that.
+* **contamination** — Tobacco800 and UCSF's Tobacco industry are the same
+  underlying archive, so scoring Tobacco800 classes against UCSF tobacco pages
+  counts correct retrievals as false positives.
+* **synthetic box tightness** — a rotated paste's ground-truth box must come
+  from the alpha bbox, not the paste rectangle, or every query crop carries a
+  third of a page of blank paper.
+
+The scripts are loose modules, not package members, so the directory goes on
+``sys.path`` and they are imported by name.
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_DOCMARKS = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "docmarks"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _on_path():
+    sys.path.insert(0, str(_DOCMARKS))
+    yield
+    with pytest.MonkeyPatch.context():
+        pass
+    if str(_DOCMARKS) in sys.path:
+        sys.path.remove(str(_DOCMARKS))
+
+
+@pytest.fixture(scope="module")
+def mods(_on_path):
+    return {
+        "cfg": importlib.import_module("docmarks_config"),
+        "common": importlib.import_module("sources._common"),
+        "spods": importlib.import_module("sources.spods"),
+        "staver": importlib.import_module("sources.staver"),
+        "tobacco800": importlib.import_module("sources.tobacco800"),
+        "ucsf": importlib.import_module("sources.ucsf"),
+        "artwork": importlib.import_module("sources.artwork"),
+        "cluster": importlib.import_module("cluster_marks"),
+        "build": importlib.import_module("build_corpus"),
+        "synth": importlib.import_module("synth_compose"),
+        "embed": importlib.import_module("embed_corpus"),
+    }
+
+
+def _page(mods, page_id, source, marks=(), path="x.png", w=1000, h=1400):
+    Mark, Page = mods["common"].Mark, mods["common"].Page
+    return Page(
+        page_id=page_id,
+        source=source,
+        path=path,
+        width=w,
+        height=h,
+        marks=[Mark(kind=k, box=b, class_id=c, provenance=p) for k, b, c, p in marks],
+    )
+
+
+# ---------------------------------------------------------------- primitives
+
+
+class TestStableRank:
+    def test_is_deterministic_and_in_range(self, mods):
+        rank = mods["common"].stable_rank
+        values = [rank(f"page/{i}", "salt") for i in range(200)]
+        assert all(0.0 <= v < 1.0 for v in values)
+        assert values == [rank(f"page/{i}", "salt") for i in range(200)]
+
+    def test_salt_changes_the_ordering(self, mods):
+        rank = mods["common"].stable_rank
+        keys = [f"page/{i}" for i in range(50)]
+        assert sorted(keys, key=lambda k: rank(k, "a")) != sorted(keys, key=lambda k: rank(k, "b"))
+
+
+class TestMaskToBoxes:
+    def test_finds_separated_components(self, mods):
+        mask = np.zeros((200, 200), dtype=np.uint8)
+        mask[10:40, 10:50] = 255
+        mask[120:160, 130:170] = 255
+        boxes = mods["common"].mask_to_boxes(mask, min_area_frac=0.0)
+        assert len(boxes) == 2
+        assert (10, 10, 40, 30) in boxes
+
+    def test_drops_speckle_below_the_area_floor(self, mods):
+        mask = np.zeros((200, 200), dtype=np.uint8)
+        mask[10:40, 10:50] = 255
+        mask[100, 100] = 255  # one pixel
+        boxes = mods["common"].mask_to_boxes(mask, min_area_frac=0.001)
+        assert len(boxes) == 1
+
+    def test_empty_mask_is_no_boxes(self, mods):
+        assert mods["common"].mask_to_boxes(np.zeros((50, 50), dtype=np.uint8)) == []
+
+
+class TestMergeOverlapping:
+    def test_merges_a_fragmented_stamp_into_one_mark(self, mods):
+        # A rubber stamp's mask breaks into a ring plus its inner text; left
+        # unmerged each fragment becomes its own "class" and the inventory is
+        # nonsense.
+        fragments = [(10, 10, 30, 5), (10, 16, 30, 5), (10, 22, 30, 5)]
+        merged = mods["common"].merge_overlapping(fragments, gap=6)
+        assert merged == [(10, 10, 30, 17)]
+
+    def test_leaves_distant_marks_alone(self, mods):
+        boxes = [(10, 10, 20, 20), (500, 500, 20, 20)]
+        assert len(mods["common"].merge_overlapping(boxes, gap=6)) == 2
+
+
+# ------------------------------------------------------------------- sources
+
+
+class TestSpods:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [("image (417).png", 417), ("image (1).png", 1), ("IMAGE (23).PNG", 23), ("notes.txt", None)],
+    )
+    def test_page_number(self, mods, name, expected):
+        assert mods["spods"].page_number(Path(name)) == expected
+
+    def test_marks_for_page_reads_every_category(self, mods, tmp_path):
+        from PIL import Image
+
+        gt = tmp_path / "gt"
+        for kind, box in (("logo", (20, 20, 60, 40)), ("stamp", (200, 300, 80, 80))):
+            arr = np.zeros((600, 500), dtype=np.uint8)
+            x, y, w, h = box
+            arr[y : y + h, x : x + w] = 255
+            (gt / kind).mkdir(parents=True)
+            Image.fromarray(arr).save(gt / kind / "image (7).png")
+
+        marks = mods["spods"].marks_for_page(gt, 7, min_area_frac=0.0)
+        by_kind = {m.kind: m.box for m in marks}
+        assert by_kind == {"logo": (20, 20, 60, 40), "stamp": (200, 300, 80, 80)}
+        # Identity is never invented at parse time: SPODS does not ship it.
+        assert all(m.class_id is None for m in marks)
+        assert all(m.provenance == "gt" for m in marks)
+
+    def test_find_tree_reports_an_unrecognised_layout(self, mods, tmp_path):
+        (tmp_path / "something-else").mkdir()
+        with pytest.raises(mods["common"].FetchError, match="layout not recognised"):
+            mods["spods"].find_tree(tmp_path)
+
+
+class TestStaver:
+    def test_parse_info_normalises_keys_and_types(self, mods):
+        parsed = mods["staver"].parse_info(
+            "Number of stamps: 2\nSignature present : yes\nStamp Color: colored\nOverlap: no\n"
+        )
+        assert parsed["number_of_stamps"] == 2
+        assert parsed["signature_present"] is True
+        assert parsed["overlap"] is False
+        assert parsed["stamp_color"] == "colored"
+
+    def test_expected_stamp_count_accepts_the_known_spellings(self, mods):
+        for key in ("number_of_stamps", "stamps", "num_stamps"):
+            assert mods["staver"].expected_stamp_count({key: 3}) == 3
+        assert mods["staver"].expected_stamp_count({"stamp_color": "black"}) is None
+
+
+class TestTobacco800:
+    GEDI = """<?xml version="1.0"?>
+    <GEDI>
+      <DL_DOCUMENT src="xyz.tif">
+        <DL_PAGE gedi_type="DL_PAGE" src="xyz00001.tif" width="2544" height="3295">
+          <DL_ZONE gedi_type="DLLogo" id="1" col="220" row="140" width="600" height="180"/>
+          <DL_ZONE gedi_type="DLSignature" id="2" col="300" row="2400"
+                   width="500" height="200" AuthorID="Horrigan"/>
+          <DL_ZONE gedi_type="DLText" id="3" col="0" row="0" width="10" height="10"/>
+        </DL_PAGE>
+      </DL_DOCUMENT>
+    </GEDI>"""
+
+    def test_parses_logo_and_signature_zones_only(self, mods):
+        parsed = mods["tobacco800"].parse_gedi(self.GEDI)
+        marks = parsed["xyz00001"]
+        assert {m.kind for m in marks} == {"logo", "signature"}
+
+    def test_logo_box_uses_col_row_width_height(self, mods):
+        logo = next(m for m in mods["tobacco800"].parse_gedi(self.GEDI)["xyz00001"] if m.kind == "logo")
+        assert logo.box == (220, 140, 600, 180)
+
+    def test_signature_identity_becomes_a_class_id(self, mods):
+        sig = next(m for m in mods["tobacco800"].parse_gedi(self.GEDI)["xyz00001"] if m.kind == "signature")
+        assert sig.class_id == "tobacco800/signature_horrigan"
+
+    def test_a_bare_serial_id_is_not_treated_as_an_identity(self, mods):
+        # `id` is a per-zone serial. Reading it as an identity would give every
+        # single mark its own singleton class, and the corpus would look full of
+        # classes while containing none.
+        logo = next(m for m in mods["tobacco800"].parse_gedi(self.GEDI)["xyz00001"] if m.kind == "logo")
+        assert logo.class_id is None
+
+
+class TestUcsf:
+    def test_build_query_quotes_multiword_values(self, mods):
+        q = mods["ucsf"].build_query(industry="Fossil Fuel", author="LOR, LORILLARD")
+        assert 'industry:"Fossil Fuel"' in q
+        assert 'author:"LOR, LORILLARD"' in q
+        assert "pages:1" in q
+
+    def test_pdf_url_uses_the_split_character_scheme(self, mods):
+        assert mods["ucsf"].pdf_url("ffbb0019").endswith("/f/f/b/b/ffbb0019/ffbb0019.pdf")
+
+    def test_pdf_url_rejects_a_short_id(self, mods):
+        with pytest.raises(ValueError, match="too short"):
+            mods["ucsf"].pdf_url("ab")
+
+    @pytest.mark.parametrize(
+        "date,expected",
+        [("1996 January 24", "1990s"), ("1965", "1960s"), ("2003 December 04", "2000s"), ("", None), (None, None)],
+    )
+    def test_decade(self, mods, date, expected):
+        assert mods["ucsf"].decade(date) == expected
+
+    def test_first_value_unwraps_solr_multivalued_fields(self, mods):
+        assert mods["ucsf"].first_value({"collection": ["Lorillard Records", "MSA"]}, "collection") == (
+            "Lorillard Records"
+        )
+
+    def test_letterhead_mark_is_weak_and_boxless(self, mods):
+        doc = {"id": "ffbb0019", "author": ["PHILIP MORRIS"], "documentdate": "1996 January 24"}
+        page = mods["ucsf"].doc_to_page(doc, "/tmp/x.png", 1700, 2200, letterhead_author="PHILIP MORRIS")
+        (mark,) = page.marks
+        assert mark.class_id == "ucsf/letterhead_philip_morris"
+        # No box is invented. The metadata says the page is *from* Philip Morris,
+        # not where on it the logo sits, and a fabricated box would be
+        # indistinguishable downstream from a real one.
+        assert mark.box == (0, 0, 0, 0)
+        assert mark.provenance == "weak"
+
+    def test_decade_split_makes_separate_classes(self, mods):
+        doc = {"id": "ffbb0019", "documentdate": "1965 May 3"}
+        page = mods["ucsf"].doc_to_page(
+            doc, "/tmp/x.png", 10, 10, letterhead_author="RJR", split_by_decade=True
+        )
+        assert page.marks[0].class_id == "ucsf/letterhead_rjr_1960s"
+
+    def test_a_page_with_no_author_carries_no_marks(self, mods):
+        page = mods["ucsf"].doc_to_page({"id": "ffbb0019"}, "/tmp/x.png", 10, 10)
+        assert page.marks == []
+
+
+class TestArtworkVoc:
+    def test_parses_pascal_voc_boxes(self, mods):
+        xml = """<annotation><object><name>Nike</name>
+                 <bndbox><xmin>10</xmin><ymin>20</ymin><xmax>110</xmax><ymax>70</ymax></bndbox>
+                 </object></annotation>"""
+        assert mods["artwork"].parse_voc(xml) == [("Nike", (10, 20, 100, 50))]
+
+    def test_skips_degenerate_boxes(self, mods):
+        xml = """<annotation><object><name>X</name>
+                 <bndbox><xmin>10</xmin><ymin>20</ymin><xmax>10</xmax><ymax>70</ymax></bndbox>
+                 </object></annotation>"""
+        assert mods["artwork"].parse_voc(xml) == []
+
+
+# ------------------------------------------------------------- contamination
+
+
+class TestContamination:
+    def test_tobacco800_may_not_use_ucsf_tobacco_as_distractors(self, mods):
+        # Both are IIT-CDIP. A UCSF tobacco page is certain to carry more
+        # instances of these same letterheads, so scoring against it counts
+        # correct retrievals as false positives.
+        assert not mods["cfg"].eligible_distractor("tobacco800", "ucsf", "Tobacco")
+
+    def test_tobacco800_may_use_other_ucsf_industries(self, mods):
+        assert mods["cfg"].eligible_distractor("tobacco800", "ucsf", "Opioids")
+
+    def test_spods_may_use_ucsf_freely(self, mods):
+        assert mods["cfg"].eligible_distractor("spods", "ucsf", "Tobacco")
+
+    def test_no_source_is_its_own_distractor(self, mods):
+        for source in ("spods", "staver", "tobacco800", "ucsf", "synth"):
+            assert not mods["cfg"].eligible_distractor(source, source)
+
+
+# ------------------------------------------------------------ class admission
+
+
+class TestClassAdmission:
+    def _corpus(self, mods, big=12, small=3):
+        pages = []
+        for i in range(big):
+            pages.append(_page(mods, f"spods/{i:03d}", "spods", [("logo", (0, 0, 200, 120), "spods/a", "gt")]))
+        for i in range(small):
+            pages.append(_page(mods, f"spods/x{i:03d}", "spods", [("logo", (0, 0, 200, 120), "spods/b", "gt")]))
+        return pages
+
+    def test_survival_curve_counts_classes_per_threshold(self, mods):
+        pages = self._corpus(mods)
+        inv = mods["build"].class_inventory(pages)
+        curve = mods["build"].survival_curve(inv, (2, 5, 10, 20))
+        assert curve == {2: 2, 5: 1, 10: 1, 20: 0}
+
+    def test_min_instances_rejects_the_thin_class(self, mods):
+        pages = self._corpus(mods)
+        inv = mods["build"].class_inventory(pages)
+        admitted, rejected = mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32)
+        assert set(admitted) == {"spods/a"}
+        assert "instance(s) < min_instances" in rejected["spods/b"]
+
+    def test_tiny_marks_are_rejected_with_a_reason(self, mods):
+        pages = [
+            _page(mods, f"spods/{i:03d}", "spods", [("logo", (0, 0, 12, 10), "spods/tiny", "gt")]) for i in range(20)
+        ]
+        inv = mods["build"].class_inventory(pages)
+        admitted, rejected = mods["build"].admit_classes(pages, inv, min_instances=5, min_mark_px=32)
+        assert admitted == {}
+        assert "min_mark_px" in rejected["spods/tiny"]
+
+    def test_signatures_are_never_queryable(self, mods):
+        pages = [
+            _page(mods, f"t/{i:03d}", "tobacco800", [("signature", (0, 0, 400, 200), "tobacco800/signature_x", "gt")])
+            for i in range(30)
+        ]
+        inv = mods["build"].class_inventory(pages)
+        admitted, rejected = mods["build"].admit_classes(pages, inv, min_instances=5, min_mark_px=32)
+        assert admitted == {}
+        assert "not queryable" in rejected["tobacco800/signature_x"]
+
+    def test_weak_boxless_classes_are_admitted(self, mods):
+        pages = [
+            _page(mods, f"ucsf/{i:03d}", "ucsf", [("logo", (0, 0, 0, 0), "ucsf/letterhead_rjr", "weak")])
+            for i in range(40)
+        ]
+        inv = mods["build"].class_inventory(pages)
+        admitted, _ = mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32)
+        assert admitted["ucsf/letterhead_rjr"]["median_mark_px"] is None
+        assert admitted["ucsf/letterhead_rjr"]["provenance"] == ["weak"]
+
+    def test_admitted_classes_record_their_eligible_distractors(self, mods):
+        pages = self._corpus(mods)
+        inv = mods["build"].class_inventory(pages)
+        admitted, _ = mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32)
+        eligible = admitted["spods/a"]["eligible_distractor_sources"]
+        assert "spods" not in eligible
+        assert "ucsf" in eligible
+
+
+# -------------------------------------------------------------------- tiers
+
+
+class TestTiers:
+    def _pages(self, mods, n_distractors=500):
+        pages = [
+            _page(mods, f"spods/{i:03d}", "spods", [("logo", (0, 0, 200, 120), "spods/a", "gt")]) for i in range(20)
+        ]
+        pages += [_page(mods, f"ucsf/d{i:05d}", "ucsf") for i in range(n_distractors)]
+        return pages
+
+    def _assign(self, mods, pages, tiers, pinned=None):
+        inv = mods["build"].class_inventory(pages)
+        admitted, _ = mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32)
+        return mods["build"].assign_tiers(
+            pages, admitted, tiers=tiers, tier_order=("s", "m", "l"), salt="test-salt", pinned_cutoffs=pinned
+        )
+
+    @staticmethod
+    def _members(tier_of, tier_order=("s", "m", "l")):
+        """Cumulative membership per tier, since tiers nest."""
+        out, running = {}, set()
+        for tier in tier_order:
+            running = running | {p for p, t in tier_of.items() if t == tier}
+            out[tier] = set(running)
+        return out
+
+    def test_tiers_are_nested_and_hit_their_budgets(self, mods):
+        tier_of, _ = self._assign(mods, self._pages(mods), {"s": 60, "m": 200, "l": 400})
+        m = self._members(tier_of)
+        assert m["s"] < m["m"] < m["l"]
+        assert (len(m["s"]), len(m["m"]), len(m["l"])) == (60, 200, 400)
+
+    def test_every_positive_page_is_in_the_smallest_tier(self, mods):
+        tier_of, _ = self._assign(mods, self._pages(mods), {"s": 60, "m": 200, "l": 400})
+        assert all(tier_of[f"spods/{i:03d}"] == "s" for i in range(20))
+
+    def test_is_deterministic_for_a_fixed_page_set(self, mods):
+        budgets = {"s": 60, "m": 200, "l": 400}
+        first, _ = self._assign(mods, self._pages(mods, 500), budgets)
+        second, _ = self._assign(mods, self._pages(mods, 500), budgets)
+        assert first == second
+
+    def test_pinned_cutoffs_survive_a_growing_source_pool(self, mods):
+        # Budgets and cross-build stability genuinely conflict: you cannot hold
+        # a page count fixed *and* hold membership fixed when the pool changes
+        # size. Pinning the rank cutoffs buys stability and lets the count
+        # drift, which is the trade a follow-up build wants so that its numbers
+        # stay comparable to the earlier one's.
+        budgets = {"s": 60, "m": 200, "l": 400}
+        _, cutoffs = self._assign(mods, self._pages(mods, 500), budgets)
+        small, _ = self._assign(mods, self._pages(mods, 500), budgets, pinned=cutoffs)
+        grown, _ = self._assign(mods, self._pages(mods, 900), budgets, pinned=cutoffs)
+
+        s_small = self._members(small)["s"]
+        s_grown = self._members(grown)["s"]
+        assert s_small <= s_grown, "pinning must never evict a page from a tier it was already in"
+
+    def test_unpinned_growth_is_documented_as_a_new_corpus_version(self, mods):
+        # The converse of the test above, pinned here so nobody "fixes" the
+        # default into silent instability without noticing: without pinning, a
+        # larger pool re-selects, and that is a new corpus, not the same one.
+        budgets = {"s": 60, "m": 200, "l": 400}
+        before, _ = self._assign(mods, self._pages(mods, 500), budgets)
+        after, _ = self._assign(mods, self._pages(mods, 900), budgets)
+        assert self._members(before)["s"] != self._members(after)["s"]
+
+    def test_pages_past_the_largest_budget_are_excluded(self, mods):
+        pages = self._pages(mods, 500)
+        tier_of, _ = self._assign(mods, pages, {"s": 60, "m": 100, "l": 150})
+        assert len(tier_of) == 150
+        assert len(pages) > len(tier_of)
+
+
+# --------------------------------------------------------------- clustering
+
+
+class TestClustering:
+    def test_phash_is_deterministic_and_64_bit(self, mods):
+        from PIL import Image
+
+        rng = np.random.default_rng(42)
+        img = Image.fromarray(rng.integers(0, 255, (120, 90), dtype=np.uint8))
+        a, b = mods["cluster"].phash(img), mods["cluster"].phash(img)
+        assert a.shape == (64,)
+        assert np.array_equal(a, b)
+
+    def test_phash_is_scale_invariant(self, mods):
+        from PIL import Image
+
+        rng = np.random.default_rng(7)
+        base = Image.fromarray(rng.integers(0, 255, (200, 200), dtype=np.uint8)).filter(
+            __import__("PIL.ImageFilter", fromlist=["GaussianBlur"]).GaussianBlur(3)
+        )
+        big, small = mods["cluster"].phash(base), mods["cluster"].phash(base.resize((80, 80)))
+        assert (big != small).mean() < 0.15
+
+    def test_single_linkage_chains_and_separates(self, mods):
+        dist = np.array(
+            [
+                [0.0, 0.1, 0.9, 0.9],
+                [0.1, 0.0, 0.15, 0.9],
+                [0.9, 0.15, 0.0, 0.9],
+                [0.9, 0.9, 0.9, 0.0],
+            ]
+        )
+        labels = mods["cluster"].single_linkage(dist, threshold=0.2)
+        assert labels[0] == labels[1] == labels[2]
+        assert labels[3] != labels[0]
+
+    def test_labels_are_dense_and_first_appearance_ordered(self, mods):
+        dist = np.ones((4, 4)) - np.eye(4)
+        labels = mods["cluster"].single_linkage(dist, threshold=0.0)
+        assert labels == [0, 1, 2, 3]
+
+    def test_aspect_gate_forces_apart_marks_of_different_shape(self, mods):
+        MarkRef = mods["cluster"].MarkRef
+        refs = [
+            MarkRef(0, 0, "p/1", "logo", (0, 0, 100, 100)),  # square
+            MarkRef(1, 0, "p/2", "logo", (0, 0, 400, 40)),  # wide banner
+        ]
+        desc = np.ones((2, 64), dtype=bool)  # identical hashes
+        dist = mods["cluster"].distance_matrix(desc, refs, backend="phash")
+        assert dist[0, 1] == 1.0
+
+    def test_class_ids_are_anchored_to_a_page_not_a_counter(self, mods):
+        MarkRef = mods["cluster"].MarkRef
+        pages = [_page(mods, "spods/00042", "spods", [("logo", (0, 0, 10, 10), None, "gt")])]
+        refs = [MarkRef(0, 0, "spods/00042", "logo", (0, 0, 10, 10))]
+        classes = mods["cluster"].assign_class_ids(pages, refs, [0], source="spods")
+        assert list(classes) == ["spods/logo_00042_0"]
+        assert pages[0].marks[0].provenance == "clustered"
+
+
+# ---------------------------------------------------------------- synthesis
+
+
+class TestSynthesis:
+    def _artwork(self, size=(120, 60)):
+        from PIL import Image, ImageDraw
+
+        img = Image.new("RGBA", size, (0, 0, 0, 0))
+        d = ImageDraw.Draw(img)
+        d.ellipse([4, 4, size[0] - 5, size[1] - 5], fill=(20, 30, 200, 255))
+        return img
+
+    def test_paste_box_is_tight_around_the_rotated_alpha(self, mods):
+        from PIL import Image
+
+        page = Image.new("RGBA", (800, 1000), (255, 255, 255, 255))
+        box = mods["synth"].paste_mark(
+            page, self._artwork(), target_px=200, rotation_deg=30.0, position=(0.5, 0.5)
+        )
+        x, y, w, h = box
+        # A 30-degree rotation expands the paste rectangle well beyond the mark.
+        # The recorded box must follow the ink, not the rectangle.
+        assert w < 200 and h < 200
+        crop = np.array(page.crop((x, y, x + w, y + h)))
+        assert crop[..., 3].max() > 0
+        # And it must be tight: every edge row/column touches ink.
+        assert crop[0, :, 3].max() > 0 and crop[-1, :, 3].max() > 0
+
+    def test_paste_lands_inside_the_page(self, mods):
+        from PIL import Image
+
+        page = Image.new("RGBA", (600, 800), (255, 255, 255, 255))
+        for pos in ((0.0, 0.0), (1.0, 1.0), (0.5, 0.5)):
+            x, y, w, h = mods["synth"].paste_mark(
+                page, self._artwork(), target_px=120, rotation_deg=0.0, position=pos
+            )
+            assert 0 <= x and 0 <= y and x + w <= page.width and y + h <= page.height
+
+    def test_build_synthetic_pages_records_exact_ground_truth(self, mods, tmp_path):
+        from PIL import Image
+
+        bg = tmp_path / "bg.png"
+        Image.new("RGB", (900, 1200), "white").save(bg)
+        pool_dir = tmp_path / "pool"
+        pool_dir.mkdir()
+        for name in ("alpha", "beta"):
+            self._artwork().save(pool_dir / f"{name}.png")
+        pool = mods["artwork"].load_pool_dir(pool_dir)
+
+        pages = mods["synth"].build_synthetic_pages(
+            [bg], pool, tmp_path / "out", instances_per_class=3, size_px=(64, 128), rotation_deg=(-5, 5), seed=1
+        )
+        assert len(pages) == 6
+        assert {m.class_id for p in pages for m in p.marks} == {"synth/alpha", "synth/beta"}
+        assert all(m.provenance == "synthetic" for p in pages for m in p.marks)
+        assert all(m.area() > 0 for p in pages for m in p.marks)
+
+    def test_synthesis_is_reproducible_from_the_seed(self, mods, tmp_path):
+        from PIL import Image
+
+        bg = tmp_path / "bg.png"
+        Image.new("RGB", (900, 1200), "white").save(bg)
+        pool_dir = tmp_path / "pool"
+        pool_dir.mkdir()
+        self._artwork().save(pool_dir / "alpha.png")
+        pool = mods["artwork"].load_pool_dir(pool_dir)
+
+        def run(out):
+            return [
+                (m.class_id, m.box)
+                for p in mods["synth"].build_synthetic_pages(
+                    [bg], pool, out, instances_per_class=4, size_px=(64, 128), rotation_deg=(-5, 5), seed=99
+                )
+                for m in p.marks
+            ]
+
+        assert run(tmp_path / "a") == run(tmp_path / "b")
+
+    def test_empty_pool_is_an_error_not_an_empty_corpus(self, mods, tmp_path):
+        with pytest.raises(ValueError, match="artwork pool"):
+            mods["synth"].build_synthetic_pages(
+                [tmp_path / "bg.png"], {}, tmp_path, instances_per_class=1, size_px=(64, 128),
+                rotation_deg=(0, 0), seed=1
+            )
+
+
+# ----------------------------------------------------------------- manifest
+
+
+class TestManifest:
+    def test_round_trips_marks_and_meta(self, mods, tmp_path):
+        pages = [
+            _page(mods, "spods/001", "spods", [("logo", (1, 2, 3, 4), "spods/a", "clustered")]),
+            _page(mods, "ucsf/x#0", "ucsf"),
+        ]
+        pages[1].meta = {"industry": "Opioids", "decade": "1990s"}
+        path = tmp_path / "corpus.jsonl"
+
+        assert mods["common"].write_manifest(pages, path) == 2
+        back = list(mods["common"].read_manifest(path))
+        assert [p.page_id for p in back] == ["spods/001", "ucsf/x#0"]
+        assert back[0].marks[0].box == (1, 2, 3, 4)
+        assert back[0].marks[0].provenance == "clustered"
+        assert back[1].meta["industry"] == "Opioids"
+
+    def test_written_records_are_stable_json(self, mods, tmp_path):
+        pages = [_page(mods, "spods/001", "spods", [("logo", (1, 2, 3, 4), "spods/a", "gt")])]
+        a, b = tmp_path / "a.jsonl", tmp_path / "b.jsonl"
+        mods["common"].write_manifest(pages, a)
+        mods["common"].write_manifest(list(mods["common"].read_manifest(a)), b)
+        assert a.read_text() == b.read_text()
+
+    def test_manifest_is_valid_jsonl(self, mods, tmp_path):
+        path = tmp_path / "c.jsonl"
+        mods["common"].write_manifest([_page(mods, "spods/1", "spods")], path)
+        for line in path.read_text().splitlines():
+            json.loads(line)
+
+
+# ------------------------------------------------------------- embed cells
+
+
+class TestEmbedCells:
+    def test_a_tier_cell_is_cumulative_over_smaller_tiers(self, mods):
+        assert mods["embed"].tiers_up_to("s") == {"s"}
+        assert mods["embed"].tiers_up_to("m") == {"s", "m"}
+        assert mods["embed"].tiers_up_to("l") == {"s", "m", "l"}
+
+    def test_cell_names_match_the_pile_convention(self, mods):
+        assert mods["embed"].cell_name("m", "sift_vlad") == "docmarks_m__sift_vlad.pkl"
+
+    def test_load_medias_carries_boxes_as_regions(self, mods, tmp_path):
+        from PIL import Image
+
+        img = tmp_path / "p.png"
+        Image.new("RGB", (400, 500), "white").save(img)
+        page = _page(mods, "spods/001", "spods", [("logo", (10, 20, 60, 40), "spods/a", "gt")], path=str(img))
+        medias = mods["embed"].load_medias([page], {}, "sift_vlad")
+        (media,) = medias.values()
+        assert media["categories"] == ["spods/a"]
+        assert media["regions"] == [
+            {"label": "spods/a", "x": 10, "y": 20, "width": 60, "height": 40, "provenance": "gt"}
+        ]
+        assert media["origin_name"] == "spods/001"
+
+    def test_weak_boxless_marks_become_a_category_but_never_a_region(self, mods, tmp_path):
+        from PIL import Image
+
+        img = tmp_path / "p.png"
+        Image.new("RGB", (400, 500), "white").save(img)
+        page = _page(mods, "ucsf/x#0", "ucsf", [("logo", (0, 0, 0, 0), "ucsf/letterhead_rjr", "weak")], path=str(img))
+        (media,) = mods["embed"].load_medias([page], {}, "siglip").values()
+        # A zero-area region would be indistinguishable from a real box once it
+        # is in the media dict, which is precisely the distinction the corpus
+        # exists to keep visible.
+        assert media["regions"] == []
+        assert media["categories"] == ["ucsf/letterhead_rjr"]
+        assert media["docmarks"]["provenances"] == ["weak"]
+
+    def test_media_ids_are_stable_under_input_ordering(self, mods, tmp_path):
+        from PIL import Image
+
+        paths = []
+        for name in ("a", "b", "c"):
+            p = tmp_path / f"{name}.png"
+            Image.new("RGB", (50, 50), "white").save(p)
+            paths.append(p)
+        pages = [_page(mods, f"spods/{n}", "spods", path=str(p)) for n, p in zip("abc", paths)]
+
+        forward = mods["embed"].load_medias(pages, {}, "siglip")
+        reverse = mods["embed"].load_medias(list(reversed(pages)), {}, "siglip")
+        assert {i: m["origin_name"] for i, m in forward.items()} == {
+            i: m["origin_name"] for i, m in reverse.items()
+        }


### PR DESCRIPTION
Builds one instance-retrieval corpus of stamps and logos in scanned documents, for structural-search experiments. Code only — nothing here has touched the real archives yet; it is meant to be run on the GRID.

## Why

The 2026-07-13 study found the **first configuration where structural search beats the deep embedder on a real corpus** (SuperPoint+LightGlue, AP 0.395/0.481 on SPODS/StaVer vs SigLIP's 0.204/0.235), then could not push on it: those corpora are 259 and 1,088 pages, with as few as 9 instances per class. That cannot separate a good ranker from a lucky one.

## What it builds

Three strata, one manifest, nested 5k/50k/200k tiers sharing class ids:

| stratum | source | gives | costs |
|---|---|---|---|
| anchor | SPODS, StaVer, Tobacco800 | real marks, real boxes | ~2,700 pages; two of three ship no identities |
| haystack | UCSF IDL | millions of real scans; weak letterhead classes at 10⁵ instances | labels are metadata-derived |
| synth | LogoDet-3K artwork on held-out scans | exact geometry, sweepable size/rotation | pasted marks aren't printed marks |

## Two findings that shaped the design

**SPODS is not offline, and it ships no instance identities.** Its page advertises `www.facweb.iitkgp.ernet.in`, a decommissioned host that 503s; `facweb.iitkgp.ac.in` serves the same 2.94 GB file. Walking the RAR headers shows the real layout is 1,088 pages plus four *binary pixel masks* per page (logo/signature/stamp/text) — with no notion of *which* logo. So the "64 logo/stamp classes" a previous study reported were derived by that study and never verified. Identity clustering is now explicit (`cluster_marks.py`), flagged `provenance="clustered"`, and routed through a human audit.

**Distractor contamination is prevented by construction, not annotation.** Tobacco800, RVL-CDIP and UCSF's Tobacco industry all descend from IIT-CDIP, so unlabelled positives in a "distractor" pool make correct retrievals score as false positives. No hand pass fixes that at 200k pages. `CONTAMINATES` encodes the rule; each class records its `eligible_distractor_sources`.

## Files

- `scripts/experiments/docmarks/` — config, four source adapters, identity clustering, synthesis, corpus driver, audit slate + verdict round-trip, pile-format embedding cells, README
- `tests_lib/datasets/test_docmarks_corpus.py` — 68 tests, no network

`embed_corpus.py` deliberately is not a `pile_config.DATASETS` entry: the pile builds the full dataset × embedder cross-product, so adding DocMarks and `sift_vlad` there would schedule `sift_vlad` cells for all six existing datasets.

## Verification

Full `./run-tests.sh` green (9046 passed, all gates). End-to-end smoke run against a fabricated SPODS-shaped tree: 72 pages → clustering recovered exactly the 3 planted classes → 3 admitted, synth classes correctly rejected under the threshold → audit `ok`/`merge_into`/`drop` round-trip applied.

Also fixes an unrelated pre-existing gate failure: a lessons file was missing its `YYYY-MM-DD —` heading prefix, which failed `gen-docs-inventories.py --check` for everyone.

## Follow-ups

Recorded in `docs/plans/structural-embedder.md`, not here. The load-bearing one: `eligible_distractor_sources` is recorded but **nothing consumes it yet** — until a scoring path restricts each class's candidate pool, the contamination design is decorative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF1MUvcTkJ4SrU1biT2wv5)_