### PR TITLE
Restructure DocMarks around a curated roster with adjudicated same/different labels

### DIFF
--- a/docs/plans/structural-embedder.md
+++ b/docs/plans/structural-embedder.md
@@ -64,32 +64,35 @@ reorders what was previously planned here.
 
 <!-- item-sep -->
 
-- **DocMarks — finish the scanned-document corpus and run it.** The builder is in
-  `scripts/experiments/docmarks/` (see its README): SPODS + StaVer + Tobacco800
-  as real-GT anchor classes, UCSF IDL as haystack and weakly-labelled letterhead
-  classes, LogoDet-3K artwork on held-out scans as a sweepable synthetic
-  stratum, in one manifest with nested 5k/50k/200k tiers. It exists because the
+- **DocMarks — build the stamp-detection eval set and run it.** The builder is
+  in `scripts/experiments/docmarks/` (see its README). It exists because the
   2026-07-13 result — the first configuration where structural search beats the
   deep embedder on a real corpus — rests on two corpora of 259 and 1,088 pages
-  with as few as 9 instances per class, which cannot separate a good ranker from
-  a lucky one. Owed:
-  - **Run it.** `build_corpus.py --probe`, then tier `s`, then
-    `embed_corpus.py`. Nothing here has touched the real archives yet: the
-    parsers are tested against fixtures built from each source's documented
+  with as few as 9 instances per class, whose class identities that study
+  derived and nobody verified.
+
+  The shape is a **curated roster**, not an inventory: about two dozen
+  hand-picked classes whose every instance is adjudicated in or out, plus
+  unlimited unlabelled distractors. Both directions of the ground truth are
+  stored — a shared class id for "must be found together", a permanent
+  `separations.json` entry for "must be told apart" — because a threshold alone
+  decides the second one, and moving the threshold silently rewrites it. Owed:
+  - **Run it, SPODS-first.** `build_corpus.py --probe`, cluster into candidates,
+    `shortlist.py` to rank, pick ~24, then the `membership` and `confusable`
+    passes, then `embed_corpus.py`. Nothing has touched the real archives yet:
+    the parsers are tested against fixtures built from each source's documented
     layout, and SPODS's layout is confirmed from its RAR headers, but StaVer's
     and Tobacco800's Kaggle mirrors are unverified until a token is present.
   - **The eval side of the contamination rule.** `classes.json` records each
-    class's `eligible_distractor_sources` and *nothing consumes it yet*. Until a
-    scoring path restricts each class's candidate pool to its eligible sources,
-    a Tobacco800 query scored over the whole corpus is being marked wrong for
-    retrieving real matches out of UCSF's tobacco archive. This is the one item
-    that makes the rest of the design load-bearing rather than decorative.
-  - **The three human passes**, in value order: `letterhead` (does the weak UCSF
-    label hold? the whole haystack layer's usability is downstream of this
-    number), `cluster` (are the derived SPODS/StaVer identities real?),
-    `distinctive` (which marks are instances rather than shapes?).
-  - **Set `--min-instances` from the real survival curve**, which the build
-    prints. The default of 10 is a placeholder chosen without data.
+    class's `eligible_distractor_sources`, and `roster.eligible_pages` splits a
+    corpus into positive / known-negative / presumed-negative — but *nothing
+    consumes either yet*. Until a scoring path honours them, a Tobacco800 query
+    scored over the whole corpus is marked wrong for retrieving real matches out
+    of UCSF's tobacco archive. This is the item that makes the rest of the
+    design load-bearing rather than decorative.
+  - **Expand the roster past SPODS** once the first eval runs: StaVer stamps
+    (the line-art case where SIFT collapsed to 5.1%), then Tobacco800 logos,
+    then UCSF letterhead via the `letterhead` candidate pass.
   - **More artwork and more haystack, if the first run justifies it**: the ICDAR
     2023 ReST seal set (10,000 real seals, behind an RRC registration, so it
     needs a manual fetch into `--synth-pool-dir`), full RVL-CDIP rather than the

--- a/scripts/experiments/docmarks/README.md
+++ b/scripts/experiments/docmarks/README.md
@@ -1,39 +1,70 @@
-# DocMarks — stamps and logos in scanned documents
+# DocMarks — eval data for stamp detection
 
-One instance-retrieval corpus, assembled from four sources in three strata, with
-nested size tiers. Built for structural-search experiments: the 2026-07-13
-screenshot/scanned-document study found the **first configuration where
-structural search beats the deep embedder on a real corpus**
-(SuperPoint+LightGlue, AP 0.395/0.481 vs SigLIP's 0.204/0.235), and then could
-not push on that result because the two document corpora it used are far too
-small — 259 and 1,088 pages, with as few as 9 instances per class.
+Labelled data for evaluating **structural similarity search on small marks in
+scanned documents** — finding a given stamp, seal or letterhead logo in a pile
+of pages. Built for the feature the structural embedder is heading toward, and
+for the experiments that will decide how it should work.
+
+The 2026-07-13 study found the first configuration where structural search beats
+the deep embedder on a real corpus (SuperPoint+LightGlue, AP 0.395/0.481 vs
+SigLIP's 0.204/0.235), then ran out of road: its two document corpora are 259
+and 1,088 pages, with as few as 9 instances per class, and their class
+identities were derived by that study rather than verified by anyone.
 
 ```bash
-python build_corpus.py --probe                        # can I reach every source?
-python build_corpus.py --sources spods --limit 40     # small real build
-python build_corpus.py --survival                     # class counts vs threshold
-python build_corpus.py                                # the whole thing
+python build_corpus.py --probe                       # can I reach every source?
+python build_corpus.py --sources spods               # cluster into candidates
+python shortlist.py --corpus <dir> --write-roster     # rank them, draft a roster
+$EDITOR <dir>/roster.json                             # pick your two dozen
+python build_corpus.py --sources spods --roster <dir>/roster.json
 
-python make_audit_slate.py --task cluster             # the human passes
-python audit_to_corrections.py --task cluster --apply
+python make_audit_slate.py --task membership          # verify every instance
+python make_audit_slate.py --task confusable          # adjudicate every pair
+python audit_to_corrections.py --task membership --apply
 
 source ../pile/pile_env.sh
 python embed_corpus.py --tier s --embedders sift_vlad,siglip
 ```
 
-## The three strata
+## The design in one idea: a curated roster, not an inventory
 
-| stratum | source | what it gives | what it costs |
-|---|---|---|---|
-| anchor | SPODS, StaVer, Tobacco800 | real marks, real scans, real boxes | small; ~2,700 pages, and two of the three ship no identities |
-| haystack | UCSF Industry Documents Library | millions of real scanned pages; weak letterhead classes at 10⁵ instances | labels are metadata-derived and unverified |
-| synth | LogoDet-3K artwork on held-out real scans | exact ground truth, sweepable size/rotation/count | pasted marks are not printed marks |
+The corpus holds two populations with completely different standards of
+evidence, and keeping them apart is the whole point:
 
-The rule that comes with the third one: **synthetic numbers quantify a
-mechanism, real numbers size the effect.** A finding that appears only in
-`synth` is a hypothesis about the pipeline, not a claim about documents.
+- **Roster classes** — a small, named, checked-in set of about two dozen. Every
+  instance is adjudicated in or out by hand; every confusable pair is
+  adjudicated same or different. Nothing enters by heuristic.
+- **Distractors** — everything else, unlabelled and unexamined, in whatever
+  quantity the tier budget allows. They need no labels, only to be *safe to
+  score against*.
 
-## What each source actually ships
+That split is what buys a trustworthy eval at a cost a person can pay.
+Verifying 24 classes exhaustively is an afternoon; verifying 400 is not, and a
+benchmark whose labels nobody checked is a benchmark whose numbers nobody should
+quote. Without a `--roster`, the builder emits candidate classes for
+`shortlist.py` to rank — those are *proposals*, and the build says so.
+
+## Both directions of the ground truth
+
+An eval for "find this mark" needs two kinds of label, and clustering can only
+ever propose one:
+
+- **same** — a shared `class_id`. These instances must all be found.
+- **different** — a recorded separation. These must be told apart.
+
+The second is what usually goes missing, and its absence is invisible: without
+it, the only thing keeping two similar marks in separate classes is where a
+distance threshold happened to land, so nudging the threshold silently rewrites
+the ground truth. Measured on the fixture corpus at a loose threshold, three
+distinct marks collapse into one class — unless the separations are on disk, in
+which case all three survive.
+
+So a `different` verdict is stored permanently in `separations.json`, keyed on
+**page ids** (which survive a re-cluster; class ids do not) and enforced as a
+cannot-link constraint on every future run. The constraint propagates, so two
+separated marks cannot be reunited through some third ambiguous crop.
+
+## What each source ships
 
 **SPODS** — 1,088 scanned pseudo-official pages, direct download, no
 registration. Confirmed by walking the RAR headers:
@@ -46,30 +77,28 @@ Ground truth (GT1)/{logo,signature,stamp,text}/image (1..1088).png
 Four **binary pixel masks per page**, one per category. Note what is *not*
 there: any notion of *which* logo. A previous study reported "64 logo/stamp
 classes" for SPODS with names like `logo_14` — those identities were derived by
-that study, not read off the dataset, and nothing verified them. Since class
-identity is the entire ground truth of an instance benchmark, that inventory was
-a hypothesis with unmeasured error bars. Here the derivation is explicit
-(`cluster_marks.py`), flagged (`provenance="clustered"`), and audited.
+that study and never verified. Since class identity is the entire ground truth
+of an instance benchmark, that inventory was a hypothesis with unmeasured error
+bars. Here the derivation is explicit (`cluster_marks.py`), flagged
+(`provenance="clustered"`), and only becomes ground truth after the membership
+audit.
 
-SPODS is **not offline**, despite having been recorded that way. Its own page
-still advertises `www.facweb.iitkgp.ernet.in`, a decommissioned host that 503s;
+SPODS is **not offline**, despite having been recorded that way: its own page
+advertises `www.facweb.iitkgp.ernet.in`, a decommissioned host that 503s, while
 `facweb.iitkgp.ac.in` serves the same 2.94 GB file. The authors' Scanned
-Document Degradation Tool is beside it (`sddt.zip`, 689 MB).
+Document Degradation Tool sits beside it (`sddt.zip`, 689 MB).
 
-**StaVer** — 400 scanned dummy bills with pixel-accurate stamp GT plus per-file
-`info` text (stamp count, colour, overlap, signature presence). Kaggle mirror;
-the DFKI original was unreachable when this was written. Again: locations, no
-identities. The recorded stamp count is used as an independent check on the mask
-decomposition — a page the dataset says has one stamp that decomposes to four
-means the merge gap is wrong, which is otherwise invisible.
+**StaVer** — 400 scanned dummy bills, pixel-accurate stamp GT, per-file `info`
+text (stamp count, colour, overlap). Kaggle mirror; DFKI's original was
+unreachable. Locations, no identities. The recorded stamp count is used as an
+independent check on the mask decomposition — a page the dataset says has one
+stamp that decomposes to four means the merge gap is wrong.
 
-**Tobacco800** — 1,290 real scanned business documents, 412 carrying a logo,
-GEDI XML ground truth from UMD's LAMP. The published logo protocol keeps the 21
-categories with **≥2 occurrences**, which cannot support a train-and-search
-eval: at two instances, using one as the query leaves one thing to retrieve. Use
-`--min-instances` and read the survival curve.
+**Tobacco800** — 1,290 real scanned business documents, 412 with a logo, GEDI
+XML ground truth from UMD's LAMP. Its published protocol keeps the 21 logo
+categories with ≥2 occurrences, which cannot support a train-and-search eval.
 
-**UCSF IDL** — an open Solr index. Measured live on 2026-08-25:
+**UCSF IDL** — an open Solr index; measured live 2026-08-25:
 
 | query | count |
 |---|---:|
@@ -77,115 +106,137 @@ eval: at two instances, using one as the query leaves one thing to retrieve. Use
 | tobacco, 1 page, `type:letter` | 1,802,100 |
 | `author:"RJR"` 1-page letters | 162,197 |
 | `author:"PHILIP MORRIS"` | 73,320 |
-| `author:"LOR, LORILLARD"` | 21,120 |
 
-Prefer `author` over `collection`. `collection` is provenance — whose filing
-cabinet the page sat in — so a letter *in* the Philip Morris collection is about
-as likely to be incoming mail on someone else's letterhead.
+**`author` is a candidate pool, not a class.** The field asserts a page is
+*from* a company; it has never looked at the mark. Making it a class id writes
+two guaranteed errors into the ground truth: a company that redesigned its
+letterhead yields one class holding two artworks (so a detector is punished for
+telling them apart), and two subsidiaries sharing artwork yield two classes
+holding one mark (so it is punished for recognising it). Those are exactly the
+errors the eval exists to measure. So the author narrows millions of pages to a
+high-yield pool, each candidate gets a coarse top-of-page band to locate the
+mark, and identity is settled by clustering plus adjudication like everything
+else. `documentdate` is recorded and never enters a class id: era is a fact
+about the calendar, not about the mark.
 
-## Contamination is prevented by construction, not by annotation
+Distractors only: `--ucsf-letterhead-per-author 0`.
 
-The trap: RVL-CDIP, Tobacco800 and UCSF's Tobacco industry all descend from
-IIT-CDIP. An American Tobacco letterhead is *certain* to appear in an RVL-CDIP
-"distractor" pool. Unlabelled positives in a distractor set do not make a
-benchmark slightly noisy — they make a correct retrieval count as a false
-positive, so the metric punishes the model for being right.
+**Synth** — real artwork (LogoDet-3K, or any `--synth-pool-dir`) pasted onto
+held-out real scans at known `(x, y, scale, rotation)` with scanner-style
+degradation. Exact ground truth, and the only stratum that can be *swept*: size,
+rotation and count are inputs, so an experiment can locate the ~32px floor or
+the inlier-count working point instead of straddling it. The rule that comes
+with it: **synthetic numbers quantify a mechanism, real numbers size the
+effect.** A finding that appears only in `synth` is a hypothesis about the
+pipeline, not a claim about documents.
 
-No amount of hand annotation fixes that at 200k pages. `CONTAMINATES` in
-`docmarks_config.py` encodes which sources may serve as distractors for which
-classes, `classes.json` records the resolved list per class, and eval code must
-score a class against its `eligible_distractor_sources` rather than the whole
-corpus. Tobacco800 classes therefore get UCSF's *non-tobacco* industries; SPODS
-and StaVer, whose marks exist nowhere else, get everything.
+## Three kinds of negative
 
-Note one residual: companies span industries (Philip Morris reaches Food through
-Kraft), so industry exclusion is a strong filter, not a proof.
+Not all distractors are equal, and the manifest keeps them distinct:
+
+- **known negative** — a page from a source exhaustively checked for this class,
+  so its *absence* of the mark is verified. These are the valuable ones: same
+  scanner, same paper, same era, known clean. A SPODS page carrying a different
+  mark is the hardest possible negative for a SPODS class, and the membership
+  audit is what makes it usable instead of a contamination risk.
+- **presumed negative** — from a contamination-safe source nobody checked
+  individually. Fine in bulk, and the only way to reach 200k.
+- **excluded** — a contamination risk, never scored.
+
+The trap that last category exists for: RVL-CDIP, Tobacco800 and UCSF's Tobacco
+industry all descend from IIT-CDIP, so an American Tobacco letterhead is
+*certain* to appear in an RVL-CDIP "distractor" pool. Unlabelled positives don't
+make a benchmark slightly noisy — they make a correct retrieval count as a false
+positive, so the metric punishes the model for being right. No hand pass fixes
+that at 200k pages; `CONTAMINATES` in `docmarks_config.py` fixes it by
+construction, and each class records its resolved
+`eligible_distractor_sources`.
 
 ## Tiers
 
 `s`=5k, `m`=50k, `l`=200k pages, **nested**: every page in `s` is in `m` is in
-`l`, and all three share class ids, so a result on one is comparable to a result
-on another. Positives are in every tier — a tier keeping 3 of a class's 30
-instances measures a different and much harder problem, not the same one more
-cheaply. Distractors get a stable hash rank and tiers are prefixes of it.
+`l`, sharing class ids, so a result on one is comparable to a result on another.
+Roster positives are in every tier — a tier keeping 3 of a class's 30 instances
+measures a different and harder problem, not the same one more cheaply.
+Distractors get a stable hash rank and tiers are prefixes of it.
 
 Two stability promises are on offer and they genuinely conflict:
 
-* **within a build** (default): exact budgets, nested. Run on `s`, then on `l`,
-  no rebuild.
-* **across builds** (`--pin-tiers <earlier build_report.json>`): membership fixed
+- **within a build** (default): exact budgets, nested. Run on `s`, then `l`, no
+  rebuild.
+- **across builds** (`--pin-tiers <earlier build_report.json>`): membership fixed
   by absolute rank cutoff, so a grown source pool cannot evict a page from a
   tier it was already in. Budgets drift instead.
 
-Without pinning, a build over a different page set is a **new corpus version**
-and should be named as one. `tests_lib/datasets/test_docmarks_corpus.py` pins
-both behaviours, including the negative one.
+Without pinning, a build over a different page set is a **new corpus version**.
+Both behaviours are pinned by tests, including the negative one.
 
-## The three human passes — and the one that isn't
+## The human passes
 
-Each exists because a specific number is otherwise *unknowable*, not merely
-unverified. In value order:
+In the order you run them. Only the first two are needed for a first eval.
 
-1. **`letterhead`** — sample ~100 pages per weak-label author and count how many
-   really carry the mark. This is the single highest-value check in the corpus:
-   at 90% the UCSF stratum is usable with a noise model, at 40% it is not usable
-   at all, and nothing except looking can tell you which. Everything else in the
-   haystack layer is downstream of this number.
-2. **`cluster`** — confirm the derived SPODS/StaVer classes. One contact sheet
-   per class, all instances; single linkage's failure mode (two classes bridged
-   by one ambiguous crop) is obvious on sight. Verdicts: `ok`, `split`,
-   `merge_into:<id>`, `drop`.
-3. **`distinctive`** — one sheet of every class's exemplar, marked `distinctive`
-   or `generic`. A plain warning triangle or a ruled box is a *shape*, not an
-   *instance*: "find this rectangle" is not a well-posed retrieval query. The
-   prior study's worst classes (`warning_diamond` at 17 keypoints,
-   `hospital_cross`) are exactly this, and averaging them into a headline AP
-   measures the dataset's junk. Generic classes are **kept and labelled**, never
-   deleted, so both numbers stay reportable.
+1. **`membership`** — every instance of every roster class, numbered on contact
+   sheets. Verdict is `ok` or the indices that are *not* this mark (`3,17`), so
+   a 30-crop class is one line. Afterwards no positive is unexamined, which is
+   what lets a miss be blamed on the detector rather than the label. A rejected
+   crop keeps its box and stays on its page — it becomes a known negative.
+2. **`confusable`** — every roster pair side by side, ranked by distance. 24
+   classes is 276 pairs, so the full matrix is adjudicated rather than sampled.
+   `same` sends you to `merge_into:` on the cluster task; `different` writes a
+   permanent separation.
+3. **`cluster`** — is a class one mark at all? Mostly useful while choosing a
+   roster. `split` is productive: it re-clusters that class alone at half the
+   threshold and re-sheets the pieces, disturbing nothing else.
+4. **`distinctive`** — mark vs shape. A plain warning triangle or ruled box is a
+   *shape*: "find this rectangle" is not a well-posed retrieval query. The prior
+   study's worst classes (`warning_diamond` at 17 keypoints, `hospital_cross`)
+   are exactly this. Generic classes are kept and labelled, never deleted.
+5. **`letterhead`** — for the later UCSF expansion: sample bands per candidate
+   author and count how many carry a printed mark at all. Decides whether that
+   pool is worth clustering.
 
-Query crops are generated automatically from each class's largest boxed instance
-(the prior study measured a 2.2× AP advantage for a clean query over a small
-in-scene crop). Weak-label classes have no box, so they are listed in
-`build_report.json` under `needs_hand_crop` — one hand-drawn crop each.
-
-**Not a pass:** exhaustively checking the distractor pool for unlabelled
-positives. Unfixable by hand at this scale; prevented by construction above.
-What *is* worth doing after a run is adjudicating the top-k false positives per
-query — a few hundred thumbnails that separate a model error from a missing
-label, which no aggregate can do.
+Query crops come from each class's largest boxed instance automatically (the
+prior study measured a 2.2× AP advantage for a clean query over a small in-scene
+crop). Band-located classes get none — auto-cropping the strip would hand the
+query a banner of letterhead plus address plus rule line and call it a logo,
+which is worse than no crop because it looks like ground truth. They are listed
+in `build_report.json` under `needs_hand_crop`.
 
 ## Output
 
 ```
 corpus.jsonl        one record per page: path, size, marks, provenance, tier
-classes.json        class inventory: instances, median px, eligible distractors, audit slots
-queries/            one query crop per admitted class
-cluster_report.json what the identity clustering did
-build_report.json   counts, survival curve, tier cutoffs, rejections with reasons, warnings
+classes.json        per class: instances, distinct_from, caveats, eligible distractors, audit state
+roster.json         the hand-picked classes an eval runs on
+separations.json    adjudicated "different mark" pairs, keyed on page ids
+queries/            one query crop per box-located roster class
+shortlist.png/json  ranked candidates for choosing a roster
+cluster_report.json what clustering did, and how many separations it honoured
+build_report.json   counts, survival curve, tier cutoffs, rejections, warnings
 ```
 
-Every mark carries a `provenance`: `gt` (shipped by the source), `clustered`
-(derived here, audit pending), `weak` (metadata-implied, unverified) or
-`synthetic` (true by construction). Do not aggregate across them without saying
-so.
+Every mark carries a `provenance`: `gt` (a box shipped by the source),
+`clustered` (identity derived here), `clustered_band` (identity derived from a
+coarse strip, so the box locates a region and not the mark), `candidate` (pool
+member, no identity yet) or `synthetic` (true by construction). A class also
+carries `audit.membership_verified` — **false means it is still a proposal**.
+Do not aggregate across provenances without saying so.
 
 ## Embedding cells
 
 `embed_corpus.py` writes `docmarks_<tier>__<embedder>.pkl` into the shared
-pile's `embeddings/` dir, in the pile's own format, via the pile's own pickle
-IO. It is deliberately *not* a `pile_config.DATASETS` entry: the pile builds the
-full dataset × embedder cross-product, so adding DocMarks and `sift_vlad` there
-would silently schedule `sift_vlad` cells for all six existing datasets — a
-dozen-odd cells nobody asked for, on a mount the playbook already calls
-chronically full.
+pile's `embeddings/` dir, in the pile's format, via its pickle IO. It is
+deliberately *not* a `pile_config.DATASETS` entry: the pile builds the full
+dataset × embedder cross-product, so adding DocMarks and `sift_vlad` there would
+silently schedule `sift_vlad` cells for all six existing datasets, on a mount
+the playbook already calls chronically full.
 
 ## Before running this on the grid
 
 `python build_corpus.py --probe` first. Every source fails differently — a
 decommissioned hostname, a missing Kaggle token, an absent RAR extractor — and
 finding out which costs seconds now and a queue slot later. SPODS needs one of
-`bsdtar` / `7z` / `unar` / `unrar`; StaVer and Tobacco800 need a Kaggle token at
-`~/.kaggle/kaggle.json` or in `KAGGLE_USERNAME`/`KAGGLE_KEY`.
+`bsdtar` / `7z` / `unar` / `unrar`; StaVer and Tobacco800 need a Kaggle token.
 
-Then `bash ../preflight.sh` as usual, and size from a real cell rather than a
-guess: build tier `s` first and read its actual seconds.
+Then `bash ../preflight.sh`, and size from a real cell rather than a guess:
+build tier `s` first and read its actual seconds.

--- a/scripts/experiments/docmarks/audit_to_corrections.py
+++ b/scripts/experiments/docmarks/audit_to_corrections.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 """Fold filled-in audit verdicts back into the corpus.
 
+    python audit_to_corrections.py --task membership --apply
     python audit_to_corrections.py --task cluster --apply
-    python audit_to_corrections.py --task distinctive --apply
+    python audit_to_corrections.py --task confusable --apply
     python audit_to_corrections.py --task letterhead          # dry run (default)
 
 Without ``--apply`` it prints what it would change and touches nothing.
@@ -44,10 +45,16 @@ def load_verdicts(path: Path) -> list[dict[str, Any]]:
 
 def apply_cluster(
     pages: list[Page], classes: dict[str, Any], verdicts: list[dict[str, Any]]
-) -> tuple[list[str], list[str]]:
-    """``ok`` / ``split`` / ``merge_into:<id>`` / ``drop`` on derived classes."""
+) -> tuple[list[str], list[str], list[str]]:
+    """``ok`` / ``split`` / ``merge_into:<id>`` / ``drop`` on derived classes.
+
+    Returns ``(changes, problems, resplit)``; *resplit* names classes the
+    reviewer judged over-merged, which the caller re-clusters at a tighter
+    threshold.
+    """
     changes: list[str] = []
     problems: list[str] = []
+    resplit: list[str] = []
 
     for row in verdicts:
         class_id = row["class_id"]
@@ -61,12 +68,16 @@ def apply_cluster(
             meta["audit"]["cluster_ok"] = True
             changes.append(f"{class_id}: confirmed")
         elif verdict == "split":
-            # A split needs per-instance labels, which a contact sheet cannot
-            # express.  Mark it unusable rather than guessing a partition: a
-            # silently wrong split is worse than a missing class.
+            # A contact sheet says "this holds more than one mark"; it cannot
+            # say which crop belongs to which. Rather than leave the class dead,
+            # re-cluster *only its own instances* at a tighter threshold and
+            # re-sheet the pieces. That converges: each round either resolves
+            # into confirmable classes or gets split again, and no other class
+            # is disturbed.
             meta["audit"]["cluster_ok"] = False
-            meta["audit"]["notes"] = (row.get("notes") or "flagged for split; excluded pending re-cluster").strip()
-            changes.append(f"{class_id}: flagged as over-merged (excluded)")
+            meta["audit"]["notes"] = (row.get("notes") or "over-merged; re-cluster this class alone").strip()
+            resplit.append(class_id)
+            changes.append(f"{class_id}: queued for re-clustering at a tighter threshold")
         elif verdict.startswith("merge_into:"):
             target = verdict.split(":", 1)[1].strip()
             if target not in classes:
@@ -89,6 +100,63 @@ def apply_cluster(
         else:
             problems.append(f"{class_id}: unrecognised verdict {verdict!r}")
 
+    return changes, problems, resplit
+
+
+def apply_membership(
+    pages: list[Page], classes: dict[str, Any], verdicts: list[dict[str, Any]]
+) -> tuple[list[str], list[str]]:
+    """Remove hand-rejected instances and mark the class fully verified.
+
+    A rejected crop loses its ``class_id`` but keeps its box and stays on its
+    page.  It is not deleted, for two reasons: the page remains a *known*
+    negative for this class — same scanner, same paper, verified clean, which is
+    the hardest and most useful kind of negative — and the mark itself is still
+    a real mark that a later roster may want.
+
+    Setting ``membership_verified`` is the point of the pass.  Before it, a
+    class is a clustering proposal; after it, every positive in the eval has
+    been looked at, so a miss is the detector's fault and not possibly the
+    label's.
+    """
+    changes: list[str] = []
+    problems: list[str] = []
+
+    for row in verdicts:
+        class_id = row["class_id"]
+        meta = classes.get(class_id)
+        if meta is None:
+            problems.append(f"{class_id}: not in classes.json")
+            continue
+
+        raw = str(row["verdict"]).strip().lower()
+        page_ids: list[str] = row.get("page_ids", [])
+        if raw == "ok":
+            rejected_idx: list[int] = []
+        else:
+            try:
+                rejected_idx = sorted({int(tok) for tok in raw.replace(" ", "").split(",") if tok})
+            except ValueError:
+                problems.append(f"{class_id}: verdict must be 'ok' or comma-separated indices, got {raw!r}")
+                continue
+        out_of_range = [i for i in rejected_idx if not 0 <= i < len(page_ids)]
+        if out_of_range:
+            problems.append(f"{class_id}: index/indices {out_of_range} are outside 0..{len(page_ids) - 1}")
+            continue
+
+        dropped = {page_ids[i] for i in rejected_idx}
+        if dropped:
+            for page in pages:
+                if page.page_id in dropped:
+                    page.marks = [
+                        Mark(m.kind, m.box, None, m.provenance) if m.class_id == class_id else m for m in page.marks
+                    ]
+            meta["page_ids"] = [p for p in meta["page_ids"] if p not in dropped]
+            meta["n_instances"] = len(meta["page_ids"])
+
+        meta["audit"]["membership_verified"] = True
+        meta["audit"]["rejected_page_ids"] = sorted(dropped)
+        changes.append(f"{class_id}: verified, {len(dropped)} rejected, {meta['n_instances']} instance(s) remain")
     return changes, problems
 
 
@@ -110,45 +178,154 @@ def apply_distinctive(classes: dict[str, Any], verdicts: list[dict[str, Any]]) -
     return changes, problems
 
 
+def apply_confusable(
+    classes: dict[str, Any],
+    verdicts: list[dict[str, Any]],
+) -> tuple[list[str], list[str], list[dict[str, Any]]]:
+    """``same`` merges two classes; ``different`` records a permanent separation.
+
+    A ``different`` verdict is the only way the corpus can state "these must be
+    told apart", and it is stored against **page ids** rather than class ids so
+    it survives every future re-cluster: class ids move when a threshold moves,
+    page ids do not. Without that, each rebuild would silently discard the
+    adjudication it was supposed to be built on.
+    """
+    changes: list[str] = []
+    problems: list[str] = []
+    separations: list[dict[str, Any]] = []
+
+    for row in verdicts:
+        left, right = row["left_class_id"], row["right_class_id"]
+        verdict = str(row["verdict"]).strip().lower()
+        lmeta, rmeta = classes.get(left), classes.get(right)
+        if lmeta is None or rmeta is None:
+            problems.append(f"{left} / {right}: one of the pair is not in classes.json")
+            continue
+
+        if verdict == "different":
+            lmeta.setdefault("distinct_from", [])
+            rmeta.setdefault("distinct_from", [])
+            if right not in lmeta["distinct_from"]:
+                lmeta["distinct_from"].append(right)
+            if left not in rmeta["distinct_from"]:
+                rmeta["distinct_from"].append(left)
+            # One representative page per side is enough to pin the constraint,
+            # and keeps the store small; the cannot-link propagates to the whole
+            # group through union-find.
+            separations.append(
+                {
+                    "left_page_id": lmeta["page_ids"][0],
+                    "right_page_id": rmeta["page_ids"][0],
+                    "left_class_id": left,
+                    "right_class_id": right,
+                    "note": row.get("notes", ""),
+                }
+            )
+            changes.append(f"{left} != {right}: separation recorded")
+        elif verdict == "same":
+            problems.append(
+                f"{left} / {right}: judged the same mark — record it as "
+                f"'merge_into:{left}' on the cluster task, which moves the instances"
+            )
+        else:
+            problems.append(f"{left} / {right}: unrecognised verdict {verdict!r} (expected same|different)")
+
+    return changes, problems, separations
+
+
 def apply_letterhead(classes: dict[str, Any], verdicts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
     changes: list[str] = []
     problems: list[str] = []
     for row in verdicts:
-        class_id = row["class_id"]
-        meta = classes.get(class_id)
-        if meta is None:
-            problems.append(f"{class_id}: not in classes.json")
-            continue
+        author = row.get("author", "?")
         try:
             hits = int(str(row["verdict"]).strip())
         except ValueError:
-            problems.append(f"{class_id}: verdict must be the count of pages carrying the mark")
+            problems.append(f"{author}: verdict must be the count of bands carrying a printed mark")
             continue
         sampled = int(row.get("sampled", 0)) or 1
-        precision = hits / sampled
-        meta["audit"]["letterhead_precision"] = round(precision, 3)
-        meta["audit"]["letterhead_sampled"] = sampled
-        flag = "" if precision >= 0.8 else "  <- below 0.8, treat this class as noisy"
-        changes.append(f"{class_id}: label precision {precision:.2f} ({hits}/{sampled}){flag}")
+        yield_frac = hits / sampled
+        flag = "" if yield_frac >= 0.5 else "  <- under half; this pool may not be worth clustering"
+        changes.append(f"{author}: candidate yield {yield_frac:.2f} ({hits}/{sampled}){flag}")
     return changes, problems
+
+
+def resplit_classes(
+    pages: list[Page],
+    classes: dict[str, Any],
+    class_ids: Sequence[str],
+    *,
+    backend: str,
+    threshold: float,
+    factor: float = 0.5,
+) -> list[str]:
+    """Re-cluster each over-merged class alone, at a tighter threshold.
+
+    Only that class's own instances are touched, so re-splitting one class can
+    never disturb another's already-confirmed membership.  The resulting pieces
+    come back as fresh candidate classes for the next ``cluster`` sheet.
+    """
+    from cluster_marks import assign_class_ids, describe_marks, distance_matrix, single_linkage
+
+    notes: list[str] = []
+    tighter = threshold * factor
+    for class_id in class_ids:
+        meta = classes.get(class_id)
+        if meta is None:
+            continue
+        refs = _refs_for_class(pages, class_id)
+        if len(refs) < 2:
+            continue
+        desc = describe_marks(pages, refs, backend=backend)
+        dist = distance_matrix(desc, refs, backend=backend)
+        labels = single_linkage(dist, tighter)
+        source = class_id.split("/", 1)[0]
+        provenance = "clustered_band" if meta.get("located_by") == "band" else "clustered"
+        pieces = assign_class_ids(pages, refs, labels, source=source, provenance=provenance)
+        classes.pop(class_id, None)
+        notes.append(f"{class_id}: re-clustered at {tighter:.3f} into {len(pieces)} piece(s)")
+    return notes
+
+
+def _refs_for_class(pages: list[Page], class_id: str) -> list[Any]:
+    from cluster_marks import MarkRef
+
+    return [
+        MarkRef(pi, mi, page.page_id, mark.kind, mark.box)
+        for pi, page in enumerate(pages)
+        for mi, mark in enumerate(page.marks)
+        if mark.class_id == class_id
+    ]
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--task", required=True, choices=("cluster", "distinctive", "letterhead"))
+    ap.add_argument(
+        "--task", required=True, choices=("membership", "cluster", "confusable", "distinctive", "letterhead")
+    )
     ap.add_argument("--corpus", type=Path, default=cfg.OUT)
     ap.add_argument("--apply", action="store_true", help="write the changes (default is a dry run)")
+    ap.add_argument("--cluster-backend", default=cfg.CLUSTER_BACKEND, choices=("phash", "siglip"))
+    ap.add_argument("--cluster-threshold", type=float, default=cfg.CLUSTER_THRESHOLD)
     args = ap.parse_args(argv)
 
     classes_path = args.corpus / "classes.json"
     manifest_path = args.corpus / "corpus.jsonl"
+    separations_path = args.corpus / "separations.json"
     classes = json.loads(classes_path.read_text(encoding="utf-8"))
     verdicts = load_verdicts(args.corpus / "audit" / args.task / "verdicts.jsonl")
 
-    pages = list(read_manifest(manifest_path)) if args.task == "cluster" else []
+    mutates_pages = args.task in ("cluster", "membership")
+    pages = list(read_manifest(manifest_path)) if mutates_pages else []
+    new_separations: list[dict[str, Any]] = []
+    resplit: list[str] = []
 
-    if args.task == "cluster":
-        changes, problems = apply_cluster(pages, classes, verdicts)
+    if args.task == "membership":
+        changes, problems = apply_membership(pages, classes, verdicts)
+    elif args.task == "cluster":
+        changes, problems, resplit = apply_cluster(pages, classes, verdicts)
+    elif args.task == "confusable":
+        changes, problems, new_separations = apply_confusable(classes, verdicts)
     elif args.task == "distinctive":
         changes, problems = apply_distinctive(classes, verdicts)
     else:
@@ -164,10 +341,24 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print("dry run — pass --apply to write")
         return 1 if problems else 0
 
+    if resplit:
+        for note in resplit_classes(
+            pages, classes, resplit, backend=args.cluster_backend, threshold=args.cluster_threshold
+        ):
+            print(f"  {note}")
+        print("  re-run make_audit_slate.py --task cluster to review the new pieces")
+
+    if new_separations:
+        from cluster_marks import load_separations, save_separations
+
+        existing = [{"left_page_id": a, "right_page_id": b} for a, b in load_separations(separations_path)]
+        save_separations(existing + new_separations, separations_path)
+        print(f"  wrote {len(new_separations)} separation(s) to {separations_path}")
+
     classes_path.write_text(json.dumps(classes, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    if args.task == "cluster":
+    if mutates_pages:
         write_manifest(pages, manifest_path)
-    print(f"wrote {classes_path}" + (f" and {manifest_path}" if args.task == "cluster" else ""))
+    print(f"wrote {classes_path}" + (f" and {manifest_path}" if mutates_pages else ""))
     return 1 if problems else 0
 
 

--- a/scripts/experiments/docmarks/build_corpus.py
+++ b/scripts/experiments/docmarks/build_corpus.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python
-"""Assemble the DocMarks corpus: stamps and logos in scanned documents.
+"""Assemble the DocMarks corpus: eval data for stamp detection.
 
-    python build_corpus.py --probe                      # what can I reach?
-    python build_corpus.py --sources spods --limit 40   # small real build
-    python build_corpus.py --survival                   # class counts vs threshold
-    python build_corpus.py                              # the whole thing
+    python build_corpus.py --probe                       # what can I reach?
+    python build_corpus.py --sources spods               # cluster into candidates
+    python build_corpus.py --sources spods --roster r.json   # the eval corpus
+
+Two modes, and which one you are in decides what the output *means*:
+
+* **candidate mode** (no ``--roster``) proposes every class clearing the numeric
+  bars, for ``shortlist.py`` to rank.  These are proposals.
+* **roster mode** admits only the hand-picked classes named in the roster file.
+  Their instances are then adjudicated one by one (``make_audit_slate.py --task
+  membership``), and *that* is the ground truth an eval quotes.
 
 Outputs, under ``docmarks_config.OUT``:
 
     corpus.jsonl      one record per page: path, size, marks, provenance, tier
-    classes.json      the class inventory, with eligibility and audit slots
-    queries/          one query crop per admitted class
-    build_report.json counts, warnings, the survival curve, what was dropped
+    classes.json      per class: instances, distinct_from, caveats, audit state
+    queries/          one query crop per box-located class
+    build_report.json counts, survival curve, tier cutoffs, rejections, warnings
 
-The three strata (anchor / haystack / synth) live in one manifest with **nested
+The strata (anchor / haystack / synth) live in one manifest with **nested
 tiers**, so ``docmarks_s`` and ``docmarks_l`` share class ids and a result on
 one is comparable to a result on the other.
 
@@ -78,42 +85,70 @@ def admit_classes(
     *,
     min_instances: int,
     min_mark_px: int,
+    roster: Optional[Any] = None,
 ) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
-    """Split the inventory into admitted query classes and rejects-with-reasons.
+    """Split the inventory into candidate classes and rejects-with-reasons.
 
-    A class is admitted when it has enough instances *and* its typical instance
-    is big enough to be findable.  The size bar matters as much as the count
-    bar: the 2026-07-13 study measured a hard floor near 32 px below which no
-    structural pipeline recovers anything, so a class built from sub-floor marks
-    measures the floor rather than the method, and averaging it in with the rest
-    drags every aggregate toward zero for a reason that has nothing to do with
-    what is being compared.
+    Two modes, and the difference is what the corpus is *for*:
+
+    * **With a roster** — only the named classes are admitted, and the numeric
+      bars are advisory.  This is the mode an eval runs in: a small hand-picked
+      set whose every instance a person has adjudicated, which is the only kind
+      of ground truth worth quoting.  A roster class that fails a bar is still
+      admitted and the reason is recorded on it, because the human who chose it
+      knows something the threshold does not.
+    * **Without one** — everything clearing both bars is admitted, as the
+      candidate pool ``shortlist.py`` ranks for roster selection.  These are
+      proposals, not ground truth.
+
+    The bars themselves: instance count, because a class you cannot both query
+    and retrieve from is not measurable; and mark size, because the 2026-07-13
+    study found a hard floor near 32 px below which no structural pipeline
+    recovers anything, so a sub-floor class measures the floor rather than the
+    method.
     """
     admitted: dict[str, dict[str, Any]] = {}
     rejected: dict[str, str] = {}
 
     for class_id, refs in sorted(inventory.items()):
+        on_roster = roster is not None and class_id in roster
+        if roster is not None and not on_roster:
+            rejected[class_id] = "not on the roster"
+            continue
+
         marks = [pages[pi].marks[mi] for pi, mi in refs]
         kinds = {m.kind for m in marks}
+        caveats: list[str] = []
+
         if not kinds & set(QUERYABLE_KINDS):
             rejected[class_id] = f"kind {sorted(kinds)} is not queryable"
             continue
         if len(refs) < min_instances:
-            rejected[class_id] = f"{len(refs)} instance(s) < min_instances={min_instances}"
-            continue
+            note = f"{len(refs)} instance(s) < min_instances={min_instances}"
+            if not on_roster:
+                rejected[class_id] = note
+                continue
+            caveats.append(note)
 
         boxed = [m for m in marks if m.area() > 0]
         provenances = {m.provenance for m in marks}
+        # A band class is located by a coarse top-of-page strip rather than a
+        # real mark box, so its pixel size describes the strip and says nothing
+        # about the mark.  Applying the size floor to it would compare the
+        # wrong number against the wrong threshold.
+        banded = provenances == {"clustered_band"}
         median_px: Optional[int] = None
-        if boxed:
-            sides = sorted(m.longest_side() for m in boxed)
-            median_px = sides[len(sides) // 2]
-            if median_px < min_mark_px:
-                rejected[class_id] = f"median mark {median_px}px < min_mark_px={min_mark_px}"
-                continue
-        elif provenances != {"weak"}:
-            rejected[class_id] = "no boxed instances and not a weak-label class"
+        if not boxed:
+            rejected[class_id] = "no located instances"
             continue
+        sides = sorted(m.longest_side() for m in boxed)
+        median_px = sides[len(sides) // 2]
+        if not banded and median_px < min_mark_px:
+            note = f"median mark {median_px}px < min_mark_px={min_mark_px}"
+            if not on_roster:
+                rejected[class_id] = note
+                continue
+            caveats.append(note)
 
         source = class_id.split("/", 1)[0]
         admitted[class_id] = {
@@ -121,12 +156,31 @@ def admit_classes(
             "source": source,
             "kind": sorted(kinds)[0],
             "n_instances": len(refs),
-            "median_mark_px": median_px,
+            "median_mark_px": None if banded else median_px,
+            "located_by": "band" if banded else "box",
             "provenance": sorted(provenances),
             "page_ids": sorted(pages[pi].page_id for pi, _ in refs),
             "eligible_distractor_sources": sorted(s for s in ALL_SOURCES if cfg.eligible_distractor(source, s)),
+            # Adjudicated "this is a different mark" partners, filled by the
+            # audit.  The corpus stores both directions of the ground truth:
+            # a shared class id says what must be found together, and this says
+            # what must be told apart.
+            "distinct_from": [],
+            "on_roster": on_roster,
+            # Bars this class fails but a human kept it anyway.  Recorded rather
+            # than silently waived: the roster overrides the threshold, and the
+            # override should be visible in the artifact.
+            "caveats": caveats,
             # Filled by the human passes; see make_audit_slate.py.
-            "audit": {"distinctive": None, "cluster_ok": None, "letterhead_precision": None, "notes": ""},
+            "audit": {
+                "distinctive": None,
+                "cluster_ok": None,
+                # Per-instance membership verification: every page id checked in
+                # or out by hand.  Until this is done the class is a proposal.
+                "membership_verified": False,
+                "rejected_page_ids": [],
+                "notes": "",
+            },
         }
     return admitted, rejected
 
@@ -226,6 +280,13 @@ def write_query_crops(
     needs_hand_crop: list[str] = []
 
     for class_id, meta in sorted(admitted.items()):
+        # A band class is located by a top-of-page strip, not by the mark. Auto-
+        # cropping the strip would hand the query a banner of letterhead plus
+        # address plus rule line and call it a logo, which is worse than having
+        # no crop: it looks like ground truth.
+        if meta.get("located_by") == "band":
+            needs_hand_crop.append(class_id)
+            continue
         refs = inventory[class_id]
         boxed = [(pi, mi) for pi, mi in refs if pages[pi].marks[mi].area() > 0]
         if not boxed:
@@ -289,10 +350,15 @@ def load_ucsf(
     *,
     distractor_budget: int,
     letterhead_per_author: int,
-    split_by_decade: bool,
+    band_frac: float,
     warnings: list[str],
 ) -> list[Page]:
-    """Pull the haystack and the weakly-labelled letterhead classes."""
+    """Pull the haystack, plus letterhead *candidate* pages.
+
+    Candidates are not classes.  They are pages an author query says are likely
+    to carry a company letterhead, carrying a coarse top-of-page band so the
+    mark can be clustered and adjudicated like any other.
+    """
     from sources import ucsf
 
     failures: list[str] = []
@@ -316,7 +382,7 @@ def load_ucsf(
                 raw,
                 out_images / "ucsf",
                 letterhead_author=author,
-                split_by_decade=split_by_decade,
+                band_frac=band_frac,
                 on_error=note,
             )
         )
@@ -401,13 +467,29 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
     ap.add_argument("--raw", type=Path, default=cfg.RAW)
     ap.add_argument("--out", type=Path, default=cfg.OUT)
     ap.add_argument("--limit", type=int, default=None, help="cap pages per anchor source (smoke builds)")
+    ap.add_argument(
+        "--roster",
+        type=Path,
+        default=None,
+        help="roster.json naming the hand-picked classes; without it every class clearing the bars is a candidate",
+    )
     ap.add_argument("--min-instances", type=int, default=cfg.MIN_INSTANCES)
     ap.add_argument("--min-mark-px", type=int, default=cfg.MIN_MARK_PX)
     ap.add_argument("--cluster-backend", default=cfg.CLUSTER_BACKEND, choices=("phash", "siglip"))
     ap.add_argument("--cluster-threshold", type=float, default=cfg.CLUSTER_THRESHOLD)
     ap.add_argument("--ucsf-distractors", type=int, default=0, help="total UCSF distractor pages to pull")
-    ap.add_argument("--ucsf-letterhead-per-author", type=int, default=0)
-    ap.add_argument("--split-letterhead-by-decade", action="store_true")
+    ap.add_argument(
+        "--ucsf-letterhead-per-author",
+        type=int,
+        default=0,
+        help="pages per author to pull as letterhead candidates (0 = distractors only)",
+    )
+    ap.add_argument(
+        "--letterhead-band-frac",
+        type=float,
+        default=cfg.LETTERHEAD_BAND_FRAC,
+        help="fraction of page height treated as the letterhead band on UCSF candidates",
+    )
     ap.add_argument("--synth-per-class", type=int, default=cfg.SYNTH_INSTANCES_PER_CLASS)
     ap.add_argument("--synth-pool-dir", type=Path, default=None, help="local artwork dir (else LogoDet-3K via Kaggle)")
     ap.add_argument("--synth-max-classes", type=int, default=200)
@@ -436,37 +518,49 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
     pages = load_anchor_sources(selected, args.raw, limit=args.limit, warnings=warnings)
     print(f"anchor sources: {len(pages)} page(s)")
 
-    # Identity clustering, for the sources that ship location without identity.
-    from cluster_marks import cluster_source, write_cluster_report
-
-    summaries = []
-    for source in ("spods", "staver"):
-        if source in selected:
-            summary = cluster_source(
-                pages,
-                source,
-                backend=args.cluster_backend,
-                threshold=args.cluster_threshold,
-            )
-            summaries.append(summary)
-            print(
-                f"  {source}: {summary['marks']} mark(s) -> {summary['classes']} candidate class(es) "
-                f"({summary.get('singletons', 0)} singleton) via {summary['backend']}"
-            )
-    if summaries:
-        write_cluster_report(summaries, args.out / "cluster_report.json")
-
     if "ucsf" in selected and (args.ucsf_distractors or args.ucsf_letterhead_per_author):
         ucsf_pages = load_ucsf(
             args.raw,
             images_dir,
             distractor_budget=args.ucsf_distractors,
             letterhead_per_author=args.ucsf_letterhead_per_author,
-            split_by_decade=args.split_letterhead_by_decade,
+            band_frac=args.letterhead_band_frac,
             warnings=warnings,
         )
         pages.extend(ucsf_pages)
         print(f"ucsf: {len(ucsf_pages)} page(s)")
+
+    # Identity clustering, for every source that ships location without
+    # identity.  UCSF is in this list on purpose: its `author` metadata is a
+    # candidate pool, not a class, so its letterhead bands are adjudicated by
+    # the same path as SPODS's and StaVer's marks rather than being trusted.
+    from cluster_marks import cluster_source, load_separations, write_cluster_report
+
+    separations = load_separations(args.out / "separations.json")
+    if separations:
+        print(f"\nhonouring {len(separations)} adjudicated different-mark pair(s)")
+
+    summaries = []
+    for source in ("spods", "staver", "ucsf"):
+        if source not in selected:
+            continue
+        summary = cluster_source(
+            pages,
+            source,
+            backend=args.cluster_backend,
+            threshold=args.cluster_threshold,
+            separations=separations,
+            provenance="clustered_band" if source == "ucsf" else "clustered",
+        )
+        if not summary["marks"]:
+            continue
+        summaries.append(summary)
+        print(
+            f"  {source}: {summary['marks']} mark(s) -> {summary['classes']} candidate class(es) "
+            f"({summary.get('singletons', 0)} singleton) via {summary['backend']}"
+        )
+    if summaries:
+        write_cluster_report(summaries, args.out / "cluster_report.json")
 
     inventory = class_inventory(pages)
     curve = survival_curve(inventory, (2, 5, 10, 15, 20, 30, 50))
@@ -513,8 +607,37 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
             print(f"synth: {len(synth_pages)} page(s) over {len(pool)} class(es); {len(used)} background(s) held out")
             inventory = class_inventory(pages)
 
-    admitted, rejected = admit_classes(pages, inventory, min_instances=args.min_instances, min_mark_px=args.min_mark_px)
-    print(f"\nadmitted {len(admitted)} class(es); rejected {len(rejected)}")
+    chosen = None
+    if args.roster:
+        import roster as _roster
+
+        chosen = _roster.load(args.roster)
+        print(f"\nroster {chosen.name!r}: {len(chosen)} class(es)")
+
+    admitted, rejected = admit_classes(
+        pages,
+        inventory,
+        min_instances=args.min_instances,
+        min_mark_px=args.min_mark_px,
+        roster=chosen,
+    )
+
+    if chosen is not None:
+        _present, missing = _roster.check(chosen, list(inventory))
+        if missing:
+            # A roster naming a class that no longer exists means the roster and
+            # the clustering have drifted apart — which would otherwise show up
+            # only as a quietly smaller eval.
+            warnings.append(f"roster names {len(missing)} class(es) absent from this build: {missing[:5]}")
+        caveated = {c: m["caveats"] for c, m in admitted.items() if m["caveats"]}
+        if caveated:
+            print(f"  {len(caveated)} roster class(es) kept despite a failed bar:")
+            for cid, notes in sorted(caveated.items()):
+                print(f"    {cid}: {'; '.join(notes)}")
+        print(f"admitted {len(admitted)} roster class(es)")
+    else:
+        print(f"\nadmitted {len(admitted)} candidate class(es); rejected {len(rejected)}")
+        print("  no roster given — these are proposals, not ground truth; rank them with shortlist.py")
 
     needs_hand_crop = write_query_crops(pages, inventory, admitted, args.out / "queries")
     if needs_hand_crop:
@@ -562,9 +685,23 @@ def main(argv: Optional[Sequence[str]] = None) -> int:  # noqa: C901
         "tier_cutoffs": tier_cutoffs,
         "classes_admitted": len(admitted),
         "classes_rejected": len(rejected),
-        "rejection_reasons": rejected,
+        "roster": chosen.name if chosen is not None else None,
+        "membership_verified": sorted(c for c, m in admitted.items() if m["audit"]["membership_verified"]),
+        # Rejection reasons are only interesting for the candidate-pool mode; in
+        # roster mode almost every entry is the uninformative "not on the
+        # roster", which would bury the real ones.
+        "rejection_reasons": ({c: r for c, r in rejected.items() if r != "not on the roster"} if chosen else rejected),
         "survival_curve": {str(k): v for k, v in curve.items()},
         "needs_hand_crop": needs_hand_crop,
+        "separations_honoured": len(separations),
+        "hard_negative_pairs": sorted(
+            {
+                tuple(sorted((cid, other)))
+                for cid, meta in admitted.items()
+                for other in meta.get("distinct_from", [])
+                if other in admitted
+            }
+        ),
         "warnings": warnings,
         "settings": {
             "sources": selected,

--- a/scripts/experiments/docmarks/cluster_marks.py
+++ b/scripts/experiments/docmarks/cluster_marks.py
@@ -178,8 +178,29 @@ def distance_matrix(
 # --------------------------------------------------------------------------
 
 
-def single_linkage(dist: np.ndarray, threshold: float) -> list[int]:
-    """Union-find single-linkage clustering.  Returns a label per row."""
+def single_linkage(
+    dist: np.ndarray,
+    threshold: float,
+    *,
+    cannot_link: Optional[Sequence[tuple[int, int]]] = None,
+) -> list[int]:
+    """Union-find single-linkage clustering.  Returns a label per row.
+
+    *cannot_link* is a list of index pairs a human has adjudicated as **different
+    marks**.  Those pairs are never merged, however similar they look, and the
+    constraint propagates: once ``a`` and ``b`` are separated, nothing may join
+    their groups through some third crop either.
+
+    This is the half of the ground truth that pure clustering cannot supply.
+    Two visually confusable marks — the same company's logo beside its
+    subsidiary's, a stamp and its reissue — are precisely the pairs an
+    instance-retrieval benchmark must pin, and precisely the pairs single
+    linkage will chain together.  Recording "these are different" makes the
+    distinction enforceable rather than a matter of where the threshold landed.
+
+    Merges are applied in increasing distance order so the result does not
+    depend on iteration order once constraints start blocking merges.
+    """
     n = dist.shape[0]
     parent = list(range(n))
 
@@ -189,12 +210,39 @@ def single_linkage(dist: np.ndarray, threshold: float) -> list[int]:
             i = parent[i]
         return i
 
-    for i in range(n):
-        for j in range(i + 1, n):
-            if dist[i, j] <= threshold:
-                ri, rj = find(i), find(j)
-                if ri != rj:
-                    parent[max(ri, rj)] = min(ri, rj)
+    # Groups that must stay apart, tracked by representative and kept current
+    # as unions happen.
+    forbidden: set[tuple[int, int]] = set()
+
+    def forbid(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            forbidden.add((min(ra, rb), max(ra, rb)))
+
+    def blocked(ra: int, rb: int) -> bool:
+        return (min(ra, rb), max(ra, rb)) in forbidden
+
+    for a, b in cannot_link or ():
+        forbid(a, b)
+
+    candidates = sorted(
+        ((dist[i, j], i, j) for i in range(n) for j in range(i + 1, n) if dist[i, j] <= threshold),
+        key=lambda t: (t[0], t[1], t[2]),
+    )
+    for _d, i, j in candidates:
+        ri, rj = find(i), find(j)
+        if ri == rj or blocked(ri, rj):
+            continue
+        keep, gone = min(ri, rj), max(ri, rj)
+        parent[gone] = keep
+        # Re-key every constraint that referenced the absorbed group.
+        if forbidden:
+            rekeyed = set()
+            for x, y in forbidden:
+                nx = keep if x == gone else x
+                ny = keep if y == gone else y
+                rekeyed.add((min(nx, ny), max(nx, ny)))
+            forbidden = rekeyed
 
     # Relabel roots to dense 0..k-1 in first-appearance order, so the labelling
     # is a pure function of the distance matrix and not of dict iteration.
@@ -214,6 +262,7 @@ def assign_class_ids(
     labels: Sequence[int],
     *,
     source: str,
+    provenance: str = "clustered",
 ) -> dict[str, list[MarkRef]]:
     """Write clustered ``class_id``\\ s back onto the pages' marks.
 
@@ -237,8 +286,38 @@ def assign_class_ids(
                 kind=mark.kind,
                 box=mark.box,
                 class_id=class_id,
-                provenance="clustered",
+                provenance=provenance,
             )
+    return out
+
+
+def resolve_separations(
+    refs: Sequence[MarkRef],
+    separations: Sequence[tuple[str, str]],
+) -> list[tuple[int, int]]:
+    """Turn adjudicated ``(page_id, page_id)`` pairs into row-index pairs.
+
+    Separations are stored against **page ids**, not row indices or class ids,
+    because those are the only identifiers that survive a re-cluster.  A row
+    index changes whenever the corpus grows; a class id changes whenever the
+    threshold moves — and a human decision that "these two marks are different"
+    must outlive both, or every re-run quietly discards the adjudication it was
+    supposed to be built on.
+
+    A pair naming a page that is no longer in the corpus is skipped rather than
+    raising: pages come and go with tier budgets, and a dropped page is not a
+    reason to refuse to build.
+    """
+    rows_by_page: dict[str, list[int]] = {}
+    for index, ref in enumerate(refs):
+        rows_by_page.setdefault(ref.page_id, []).append(index)
+
+    out: list[tuple[int, int]] = []
+    for left, right in separations:
+        for a in rows_by_page.get(left, ()):
+            for b in rows_by_page.get(right, ()):
+                if a != b:
+                    out.append((a, b))
     return out
 
 
@@ -262,16 +341,24 @@ def cluster_source(
     kinds: Iterable[str] = ("logo", "stamp"),
     backend: str = "phash",
     threshold: float = 0.18,
+    separations: Optional[Sequence[tuple[str, str]]] = None,
+    provenance: str = "clustered",
 ) -> dict[str, Any]:
-    """Cluster one source's marks in place.  Returns a summary for the report."""
+    """Cluster one source's marks in place.  Returns a summary for the report.
+
+    *separations* are adjudicated "these are different marks" pairs, as
+    ``(page_id, page_id)``.  They survive re-clustering: a human decision about
+    two marks must not be undone by someone later nudging the threshold.
+    """
     refs = collect_refs(pages, kinds=kinds, source=source)
     if not refs:
         return {"source": source, "marks": 0, "classes": 0, "backend": backend, "threshold": threshold}
 
     desc = describe_marks(pages, refs, backend=backend)
     dist = distance_matrix(desc, refs, backend=backend)
-    labels = single_linkage(dist, threshold)
-    classes = assign_class_ids(pages, refs, labels, source=source)
+    cannot_link = resolve_separations(refs, separations or ())
+    labels = single_linkage(dist, threshold, cannot_link=cannot_link)
+    classes = assign_class_ids(pages, refs, labels, source=source, provenance=provenance)
 
     sizes = sorted((len(v) for v in classes.values()), reverse=True)
     return {
@@ -280,6 +367,7 @@ def cluster_source(
         "classes": len(classes),
         "backend": backend,
         "threshold": threshold,
+        "separations_applied": len(cannot_link),
         "largest_clusters": sizes[:10],
         "singletons": sum(1 for s in sizes if s == 1),
     }
@@ -288,3 +376,39 @@ def cluster_source(
 def write_cluster_report(summaries: list[dict[str, Any]], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(summaries, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# Adjudicated same/different decisions
+# --------------------------------------------------------------------------
+#
+# The corpus stores *both* directions of the ground truth, because a benchmark
+# needs both: same-mark pairs say what the detector must find, different-mark
+# pairs say what it must keep apart.  Clustering can only ever propose the
+# first; the second has to be adjudicated and then enforced, which is what
+# `cannot_link` in single_linkage does with these.
+
+
+def load_separations(path: Path) -> list[tuple[str, str]]:
+    """Read adjudicated different-mark pairs.  Missing file means none yet."""
+    if not path.exists():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return [(row["left_page_id"], row["right_page_id"]) for row in payload.get("separations", [])]
+
+
+def save_separations(pairs: Sequence[dict[str, Any]], path: Path) -> None:
+    """Write adjudicated different-mark pairs, deduplicated and ordered.
+
+    Pairs are stored unordered-within-pair (sorted) so that adjudicating
+    ``(a, b)`` and later ``(b, a)`` records one decision rather than two.
+    """
+    seen: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in pairs:
+        key = tuple(sorted((row["left_page_id"], row["right_page_id"])))
+        merged = dict(row)
+        merged["left_page_id"], merged["right_page_id"] = key
+        seen[key] = merged  # type: ignore[index]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"separations": [seen[k] for k in sorted(seen)]}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/experiments/docmarks/docmarks_config.py
+++ b/scripts/experiments/docmarks/docmarks_config.py
@@ -121,11 +121,21 @@ CONTAMINATES: dict[str, frozenset[str]] = {
 #: scanned letterhead for the weakly-labelled classes, not despite the clash.
 UCSF_INDUSTRIES: tuple[str, ...] = ("Tobacco", "Opioids", "Chemical", "Fossil Fuel", "Drug", "Food")
 
-#: Companies whose single-page letters form the weakly-labelled letterhead
-#: classes.  ``author`` (who wrote it), not ``collection`` (whose files it sat
-#: in): a letter *in* the Philip Morris collection is as likely to be incoming
-#: mail on a law firm's letterhead.  Live counts of single-page ``type:letter``
+#: Fraction of page height treated as the letterhead band on a UCSF candidate
+#: page.  UCSF ships no boxes, and a mark nobody can see cannot be adjudicated;
+#: a letterhead is at the top of the page by definition, so the top strip is a
+#: coarse but honest locator to cluster on.  It is never a ground-truth box —
+#: the tight box comes from the hand-drawn query crop after adjudication.
+LETTERHEAD_BAND_FRAC = float(os.environ.get("VTS_DOCMARKS_LETTERHEAD_BAND_FRAC", "0.22"))
+
+#: Companies whose single-page letters form the letterhead **candidate pool**.
+#: ``author`` (who wrote it), not ``collection`` (whose files it sat in): a
+#: letter *in* the Philip Morris collection is as likely to be incoming mail on
+#: a law firm's letterhead.  Live counts of single-page ``type:letter``
 #: documents per author, measured 2026-08-25, are in the README.
+#:
+#: An author is a pool, never a class.  See ``sources/ucsf.py`` for why turning
+#: one into a class id would write two guaranteed errors into the ground truth.
 UCSF_LETTERHEAD_AUTHORS: tuple[str, ...] = (
     "PHILIP MORRIS",
     "RJR",

--- a/scripts/experiments/docmarks/embed_corpus.py
+++ b/scripts/experiments/docmarks/embed_corpus.py
@@ -119,11 +119,12 @@ def pages_for_tier(corpus: Path, tier: str) -> list[Page]:
 def load_medias(pages: Sequence[Page], classes: dict[str, Any], embedder: str) -> dict[int, dict]:
     """Turn manifest pages into the media dicts the embedding stage expects.
 
-    ``regions`` carries every ground-truth mark, so a region-voting arm can drag
-    the real box rather than the whole page.  Weak (boxless) marks are recorded
-    in ``categories`` but contribute no region — a zero-area box would be
-    indistinguishable from a real one downstream, which is exactly the
-    distinction the corpus is built to preserve.
+    ``regions`` carries every located mark, so a region-voting arm can drag the
+    real box rather than the whole page.  A region records the ``provenance`` it
+    came with, so a downstream arm can tell an adjudicated box from a coarse
+    letterhead band; unlocated marks contribute no region at all, because a
+    zero-area box would be indistinguishable from a real one and that is exactly
+    the distinction the corpus exists to preserve.
     """
     medias: dict[int, dict] = {}
     for index, page in enumerate(sorted(pages, key=lambda p: p.page_id)):
@@ -170,7 +171,7 @@ def load_medias(pages: Sequence[Page], classes: dict[str, Any], embedder: str) -
                 "tier": page.meta.get("tier"),
                 "provenances": sorted({m.provenance for m in page.marks}),
                 "industry": page.meta.get("industry"),
-                "decade": page.meta.get("decade"),
+                "year": page.meta.get("year"),
             },
         }
     return medias

--- a/scripts/experiments/docmarks/make_audit_slate.py
+++ b/scripts/experiments/docmarks/make_audit_slate.py
@@ -1,25 +1,43 @@
 #!/usr/bin/env python
 """Render the contact sheets for the DocMarks human passes.
 
-    python make_audit_slate.py --task cluster      # are the derived classes real?
-    python make_audit_slate.py --task distinctive  # is this mark an instance at all?
-    python make_audit_slate.py --task letterhead   # does the weak label hold?
+    python make_audit_slate.py --task letterhead   # is a mark there at all?
+    python make_audit_slate.py --task cluster      # is this class one mark?
+    python make_audit_slate.py --task confusable   # are these two the same mark?
+    python make_audit_slate.py --task distinctive  # is this a mark or a shape?
 
 Each task writes PNG sheets plus a ``verdicts.jsonl`` template into
 ``<out>/audit/<task>/``.  Fill in the verdict field, then fold the answers back
 with ``audit_to_corrections.py``.
 
-**These are the only three annotation passes the corpus asks for**, and each one
-exists because a specific number is otherwise unknowable rather than merely
-unverified:
+The corpus stores **both directions** of the ground truth, because an eval needs
+both: a shared class id says what the detector must find together, and a
+recorded separation says what it must tell apart.  Clustering can only ever
+propose the first.  These passes supply the second and confirm the first.
+
+``letterhead``
+    Runs first, on UCSF candidate pages.  Not "are these crops one mark" but "is
+    any of this a mark" — an author query returns letters, and some are plain
+    paper, carbon copies, or the second page of something.  A band with nothing
+    printed on it must be a distractor, and no amount of clustering discovers
+    that on its own.
 
 ``cluster``
-    SPODS and StaVer ship mark locations without identities, so their class
-    inventory is derived by :mod:`cluster_marks` and is currently a hypothesis.
-    A previous study published per-class results on exactly this kind of derived
-    inventory without checking it.  Reviewing the largest clusters catches the
-    single-linkage failure mode (two classes bridged by one ambiguous crop) in
-    about a minute per class.
+    SPODS and StaVer ship mark locations without identities, and UCSF ships
+    neither, so every class in those strata is derived and is a hypothesis until
+    looked at.  A previous study published per-class results on exactly this
+    kind of unchecked inventory.  One sheet per class, all instances; single
+    linkage's failure mode (two marks bridged by one ambiguous crop) is obvious
+    on sight.  ``split`` is productive here — it re-clusters that class alone at
+    a tighter threshold and re-sheets the pieces.
+
+``confusable``
+    The nearest class pairs, side by side, ranked by descriptor distance so the
+    genuinely ambiguous ones come first.  ``different`` records a permanent
+    separation that every future re-cluster honours; ``same`` sends you to
+    ``merge_into:`` on the cluster task.  Without this the corpus can only ever
+    assert similarity, and the pairs a detector most needs to distinguish are
+    precisely the ones a threshold decided by a hair.
 
 ``distinctive``
     A plain warning triangle or a ruled box is a *shape*, not an *instance*: no
@@ -29,13 +47,6 @@ unverified:
     headline AP measures the dataset's junk rather than the method.  Splitting
     them out as a labelled stratum — not deleting them — lets both numbers be
     reported.
-
-``letterhead``
-    The UCSF stratum's labels come from metadata: ``author:"PHILIP MORRIS"``
-    implies a Philip Morris letterhead.  Nobody has measured how often that is
-    true.  If it is 90% the stratum is usable with a noise model; if it is 40%
-    it is not usable at all.  ~100 sampled pages per author settles it, and
-    nothing else can.
 
 Deliberately **not** an annotation pass: exhaustively checking the distractor
 pool for unlabelled positives.  That is unfixable by hand at 200k pages and is
@@ -48,12 +59,16 @@ from __future__ import annotations
 import argparse
 import json
 import random
+import re
 import sys
 from pathlib import Path
 from typing import Any, Optional, Sequence
 
+import numpy as np
+
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import cluster_marks as _cluster  # noqa: E402
 import docmarks_config as cfg  # noqa: E402
 from sources._common import Page, read_manifest  # noqa: E402
 
@@ -103,7 +118,7 @@ def task_cluster(pages: list[Page], classes: dict[str, Any], out: Path, *, max_p
     """One sheet per derived class: every instance, so a bad merge is obvious."""
     by_id = {p.page_id: p for p in pages}
     verdicts = []
-    derived = {k: v for k, v in classes.items() if "clustered" in v.get("provenance", [])}
+    derived = {k: v for k, v in classes.items() if any(p.startswith("clustered") for p in v.get("provenance", []))}
 
     for class_id, meta in sorted(derived.items(), key=lambda kv: -kv[1]["n_instances"]):
         crops, caps = [], []
@@ -126,7 +141,151 @@ def task_cluster(pages: list[Page], classes: dict[str, Any], out: Path, *, max_p
                 "class_id": class_id,
                 "n_instances": meta["n_instances"],
                 "sheet": f"{name}.png",
-                # one of: ok | split | merge_into:<class_id> | drop
+                # one of:
+                #   ok                     every crop on the sheet is one mark
+                #   merge_into:<class_id>  this and that class are the same mark
+                #   split                  the sheet holds more than one mark;
+                #                          re-clusters this class alone at a
+                #                          tighter threshold and re-sheets it
+                #   drop                   not a usable mark at all
+                "verdict": "",
+                "notes": "",
+            }
+        )
+    return verdicts
+
+
+def task_membership(pages: list[Page], classes: dict[str, Any], out: Path) -> list[dict]:
+    """Every instance of every roster class, numbered, for an in/out call.
+
+    This is the pass that makes a roster worth having.  ``cluster`` asks whether
+    a class is *one* mark; this asks, of each individual crop, whether it really
+    is *that* mark.  On a curated roster the two dozen classes come to a few
+    hundred crops, which is an afternoon — and afterwards no positive in the
+    eval is unexamined, so a false negative is unambiguously the detector's
+    fault rather than possibly the label's.
+
+    Verdicts are recorded as **indices to reject** rather than one row per crop,
+    because the sheets are numbered and "3,17" is the whole answer for a class
+    that is 30-for-32 correct.  An empty verdict on a reviewed class means every
+    crop is good, so the row must still be marked — ``ok`` says so explicitly.
+    """
+    by_id = {p.page_id: p for p in pages}
+    roster_classes = {k: v for k, v in classes.items() if v.get("on_roster")}
+    if not roster_classes:
+        return []
+
+    verdicts = []
+    for class_id, meta in sorted(roster_classes.items()):
+        crops, caps, page_ids = [], [], []
+        for page_id in meta["page_ids"]:
+            page = by_id.get(page_id)
+            if page is None:
+                continue
+            for mark in page.marks:
+                if mark.class_id == class_id:
+                    crops.append(_crop(page, mark.box))
+                    caps.append(f"[{len(crops) - 1}] {page_id.split('/')[-1]}")
+                    page_ids.append(page_id)
+                    break
+        if not crops:
+            continue
+
+        name = class_id.replace("/", "__")
+        for start in range(0, len(crops), COLS * 4):
+            _sheet(
+                crops[start : start + COLS * 4],
+                f"{class_id} — instances {start}..{start + len(crops[start : start + COLS * 4]) - 1} "
+                f"of {len(crops)} — which are NOT this mark?",
+                out / f"{name}_{start // (COLS * 4):02d}.png",
+                caps[start : start + COLS * 4],
+            )
+        verdicts.append(
+            {
+                "task": "membership",
+                "class_id": class_id,
+                "n_instances": len(crops),
+                # Index -> page id, so a verdict of "3,17" resolves without the
+                # reviewer ever handling a page id.
+                "page_ids": page_ids,
+                # "ok" = every crop is this mark. Otherwise a comma-separated
+                # list of the numbered crops that are NOT (e.g. "3,17").
+                "verdict": "",
+                "notes": "",
+            }
+        )
+    return verdicts
+
+
+def task_confusable(
+    pages: list[Page],
+    classes: dict[str, Any],
+    out: Path,
+    *,
+    top_n: int = 60,
+) -> list[dict]:
+    """Side-by-side sheets of the *nearest* class pairs — same mark, or not?
+
+    This is the half of the ground truth clustering cannot produce.  A shared
+    class id already says "these must be found together"; nothing yet says
+    "these must be told apart", and the pairs where that matters are exactly the
+    ones a threshold decided by a hair.  Ranking pairs by descriptor distance
+    puts the genuinely ambiguous ones first, so the adjudication effort lands
+    where the labels are actually undetermined rather than being spread evenly
+    over pairs no one could confuse.
+
+    A ``different`` verdict is recorded as a permanent separation and is
+    enforced on every future re-cluster, so this decision is made once.
+    """
+    from PIL import Image
+
+    # On a roster the full matrix is small enough to adjudicate exhaustively:
+    # 24 classes is 276 pairs, and every pair judged means the "different"
+    # half of the ground truth is complete rather than sampled. top_n only
+    # bites on a candidate pool, where the count would otherwise be quadratic
+    # in a few hundred classes.
+    pool = {k: v for k, v in classes.items() if v.get("on_roster")} or classes
+    exemplars: list[tuple[str, Any]] = []
+    for class_id, meta in sorted(pool.items()):
+        crop = meta.get("query_crop")
+        if crop and Path(crop).exists():
+            exemplars.append((class_id, Image.open(crop)))
+    if len(exemplars) < 2:
+        return []
+
+    desc = np.array([_cluster.phash(im) for _cid, im in exemplars], dtype=bool)
+    bits = desc.astype(np.uint8)
+    inv = 1 - bits
+    dist = (bits @ inv.T + inv @ bits.T).astype(float) / desc.shape[1]
+    np.fill_diagonal(dist, 1.0)
+
+    all_pairs = sorted(
+        ((dist[i, j], i, j) for i in range(len(exemplars)) for j in range(i + 1, len(exemplars))),
+        key=lambda t: (t[0], t[1], t[2]),
+    )
+    pairs = all_pairs if len(all_pairs) <= top_n else all_pairs[:top_n]
+
+    verdicts = []
+    for rank, (d, i, j) in enumerate(pairs):
+        left_id, left_im = exemplars[i]
+        right_id, right_im = exemplars[j]
+        name = f"pair_{rank:03d}"
+        _sheet(
+            [left_im, right_im],
+            f"{left_id}   vs   {right_id}   (distance {d:.3f}) — same mark, or different?",
+            out / f"{name}.png",
+            [left_id.split("/")[-1], right_id.split("/")[-1]],
+        )
+        verdicts.append(
+            {
+                "task": "confusable",
+                "left_class_id": left_id,
+                "right_class_id": right_id,
+                "distance": round(float(d), 4),
+                "sheet": f"{name}.png",
+                # one of: same | different
+                # "different" is recorded permanently and blocks these two from
+                # ever being merged by a later re-cluster.
                 "verdict": "",
                 "notes": "",
             }
@@ -169,42 +328,50 @@ def task_distinctive(pages: list[Page], classes: dict[str, Any], out: Path) -> l
     return verdicts
 
 
-def task_letterhead(pages: list[Page], out: Path, *, sample_per_author: int = 100, seed: int = 7) -> list[dict]:
-    """Sampled full pages per weak-label author: does the letterhead exist?"""
+def task_letterhead(pages: list[Page], out: Path, *, sample_per_author: int = 60, seed: int = 7) -> list[dict]:
+    """Sampled letterhead bands per candidate author — is a mark there at all?
+
+    This runs *before* clustering can be trusted, and it answers a different
+    question from ``cluster``: not "are these crops one mark" but "is any of
+    this a mark".  An author query returns letters; some are printed on plain
+    paper, some are carbon copies, some are the second page of something.  A
+    band with no mark on it is a page that must be a distractor, not a class
+    member, and no amount of clustering discovers that on its own.
+    """
     from PIL import Image
 
     rng = random.Random(seed)
-    by_class: dict[str, list[Page]] = {}
+    by_author: dict[str, list[Page]] = {}
     for page in pages:
-        for mark in page.marks:
-            if mark.provenance == "weak" and mark.class_id:
-                by_class.setdefault(mark.class_id, []).append(page)
+        author = page.meta.get("letterhead_author")
+        if author and any(m.provenance in ("candidate", "clustered_band") for m in page.marks):
+            by_author.setdefault(author, []).append(page)
 
     verdicts = []
-    for class_id, group in sorted(by_class.items()):
+    for author, group in sorted(by_author.items()):
         sample = rng.sample(group, min(sample_per_author, len(group)))
-        name = class_id.replace("/", "__")
+        name = re.sub(r"[^a-z0-9]+", "_", author.lower()).strip("_")
         thumbs = []
         for page in sample:
             with Image.open(page.path) as im:
-                # Only the top third: a letterhead lives at the top of the page,
-                # and a full-page thumbnail at this size shows nothing useful.
-                thumbs.append(im.convert("RGB").crop((0, 0, im.width, im.height // 3)))
+                band = next((m.box for m in page.marks if m.area() > 0), (0, 0, im.width, im.height // 4))
+                x, y, w, h = band
+                thumbs.append(im.convert("RGB").crop((x, y, x + w, y + h)))
         for start in range(0, len(thumbs), COLS * 5):
             _sheet(
                 thumbs[start : start + COLS * 5],
-                f"{class_id} — page tops — which carry the letterhead?",
+                f"{author} — letterhead bands — how many carry a printed mark?",
                 out / f"{name}_{start // (COLS * 5):03d}.png",
             )
         verdicts.append(
             {
                 "task": "letterhead",
-                "class_id": class_id,
+                "author": author,
                 "sampled": len(sample),
                 "population": len(group),
-                # Fill in the count of sampled pages that DO carry the mark.
-                # That count divided by `sampled` is the stratum's label
-                # precision, which is the number the whole layer hangs on.
+                # Count of sampled bands that DO carry a printed mark. Divided
+                # by `sampled` this is the candidate pool's yield, which decides
+                # whether the UCSF stratum is worth clustering at all.
                 "verdict": "",
                 "notes": "",
             }
@@ -214,9 +381,17 @@ def task_letterhead(pages: list[Page], out: Path, *, sample_per_author: int = 10
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--task", required=True, choices=("cluster", "distinctive", "letterhead"))
+    ap.add_argument(
+        "--task", required=True, choices=("membership", "cluster", "confusable", "distinctive", "letterhead")
+    )
     ap.add_argument("--corpus", type=Path, default=cfg.OUT)
-    ap.add_argument("--sample-per-author", type=int, default=100)
+    ap.add_argument("--sample-per-author", type=int, default=60)
+    ap.add_argument(
+        "--top-pairs",
+        type=int,
+        default=400,
+        help="confusable: cap on pairs; a 24-class roster's full 276-pair matrix fits under the default",
+    )
     args = ap.parse_args(argv)
 
     pages = list(read_manifest(args.corpus / "corpus.jsonl"))
@@ -226,8 +401,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     out = args.corpus / "audit" / args.task
     out.mkdir(parents=True, exist_ok=True)
 
-    if args.task == "cluster":
+    if args.task == "membership":
+        verdicts = task_membership(pages, classes, out)
+    elif args.task == "cluster":
         verdicts = task_cluster(pages, classes, out)
+    elif args.task == "confusable":
+        verdicts = task_confusable(pages, classes, out, top_n=args.top_pairs)
     elif args.task == "distinctive":
         verdicts = task_distinctive(pages, classes, out)
     else:

--- a/scripts/experiments/docmarks/roster.py
+++ b/scripts/experiments/docmarks/roster.py
@@ -1,0 +1,141 @@
+"""The roster — the hand-picked classes an eval actually runs on.
+
+DocMarks is not trying to be an exhaustive inventory of every mark in every
+source.  It is trying to answer one question — *can this pipeline find a given
+stamp in a pile of documents* — and that question is answered better by two
+dozen classes whose every instance a human has checked than by four hundred
+classes assembled by a threshold nobody validated.
+
+So the corpus has two populations with completely different standards of
+evidence:
+
+* **roster classes** — a small, named, checked-in set.  Every instance is
+  adjudicated in or out by hand, and every confusable pair is adjudicated same
+  or different.  Nothing enters by heuristic.
+* **distractors** — everything else, unlabelled and unexamined, in whatever
+  quantity the tier budget allows.  They need no labels; they only need to be
+  safe to score against, which ``docmarks_config.CONTAMINATES`` decides.
+
+That split is what makes the eval trustworthy at a cost a person can actually
+pay.  Verifying 24 classes exhaustively is an afternoon; verifying 400 is not,
+and a benchmark whose labels nobody checked is a benchmark whose numbers nobody
+should quote.
+
+The roster file is small and human-editable on purpose — it is a decision, not
+an artifact:
+
+    {
+      "name": "spods-v1",
+      "notes": "why these",
+      "classes": ["spods/logo_00042_0", "spods/stamp_00117_1", ...]
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+
+@dataclass
+class Roster:
+    """The chosen classes, plus provenance for why they were chosen."""
+
+    name: str
+    classes: list[str] = field(default_factory=list)
+    notes: str = ""
+
+    def __contains__(self, class_id: str) -> bool:
+        return class_id in set(self.classes)
+
+    def __len__(self) -> int:
+        return len(self.classes)
+
+
+def load(path: Path) -> Roster:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    classes = list(dict.fromkeys(payload.get("classes", [])))
+    return Roster(name=payload.get("name", path.stem), classes=classes, notes=payload.get("notes", ""))
+
+
+def save(roster: Roster, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "name": roster.name,
+        "notes": roster.notes,
+        "classes": sorted(roster.classes),
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def check(roster: Roster, available: Sequence[str]) -> tuple[list[str], list[str]]:
+    """``(present, missing)`` — roster entries that do and do not exist.
+
+    A missing entry is reported rather than ignored.  Class ids move when the
+    clustering threshold moves, so a roster naming a class that no longer exists
+    is the signal that the roster and the corpus have drifted apart — which is
+    exactly the failure that would otherwise show up as a quietly smaller eval.
+    """
+    have = set(available)
+    present = [c for c in roster.classes if c in have]
+    missing = [c for c in roster.classes if c not in have]
+    return present, missing
+
+
+def starter(name: str, candidates: Sequence[dict[str, Any]], size: int = 24) -> Roster:
+    """A first-draft roster from the top *size* shortlist candidates.
+
+    Meant as a starting point for a human to edit, never as the final word: the
+    ranking can order candidates by every measurable proxy and still cannot tell
+    whether a mark is *interesting*.  ``shortlist.py`` prints the table and the
+    contact sheet that make that judgement possible.
+    """
+    return Roster(
+        name=name,
+        classes=[c["class_id"] for c in candidates[:size]],
+        notes=(
+            f"first draft from the top {size} shortlist candidates; edit by hand before running the membership audit"
+        ),
+    )
+
+
+def eligible_pages(
+    class_meta: dict[str, Any],
+    pages_by_source: dict[str, list[str]],
+    verified_negative_sources: Optional[Sequence[str]] = None,
+) -> dict[str, list[str]]:
+    """Split the corpus into what may be scored against this class.
+
+    Three populations, and the distinction matters for what a number means:
+
+    * ``positive`` — adjudicated instances of the mark.
+    * ``known_negative`` — pages from a source that was exhaustively checked for
+      this class, so their *absence* of the mark is a verified fact.  These are
+      the valuable negatives: same scanner, same paper, same era, and known
+      clean.  A SPODS page carrying a different mark is the hardest possible
+      negative for a SPODS class, and exhaustive verification is what makes it
+      usable instead of a contamination risk.
+    * ``presumed_negative`` — pages from a contamination-safe source that nobody
+      checked individually.  Fine in bulk, and the only way to reach 200k.
+    """
+    positives = set(class_meta.get("page_ids", []))
+    verified = set(verified_negative_sources or ())
+    eligible = set(class_meta.get("eligible_distractor_sources", []))
+
+    known: list[str] = []
+    presumed: list[str] = []
+    for source, page_ids in sorted(pages_by_source.items()):
+        for page_id in page_ids:
+            if page_id in positives:
+                continue
+            if source in verified:
+                known.append(page_id)
+            elif source in eligible:
+                presumed.append(page_id)
+    return {
+        "positive": sorted(positives),
+        "known_negative": sorted(known),
+        "presumed_negative": sorted(presumed),
+    }

--- a/scripts/experiments/docmarks/shortlist.py
+++ b/scripts/experiments/docmarks/shortlist.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""Rank candidate classes so a human can pick a roster from a shortlist.
+
+    python shortlist.py --corpus <dir>                  # ranked table + sheet
+    python shortlist.py --corpus <dir> --write-roster    # also draft roster.json
+
+The corpus builder clusters every mark it can find, which on SPODS alone
+proposes on the order of a hundred candidate classes.  Two dozen of them are
+worth hand-verifying and the rest are not, and the difference is mostly legible
+from measurable properties.  This ranks them and renders one contact sheet of
+exemplars, so picking a roster is looking at a page rather than reading JSON.
+
+**The ranking is an ordering aid, not a decision.**  Every signal here is a
+proxy: they can say a mark is big, common, sharply clustered and unlike its
+neighbours, and none of them can say it is *interesting* — that this is the kind
+of stamp somebody would actually search for.  Take the table as the order to
+review in, not the answer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cluster_marks as _cluster  # noqa: E402
+import docmarks_config as cfg  # noqa: E402
+import roster as _roster  # noqa: E402
+from sources._common import Page, read_manifest  # noqa: E402
+
+#: How the signals combine into one score.  Deliberately simple and flat: a
+#: cleverer weighting would imply a precision the proxies do not have.
+WEIGHTS = {
+    "instances": 0.30,  # more instances = more retrievable, more to learn from
+    "size": 0.25,  # bigger marks clear the ~32px structural floor
+    "tightness": 0.20,  # a sharply clustered class is probably really one mark
+    "separation": 0.25,  # far from its nearest neighbour = unambiguous label
+}
+
+
+def _norm(values: np.ndarray) -> np.ndarray:
+    """Min-max to ``[0, 1]``; a flat vector scores 0.5 rather than dividing by 0."""
+    lo, hi = float(values.min()), float(values.max())
+    if hi - lo < 1e-12:
+        return np.full_like(values, 0.5, dtype=float)
+    return (values - lo) / (hi - lo)
+
+
+def score_candidates(
+    pages: Sequence[Page],
+    classes: dict[str, dict[str, Any]],
+    *,
+    backend: str = "phash",
+) -> list[dict[str, Any]]:
+    """Rank every class, returning one record each, best first."""
+    class_ids = sorted(classes)
+    if not class_ids:
+        return []
+
+    by_id = {p.page_id: p for p in pages}
+    exemplar_desc: list[np.ndarray] = []
+    intra: list[float] = []
+    rows: list[dict[str, Any]] = []
+
+    for class_id in class_ids:
+        meta = classes[class_id]
+        descs = []
+        for page_id in meta["page_ids"][:24]:
+            page = by_id.get(page_id)
+            if page is None:
+                continue
+            for mark in page.marks:
+                if mark.class_id == class_id:
+                    from PIL import Image
+
+                    with Image.open(page.path) as im:
+                        descs.append(_cluster.phash(_cluster.crop_mark(im.convert("L"), mark.box)))
+                    break
+        if not descs:
+            continue
+        block = np.array(descs, dtype=bool)
+        exemplar_desc.append(block[0])
+        # Mean pairwise Hamming inside the class: low means the instances really
+        # do look like each other, which is weak evidence the cluster is one mark.
+        if len(block) > 1:
+            bits = block.astype(np.uint8)
+            inv = 1 - bits
+            d = (bits @ inv.T + inv @ bits.T) / block.shape[1]
+            intra.append(float(d[np.triu_indices(len(block), k=1)].mean()))
+        else:
+            intra.append(1.0)
+        rows.append(
+            {
+                "class_id": class_id,
+                "source": meta.get("source", class_id.split("/", 1)[0]),
+                "kind": meta.get("kind", "?"),
+                "n_instances": meta["n_instances"],
+                "median_mark_px": meta.get("median_mark_px"),
+                "located_by": meta.get("located_by", "box"),
+            }
+        )
+
+    if not rows:
+        return []
+
+    # Nearest-other-class distance: a class that sits far from every other one
+    # has an unambiguous label; a close pair is a coin flip until adjudicated.
+    exemplars = np.array(exemplar_desc, dtype=bool)
+    bits = exemplars.astype(np.uint8)
+    inv = 1 - bits
+    between = (bits @ inv.T + inv @ bits.T).astype(float) / exemplars.shape[1]
+    np.fill_diagonal(between, np.inf)
+    nearest = between.min(axis=1)
+    nearest_idx = between.argmin(axis=1)
+
+    instances = np.array([r["n_instances"] for r in rows], dtype=float)
+    sizes = np.array([r["median_mark_px"] or 0 for r in rows], dtype=float)
+    tightness = 1.0 - np.array(intra, dtype=float)
+
+    scores = (
+        WEIGHTS["instances"] * _norm(np.log1p(instances))
+        + WEIGHTS["size"] * _norm(np.log1p(sizes))
+        + WEIGHTS["tightness"] * _norm(tightness)
+        + WEIGHTS["separation"] * _norm(nearest)
+    )
+
+    for i, row in enumerate(rows):
+        row["intra_distance"] = round(float(intra[i]), 4)
+        row["nearest_other"] = rows[int(nearest_idx[i])]["class_id"]
+        row["nearest_distance"] = round(float(nearest[i]), 4)
+        row["score"] = round(float(scores[i]), 4)
+
+    return sorted(rows, key=lambda r: -r["score"])
+
+
+def render_sheet(candidates: Sequence[dict[str, Any]], classes: dict[str, Any], out_path: Path) -> None:
+    """One numbered contact sheet of exemplars, in ranked order."""
+    from PIL import Image, ImageDraw
+
+    thumbs = []
+    for rank, cand in enumerate(candidates):
+        crop = classes[cand["class_id"]].get("query_crop")
+        if crop and Path(crop).exists():
+            thumbs.append((rank, cand, Image.open(crop)))
+    if not thumbs:
+        return
+
+    cols, size, pad, cap = 8, 170, 8, 26
+    n_rows = (len(thumbs) + cols - 1) // cols
+    sheet = Image.new("RGB", (cols * (size + pad) + pad, n_rows * (size + pad + cap) + 30), "white")
+    draw = ImageDraw.Draw(sheet)
+    draw.text((pad, 8), "DocMarks roster shortlist — ranked; pick the ones worth verifying", fill="black")
+
+    for i, (rank, cand, im) in enumerate(thumbs):
+        r, c = divmod(i, cols)
+        thumb = im.convert("RGB").copy()
+        thumb.thumbnail((size, size))
+        x, y = pad + c * (size + pad), 30 + r * (size + pad + cap)
+        sheet.paste(thumb, (x, y))
+        draw.rectangle([x, y, x + thumb.width, y + thumb.height], outline="#bbbbbb")
+        draw.text((x, y + thumb.height + 2), f"#{rank}  {cand['class_id'].split('/')[-1]}"[:30], fill="#222222")
+        draw.text(
+            (x, y + thumb.height + 13),
+            f"n={cand['n_instances']} px={cand['median_mark_px']} sep={cand['nearest_distance']:.2f}",
+            fill="#666666",
+        )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(out_path)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--corpus", type=Path, default=cfg.OUT)
+    ap.add_argument("--top", type=int, default=48, help="how many candidates to table and sheet")
+    ap.add_argument("--roster-size", type=int, default=24)
+    ap.add_argument("--write-roster", action="store_true", help="draft roster.json from the top candidates")
+    ap.add_argument("--name", default="spods-v1", help="roster name")
+    args = ap.parse_args(argv)
+
+    classes = json.loads((args.corpus / "classes.json").read_text(encoding="utf-8"))
+    pages = list(read_manifest(args.corpus / "corpus.jsonl"))
+
+    candidates = score_candidates(pages, classes)
+    if not candidates:
+        print("no candidate classes — has the corpus been built?")
+        return 1
+
+    print(f"{len(candidates)} candidate class(es); top {min(args.top, len(candidates))}:\n")
+    print(f"  {'#':>3}  {'score':>5}  {'n':>4}  {'px':>5}  {'sep':>5}  class / nearest other")
+    for rank, c in enumerate(candidates[: args.top]):
+        px = c["median_mark_px"] if c["median_mark_px"] is not None else "band"
+        print(
+            f"  {rank:>3}  {c['score']:>5.3f}  {c['n_instances']:>4}  {str(px):>5}  "
+            f"{c['nearest_distance']:>5.2f}  {c['class_id']}  ~ {c['nearest_other'].split('/')[-1]}"
+        )
+
+    sheet = args.corpus / "shortlist.png"
+    render_sheet(candidates[: args.top], classes, sheet)
+    (args.corpus / "shortlist.json").write_text(json.dumps(candidates, indent=2) + "\n", encoding="utf-8")
+    print(f"\nsheet  {sheet}\ntable  {args.corpus / 'shortlist.json'}")
+
+    if args.write_roster:
+        path = args.corpus / "roster.json"
+        if path.exists():
+            print(f"\n{path} already exists — not overwriting a roster someone has edited")
+            return 0
+        _roster.save(_roster.starter(args.name, candidates, size=args.roster_size), path)
+        print(f"\ndrafted {path} with the top {args.roster_size} — edit it by hand before verifying")
+    else:
+        print("\npick from the sheet, then write roster.json (or re-run with --write-roster for a draft)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/docmarks/sources/ucsf.py
+++ b/scripts/experiments/docmarks/sources/ucsf.py
@@ -1,4 +1,4 @@
-"""UCSF Industry Documents Library — the haystack, and weak letterhead classes.
+"""UCSF Industry Documents Library — the haystack, and letterhead candidates.
 
 Two jobs, from one open Solr index (no registration, no token):
 
@@ -7,11 +7,9 @@ makes a retrieval number mean something: StaVer's own 259 pages cannot separate
 a good ranker from a lucky one, and the shipped SPODS/StaVer/Tobacco800 sets
 together are ~2,700 pages.
 
-**Weakly-labelled letterhead classes.** Single-page documents of ``type:letter``
-written by a given company are, in the overwhelming majority, that company's
-letterhead — so the ``author`` field is an instance label for the letterhead
-logo, at a scale no hand annotation reaches.  Measured 2026-08-25 against the
-live index, single-page ``type:letter`` counts per author:
+**Letterhead candidates.** Single-page ``type:letter`` documents written by a
+given company are, in the overwhelming majority, printed on that company's
+letterhead.  Measured 2026-08-25 against the live index:
 
     RJR                          162,197
     PHILIP MORRIS                 73,320
@@ -20,14 +18,26 @@ live index, single-page ``type:letter`` counts per author:
 with 1,802,100 single-page tobacco letters in total and 13,216,456 short
 tobacco documents carrying a ``collection``.
 
-**The label is weak and this module never pretends otherwise.**  Marks it emits
-carry ``provenance="weak"`` and no box: the metadata says the page is *from*
-Philip Morris, not *where* on the page the logo is, nor even that a logo was
-printed at all.  Two things must happen before this stratum is quoted:
+**``author`` is a candidate pool, not a class.**  This is the one thing to get
+right here.  The field asserts a page is *from* a company; it has never looked
+at the mark.  Making it a class id bakes two failures straight into the ground
+truth:
 
-1. a human spot-check of sampled pages per author, to estimate what fraction
-   really carry the letterhead (``make_audit_slate.py --task letterhead``), and
-2. one hand-drawn query crop per class, since there is no box to crop from.
+* a company that redesigned its letterhead yields **one class holding two
+  different artworks**, so a detector is punished for telling them apart;
+* two subsidiaries sharing artwork yield **two classes holding the same mark**,
+  so a detector is punished for recognising it.
+
+Both are exactly the errors a mark-retrieval eval exists to measure, silently
+written into the labels.  A class means *this artwork* and nothing else, so the
+author narrows millions of pages to a high-yield pool and identity is then
+settled by looking: cluster the letterhead bands, adjudicate the clusters, and
+record same/different explicitly.  Marks emitted here carry
+``provenance="candidate"`` and are never admitted as query classes until that
+has happened.
+
+For the same reason ``documentdate`` is recorded but never enters a class id.
+Era is a fact about the calendar, not about the mark.
 
 Prefer ``author`` over ``collection``.  ``collection`` is provenance — whose
 filing cabinet the page sat in — so a letter *in* the Philip Morris collection
@@ -47,9 +57,8 @@ from ._common import Mark, Page
 API_URL = "https://metadata.idl.ucsf.edu/solr/ltdl3/query"
 DOWNLOAD_URL = "https://download.industrydocuments.ucsf.edu"
 
-#: Fields worth carrying into the manifest.  ``documentdate`` earns its place:
-#: a corporate logo is redesigned every decade or so, and a class that silently
-#: spans two designs will look like a method failure rather than what it is.
+#: Fields worth carrying into the manifest, as provenance for a page.  None of
+#: them decides a class: identity comes from adjudicating the mark itself.
 FIELDS = "id,collection,collectioncode,author,industry,type,documentdate,pages,title,brand"
 
 #: The endpoint ignores ``rows`` and returns up to this many docs per request.
@@ -152,20 +161,31 @@ def first_value(doc: dict[str, Any], key: str) -> Optional[str]:
     return str(value) if value is not None else None
 
 
-def decade(documentdate: Optional[str]) -> Optional[str]:
-    """``"1996 January 24"`` -> ``"1990s"``.
+def year(documentdate: Optional[str]) -> Optional[int]:
+    """``"1996 January 24"`` -> ``1996``.
 
-    Used to optionally split a letterhead class by era.  A 1965 Philip Morris
-    mark and a 1995 one may be different artwork; whether structural search
-    should treat them as one class is a *finding*, not a nuisance, so the corpus
-    records the decade and lets the study decide.
+    Recorded as provenance only.  It is deliberately **not** part of any class
+    id: a class means "this artwork", and splitting one artwork across eras — or
+    fusing two different artworks because they share an era — would make the
+    label a statement about the calendar rather than about the mark.
     """
     if not documentdate:
         return None
     m = re.search(r"\b(1[89]\d{2}|20\d{2})\b", documentdate)
-    if not m:
-        return None
-    return f"{int(m.group(1)) // 10 * 10}s"
+    return int(m.group(1)) if m else None
+
+
+def letterhead_band(width: int, height: int, band_frac: float) -> tuple[int, int, int, int]:
+    """The top-of-page strip a letterhead occupies, as ``(x, y, w, h)``.
+
+    UCSF ships no boxes, and a class cannot be adjudicated from a mark nobody
+    can see.  A letterhead sits at the top of the page by definition, so the top
+    strip is a coarse but *honest* locator: wide enough to contain the mark,
+    tight enough that clustering the strips separates one company's artwork from
+    another's.  It is a candidate region, never a ground-truth box — the tight
+    box comes from the hand-drawn query crop after adjudication.
+    """
+    return (0, 0, width, max(1, int(round(height * band_frac))))
 
 
 def doc_to_page(
@@ -176,25 +196,36 @@ def doc_to_page(
     *,
     page_index: int = 0,
     letterhead_author: Optional[str] = None,
-    split_by_decade: bool = False,
+    band_frac: float = 0.22,
 ) -> Page:
     """One rendered page image plus its Solr metadata as a :class:`Page`.
 
-    When *letterhead_author* is given the page gets a boxless ``weak`` mark for
-    that author's letterhead class.  No box is invented: a fabricated box would
-    be indistinguishable downstream from a real one, and the whole point of the
-    ``provenance`` field is that the difference stays visible.
+    When *letterhead_author* is given, the page gets a **candidate** mark over
+    the top-of-page band — deliberately *not* a class.  The author field says
+    the page is *from* a company; it has not looked at the mark, so it cannot
+    say which artwork is on it, or whether one is there at all.  Turning that
+    into a class id would bake two failures into the ground truth: one company
+    that redesigned its letterhead becomes a single class holding two different
+    marks, and two subsidiaries sharing artwork become two classes holding the
+    same mark.
+
+    So the author narrows millions of pages to a high-yield pool, and identity
+    is settled downstream by clustering the bands and adjudicating them — the
+    same path SPODS and StaVer take.  ``provenance="candidate"`` marks are never
+    admitted as query classes until that has happened.
     """
     doc_id = str(doc["id"])
-    industry = first_value(doc, "industry")
-    era = decade(first_value(doc, "documentdate"))
 
     marks: list[Mark] = []
     if letterhead_author:
-        class_id = f"ucsf/letterhead_{_slug(letterhead_author)}"
-        if split_by_decade and era:
-            class_id = f"{class_id}_{era}"
-        marks.append(Mark(kind="logo", box=(0, 0, 0, 0), class_id=class_id, provenance="weak"))
+        marks.append(
+            Mark(
+                kind="logo",
+                box=letterhead_band(width, height, band_frac),
+                class_id=None,
+                provenance="candidate",
+            )
+        )
 
     return Page(
         page_id=f"ucsf/{doc_id}#{page_index}",
@@ -205,12 +236,13 @@ def doc_to_page(
         marks=marks,
         meta={
             "doc_id": doc_id,
-            "industry": industry,
+            "industry": first_value(doc, "industry"),
             "collection": first_value(doc, "collection"),
             "author": first_value(doc, "author"),
+            "letterhead_author": letterhead_author,
             "type": first_value(doc, "type"),
             "documentdate": first_value(doc, "documentdate"),
-            "decade": era,
+            "year": year(first_value(doc, "documentdate")),
             "title": first_value(doc, "title"),
         },
     )
@@ -223,7 +255,7 @@ def fetch_and_render(
     *,
     dpi: int = 150,
     letterhead_author: Optional[str] = None,
-    split_by_decade: bool = False,
+    band_frac: float = 0.22,
     max_pages_per_doc: int = 1,
     on_error: Optional[Any] = None,
 ) -> list[Page]:
@@ -267,7 +299,7 @@ def fetch_and_render(
                     image.height,
                     page_index=idx,
                     letterhead_author=letterhead_author,
-                    split_by_decade=split_by_decade,
+                    band_frac=band_frac,
                 )
             )
     return pages

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -58,6 +58,9 @@ def mods(_on_path):
         "build": importlib.import_module("build_corpus"),
         "synth": importlib.import_module("synth_compose"),
         "embed": importlib.import_module("embed_corpus"),
+        "roster": importlib.import_module("roster"),
+        "shortlist": importlib.import_module("shortlist"),
+        "audit": importlib.import_module("audit_to_corrections"),
     }
 
 
@@ -224,31 +227,45 @@ class TestUcsf:
 
     @pytest.mark.parametrize(
         "date,expected",
-        [("1996 January 24", "1990s"), ("1965", "1960s"), ("2003 December 04", "2000s"), ("", None), (None, None)],
+        [("1996 January 24", 1996), ("1965", 1965), ("2003 December 04", 2003), ("", None), (None, None)],
     )
-    def test_decade(self, mods, date, expected):
-        assert mods["ucsf"].decade(date) == expected
+    def test_year(self, mods, date, expected):
+        assert mods["ucsf"].year(date) == expected
 
     def test_first_value_unwraps_solr_multivalued_fields(self, mods):
         assert mods["ucsf"].first_value({"collection": ["Lorillard Records", "MSA"]}, "collection") == (
             "Lorillard Records"
         )
 
-    def test_letterhead_mark_is_weak_and_boxless(self, mods):
+    def test_an_author_is_a_candidate_pool_never_a_class(self, mods):
+        # The metadata says the page is *from* Philip Morris; it has never
+        # looked at the mark. Making it a class id would put two different
+        # artworks in one class whenever a company redesigned its letterhead,
+        # and split one artwork across two classes whenever subsidiaries shared
+        # it -- both of them errors the eval exists to measure, written straight
+        # into the labels.
         doc = {"id": "ffbb0019", "author": ["PHILIP MORRIS"], "documentdate": "1996 January 24"}
         page = mods["ucsf"].doc_to_page(doc, "/tmp/x.png", 1700, 2200, letterhead_author="PHILIP MORRIS")
         (mark,) = page.marks
-        assert mark.class_id == "ucsf/letterhead_philip_morris"
-        # No box is invented. The metadata says the page is *from* Philip Morris,
-        # not where on it the logo sits, and a fabricated box would be
-        # indistinguishable downstream from a real one.
-        assert mark.box == (0, 0, 0, 0)
-        assert mark.provenance == "weak"
+        assert mark.class_id is None
+        assert mark.provenance == "candidate"
+        assert page.meta["letterhead_author"] == "PHILIP MORRIS"
 
-    def test_decade_split_makes_separate_classes(self, mods):
+    def test_candidate_carries_a_locatable_band(self, mods):
+        page = mods["ucsf"].doc_to_page(
+            {"id": "ffbb0019"}, "/tmp/x.png", 1700, 2200, letterhead_author="RJR", band_frac=0.2
+        )
+        # A mark nobody can see cannot be adjudicated, so the candidate gets a
+        # coarse top-of-page strip to cluster on -- never a ground-truth box.
+        assert page.marks[0].box == (0, 0, 1700, 440)
+
+    def test_the_year_never_reaches_a_class_id(self, mods):
         doc = {"id": "ffbb0019", "documentdate": "1965 May 3"}
-        page = mods["ucsf"].doc_to_page(doc, "/tmp/x.png", 10, 10, letterhead_author="RJR", split_by_decade=True)
-        assert page.marks[0].class_id == "ucsf/letterhead_rjr_1960s"
+        page = mods["ucsf"].doc_to_page(doc, "/tmp/x.png", 100, 100, letterhead_author="RJR")
+        assert page.meta["year"] == 1965
+        # Era is a fact about the calendar, not about the mark. A class means
+        # "this artwork" and nothing else.
+        assert page.marks[0].class_id is None
 
     def test_a_page_with_no_author_carries_no_marks(self, mods):
         page = mods["ucsf"].doc_to_page({"id": "ffbb0019"}, "/tmp/x.png", 10, 10)
@@ -334,15 +351,29 @@ class TestClassAdmission:
         assert admitted == {}
         assert "not queryable" in rejected["tobacco800/signature_x"]
 
-    def test_weak_boxless_classes_are_admitted(self, mods):
+    def test_band_classes_skip_the_mark_size_floor(self, mods):
+        # A band's pixel size describes the top-of-page strip, not the mark, so
+        # checking it against the 32px mark floor compares the wrong number
+        # against the wrong threshold -- and reporting it as median_mark_px
+        # would misdescribe the class.
         pages = [
-            _page(mods, f"ucsf/{i:03d}", "ucsf", [("logo", (0, 0, 0, 0), "ucsf/letterhead_rjr", "weak")])
+            _page(mods, f"ucsf/{i:03d}", "ucsf", [("logo", (0, 0, 1700, 440), "ucsf/logo_a_0", "clustered_band")])
             for i in range(40)
         ]
         inv = mods["build"].class_inventory(pages)
         admitted, _ = mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32)
-        assert admitted["ucsf/letterhead_rjr"]["median_mark_px"] is None
-        assert admitted["ucsf/letterhead_rjr"]["provenance"] == ["weak"]
+        assert admitted["ucsf/logo_a_0"]["located_by"] == "band"
+        assert admitted["ucsf/logo_a_0"]["median_mark_px"] is None
+
+    def test_unlocated_classes_are_rejected(self, mods):
+        pages = [
+            _page(mods, f"ucsf/{i:03d}", "ucsf", [("logo", (0, 0, 0, 0), "ucsf/nowhere", "candidate")])
+            for i in range(40)
+        ]
+        inv = mods["build"].class_inventory(pages)
+        admitted, rejected = mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32)
+        assert admitted == {}
+        assert "no located instances" in rejected["ucsf/nowhere"]
 
     def test_admitted_classes_record_their_eligible_distractors(self, mods):
         pages = self._corpus(mods)
@@ -351,6 +382,148 @@ class TestClassAdmission:
         eligible = admitted["spods/a"]["eligible_distractor_sources"]
         assert "spods" not in eligible
         assert "ucsf" in eligible
+
+
+# ------------------------------------------------------------------- roster
+
+
+class TestRoster:
+    def _pages(self, mods, n_a=14, n_b=3):
+        pages = [
+            _page(mods, f"spods/a{i:03d}", "spods", [("logo", (0, 0, 200, 120), "spods/a", "clustered")])
+            for i in range(n_a)
+        ]
+        pages += [
+            _page(mods, f"spods/b{i:03d}", "spods", [("logo", (0, 0, 12, 10), "spods/b", "clustered")])
+            for i in range(n_b)
+        ]
+        return pages
+
+    def _admit(self, mods, pages, roster=None):
+        inv = mods["build"].class_inventory(pages)
+        return mods["build"].admit_classes(pages, inv, min_instances=10, min_mark_px=32, roster=roster)
+
+    def test_without_a_roster_the_bars_decide(self, mods):
+        admitted, rejected = self._admit(mods, self._pages(mods))
+        assert set(admitted) == {"spods/a"}
+        assert "spods/b" in rejected
+
+    def test_a_roster_restricts_admission_to_its_own_classes(self, mods):
+        roster = mods["roster"].Roster(name="t", classes=["spods/a"])
+        admitted, rejected = self._admit(mods, self._pages(mods), roster)
+        assert set(admitted) == {"spods/a"}
+        assert rejected["spods/b"] == "not on the roster"
+
+    def test_a_roster_class_overrides_the_bars_but_records_why(self, mods):
+        # The human who picked it knows something the threshold does not; the
+        # override is kept visible in the artifact rather than silently waived.
+        roster = mods["roster"].Roster(name="t", classes=["spods/a", "spods/b"])
+        admitted, _ = self._admit(mods, self._pages(mods), roster)
+        assert set(admitted) == {"spods/a", "spods/b"}
+        assert admitted["spods/a"]["caveats"] == []
+        assert any("min_instances" in c for c in admitted["spods/b"]["caveats"])
+        assert any("min_mark_px" in c for c in admitted["spods/b"]["caveats"])
+
+    def test_classes_start_unverified(self, mods):
+        roster = mods["roster"].Roster(name="t", classes=["spods/a"])
+        admitted, _ = self._admit(mods, self._pages(mods), roster)
+        # Until the membership pass runs, a class is a clustering proposal.
+        assert admitted["spods/a"]["audit"]["membership_verified"] is False
+        assert admitted["spods/a"]["on_roster"] is True
+
+    def test_check_reports_drift_between_roster_and_corpus(self, mods):
+        roster = mods["roster"].Roster(name="t", classes=["spods/a", "spods/gone"])
+        present, missing = mods["roster"].check(roster, ["spods/a", "spods/b"])
+        assert present == ["spods/a"]
+        assert missing == ["spods/gone"]
+
+    def test_roster_round_trips_and_deduplicates(self, mods, tmp_path):
+        path = tmp_path / "roster.json"
+        mods["roster"].save(mods["roster"].Roster("t", ["b", "a", "b"], notes="why"), path)
+        back = mods["roster"].load(path)
+        assert back.classes == ["a", "b"]
+        assert back.notes == "why"
+
+    def test_known_negatives_come_only_from_verified_sources(self, mods):
+        meta = {
+            "page_ids": ["spods/a000"],
+            "eligible_distractor_sources": ["ucsf", "synth"],
+        }
+        pages_by_source = {
+            "spods": ["spods/a000", "spods/x001"],
+            "ucsf": ["ucsf/d1", "ucsf/d2"],
+        }
+        # SPODS contaminates SPODS by default -- but once SPODS has been
+        # exhaustively checked for this class, its non-members become *known*
+        # negatives: same scanner, same paper, verified clean, which is the
+        # hardest and most useful negative there is.
+        split = mods["roster"].eligible_pages(meta, pages_by_source, verified_negative_sources=["spods"])
+        assert split["positive"] == ["spods/a000"]
+        assert split["known_negative"] == ["spods/x001"]
+        assert split["presumed_negative"] == ["ucsf/d1", "ucsf/d2"]
+
+    def test_without_verification_same_source_pages_are_not_usable(self, mods):
+        meta = {"page_ids": ["spods/a000"], "eligible_distractor_sources": ["ucsf"]}
+        split = mods["roster"].eligible_pages(meta, {"spods": ["spods/a000", "spods/x001"], "ucsf": ["ucsf/d1"]})
+        assert split["known_negative"] == []
+        assert split["presumed_negative"] == ["ucsf/d1"]
+
+
+class TestMembershipAudit:
+    def _setup(self, mods):
+        pages = [
+            _page(mods, f"spods/{i:03d}", "spods", [("logo", (0, 0, 200, 120), "spods/a", "clustered")])
+            for i in range(5)
+        ]
+        classes = {
+            "spods/a": {
+                "class_id": "spods/a",
+                "n_instances": 5,
+                "page_ids": [f"spods/{i:03d}" for i in range(5)],
+                "audit": {"membership_verified": False, "rejected_page_ids": []},
+            }
+        }
+        return pages, classes
+
+    def test_ok_verifies_without_dropping_anything(self, mods):
+        pages, classes = self._setup(mods)
+        row = {"class_id": "spods/a", "page_ids": classes["spods/a"]["page_ids"], "verdict": "ok"}
+        changes, problems = mods["audit"].apply_membership(pages, classes, [row])
+        assert not problems
+        assert classes["spods/a"]["n_instances"] == 5
+        assert classes["spods/a"]["audit"]["membership_verified"] is True
+
+    def test_rejected_indices_are_removed_from_the_class(self, mods):
+        pages, classes = self._setup(mods)
+        row = {"class_id": "spods/a", "page_ids": classes["spods/a"]["page_ids"], "verdict": "1, 3"}
+        mods["audit"].apply_membership(pages, classes, [row])
+        assert classes["spods/a"]["page_ids"] == ["spods/000", "spods/002", "spods/004"]
+        assert classes["spods/a"]["audit"]["rejected_page_ids"] == ["spods/001", "spods/003"]
+
+    def test_a_rejected_instance_keeps_its_box_and_page(self, mods):
+        # It stops being a positive, but the page stays a *known* negative and
+        # the mark is still a real mark a later roster might want.
+        pages, classes = self._setup(mods)
+        row = {"class_id": "spods/a", "page_ids": classes["spods/a"]["page_ids"], "verdict": "1"}
+        mods["audit"].apply_membership(pages, classes, [row])
+        dropped = next(p for p in pages if p.page_id == "spods/001")
+        assert len(dropped.marks) == 1
+        assert dropped.marks[0].class_id is None
+        assert dropped.marks[0].box == (0, 0, 200, 120)
+
+    def test_an_out_of_range_index_is_refused_not_silently_clamped(self, mods):
+        pages, classes = self._setup(mods)
+        row = {"class_id": "spods/a", "page_ids": classes["spods/a"]["page_ids"], "verdict": "9"}
+        changes, problems = mods["audit"].apply_membership(pages, classes, [row])
+        assert not changes
+        assert "outside 0..4" in problems[0]
+        assert classes["spods/a"]["n_instances"] == 5
+
+    def test_a_malformed_verdict_is_refused(self, mods):
+        pages, classes = self._setup(mods)
+        row = {"class_id": "spods/a", "page_ids": classes["spods/a"]["page_ids"], "verdict": "maybe"}
+        _changes, problems = mods["audit"].apply_membership(pages, classes, [row])
+        assert "must be 'ok' or comma-separated indices" in problems[0]
 
 
 # -------------------------------------------------------------------- tiers
@@ -477,6 +650,70 @@ class TestClustering:
         desc = np.ones((2, 64), dtype=bool)  # identical hashes
         dist = mods["cluster"].distance_matrix(desc, refs, backend="phash")
         assert dist[0, 1] == 1.0
+
+    def test_cannot_link_keeps_adjudicated_marks_apart(self, mods):
+        # Two crops close enough that the threshold would merge them, which a
+        # human has said are different marks. The whole point of recording that
+        # is that it survives the clustering that would otherwise overrule it.
+        dist = np.array([[0.0, 0.05], [0.05, 0.0]])
+        assert mods["cluster"].single_linkage(dist, 0.2) == [0, 0]
+        assert mods["cluster"].single_linkage(dist, 0.2, cannot_link=[(0, 1)]) == [0, 1]
+
+    def test_a_separation_propagates_through_a_third_crop(self, mods):
+        # a-b are separated; c is near both. Without propagation c would merge
+        # with a and then with b, reuniting the pair through the back door.
+        dist = np.array(
+            [
+                [0.0, 0.9, 0.05],
+                [0.9, 0.0, 0.05],
+                [0.05, 0.05, 0.0],
+            ]
+        )
+        labels = mods["cluster"].single_linkage(dist, 0.2, cannot_link=[(0, 1)])
+        assert labels[0] != labels[1]
+
+    def test_separations_resolve_by_page_id_not_row_index(self, mods):
+        MarkRef = mods["cluster"].MarkRef
+        refs = [
+            MarkRef(0, 0, "spods/001", "logo", (0, 0, 10, 10)),
+            MarkRef(1, 0, "spods/002", "logo", (0, 0, 10, 10)),
+        ]
+        assert mods["cluster"].resolve_separations(refs, [("spods/001", "spods/002")]) == [(0, 1)]
+
+    def test_a_separation_naming_a_dropped_page_is_skipped(self, mods):
+        MarkRef = mods["cluster"].MarkRef
+        refs = [MarkRef(0, 0, "spods/001", "logo", (0, 0, 10, 10))]
+        # Pages come and go with tier budgets; a stale pair must not refuse the
+        # build.
+        assert mods["cluster"].resolve_separations(refs, [("spods/001", "spods/999")]) == []
+
+    def test_separations_round_trip_and_deduplicate(self, mods, tmp_path):
+        path = tmp_path / "separations.json"
+        mods["cluster"].save_separations(
+            [
+                {"left_page_id": "b", "right_page_id": "a"},
+                {"left_page_id": "a", "right_page_id": "b"},
+            ],
+            path,
+        )
+        # (a, b) and (b, a) are one decision, not two.
+        assert mods["cluster"].load_separations(path) == [("a", "b")]
+
+    def test_no_separations_file_means_no_constraints(self, mods, tmp_path):
+        assert mods["cluster"].load_separations(tmp_path / "missing.json") == []
+
+    def test_merge_order_is_independent_of_row_order(self, mods):
+        # Once constraints can block a merge, "which merge happened first"
+        # decides the outcome, so merges are applied in distance order rather
+        # than whatever order the loops produce.
+        dist = np.array(
+            [
+                [0.0, 0.10, 0.15],
+                [0.10, 0.0, 0.05],
+                [0.15, 0.05, 0.0],
+            ]
+        )
+        assert mods["cluster"].single_linkage(dist, 0.12, cannot_link=[(0, 2)]) == [0, 1, 1]
 
     def test_class_ids_are_anchored_to_a_page_not_a_counter(self, mods):
         MarkRef = mods["cluster"].MarkRef


### PR DESCRIPTION
Follow-up to #3253 (merged). Reshapes DocMarks from "build an inventory of every mark" into "build eval data for stamp detection that we can trust".

## Why the shape changed

Two dozen hand-picked classes whose every instance a person has checked beat four hundred classes assembled by a threshold nobody validated — and cost an afternoon instead of a month. The corpus now holds two populations with different standards of evidence: a small **roster** of adjudicated classes, and unlimited unlabelled distractors that only need to be safe to score against.

Without `--roster` the builder still emits candidates, but now says out loud that they are proposals rather than ground truth.

## Both directions of the ground truth

An eval for "find this mark" needs to state both *these must be found together* and *these must be told apart*. Only the first was representable before, and the gap was invisible: nothing but a distance threshold kept two similar marks in separate classes, so nudging the threshold silently rewrote the labels.

Measured on the fixture corpus at a loose threshold, three distinct marks collapse into one class — and all three survive with the separations on disk. A `different` verdict is stored permanently in `separations.json`, keyed on **page ids** (which survive a re-cluster; class ids do not) and enforced as a cannot-link constraint that propagates, so two separated marks can't be reunited through a third ambiguous crop.

## What's new

- **`roster.py` / `shortlist.py`** — rank candidates on instance count, mark size, cluster tightness and distance to the nearest other class; render one numbered contact sheet; draft a `roster.json` to edit by hand. The ranking is explicitly an ordering aid: it can't tell whether a mark is *interesting*.
- **`membership` audit** — every instance of every roster class, numbered, verdict `ok` or the indices that aren't this mark (`3,17`). A rejected crop keeps its box and stays on its page: it becomes a *known negative*, the hardest and most useful kind.
- **Three kinds of negative** — known (source exhaustively checked, absence verified), presumed (contamination-safe but unexamined), excluded.
- **`confusable`** now adjudicates the full pairwise matrix on a roster (24 classes = 276 pairs) instead of a sampled top-N.
- **`split`** is productive: re-clusters that class alone at half the threshold and re-sheets the pieces.
- Roster classes override the numeric bars, and the override is recorded in `caveats` rather than silently waived.

## Dropped: cross-decade class splitting

That was scope creep on my part — it turned an ambiguity in the labels into a research question instead of resolving it. UCSF's `author` is now a candidate pool, not a class id: the field never looked at the mark, so making it a class writes two guaranteed errors into the ground truth — one class holding two artworks when a company redesigned its letterhead, two classes holding one artwork when subsidiaries shared it. Candidates get a coarse top-of-page band and go through the same clustering and adjudication as everything else. The document date is recorded as provenance and never enters a class id.

## Verification

Full `./run-tests.sh` green (9105 passed, all gates). End-to-end on a fabricated SPODS-shaped tree: build → shortlist → roster → membership (2 of 14 rejected) → confusable (3 separations) → re-cluster at 0.45 keeps all three classes, and collapses to one with the separations removed.

## Still owed

In `docs/plans/structural-embedder.md`. The load-bearing one is unchanged: `eligible_distractor_sources` and `roster.eligible_pages` are recorded and **nothing consumes them yet** — until a scoring path honours them, the contamination design is decorative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF1MUvcTkJ4SrU1biT2wv5)_