### PR TITLE
#3115: correct the confounded mode attribution, and the run that breaks it

### DIFF
--- a/docs/experiments/calibration-fold-combine/REPORT.md
+++ b/docs/experiments/calibration-fold-combine/REPORT.md
@@ -210,6 +210,18 @@ inclusion 0, `PRODUCTION_HEAD`. Analyzed at dev `e87c90956` + this branch.
 > `whole_image` alongside `max_patch` in the same cell, which fills the missing
 > corner and decomposes mode from embedder. Read everything below as
 > "cell A vs cell B", not "binary vs region", until that lands.
+>
+> **What that run can and cannot settle.** It makes one sharp prediction — if the
+> `space` leg follows the *embedder*, `dinov3 × whole_image` should prefer
+> percentiles like `dinov3 × max_patch` does; if it follows the *voting mode*, it
+> should prefer raw scores like `siglip × whole_image` does. Those are
+> distinguishable outcomes and one of them will be observed.
+>
+> It is still **one embedder for the mode contrast and one mode for the embedder
+> contrast**, so it discriminates between two hypotheses rather than establishing
+> either. A third outcome — the new cell landing between the two — would say the
+> effect is neither cleanly, and would need a second patch embedder to take
+> further.
 
 ### BLUF
 

--- a/docs/experiments/calibration-fold-combine/REPORT.md
+++ b/docs/experiments/calibration-fold-combine/REPORT.md
@@ -185,6 +185,32 @@ legs are untested rather than refuted, and the report must say so.
 12 classes × 4 seeds, K ∈ {1,2,3,4,6,8,12,16}, `calibrate_count=2` live,
 inclusion 0, `PRODUCTION_HEAD`. Analyzed at dev `e87c90956` + this branch.
 
+> ### ⚠ Correction, 2026-08-25: the mode attribution is confounded
+>
+> This grid has exactly two cells — `vg_scale_any × siglip × whole_image`
+> (labelled "binary") and `vg_scale_any × dinov3_patch × max_patch` (labelled
+> "region"). **Voting mode and embedder are perfectly confounded.** Every claim
+> below that attributes the `space` leg's sign flip to *voting mode* is equally
+> consistent with attributing it to *the embedder* — e.g. "DINOv3's fold models
+> have less comparable score scales than SigLIP's, so percentiles help." The data
+> cannot separate the two.
+>
+> **What survives:** `combine` (averaging beats pooling) is measured *within*
+> each cell, so the confound does not touch it. `tmean` remains the safe floor.
+>
+> **What does not:** every recommendation about *which* rule to use *where*. The
+> sign flip is real; its attribution is not.
+>
+> The design was sold as removing a confound ("both voting modes from one
+> dataset") — true of the **dataset**, while substituting the **embedder**.
+> Preflight asserted that region voting genuinely *happens* on the DINOv3 cell;
+> nothing asserted the contrast was *attributable* to it.
+>
+> The disambiguating run is cheap and is tracked in #3258: `dinov3_patch` can run
+> `whole_image` alongside `max_patch` in the same cell, which fills the missing
+> corner and decomposes mode from embedder. Read everything below as
+> "cell A vs cell B", not "binary vs region", until that lands.
+
 ### BLUF
 
 **Both docstrings are wrong, and they are wrong in different places.**
@@ -398,11 +424,13 @@ Still: `vg_scale_any` inherits whatever `vg_scale` holds, and `build_pile.py
 `pile_config.py` beside the dataset entry.
 
 ### What this study does not license
-- **One dataset.** `vg_scale_any` is 12 hand-checked classes at uniform
-  prevalence — chosen to isolate the combine rule, which also means the result
-  has not been shown to travel. The mode contrast is internal to this dataset,
-  which removes the dataset/mode confound but does not replace a second
-  environment.
+- **One dataset, and — the real limit — one embedder per voting mode.**
+  `vg_scale_any` is 12 hand-checked classes at uniform prevalence, chosen to
+  isolate the combine rule. Holding the dataset fixed removed the dataset/mode
+  confound that #2897 had, but it left **mode perfectly confounded with the
+  embedder**: SigLIP is the only binary cell and DINOv3 the only region one. See
+  the correction at the top; this is the study's principal weakness and it was
+  not caught before the run.
 - **Uniform prevalence.** The grid deliberately holds prevalence fixed at 7.1%,
   so nothing here says how the combine rule behaves on a rare category.
 

--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -72,6 +72,7 @@ correct union of the two branches with no judgement involved.
 
 | Date | Lesson | Issue |
 |---|---|---|
+| 2026-08-25 | [a "voting mode" headline that was equally an embedder headline](lessons/2026-08-25-a-mode-contrast-that-was-an-embedder-contrast.md) | #3115 |
 | 2026-08-25 | [preflight failed for a reason that had nothing to do with the run](lessons/2026-08-25-preflight-without-a-venv.md) | #3115 |
 | 2026-08-24 | [a cost re-evaluated at a rounded threshold is a different cost](lessons/2026-08-24-a-cost-recomputed-at-a-rounded-threshold.md) | #2883 |
 | 2026-08-24 | [a login-node timing nearly cut a whole arm from a study](lessons/2026-08-24-a-login-node-timing-nearly-cut-an-arm.md) | #2883 |

--- a/scripts/experiments/calibration/analyze_folds_2897.py
+++ b/scripts/experiments/calibration/analyze_folds_2897.py
@@ -161,8 +161,17 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     # on a single-vector embedder was reported as a region arm.  #2897's report
     # regrouped that cell into binary **by hand** while this column still called
     # it region; deriving it here is what stops the next study needing to know.
+    # Style is part of it, not just (dataset, embedder).  A patch embedder can be
+    # asked to run `whole_image`, and then each Bad vote contributes ONE row
+    # rather than ~197, so `_flood_context` finds no flooding, `cal_groups` stays
+    # None and the ROW-WISE calibrator runs - a binary cell on a patch embedder.
+    # That combination is exactly how #3115's mode-vs-embedder confound gets
+    # broken, so mislabelling it as region would defeat the run that fixes it.
     df["voting"] = np.where(
-        [region_voting_for(d, e) for d, e in zip(df["dataset"], df["embedder"], strict=True)],
+        [
+            region_voting_for(d, e) and st != "whole_image"
+            for d, e, st in zip(df["dataset"], df["embedder"], df["style"], strict=True)
+        ],
         "region",
         "binary",
     )

--- a/scripts/experiments/calibration/folds_combine_3115.py
+++ b/scripts/experiments/calibration/folds_combine_3115.py
@@ -118,7 +118,7 @@ def _paired(v: pd.DataFrame, arm: str, ref: str) -> pd.DataFrame:
     than being compared against a different set of steps.
     """
     keys = [*STEP_KEYS, "k"]
-    cols = ["threshold", "n_folds_used", "window", "window_hi", "voting", *METRICS]
+    cols = ["threshold", "n_folds_used", "window", "window_hi", "voting", "env", *METRICS]
     a = v[v["arm"] == arm].set_index(keys)
     b = v[v["arm"] == ref].set_index(keys)
     a, b = a[~a.index.duplicated()], b[~b.index.duplicated()]
@@ -126,7 +126,9 @@ def _paired(v: pd.DataFrame, arm: str, ref: str) -> pd.DataFrame:
     j = pd.concat([a[have].add_suffix("_a"), b[have].add_suffix("_b")], axis=1, join="inner")
     if j.empty:
         return j
-    j = j.reset_index().rename(columns={"window_a": "window", "window_hi_a": "window_hi", "voting_a": "voting"})
+    j = j.reset_index().rename(
+        columns={"window_a": "window", "window_hi_a": "window_hi", "voting_a": "voting", "env_a": "env"}
+    )
     for m in METRICS:
         if f"{m}_a" in j.columns:
             j[f"d_{m}"] = j[f"{m}_a"] - j[f"{m}_b"]
@@ -150,7 +152,12 @@ def _summarise(j: pd.DataFrame, name: str, arm: str, ref: str, collapses: bool) 
     if j.empty:
         return rows
     deltas = [f"d_{m}" for m in METRICS if f"d_{m}" in j.columns]
-    for (voting, window, k), g in j.groupby(["voting", "window", "k"], observed=True):
+    # Grouped by ENV as well as voting mode.  #3115's first run had one env per
+    # mode, so "binary" and "SigLIP" named the same rows and the headline could
+    # not tell a voting-mode effect from an embedder effect.  Keeping env here
+    # lets a grid with two envs in one mode separate them; where there is only
+    # one env per mode this changes nothing.
+    for (voting, env, window, k), g in j.groupby(["voting", "env", "window", "k"], observed=True):
         cells = g.groupby(CELL_KEYS, observed=True)[[*deltas, "moved", "dropped_a"]].mean()
         d = cells["d_regret"].to_numpy()
         n = len(d)
@@ -163,6 +170,7 @@ def _summarise(j: pd.DataFrame, name: str, arm: str, ref: str, collapses: bool) 
             "arm": arm,
             "ref": ref,
             "voting": voting,
+            "env": env,
             "window": str(window),
             "window_hi": int(g["window_hi"].iloc[0]),
             "k": int(k),
@@ -197,7 +205,7 @@ def contrast_table(v: pd.DataFrame, agg) -> pd.DataFrame:
         rows.extend(_summarise(_paired(v, arm, ref), name, arm, ref, collapses))
     t = pd.DataFrame(rows)
     if not t.empty:
-        t = t.sort_values(["contrast", "voting", "window_hi", "k"])
+        t = t.sort_values(["contrast", "voting", "env", "window_hi", "k"])
     t.to_csv(agg / "combine_contrasts.csv", index=False)
     return t
 
@@ -283,6 +291,21 @@ def verdicts(t: pd.DataFrame, deep_min: int, margin: float) -> dict:
     if t.empty:
         return out
     deep = t[(t["window_hi"] >= deep_min) & (t["k"] >= COLLAPSE_BELOW_K)]
+    # Per ENV as well as per mode.  When a mode holds more than one env, the
+    # per-mode number is an average over cells that may disagree - which is the
+    # #3115 confound in miniature - so the env breakdown is what a reader should
+    # check before believing a mode headline.
+    out["by_env"] = {}
+    for env, g in deep.groupby("env", observed=True):
+        out["by_env"][env] = {
+            name: {
+                "d_regret": float(np.average(sub["d_regret"], weights=sub["n_cells"])),
+                "se": float(np.average(sub["se_regret"], weights=sub["n_cells"])),
+                "n_cells": int(sub["n_cells"].sum()),
+            }
+            for name, sub in g.groupby("contrast", observed=True)
+            if sub["n_cells"].sum()
+        }
     for voting, g in deep.groupby("voting", observed=True):
         per: dict = {}
         for name, sub in g.groupby("contrast", observed=True):

--- a/scripts/experiments/calibration/launch_folds_3115.sh
+++ b/scripts/experiments/calibration/launch_folds_3115.sh
@@ -55,7 +55,8 @@ HERE="$WT/scripts/experiments/calibration"
 
 # /exp is a shared quota; the fold-count arms emit ~8 arms x 8 counts per step,
 # so the cells dir runs to a few GB.  Keep it on the 500G scratch.
-export CALIB_EXP="${CALIB_EXP:-/expscratch/$USER/folds-combine-3115}"
+# One study, one dir: this is the confound-breaking grid, not the first run's.
+export CALIB_EXP="${CALIB_EXP:-/expscratch/$USER/folds-combine-3115-modes}"
 export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
 # --- science knobs ---
@@ -116,7 +117,23 @@ export CALIB_DATASETS="${CALIB_DATASETS:-vg_scale_any}"
 export CALIB_VGSCALE_EMBEDDERS="${CALIB_VGSCALE_EMBEDDERS:-siglip,dinov3_patch}"
 export CALIB_CATEGORY_MODE="${CALIB_CATEGORY_MODE:-prevalence}"
 export CALIB_N_CATEGORIES="${CALIB_N_CATEGORIES:-12}"
-export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
+# BOTH styles on the patch embedder, which is what breaks the mode-vs-embedder
+# confound the first run shipped with.  That run held exactly two cells -
+# `siglip x whole_image` (all the "binary" rows) and `dinov3_patch x max_patch`
+# (all the "region" rows) - so voting mode and embedder moved together and its
+# per-mode headline was equally a per-embedder one.
+#
+# `dinov3_patch x whole_image` is the missing corner, and it is a genuine BINARY
+# cell: under `whole_image` a Bad vote contributes one row rather than ~197, so
+# `_flood_context` finds no flooding, `cal_groups` stays None and the row-wise
+# calibrator runs.  It costs almost nothing - the style runs inside the existing
+# cell on the already-loaded pickle.
+#
+#   siglip/whole  vs  dinov3/whole      -> the EMBEDDER, at fixed voting mode
+#   dinov3/whole  vs  dinov3/max_patch  -> the VOTING MODE, at fixed embedder
+#
+# (`siglip x max_patch` is the impossible fourth corner: no patch grid.)
+export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-whole_image,max_patch}"
 export CALIB_REPOOL_VARIANTS=""
 
 # --- sizing ---
@@ -280,6 +297,7 @@ case "$MODE" in
       bash "$WT/scripts/experiments/preflight.sh" --exp "$CALIB_EXP" --need-gb 20 \
         --require-region-voting vg_scale_any:dinov3_patch \
         --require-min-positives 100 \
+        --contrasts-voting-modes \
         --job-name cal-cells --mem "$CALIB_MEM" --conc "$CALIB_CONC" || {
         echo "preflight FAILED" >&2; [[ "${PREFLIGHT_SKIP:-0}" == "1" ]] || exit 1
       }

--- a/scripts/experiments/lessons/2026-08-25-a-mode-contrast-that-was-an-embedder-contrast.md
+++ b/scripts/experiments/lessons/2026-08-25-a-mode-contrast-that-was-an-embedder-contrast.md
@@ -1,0 +1,46 @@
+# 2026-08-25 — a "voting mode" headline that was equally an embedder headline (#3115)
+
+**Study:** #3115 fold combine-rule run. **Cost:** the run's principal claim, and a
+follow-up issue (#3258) filed on it before anyone caught the problem. Found by the
+owner reading the result, not by any check.
+
+The study reported its headline per **voting mode**: quantile-space combining is
+worth −0.032 regret on region voting and costs +0.036 on binary. The grid held
+exactly two cells:
+
+```
+vg_scale_any  whole_image  siglip        <- everything labelled "binary"
+vg_scale_any  max_patch    dinov3_patch  <- everything labelled "region"
+```
+
+Every binary cell is SigLIP. Every region cell is DINOv3. **The two axes move
+together, so the data cannot tell them apart.** *"Region voting likes
+percentiles"* and *"DINOv3's fold models have less comparable score scales than
+SigLIP's, so percentiles help"* predict the identical table, and they imply
+different fixes — key the rule on the geometry, or on the encoder.
+
+**The part that makes this worth a file: the design was sold as removing a
+confound.** #2897 contrasted binary against region across *different datasets*
+(Caltech vs VG). #3115 fixed that by taking both modes from one dataset, said so
+in the report, and substituted the embedder without noticing. Removing a named
+confound feels like rigour and reads like rigour, which is exactly what stops the
+next question — *what else moves with this axis?* — from being asked.
+
+Preflight did not help, and it is instructive that it looked like it had.
+Check 6 (`--require-region-voting`) asserted that region voting genuinely
+**happens** on the DINOv3 cell (`patch_grid=7749/7749`), which it does. That is a
+premise check on one cell. It says nothing about whether a **contrast between**
+cells is attributable to the axis it is named after. A green premise check on
+each arm is not a valid contrast.
+
+**The general form.** *Asserting that an axis is real is not asserting that a
+difference is caused by it.* Before reporting "A vs B" where A and B are groups
+of cells, list every column that differs between the groups. If more than one
+does, the headline names a conjunction, not a factor.
+
+**Status: prevented.** `preflight.sh` gains `--contrasts-voting-modes`: it derives
+each cell's mode the way the runner does and fails when the embedder sets for the
+two modes are disjoint, pointing at the cheap fix — a patch embedder can run
+`whole_image` too, so adding it to `CALIB_PATCH_STYLES` gives one embedder both
+modes. Opt-in, because a study that reports one cell per mode and never contrasts
+across them is doing nothing wrong; the failure is claiming the contrast.

--- a/scripts/experiments/preflight.sh
+++ b/scripts/experiments/preflight.sh
@@ -22,6 +22,7 @@ WARN_ONLY=0
 REPO="${VTS_REPO:-}"
 REGION_ARM=""
 MIN_POSITIVES=""
+MODE_CONTRAST=""
 REUSE_PREPARE=""
 JOB_NAME=""
 MEM_PER_TASK=""
@@ -35,6 +36,7 @@ while [[ $# -gt 0 ]]; do
     --need-gb) NEED_GB="$2"; shift 2 ;;
     --require-region-voting) REGION_ARM="$2"; shift 2 ;;
     --require-min-positives) MIN_POSITIVES="$2"; shift 2 ;;
+    --contrasts-voting-modes) MODE_CONTRAST=1; shift ;;
     --reuse-prepare) REUSE_PREPARE="$2"; shift 2 ;;
     --job-name) JOB_NAME="$2"; shift 2 ;;
     --diverges) DIVERGES="$2"; shift 2 ;;
@@ -558,6 +560,62 @@ PYDIV
   if [[ "$unacked" -gt 0 ]]; then
     echo "        -> if that is the axis this study sweeps, pass --diverges <knob>[,<knob>]"
     echo "        -> if it is not, the run would measure a detector nobody ships"
+  fi
+fi
+
+# --- 13b. A contrast axis that is confounded with another axis -----------------
+# #3115 swept the fold COMBINE rule and reported its headline per "voting mode".
+# Its grid held exactly two cells - `siglip x whole_image` and
+# `dinov3_patch x max_patch` - so every binary cell was SigLIP and every region
+# cell DINOv3.  The sign flip it measured is real; its ATTRIBUTION to voting mode
+# is not, because the embedder moved with it.  Check 6 asserts that region voting
+# genuinely *happens* on a cell; nothing asserted that a per-mode contrast is
+# attributable to the mode.
+#
+# So: whenever a run will be read per voting mode, both modes need more than one
+# embedder between them, or the two axes cannot be told apart.  Opt-in, because
+# plenty of studies legitimately report a single cell per mode and never contrast
+# across them - the failure is claiming the contrast, not running the grid.
+if [[ -n "$MODE_CONTRAST" && -n "$REPO" ]]; then
+  if [[ "$PY_USABLE" == "0" ]]; then
+    say_fail "mode-contrast confound NOT checked: python cannot import the tree (see above)"
+  else
+    CONF=$(CALIB_EXP="$EXP" python - "$REPO" <<'PY' 2>&1
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(sys.argv[1]) / "scripts" / "experiments" / "calibration"))
+import experiment_config as cfg
+
+by_mode: dict[str, set[str]] = {"binary": set(), "region": set()}
+for ds in cfg.DATASETS:
+    for emb in cfg.embedders_for_dataset(ds):
+        for style in cfg.styles_for(ds, emb):
+            mode = "region" if (cfg.region_voting_for(ds, emb) and style != "whole_image") else "binary"
+            by_mode[mode].add(emb)
+shared = by_mode["binary"] & by_mode["region"]
+if not by_mode["binary"] or not by_mode["region"]:
+    print("SKIP only one voting mode in this grid; there is no cross-mode contrast to confound")
+elif shared:
+    print("HOLDS embedder(s) in BOTH modes: " + ", ".join(sorted(shared)))
+else:
+    print(
+        "FAILS binary={%s} region={%s} - disjoint"
+        % (",".join(sorted(by_mode["binary"])), ",".join(sorted(by_mode["region"])))
+    )
+PY
+)
+    case "$CONF" in
+      HOLDS*) say_ok "mode contrast is not embedder-confounded (${CONF#HOLDS })" ;;
+      SKIP*)  say_ok "mode-contrast check skipped (${CONF#SKIP })" ;;
+      FAILS*)
+        say_fail "voting mode is CONFOUNDED with the embedder: ${CONF#FAILS }"
+        echo "        -> a per-mode headline from this grid is equally a per-embedder one"
+        echo "        -> give one embedder both modes (a patch embedder can run whole_image"
+        echo "           too: add it to CALIB_PATCH_STYLES), or do not contrast across modes"
+        ;;
+      *) say_fail "could not check the mode-contrast confound: $CONF" ;;
+    esac
   fi
 fi
 


### PR DESCRIPTION
`dev` currently carries #3115's report claiming a **voting-mode** result. It is confounded, and this ships the correction plus the run that resolves it.

## The defect

#3115's grid held exactly two cells:

```
vg_scale_any  whole_image  siglip        <- everything labelled "binary"
vg_scale_any  max_patch    dinov3_patch  <- everything labelled "region"
```

Every binary cell is SigLIP; every region cell is DINOv3. **Voting mode and embedder are perfectly confounded.** *"Region voting likes percentiles"* and *"DINOv3's fold models have less comparable score scales, so percentiles help"* predict the identical table and imply different fixes. Caught by the repo owner reading the result, not by any check.

**What survives:** `combine` (averaging beats pooling, −0.0078 and −0.016) is measured *within* each cell, so the confound does not touch it. **What does not:** every recommendation about which rule to use where. The sign flip is real; its attribution is not.

Worth recording that the design was *sold* as removing a confound — #2897 contrasted the modes across different datasets, this run fixed that by taking both from one dataset, said so in the report, and substituted the embedder. Removing a named confound reads like rigour, which is what stopped the next question being asked.

## What ships

- **Correction banner** at the top of the report: read it as "cell A vs cell B", not "binary vs region".
- **`preflight.sh --contrasts-voting-modes`** — derives each cell's mode the way the runner does and fails when the two modes' embedder sets are disjoint. It would have failed the original grid. Check 6 asserted region voting genuinely *happens* on the DINOv3 cell; a green premise check on each arm is not a valid contrast between them.
- **Lesson filed** (`2026-08-25-a-mode-contrast-that-was-an-embedder-contrast.md`).
- **#3258 flagged and rescoped** to `tmean`, the half that survives.

## The run that breaks it

`dinov3_patch` runs `whole_image` alongside `max_patch` in the same cell on the already-loaded pickle:

| | `whole_image` (binary) | `max_patch` (region) |
|---|---|---|
| siglip | have | impossible — no patch grid |
| dinov3_patch | **new** | have |

`siglip/whole` vs `dinov3/whole` isolates the embedder; `dinov3/whole` vs `dinov3/max_patch` isolates the voting mode.

It is a *genuine* binary cell, not a relabelled region one: under `whole_image` a Bad vote contributes one row instead of ~197, so `_flood_context` finds no flooding, `cal_groups` stays `None`, and the row-wise calibrator runs.

Two analyzer fixes it needs, or the new cell is unreadable:

- **`voting` now derives from style**, not just `(dataset, embedder)` — `region_voting_for` is True for `dinov3_patch` whatever style runs, so the new binary cell would have been labelled region, defeating the run that fixes the confound.
- **the contrast table and verdicts carry `env`**, so three cells read separately rather than averaging into two modes.

The reading is **pre-registered before the cells land**: if the `space` leg follows the embedder, `dinov3 × whole_image` prefers percentiles; if it follows the mode, it prefers raw scores. Still one embedder for the mode contrast and one mode for the embedder contrast, so it discriminates between two hypotheses rather than establishing either.

Refs #3115, refs #3258.