### PR TITLE
Good Mining: parameterise the Autopilot opening, and the study that sweeps it

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -279,11 +279,11 @@ Two columns make this visible in the output:
 
 Metrics are still recorded at every trainable step in both modes — fidelity changes the *vote order* and the `app_trained` flag, not measurement coverage.
 
-#### The acquisition cut (`acq_inclusion_offset`, default `-3`)
+#### The acquisition cut (`acq_inclusion_offset`, default: whatever `vtscore.training.thresholds` ships)
 
 The selector and the metrics read **different thresholds**. Reporting and every emitted metric stay at `inclusion`; the threshold handed to the picks is re-cut at `inclusion + acq_inclusion_offset` from the same fold-anchored fit. This mirrors production, which decoupled the two jobs in PR #2876 — see [`docs/ML.md`](ML.md#threshold-calibration) for the mechanism and the measured effect.
 
-The default is the shipped `-3`, **not** `0`, so an unconfigured run measures what users actually get. Pass `acq_inclusion_offset=0` for the pre-#2876 control where one threshold did both jobs; that is also the value the study's `prod` arm ran at. Note that this changes what a re-run of any *pre-#2876* study measures: those runs were all implicitly at offset 0, so reproducing one byte-for-byte means passing it explicitly, the same way `autopilot_fidelity=False` reproduces the pre-fidelity harness.
+The default is `ACQUISITION_INCLUSION_OFFSET` — the shipped value, **not** `0` — so an unconfigured run measures what users actually get. (PR #2876 shipped `-3`; PR #2891 cut it to `-1` after a second environment rejected `-3`. Read the constant, not a number written here.) Pass `acq_inclusion_offset=0` for the pre-#2876 control where one threshold did both jobs; that is also the value the study's `prod` arm ran at. Note that this changes what a re-run of any *pre-#2876* study measures: those runs were all implicitly at offset 0, so reproducing one byte-for-byte means passing it explicitly, the same way `autopilot_fidelity=False` reproduces the pre-fidelity harness.
 
 Three columns make the lever verifiable rather than assumed, all measured in the **pool** distribution the selector ranks:
 
@@ -293,6 +293,31 @@ Three columns make the lever verifiable rather than assumed, all measured in the
 The pool is scored in **the same geometry the cuts are fitted in** — the style's region max-pool on a patch dataset, the whole-image vector on a single-vector one — because the Hard pick locates its cutoff by comparing scores against the threshold *absolutely*, so a ranking and a cut in different spaces put the cutoff index in the wrong place. Before #2943 the pool was scored whole-image while every cut was fitted on pooled scores; since a max over ~197 patch rows dominates the single whole-image row, the whole pool sat below the cut, both percentiles pinned at `1.0` on every patch step, and the simulated picks came from systematically higher-ranked items than the app's. Patch-dataset studies published before that fix — including the #2876 acquisition-inclusion report — measured that mismatch.
 
 The direction is counter-intuitive (negative offset → *higher* cut → *more* positives, because the pick reads the threshold as a rank position), so a sign error would otherwise look exactly like the lever not working. `acq_rank_percentile` is the alternative parameterisation — pin the cut at a fixed quantile of the simulation-set scores — and it requires `acq_inclusion_offset=0`, since the two name the same cut. It is measured and **worse**; it exists as an arm, not as an option.
+
+#### The opening (`startup_schedule`, default: the app's own)
+
+Autopilot's **opening** — the clicks spent before the first learned sort — is what decides how many positives a run has when its detector is first trained, and a Good-starved run is the one that fails (issue #3267). It is a parameter, so a study can ask whether a different opening mines better.
+
+The parameterisation rests on one observation: both of today's opening phases are the *same operation* at two different cuts. The Good phase's `top` select is the rank-space `hard` select against a cut placed above every score; the Bad phase's is that select against the seed sort's own fitted GMM, split at the production midpoint. So an opening is a list of rounds, each naming how many clicks to spend and where on the sort — which is what a schedule spells:
+
+| round | meaning |
+|---|---|
+| `g3` / `b4` | stay until 3 goods / 4 bads exist (a **global** count, as in the app) |
+| `n8` | stay for 8 clicks, whatever they turn out to be |
+| `@top` | cut above every score — the top of the sort |
+| `@mid` | the shipped GMM midpoint, i.e. every cosine sort's cutoff |
+| `@k-3` | that same fitted GMM, split at **inclusion −3** |
+| `@q0.05` | the sort's 5th rank percentile, named directly |
+
+`PRODUCTION_STARTUP` (`"g3@top,b4@mid"`) is today's opening, and [`vtscore/eval/startup_schedule.py`](../vtscore/eval/startup_schedule.py) is the full reference. `startup_schedule=None` — the default — leaves every trajectory byte-for-byte what it was; the explicit production spec is *required* to reproduce a default run click for click, which `tests_lib/detectors/test_startup_schedule.py` asserts and `scripts/check-eval-app-sync.py`'s `autopilot.startup_default` mirror keeps true.
+
+Rounds appear in the `phase` column as `s0`, `s1`, …, and `app_trained` is `0` throughout one: a round is on the seed sort by construction, so the app would have no detector on screen however many votes have been cast. Every row also carries **`startup_schedule`**, so a pooled frame says which arm it came from without depending on the directory it was read out of.
+
+`@k` and `@q` are not redundant. `@k` is the arm that could *ship* — the app has an Inclusion knob and no rank-position knob — but how far a given inclusion moves the pick is a property of the fitted mixture, so on a steep sort the whole usable range can land inside a couple of rank percent. `@q` names the position directly, which is what establishes whether *position* is the mechanism before asking whether `k` is a usable handle on it.
+
+#### The pick log (`pick_sink`)
+
+Pass a list as `pick_sink` to get one row per **click** (columns: `_PICK_COLUMNS`) — what was picked, whether it was a positive, and where on the seed sort it came from. The main frame starts at the first *trainable* step, because before one Good and one Bad vote coexist there is no model, no threshold and no metrics row; so the opening is exactly the part it does not record. An opening that never finds both classes emits **no main row at all**, which is a result about that opening rather than a missing cell.
 
 Pass `autopilot_fidelity=False` to reproduce studies published before the flow was aligned (the Max-Patch, MLP-vs-SVM, and Inclusion-knob reports); that path is byte-for-byte the old behaviour. New studies should leave it on.
 

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -53,6 +53,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 PINS_PATH = REPO_ROOT / "scripts" / "eval-app-sync.pins.json"
 
 AUTOPILOT_TS = "frontend/src/app/services/autopilot-state.service.ts"
+LABEL_VIEW_TS = "frontend/src/app/components/label-view/label-view.component.ts"
 
 
 @dataclass(frozen=True)
@@ -105,6 +106,42 @@ MIRRORS: list[Mirror] = [
             "goodToStart / badToStart are copied as GOOD_TARGET / BAD_TARGET, which decide how "
             "many votes the simulation spends before its first learned sort. Pinned literally "
             "by tests_lib/detectors/test_autopilot_flow.py::TestPortedConstants."
+        ),
+    ),
+    Mirror(
+        id="autopilot.phase_sort_select",
+        app=f"ts:{LABEL_VIEW_TS}::onAutopilotStop(",
+        harness="vtscore/eval/al_strategies.py::_select_phase_faithful",
+        kind="ported",
+        note=(
+            "Which Sort and which Select each Autopilot phase drives - good=text+top, "
+            "bad=text+hard, hard=learned+hard, new=learned+new. The simulated user picks the "
+            "next item from exactly this pairing, so re-pointing a phase at a different sort "
+            "or select here silently changes what every study's vote order means. The load- "
+            "bearing row is `bad`: it is still on the TEXT sort, so the harness must not "
+            "consult detector scores there even though a model exists for measurement."
+        ),
+        divergence=(
+            "onAutopilotStop applies the mapping when the user stops Autopilot; the live "
+            "mapping is the phase subscription in the same component, which additionally "
+            "kicks off the sort request. This anchor is the one place the whole table is "
+            "written out in one block, so it is what the digest watches."
+        ),
+    ),
+    Mirror(
+        id="autopilot.startup_default",
+        app=f"ts:{AUTOPILOT_TS}::const INITIAL_STATE",
+        harness="vtscore/eval/startup_schedule.py::PRODUCTION_STARTUP",
+        kind="default",
+        note=(
+            "issue #3267 made the Autopilot opening a parameter, so the harness now has a "
+            "spelling of the app's own opening - 'g3@top,b4@mid' - that a study's control arm "
+            "runs. If goodToStart/badToStart move, or the opening stops being 'top of the "
+            "seed sort then its cutoff', this constant has to move with them or every #3267 "
+            "study measures its deviations from an opening nobody ships. "
+            "tests_lib/detectors/test_startup_schedule.py pins it two ways: literally against "
+            "GOOD_TARGET/BAD_TARGET, and behaviourally by requiring it to reproduce a "
+            "default-arm run click for click."
         ),
     ),
     Mirror(

--- a/scripts/eval-app-sync.pins.json
+++ b/scripts/eval-app-sync.pins.json
@@ -1,5 +1,7 @@
 {
   "autopilot.phase_machine": "8ad8a0c2a72103a3ca0061201f57977869225a458894d79efd41a18e5e342fc7",
+  "autopilot.phase_sort_select": "f67f2a6f59fba5813aa1f284fefc83520c6675251256cfcd2ed5729a4a1566d6",
+  "autopilot.startup_default": "6b15d45162cc406b8924e37a23286950d5e5dde551cbcd0d9d4c2500cec044f9",
   "autopilot.vote_targets": "6b15d45162cc406b8924e37a23286950d5e5dde551cbcd0d9d4c2500cec044f9",
   "progress.smart_status": "89b7600be625c7de64c21b54bfcf96e20bcee6229d28dc4f879386cdb3a67e24",
   "progress.span_status": "7da887d32d0559066dd3d51ad1045e5b9322f2e295aa6bc8e5ca62e6f81ba3a3",

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -213,3 +213,69 @@ pre-registered decision rules: `docs/experiments/calibration-fold-count/REPORT.m
 Not to be confused with the older `analyze_folds.py` / `launch_folds_2861.sh`,
 which moved the fold count to 4 only to unlock the anchored `qmean`/`qmedian`
 combine question — it measures no cost and covers region voting only.
+
+## Good Mining: sweeping the Autopilot **opening** (issue #3267)
+
+Getting enough Goods looks like what separates a VTSearch run that works from
+one that fails, and the *opening* is where Goods come from. Today it is fixed:
+the top of the seed sort until 3 positives, that sort's cutoff until 4
+negatives, then the learned Hard sort ever after.
+
+Both of those phases are the **same operation** — a rank-space `hard` select
+against a cut drawn on the seed sort — at two different cuts. The Good phase's
+`top` select is that select against a cut placed above every score; the Bad
+phase's is against the sort's own fitted GMM, split at the production midpoint.
+So the opening collapses to a list of rounds, each naming *how many clicks* and
+*where on the sort*, which is what `CALIB_STARTUP_SCHEDULE` sweeps.
+
+```bash
+GM_STAGE=live bash launch_good_mining.sh    # coco_val + visual_genome_m
+GM_STAGE=bands bash launch_good_mining.sh   # vg_box_small/medium/large
+python analyze_startup.py                   # once every arm drains
+python selftest_analyze_startup.py          # planted-answer check on the analyzer
+```
+
+Grammar (full reference: [`vtscore/eval/startup_schedule.py`](../../../vtscore/eval/startup_schedule.py)):
+`<g|b|n><count>@<top|mid|k[-]N|q<frac>>`, comma-separated. `g3` stays until 3
+goods exist, `b4` until 4 bads, `n8` for 8 clicks; `@top` cuts above every score,
+`@mid` at the shipped GMM midpoint, `@k-3` at that GMM split under inclusion −3,
+`@q0.05` at the sort's 5th rank percentile. `g3@top,b4@mid` is today's opening
+and is *required* to reproduce a default run click for click.
+
+**Two arms are load-bearing.**
+
+- `deep_first` (`n10@q0.35,n6@mid`) is the **falsifier**: it opens below the good
+  mass and must mine *fewer* positives. If it does not, depth is not the
+  mechanism and no other number in the run is interpretable — `analyze_startup.py`
+  withholds the verdict rather than reporting one.
+- `flat_mid` (`n16@mid`) is the **length-matched control**. Every banded arm
+  spends 16 opening clicks against `prod`'s ~7, so a win over `prod` alone could
+  be "spend more clicks before training". Read each banded arm against both.
+
+**Expect the `k` family to be partly inert, and check rather than assume.** How
+far a given inclusion moves the pick is a property of the fitted mixture, not of
+the inclusion: on a steep sort the whole usable range can land inside a couple of
+rank percent, so a grid that looks well spread in `k` can be nearly a point in
+the space the picks actually live in. That is exactly why the `q` family exists
+beside it — `q` establishes whether *position* is the mechanism, `k` asks whether
+the app's existing Inclusion knob is a usable handle on it. The analyzer reads
+each arm's realized `startup_cut_percentile` and reports "measured nothing"
+rather than "the lever does nothing".
+
+### The pick log
+
+`CALIB_EMIT_PICKS=1` (the default) writes `task_*__picks.csv`: **one row per
+click**, carrying what was picked, whether it turned out to be a positive, and
+where on the seed sort it came from. The main frame cannot answer this study's
+questions — it starts at the first *trainable* step, so the opening, which is
+the whole subject, is exactly the part it does not record. A cell whose opening
+never found both classes emits no main row at all; that is a result about that
+arm (the starvation regime), and the analyzer counts those cells rather than
+dropping them.
+
+### Sizing
+
+`live` is 2 datasets × `siglip` × (6 COCO + 4 bands × 3 VG) categories × 6 seeds
+× 8 arms ≈ 860 cells at `CALIB_MAX_STEPS=100`. `bands` triples the dataset count.
+Per the [GRID playbook](../GRID-PLAYBOOK.md), time **one real cell** before
+submitting `bands` — do not extrapolate from the `live` stage's slowest cell.

--- a/scripts/experiments/calibration/analyze_startup.py
+++ b/scripts/experiments/calibration/analyze_startup.py
@@ -1,0 +1,619 @@
+"""Does a different Autopilot **opening** mine better positives?  (issue #3267)
+
+The run sweeps the opening: how many clicks to spend before the first learned
+sort, and how deep in the seed sort to spend them.  ``launch_good_mining.sh``
+defines the arms; ``vtscore/eval/startup_schedule.py`` defines the grammar.
+
+The question is not only "which arm scores best".  An opening can win for two
+very different reasons - it found *more* positives, or it found *harder* ones -
+and those imply different follow-ups, so this analyzer reports the mining
+behaviour separately from the outcome and never collapses the two.
+
+Four things it refuses to do quietly:
+
+1. **Report an arm without checking its opening actually moved.**  Every arm's
+   realized ``startup_cut_percentile`` is compared against the control's
+   sampling depth.  An inclusion (``k``) arm is the likely offender: how far a
+   given ``k`` moves the pick is a property of the fitted mixture, and on a
+   steep sort the whole usable range can land inside a couple of rank percent.
+   Such an arm **measured nothing**, which is a different finding from "the
+   lever does nothing".
+2. **Compare a 16-click opening against a 7-click one and call the difference
+   depth.**  Every banded arm is reported against ``flat_mid`` (the
+   length-matched control) as well as against ``prod``, and the opening's own
+   click count is a reported column.
+3. **Read the falsification arm as decoration.**  ``deep_first`` opens *below*
+   the good mass and must mine fewer positives.  If it does not, depth is not
+   the mechanism and the verdict is withheld.
+4. **Hide the cells that produced nothing.**  An opening that never finds both
+   classes trains no detector and emits no main row; that is a *result* about
+   that arm, not a missing file, so those cells are counted per arm and
+   reported.  Paired tests lose them, which is exactly why the count matters.
+
+Writes ``agg/*.csv``, ``startup_summary.json``, ``figures/*.png`` and
+``REPORT_startup.md`` under ``$CALIB_EXP/analysis``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+import analyze_spikes as sp  # noqa: E402  (reuse the #2847 loader)
+
+try:
+    from scipy.stats import wilcoxon as _wilcoxon
+except Exception:  # noqa: BLE001
+    _wilcoxon = None
+
+#: Arms, in the order the report reads them.  Keep in step with
+#: ``launch_good_mining.sh``; an arm listed here with no cells is reported as
+#: absent rather than silently skipped.
+ARMS: tuple[str, ...] = (
+    "prod",
+    "top_long",
+    "easy_med_hard",
+    "band_wide",
+    "incl_k",
+    "incl_k_wide",
+    "flat_mid",
+    "deep_first",
+)
+CONTROL = "prod"
+#: The length-matched control: same opening budget as the banded arms, none of
+#: it spent mining.  A banded arm that beats ``prod`` but not this one won on
+#: *clicks*, not on *depth*.
+LENGTH_CONTROL = "flat_mid"
+FALSIFIER = "deep_first"
+
+ARM_SCHEDULE: dict[str, str] = {
+    "prod": "(app default: g3@top,b4@mid)",
+    "top_long": "g8@top,b4@mid",
+    "easy_med_hard": "n5@q0.02,n5@q0.10,n6@mid",
+    "band_wide": "n5@q0.05,n5@q0.25,n6@mid",
+    "incl_k": "n5@k-6,n5@k-2,n6@k0",
+    "incl_k_wide": "n5@k-10,n5@k-4,n6@k0",
+    "flat_mid": "n16@mid",
+    "deep_first": "n10@q0.35,n6@mid",
+}
+
+#: An arm's opening counts as having moved if its median sampling depth differs
+#: from the control's by at least this many rank percent.  Below it the arm is
+#: reported as having measured nothing.
+DEPTH_EPS = float(os.environ.get("GM_DEPTH_EPS", "0.01"))
+#: Ship rule, mirroring the acquisition-inclusion study's: positives must rise
+#: and cost must not regress by more than this at the 95% upper bound.
+COST_REGRESSION_TOLERANCE = float(os.environ.get("GM_COST_TOL", "0.01"))
+ALPHA = 0.05
+#: Click marks the mining curve is read at.  The axis a user spends is clicks,
+#: which is not the axis the method converges on - so both are reported.
+CLICK_MARKS = (10, 20, 50, 100)
+
+OUT = Path(os.environ.get("GM_OUT", str(common.EXP / "analysis")))
+KEYS = ("dataset", "embedder", "category", "seed")
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_picks(arm_dir: Path) -> tuple[pd.DataFrame, dict]:
+    """Concatenate one arm's ``__picks.csv`` cells, with provenance.
+
+    Separate from :func:`analyze_spikes.load_arm` because the pick log is the
+    frame that records the *opening*, and the opening emits no main row.  An
+    unreadable or zero-byte cell is counted, never dropped in silence.
+    """
+    cells = arm_dir / "cells"
+    files = sorted(cells.glob("task_*__picks.csv")) if cells.is_dir() else []
+    frames, bad, empty, headless = [], [], [], []
+    for f in files:
+        if f.stat().st_size == 0:
+            empty.append(f.name)
+            continue
+        try:
+            fr = pd.read_csv(f)
+        except Exception:  # noqa: BLE001
+            bad.append(f.name)
+            continue
+        if fr.empty:
+            headless.append(f.name)
+            continue
+        frames.append(fr)
+    prov = {"n_files": len(files), "n_read": len(frames), "unreadable": bad, "zero_byte": empty, "empty": headless}
+    if not frames:
+        return pd.DataFrame(), prov
+    df = pd.concat(frames, ignore_index=True)
+    prov["n_rows"] = int(len(df))
+    return df, prov
+
+
+def load_all(root: Path) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
+    """``(main, picks, provenance)`` over every arm, each tagged with ``arm``."""
+    mains, picks, prov = [], [], {}
+    for arm in ARMS:
+        m, pm = sp.load_arm(root / arm)
+        p, pp = load_picks(root / arm)
+        prov[arm] = {"main": pm, "picks": pp}
+        for df, sink in ((m, mains), (p, picks)):
+            if not df.empty:
+                df = df.copy()
+                df["arm"] = arm
+                sink.append(df)
+    main = pd.concat(mains, ignore_index=True) if mains else pd.DataFrame()
+    pick = pd.concat(picks, ignore_index=True) if picks else pd.DataFrame()
+    return main, pick, prov
+
+
+def _keys(df: pd.DataFrame) -> list[str]:
+    return [k for k in KEYS if k in df.columns]
+
+
+# ---------------------------------------------------------------------------
+# Mining: what the opening actually did
+# ---------------------------------------------------------------------------
+
+
+def opening_stats(picks: pd.DataFrame) -> pd.DataFrame:
+    """One row per ``(arm, cell)`` describing that trajectory's **opening**.
+
+    The opening is every click spent before the first learned sort, i.e. every
+    click carrying a schedule round (``startup_round >= 0``) - or, on the
+    control, every click in the ``good`` / ``bad`` phases, which is the same
+    thing under a different name.
+    """
+    if picks.empty:
+        return pd.DataFrame()
+    keys = ["arm", *_keys(picks)]
+    out = []
+    for key, g in picks.groupby(keys, dropna=False):
+        g = g.sort_values("t")
+        in_open = (
+            g["startup_round"] >= 0 if (g["startup_round"] >= 0).any() else g["phase"].astype(str).isin(("good", "bad"))
+        )
+        op = g[in_open]
+        rec = dict(zip(keys, key if isinstance(key, tuple) else (key,), strict=False))
+        rec.update(
+            n_clicks=int(len(g)),
+            open_clicks=int(len(op)),
+            open_positives=int(op["picked_label"].sum()) if len(op) else 0,
+            open_yield=float(op["picked_label"].mean()) if len(op) else np.nan,
+            # Where the opening sampled, and how deep it actually had to reach
+            # for the positives it found.  The first is the arm's *intent*, the
+            # second its *outcome*; an arm can move the first without moving the
+            # second, and that is the case worth catching.
+            open_cut_depth=float(op["startup_cut_percentile"].median()) if len(op) else np.nan,
+            open_pick_depth=float(op["picked_seed_percentile"].median()) if len(op) else np.nan,
+            open_pos_depth=(
+                float(op.loc[op["picked_label"] == 1, "picked_seed_percentile"].median())
+                if len(op) and (op["picked_label"] == 1).any()
+                else np.nan
+            ),
+            # An opening that never produced both classes: the harness kept
+            # voting past the schedule to get a trainable pair.  A non-zero
+            # count is a finding about that arm's opening, not noise.
+            open_overrun=int(max(0, len(op) - _declared_clicks(g))),
+            trained_at=int(g.loc[g["phase"].astype(str).isin(("hard", "new", "done")), "t"].min())
+            if g["phase"].astype(str).isin(("hard", "new", "done")).any()
+            else -1,
+        )
+        for mark in CLICK_MARKS:
+            head = g[g["t"] <= mark]
+            rec[f"positives_{mark}"] = int(head["picked_label"].sum())
+        out.append(rec)
+    return pd.DataFrame(out)
+
+
+def _declared_clicks(g: pd.DataFrame) -> int:
+    """How many opening clicks the arm's schedule *asked* for.
+
+    Read off the pick log rather than re-parsing the spec, so an arm whose
+    rounds were cut short by a small pool is measured as it ran.
+    """
+    rounds = g[g["startup_round"] >= 0]
+    if rounds.empty:
+        return int(len(g[g["phase"].astype(str).isin(("good", "bad"))]))
+    # Every click in a round the trajectory genuinely entered, minus the ones
+    # spent held on the last round waiting for the missing vote class.
+    last = int(rounds["startup_round"].max())
+    return int((rounds["startup_round"] < last).sum() + min((rounds["startup_round"] == last).sum(), len(rounds)))
+
+
+# ---------------------------------------------------------------------------
+# Outcome: what the detector did afterwards
+# ---------------------------------------------------------------------------
+
+
+def trajectory_stats(main: pd.DataFrame) -> pd.DataFrame:
+    """One row per ``(arm, cell)`` carrying the endpoints the ship rule reads."""
+    if main.empty:
+        return pd.DataFrame()
+    keys = ["arm", *_keys(main)]
+    out = []
+    for key, g in main.groupby(keys, dropna=False):
+        g = g.sort_values("t")
+        cost = g["cost"].to_numpy(dtype=float)
+        rec = dict(zip(keys, key if isinstance(key, tuple) else (key,), strict=False))
+        rec.update(
+            n_steps=int(len(g)),
+            final_cost=float(cost[-1]),
+            mean_cost_warm=float(np.nanmean(cost[g["t"].to_numpy(dtype=float) >= sp.WARM_T]))
+            if (g["t"] >= sp.WARM_T).any()
+            else np.nan,
+            final_ap=float(g["average_precision"].iloc[-1]) if "average_precision" in g.columns else np.nan,
+            final_n_good=int(g["n_good"].iloc[-1]),
+        )
+        out.append(rec)
+    return pd.DataFrame(out)
+
+
+# ---------------------------------------------------------------------------
+# Paired comparison
+# ---------------------------------------------------------------------------
+
+
+def paired(traj: pd.DataFrame, metric: str, arm: str, control: str) -> dict:
+    """Wilcoxon + bootstrap CI on the paired ``(cell)`` delta ``arm - control``.
+
+    Paired on the identical (dataset, embedder, category, seed) so the arms are
+    compared on the same data and the same splits; a cell missing from either
+    side drops out of the pair and is counted in ``n_pairs``.
+    """
+    keys = _keys(traj)
+    a = traj[traj["arm"] == control].set_index(keys)[metric]
+    b = traj[traj["arm"] == arm].set_index(keys)[metric]
+    j = pd.concat([a.rename("ctl"), b.rename("arm")], axis=1).dropna()
+    if j.empty:
+        return {"n_pairs": 0}
+    d = (j["arm"] - j["ctl"]).to_numpy(dtype=float)
+    rng = np.random.default_rng(12345)  # fixed: a CI must not move between runs
+    boot = np.array([np.mean(rng.choice(d, size=len(d), replace=True)) for _ in range(4000)])
+    res = {
+        "n_pairs": int(len(j)),
+        "control_median": float(j["ctl"].median()),
+        "arm_median": float(j["arm"].median()),
+        "median_delta": float(np.median(d)),
+        "mean_delta": float(np.mean(d)),
+        "ci95_lo": float(np.percentile(boot, 2.5)),
+        "ci95_hi": float(np.percentile(boot, 97.5)),
+        "frac_arm_higher": float((d > 0).mean()),
+    }
+    if _wilcoxon is not None and np.any(d != 0):
+        try:
+            res["p"] = float(_wilcoxon(j["ctl"], j["arm"]).pvalue)
+        except Exception:  # noqa: BLE001
+            pass
+    return res
+
+
+def lever_moved(opening: pd.DataFrame, arm: str, control: str = CONTROL) -> dict:
+    """Did *arm*'s opening sample somewhere else than the control's?
+
+    The check that stops "no effect" being reported for an arm whose cut never
+    left the control's rank position.  Measured on where the opening's picks
+    *landed*, not on the cut's nominal value: two very different inclusions can
+    name the same rank on a steep sort, and rank is what the pick reads.
+    """
+    if opening.empty:
+        return {"moved": False, "reason": "no pick rows"}
+    a = opening[opening["arm"] == arm]["open_pick_depth"].median()
+    c = opening[opening["arm"] == control]["open_pick_depth"].median()
+    if not np.isfinite(a) or not np.isfinite(c):
+        return {"moved": False, "reason": "no opening depth recorded"}
+    return {
+        "moved": bool(abs(a - c) >= DEPTH_EPS),
+        "arm_depth": float(a),
+        "control_depth": float(c),
+        "delta": float(a - c),
+        "eps": DEPTH_EPS,
+    }
+
+
+def verdict(summary: dict) -> str:
+    """The pre-registered read, or a withheld one and why.
+
+    Withheld beats wrong: the falsifier failing to falsify means depth is not
+    the mechanism, and no arm-vs-control number in the run is interpretable
+    until that is understood.
+    """
+    fals = summary["arms"].get(FALSIFIER, {})
+    fals_pos = fals.get("positives_100", {})
+    if not fals_pos.get("n_pairs"):
+        return f"WITHHELD: the falsification arm ({FALSIFIER}) produced no pairs."
+    if fals_pos.get("median_delta", 0.0) >= 0:
+        return (
+            f"WITHHELD: {FALSIFIER} opens below the good mass and should mine FEWER positives, "
+            f"but its paired delta is {fals_pos['median_delta']:+.3g}. Depth is not behaving as "
+            "the mechanism assumes; nothing else here is interpretable until that is resolved."
+        )
+    winners = []
+    for arm, rec in summary["arms"].items():
+        if arm in (CONTROL, FALSIFIER):
+            continue
+        if not rec.get("lever", {}).get("moved"):
+            continue
+        pos = rec.get("positives_100", {})
+        cost = rec.get("final_cost", {})
+        if not pos.get("n_pairs") or not cost.get("n_pairs"):
+            continue
+        beats_len = rec.get("vs_length_control", {}).get("positives_100", {}).get("median_delta", 0.0)
+        if pos.get("median_delta", 0.0) > 0 and cost.get("ci95_hi", 1.0) <= COST_REGRESSION_TOLERANCE:
+            winners.append((arm, pos["median_delta"], cost["ci95_hi"], beats_len))
+    if not winners:
+        return "NO ARM SHIPS: no opening both mined more positives and held cost within tolerance."
+    winners.sort(key=lambda w: -w[1])
+    arm, dpos, chi, dlen = winners[0]
+    tail = (
+        f" It also beats the length-matched control ({LENGTH_CONTROL}) by {dlen:+.3g} positives, "
+        "so the gain is depth rather than budget."
+        if dlen > 0
+        else (
+            f" But it does NOT beat the length-matched control ({LENGTH_CONTROL}) ({dlen:+.3g}), "
+            "so the gain may be the extra opening clicks rather than where they were spent."
+        )
+    )
+    return (
+        f"CANDIDATE: {arm} ({ARM_SCHEDULE.get(arm, '?')}) mines {dpos:+.3g} more positives per 100 "
+        f"clicks with cost regression bounded at {chi:+.3g}.{tail}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Figures
+# ---------------------------------------------------------------------------
+
+
+def make_figures(picks: pd.DataFrame, opening: pd.DataFrame, outdir: Path) -> list[str]:
+    """Mining curve (mean and per-run), opening depth, and yield by depth."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    written: list[str] = []
+    if picks.empty:
+        return written
+
+    # 1. Positives found vs clicks spent - the figure that answers "what do I
+    #    get after 20 clicks?".  Mean over cells, with a spread band.
+    fig, ax = plt.subplots(figsize=(7.5, 4.6))
+    for arm in ARMS:
+        g = picks[picks["arm"] == arm]
+        if g.empty:
+            continue
+        cum = g.sort_values("t").groupby([*_keys(g), "t"])["picked_label"].sum().groupby(level=_keys(g)).cumsum()
+        wide = cum.reset_index().pivot_table(index="t", columns=_keys(g), values="picked_label")
+        ax.plot(wide.index, wide.mean(axis=1), label=arm, lw=1.6)
+        ax.fill_between(wide.index, wide.quantile(0.25, axis=1), wide.quantile(0.75, axis=1), alpha=0.10)
+    ax.set_xlabel("clicks spent")
+    ax.set_ylabel("positives found (cumulative)")
+    ax.set_title("Good mining: positives per click, by opening")
+    ax.legend(fontsize=7, ncol=2)
+    fig.tight_layout()
+    p = outdir / "mining_curve.png"
+    fig.savefig(p, dpi=130)
+    plt.close(fig)
+    written.append(p.name)
+
+    # 2. The same, one line per run.  A mean hides that some runs never leave
+    #    the floor, and that spread is usually the real finding.
+    arms_present = [a for a in ARMS if not picks[picks["arm"] == a].empty]
+    fig, axes = plt.subplots(1, len(arms_present), figsize=(2.5 * len(arms_present), 3.4), sharey=True)
+    axes = np.atleast_1d(axes)
+    for ax, arm in zip(axes, arms_present, strict=False):
+        g = picks[picks["arm"] == arm]
+        for _, run in g.groupby(_keys(g)):
+            run = run.sort_values("t")
+            ax.plot(run["t"], run["picked_label"].cumsum(), lw=0.6, alpha=0.45, color="#2b6cb0")
+        ax.set_title(arm, fontsize=8)
+        ax.set_xlabel("clicks")
+    axes[0].set_ylabel("positives found")
+    fig.suptitle("Per-run mining curves (a mean hides the runs that never start)", fontsize=9)
+    fig.tight_layout()
+    p = outdir / "mining_per_run.png"
+    fig.savefig(p, dpi=130)
+    plt.close(fig)
+    written.append(p.name)
+
+    # 3. Where each opening actually sampled, against where it was aimed.  An
+    #    arm whose two bars coincide with the control's measured nothing.
+    if not opening.empty:
+        fig, ax = plt.subplots(figsize=(7.0, 4.0))
+        arms_present = [a for a in ARMS if (opening["arm"] == a).any()]
+        x = np.arange(len(arms_present))
+        aimed = [opening.loc[opening["arm"] == a, "open_cut_depth"].median() for a in arms_present]
+        landed = [opening.loc[opening["arm"] == a, "open_pick_depth"].median() for a in arms_present]
+        ax.bar(x - 0.2, aimed, 0.4, label="cut depth (aimed)")
+        ax.bar(x + 0.2, landed, 0.4, label="pick depth (landed)")
+        ax.set_xticks(x)
+        ax.set_xticklabels(arms_present, rotation=30, ha="right", fontsize=8)
+        ax.set_ylabel("depth in the seed sort (0 = top)")
+        ax.set_title("Did the opening move? aimed vs landed")
+        ax.legend(fontsize=8)
+        fig.tight_layout()
+        p = outdir / "opening_depth.png"
+        fig.savefig(p, dpi=130)
+        plt.close(fig)
+        written.append(p.name)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def _fmt(d: dict, key: str, digits: int = 2) -> str:
+    v = d.get(key)
+    return "-" if v is None or (isinstance(v, float) and not np.isfinite(v)) else f"{v:.{digits}g}"
+
+
+def write_report(summary: dict, figures: list[str], outdir: Path) -> Path:
+    lines = [
+        "# Good Mining: does a different Autopilot opening find better positives?",
+        "",
+        f"Issue #3267.  Arms: `{'`, `'.join(ARMS)}`.  Control: `{CONTROL}`; ",
+        f"length-matched control: `{LENGTH_CONTROL}`; falsifier: `{FALSIFIER}`.",
+        "",
+        f"**Verdict.** {summary['verdict']}",
+        "",
+        "## Coverage",
+        "",
+        "| arm | schedule | cells (main) | cells (picks) | no detector trained | unreadable |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for arm in ARMS:
+        pv = summary["provenance"].get(arm, {})
+        m, p = pv.get("main", {}), pv.get("picks", {})
+        lines.append(
+            f"| `{arm}` | `{ARM_SCHEDULE.get(arm, '?')}` | {m.get('n_read', 0)} | {p.get('n_read', 0)} | "
+            f"{len(m.get('no_positive_found', []))} | {len(m.get('unreadable', [])) + len(p.get('unreadable', []))} |"
+        )
+    lines += [
+        "",
+        "A cell under **no detector trained** is a result, not a missing file: that opening never",
+        "found both vote classes inside the horizon, so it emitted no main row.  Those cells drop",
+        "out of every paired test below, which is why the count belongs here.",
+        "",
+        "## Did each opening move?",
+        "",
+        "| arm | aimed depth | landed depth | vs control | moved? |",
+        "|---|---:|---:|---:|:--:|",
+    ]
+    for arm in ARMS:
+        rec = summary["arms"].get(arm, {})
+        lv = rec.get("lever", {})
+        aim = rec.get("open_cut_depth")
+        lines.append(
+            f"| `{arm}` | {'-' if aim is None else f'{aim:.2g}'} | {_fmt(lv, 'arm_depth')} | "
+            f"{_fmt(lv, 'delta')} | {'yes' if lv.get('moved') else '**no**'} |"
+        )
+    lines += [
+        "",
+        "Depth is a rank position in the seed sort (0 = the top).  An arm marked **no** sampled",
+        f"within {DEPTH_EPS:.2g} of the control and therefore measured nothing - do not read its",
+        "outcome columns as evidence that the opening does not matter.",
+        "",
+        "## Mining and outcome, paired against the control",
+        "",
+        "| arm | open clicks | open yield | positives@100 Δ | [95% CI] | final cost Δ | [95% CI] | AP Δ |",
+        "|---|---:|---:|---:|---|---:|---|---:|",
+    ]
+    for arm in ARMS:
+        if arm == CONTROL:
+            continue
+        rec = summary["arms"].get(arm, {})
+        pos, cost, ap = rec.get("positives_100", {}), rec.get("final_cost", {}), rec.get("final_ap", {})
+        lines.append(
+            f"| `{arm}` | {_fmt(rec, 'open_clicks')} | {_fmt(rec, 'open_yield')} | "
+            f"{_fmt(pos, 'median_delta')} | [{_fmt(pos, 'ci95_lo')}, {_fmt(pos, 'ci95_hi')}] | "
+            f"{_fmt(cost, 'median_delta')} | [{_fmt(cost, 'ci95_lo')}, {_fmt(cost, 'ci95_hi')}] | "
+            f"{_fmt(ap, 'median_delta')} |"
+        )
+    lines += [
+        "",
+        "Every delta is paired on the identical (dataset, embedder, category, seed).  A difference",
+        "smaller than twice its standard error is not resolvable here, and saying so is a finding.",
+        "",
+        "## Against the length-matched control",
+        "",
+        f"Every banded arm spends more opening clicks than `{CONTROL}`, so a win against it could be",
+        f"budget rather than depth.  `{LENGTH_CONTROL}` spends the same budget with no mining round.",
+        "",
+        "| arm | positives@100 Δ vs length control | [95% CI] | final cost Δ | [95% CI] |",
+        "|---|---:|---|---:|---|",
+    ]
+    for arm in ARMS:
+        if arm in (CONTROL, LENGTH_CONTROL):
+            continue
+        vs = summary["arms"].get(arm, {}).get("vs_length_control", {})
+        pos, cost = vs.get("positives_100", {}), vs.get("final_cost", {})
+        lines.append(
+            f"| `{arm}` | {_fmt(pos, 'median_delta')} | [{_fmt(pos, 'ci95_lo')}, {_fmt(pos, 'ci95_hi')}] | "
+            f"{_fmt(cost, 'median_delta')} | [{_fmt(cost, 'ci95_lo')}, {_fmt(cost, 'ci95_hi')}] |"
+        )
+    if figures:
+        lines += ["", "## Figures", ""]
+        for name in figures:
+            lines.append(f"![{name}](figures/{name})")
+            lines.append("")
+    lines += [
+        "## What is still owed",
+        "",
+        "This analyzer reports *whether* an opening mined better.  The issue also asks **why**,",
+        "and that is a question about the items themselves: dump the opening's picks with",
+        "`VTS_DUMP_TEST_SCORES` and render them with `make_error_sheets.py`, so a winning arm's",
+        "extra positives can be looked at rather than counted.  On image data, show the images.",
+        "",
+    ]
+    outdir.mkdir(parents=True, exist_ok=True)
+    path = outdir / "REPORT_startup.md"
+    path.write_text("\n".join(lines))
+    return path
+
+
+def analyze(root: Path, outdir: Path) -> dict:
+    main, picks, prov = load_all(root)
+    opening = opening_stats(picks)
+    traj = trajectory_stats(main)
+
+    summary: dict = {"provenance": prov, "arms": {}, "n_main_rows": int(len(main)), "n_pick_rows": int(len(picks))}
+    for arm in ARMS:
+        rec: dict = {"schedule": ARM_SCHEDULE.get(arm, "?")}
+        if not opening.empty and (opening["arm"] == arm).any():
+            g = opening[opening["arm"] == arm]
+            rec["open_clicks"] = float(g["open_clicks"].median())
+            rec["open_yield"] = float(g["open_yield"].median())
+            rec["open_cut_depth"] = float(g["open_cut_depth"].median())
+            rec["open_pos_depth"] = float(g["open_pos_depth"].median())
+            rec["open_overrun_cells"] = int((g["open_overrun"] > 0).sum())
+        rec["lever"] = lever_moved(opening, arm)
+        if arm != CONTROL:
+            if not opening.empty:
+                for mark in CLICK_MARKS:
+                    rec[f"positives_{mark}"] = paired(opening, f"positives_{mark}", arm, CONTROL)
+            if not traj.empty:
+                for metric in ("final_cost", "final_ap"):
+                    rec[metric] = paired(traj, metric, arm, CONTROL)
+            if arm != LENGTH_CONTROL:
+                vs: dict = {}
+                if not opening.empty:
+                    vs["positives_100"] = paired(opening, "positives_100", arm, LENGTH_CONTROL)
+                if not traj.empty:
+                    vs["final_cost"] = paired(traj, "final_cost", arm, LENGTH_CONTROL)
+                rec["vs_length_control"] = vs
+        summary["arms"][arm] = rec
+    summary["verdict"] = verdict(summary)
+
+    agg = outdir / "agg"
+    agg.mkdir(parents=True, exist_ok=True)
+    if not opening.empty:
+        opening.to_csv(agg / "opening_stats.csv", index=False)
+    if not traj.empty:
+        traj.to_csv(agg / "trajectory_stats.csv", index=False)
+    figures = make_figures(picks, opening, outdir / "figures")
+    (outdir / "startup_summary.json").write_text(json.dumps(summary, indent=2, default=str))
+    write_report(summary, figures, outdir)
+    return summary
+
+
+def main() -> int:
+    root = Path(os.environ.get("GM_RESULTS", str(common.EXP / "results")))
+    summary = analyze(root, OUT)
+    print(summary["verdict"])
+    print(f"report -> {OUT / 'REPORT_startup.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/analyze_startup.py
+++ b/scripts/experiments/calibration/analyze_startup.py
@@ -325,8 +325,8 @@ def verdict(summary: dict) -> str:
     the mechanism, and no arm-vs-control number in the run is interpretable
     until that is understood.
     """
-    fals = summary["arms"].get(FALSIFIER, {})
-    fals_pos = fals.get("positives_100", {})
+    fals_arm = summary["arms"].get(FALSIFIER, {})
+    fals_pos = fals_arm.get("positives_100", {})
     if not fals_pos.get("n_pairs"):
         return f"WITHHELD: the falsification arm ({FALSIFIER}) produced no pairs."
     if fals_pos.get("median_delta", 0.0) >= 0:

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -276,6 +276,24 @@ if ACQ_INCLUSION_OFFSET is None:
 #: ``CALIB_ACQ_INCLUSION_OFFSET=0``; the two name the same cut.
 ACQ_RANK_PERCENTILE = _opt_float("CALIB_ACQ_RANK_PERCENTILE")
 
+#: The **Autopilot opening** this arm runs (issue #3267), in the grammar of
+#: :mod:`vtscore.eval.startup_schedule` - e.g. ``"n6@k-6,n6@k-2,n6@k0"``.
+#:
+#: Unset = the app's own opening (three positives off the top of the seed sort,
+#: then four negatives at its cutoff), which is what every study before #3267
+#: ran and what the `prod` control arm must keep running.  Do **not** write the
+#: production spelling in here as a "default": a schedule string frozen in this
+#: file goes stale the moment the app's opening moves, and the control arm would
+#: then quietly stop being the control.  ``PRODUCTION_STARTUP`` exists for a run
+#: that wants to name it explicitly, and is pinned against the app.
+STARTUP_SCHEDULE = os.environ.get("CALIB_STARTUP_SCHEDULE", "").strip() or None
+
+#: Emit the per-click pick log (``task_*__picks.csv``).  On by default for a
+#: #3267 run and harmless everywhere else - one small row per vote.  It is the
+#: only frame that records the **opening**, which emits no main row because no
+#: detector exists yet, so an arm's mining behaviour is invisible without it.
+EMIT_PICKS = os.environ.get("CALIB_EMIT_PICKS", "1") not in ("", "0")
+
 #: Minimum positives a category must have **in the simulation half** to be kept.
 #: A long-horizon run (#2841 follow-up: does pure x-cal ever overtake the blend?)
 #: is bounded by positives, not pool size: once autopilot has exhausted them,

--- a/scripts/experiments/calibration/launch_good_mining.sh
+++ b/scripts/experiments/calibration/launch_good_mining.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Good Mining — does a different Autopilot *opening* find better positives?  (#3267)
+#
+# Getting enough Goods looks like what separates a VTSearch run that works from
+# one that fails, and the opening is where Goods come from.  Today it is fixed:
+# the top of the seed sort until 3 positives, that sort's cutoff until 4
+# negatives, then the learned Hard sort forever.  Both of those phases are the
+# same operation - a rank-space `hard` select against a cut on the seed sort -
+# at two different cuts, so the opening is really "how many clicks, at what
+# depth", and this run sweeps that.  See vtscore/eval/startup_schedule.py for
+# the grammar and docs/EVAL.md for how the arms are read.
+#
+#   prod           (unset)                     CONTROL - today's opening, so this
+#                                              arm is comparable to every prior run
+#   top_long       g8@top,b4@mid               the simplest hypothesis: just mine
+#                                              more Goods before the Bad round
+#   easy_med_hard  n5@q0.02,n5@q0.10,n6@mid    the issue's Easy/Medium/Hard bands
+#   band_wide      n5@q0.05,n5@q0.25,n6@mid    the same shape, spread wider
+#   incl_k         n5@k-6,n5@k-2,n6@k0         the SHIPPABLE lever: the seed sort's
+#   incl_k_wide    n5@k-10,n5@k-4,n6@k0        own GMM split at three inclusions
+#   flat_mid       n16@mid                     length-matched control: 16 opening
+#                                              clicks, none of them Good-mining
+#   deep_first     n10@q0.35,n6@mid            FALSIFIER - opens below the good
+#                                              mass; must mine FEWER positives
+#
+# The falsifier is load-bearing.  If opening deliberately *below* the positives
+# does not lose positives, then depth is not the mechanism and nothing else in
+# the run is interpretable.
+#
+# `flat_mid` is the other load-bearing arm: every banded arm spends 16 opening
+# clicks against prod's ~7, so without a length-matched control a win could just
+# be "spend more clicks before training".  Read `easy_med_hard` against BOTH.
+#
+# The k-family arms may turn out to be inert: how far a given inclusion moves the
+# pick is a property of the fitted mixture, and on a steep sort the whole usable
+# range can land inside a couple of rank percent.  The analyzer checks that from
+# `startup_cut_percentile` in the pick log and reports "measured nothing" rather
+# than "the lever does nothing" - the same discipline analyze_acq.py applies.
+#
+# Prepare is REUSED (no GPU stage): every cell reads a pile pickle.
+set -uo pipefail
+
+export VTS_REPO=${VTS_REPO:-/exp/$USER/projects/vts-good-mining}
+WT="$VTS_REPO"
+HERE="$WT/scripts/experiments/calibration"
+
+export CALIB_EXP="/exp/$USER/good-mining"
+
+# --- stages ---------------------------------------------------------------
+# `live` is the two environments the acquisition-inclusion study ran on, so this
+# run's `prod` is directly comparable to that one's.  `bands` adds the box-scale
+# axis and TRIPLES the grid - launch it only after `live` has told you what a
+# cell actually costs (GRID-PLAYBOOK.md: size it from a real cell, not a guess).
+GM_STAGE="${GM_STAGE:-live}"
+case "$GM_STAGE" in
+  live)  export CALIB_DATASETS=coco_val,visual_genome_m ;;
+  bands) export CALIB_DATASETS=vg_box_small,vg_box_medium,vg_box_large ;;
+  *) echo "ERROR: GM_STAGE must be 'live' or 'bands' (got '$GM_STAGE')" >&2; exit 1 ;;
+esac
+
+# One embedder everywhere: siglip is the shipped default and the only pile
+# column present for all five datasets, so an arm difference is never confounded
+# with which embedder that dataset happened to carry.
+export CALIB_COCO_EMBEDDERS=siglip
+export CALIB_VG_EMBEDDERS=siglip
+export CALIB_VGBOX_EMBEDDERS=siglip
+
+export CALIB_MAX_STEPS=${CALIB_MAX_STEPS:-100}
+export CALIB_N_SEEDS=${CALIB_N_SEEDS:-6}
+export CALIB_N_CATEGORIES=${CALIB_N_CATEGORIES:-6}
+export CALIB_N_PER_BAND=${CALIB_N_PER_BAND:-3}
+export CALIB_HEAD=linear
+export CALIB_SAFE_THRESHOLDS=1
+export CALIB_ANCHORED=0
+export CALIB_SCHEDULE_VARIANTS=
+export CALIB_REPOOL_VARIANTS=
+# The pick log IS the study: the opening emits no main row (no detector exists
+# yet), so without this an arm's mining behaviour is invisible.
+export CALIB_EMIT_PICKS=1
+
+# --- ops: cpu partition, single-threaded cells (see launch_acq_incl.sh) ---
+export CALIB_PARTITION=cpu
+export CALIB_GRES=none
+export CALIB_MEM=${CALIB_MEM:-8G}
+export CALIB_CPUS=1
+export CALIB_TIME=${CALIB_TIME:-2:00:00}
+export CALIB_CONC=${CALIB_CONC:-18}
+
+export VTSEARCH_DATA_DIR="$CALIB_EXP/datadir"
+export VTSEARCH_MODELS_DIR="/exp/$USER/max-patch/models"
+export HF_HOME="/exp/$USER/.cache/huggingface"
+
+# Analysis is cross-arm and runs once, by hand, after every arm drains.
+export CALIB_ANALYZE=${CALIB_ANALYZE:-noop.py}
+
+mkdir -p "$CALIB_EXP/logs"
+
+if [[ ! -f "$CALIB_EXP/results/prepare_info.json" ]]; then
+  echo "ERROR: no prepare_info.json at $CALIB_EXP/results" >&2
+  echo "  Reuse a finished study's prepare, or run prepare_data.py for this grid." >&2
+  exit 1
+fi
+
+ARM_ORDER=(prod top_long easy_med_hard band_wide incl_k incl_k_wide flat_mid deep_first)
+declare -A ARMS=(
+  [prod]=""
+  [top_long]="g8@top,b4@mid"
+  [easy_med_hard]="n5@q0.02,n5@q0.10,n6@mid"
+  [band_wide]="n5@q0.05,n5@q0.25,n6@mid"
+  [incl_k]="n5@k-6,n5@k-2,n6@k0"
+  [incl_k_wide]="n5@k-10,n5@k-4,n6@k0"
+  [flat_mid]="n16@mid"
+  [deep_first]="n10@q0.35,n6@mid"
+)
+
+# Reject a typo'd schedule here, not four hours into the array.  Every arm is
+# parsed by the same code the cells will run.
+for arm in "${ARM_ORDER[@]}"; do
+  [[ -z "${ARMS[$arm]}" ]] && continue
+  ( cd "$HERE" && python -c "
+import sys
+sys.path.insert(0, '$WT')
+from vtscore.eval.startup_schedule import parse_startup_schedule
+parse_startup_schedule('${ARMS[$arm]}')
+" ) || { echo "ERROR: arm '$arm' has an unparseable schedule '${ARMS[$arm]}'" >&2; exit 1; }
+done
+
+if [[ -x "$WT/scripts/experiments/preflight.sh" ]]; then
+  bash "$WT/scripts/experiments/preflight.sh" --exp "$CALIB_EXP" \
+    --arms "$(IFS=,; echo "${ARM_ORDER[*]}")" --job-name cal-cells \
+    --mem "$CALIB_MEM" --conc "$CALIB_CONC" --need-gb 4 || {
+    echo "preflight FAILED" >&2; [[ "${PREFLIGHT_SKIP:-0}" == "1" ]] || exit 1
+  }
+fi
+
+for arm in "${ARM_ORDER[@]}"; do
+  export CALIB_STARTUP_SCHEDULE="${ARMS[$arm]}"
+  export CALIB_RESULTS="$CALIB_EXP/results/$arm"
+  mkdir -p "$CALIB_RESULTS/cells"
+  ln -sfn "$CALIB_EXP/results/prepare_info.json" "$CALIB_RESULTS/prepare_info.json"
+  ln -sfn "$CALIB_EXP/results/crops" "$CALIB_RESULTS/crops"
+  echo "=== arm $arm (startup_schedule='${CALIB_STARTUP_SCHEDULE:-app default}')"
+  bash "$HERE/launch_cells.sh" || echo "ARM $arm SUBMIT FAILED" >&2
+done
+
+cat <<'NOTE'
+
+Submitted.  A submission is not a launch: check every arm came back with a
+numeric job id, then watch cells appear rather than watching squeue.
+
+  squeue -u $USER -n cal-cells
+  for a in prod top_long easy_med_hard band_wide incl_k incl_k_wide flat_mid deep_first; do
+    printf '%-14s %s\n' "$a" "$(ls $CALIB_EXP/results/$a/cells/task_*.csv 2>/dev/null | grep -c . )"
+  done
+
+When the queue drains:  python analyze_startup.py
+NOTE

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -82,7 +82,8 @@ def main(argv: list[str] | None = None) -> int:
         f"styles={styles} head={cfg.HEAD or 'default (production)'} safe_thresholds={cfg.SAFE_THRESHOLDS} "
         f"calibrate_count={cfg.CALIBRATE_COUNT} fold_counts={cfg.FOLD_COUNTS or 'off'} "
         f"cut_incl_ks={cfg.CUT_INCLUSION_KS or 'off'} "
-        f"acq_inclusion_offset={cfg.ACQ_INCLUSION_OFFSET} acq_rank_percentile={cfg.ACQ_RANK_PERCENTILE}"
+        f"acq_inclusion_offset={cfg.ACQ_INCLUSION_OFFSET} acq_rank_percentile={cfg.ACQ_RANK_PERCENTILE} "
+        f"startup_schedule={cfg.STARTUP_SCHEDULE or 'app default'}"
     )
 
     import pandas as pd
@@ -93,6 +94,7 @@ def main(argv: list[str] | None = None) -> int:
         _CUT_DIAGNOSTIC_COLUMNS,
         _CUT_INCLUSION_COLUMNS,
         _INCLUSION_SWEEP_COLUMNS,
+        _PICK_COLUMNS,
         simulate_voting_iterations,
     )
 
@@ -112,6 +114,7 @@ def main(argv: list[str] | None = None) -> int:
     all_sweep: list[dict] = []
     all_cutdiag: list[dict] = []
     all_cutincl: list[dict] = []
+    all_picks: list[dict] = []
     for style in styles:
         seed_scores = None
         if crop_vec is not None:
@@ -120,6 +123,7 @@ def main(argv: list[str] | None = None) -> int:
         sweep_local: list[dict] = []
         cutdiag_local: list[dict] = []
         cutincl_local: list[dict] = []
+        picks_local: list[dict] | None = [] if cfg.EMIT_PICKS else None
         rows = simulate_voting_iterations(
             medias,
             target_category=cat,
@@ -155,6 +159,8 @@ def main(argv: list[str] | None = None) -> int:
             cut_inclusion_qtilt_steps=cfg.CUT_INCLUSION_QTILT_STEPS or None,
             acq_inclusion_offset=cfg.ACQ_INCLUSION_OFFSET,
             acq_rank_percentile=cfg.ACQ_RANK_PERCENTILE,
+            startup_schedule=cfg.STARTUP_SCHEDULE,
+            pick_sink=picks_local,
         )
         for r in rows:
             r["embedder"] = emb
@@ -165,10 +171,13 @@ def main(argv: list[str] | None = None) -> int:
             dr["embedder"] = emb
         for cr in cutincl_local:
             cr["embedder"] = emb
+        for pr in picks_local or []:
+            pr["embedder"] = emb
         all_rows.extend(rows)
         all_sweep.extend(sweep_local)
         all_cutdiag.extend(cutdiag_local)
         all_cutincl.extend(cutincl_local)
+        all_picks.extend(picks_local or [])
         common.log(
             f"  style={style}: {len(rows)} rows, {len(sweep_local)} sweep rows, "
             f"{len(cutdiag_local)} cut-diagnostic rows, {len(cutincl_local)} cut-inclusion rows"
@@ -193,10 +202,17 @@ def main(argv: list[str] | None = None) -> int:
     cutincl_cols = [*_CUT_INCLUSION_COLUMNS, "embedder"]
     cutincl_out = outdir / f"task_{idx:04d}__cutincl.csv"
     pd.DataFrame(all_cutincl, columns=pd.Index(cutincl_cols)).to_csv(cutincl_out, index=False)
+    # The #3267 per-click pick log.  Written unconditionally, like the frames
+    # above, so an empty file with the right header says "the log was off"
+    # rather than "the cell failed".
+    picks_cols = [*_PICK_COLUMNS, "embedder"]
+    picks_out = outdir / f"task_{idx:04d}__picks.csv"
+    pd.DataFrame(all_picks, columns=pd.Index(picks_cols)).to_csv(picks_out, index=False)
     common.log(
         f"wrote {len(all_rows)} rows to {out}, {len(all_sweep)} sweep rows to {sweep_out}, "
         f"{len(all_cutdiag)} cut-diagnostic rows to {cutdiag_out}, "
-        f"and {len(all_cutincl)} cut-inclusion rows to {cutincl_out}"
+        f"{len(all_cutincl)} cut-inclusion rows to {cutincl_out}, "
+        f"and {len(all_picks)} pick rows to {picks_out}"
     )
     return 0
 

--- a/scripts/experiments/calibration/selftest_analyze_startup.py
+++ b/scripts/experiments/calibration/selftest_analyze_startup.py
@@ -1,0 +1,191 @@
+"""Planted-answer self-test for ``analyze_startup.py`` (issue #3267).
+
+Fabricates arms whose answer is known by construction and asserts the analyzer
+recovers it - in particular the four things that would otherwise read as good
+news:
+
+* an arm whose opening never left the control's sampling depth must be reported
+  as having **measured nothing**, not as "depth does not matter";
+* the falsification arm failing to falsify must **withhold** the verdict;
+* an arm that mines more positives only because it spent more opening clicks
+  must be visible as such against the length-matched control;
+* cells whose opening never found both classes must be **counted**, not
+  silently dropped - they are the starvation regime the study is about.
+
+Run: ``python selftest_analyze_startup.py``
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent))
+import analyze_startup as A  # noqa: E402
+
+N_CAT, N_SEED, N_STEP = 4, 6, 100
+
+#: Per arm: (positives per 100 clicks, opening clicks, opening pick depth,
+#: final cost).  `easy_med_hard` is the planted winner - more positives, cost
+#: unchanged, and it beats the length-matched control.  `band_wide` mines more
+#: only by spending more clicks, so it must NOT beat `flat_mid`.  `incl_k` never
+#: moved its opening depth -> must be flagged as having measured nothing.
+PLANT = {
+    "prod": (18, 7, 0.05, 0.140),
+    "top_long": (24, 12, 0.03, 0.139),
+    "easy_med_hard": (30, 16, 0.02, 0.138),
+    "band_wide": (26, 16, 0.12, 0.141),
+    "incl_k": (18, 16, 0.05, 0.140),  # depth stuck at the control's
+    "incl_k_wide": (22, 16, 0.03, 0.139),
+    "flat_mid": (20, 16, 0.26, 0.140),
+    "deep_first": (9, 16, 0.35, 0.145),  # falsifier: fewer positives
+}
+
+
+def _write_arm(root: Path, arm: str, *, starved_cells: int = 0) -> None:
+    """One arm's cells, with the planted mining rate and outcome."""
+    cells = root / arm / "cells"
+    cells.mkdir(parents=True, exist_ok=True)
+    positives, open_clicks, depth, cost = PLANT[arm]
+    idx = 0
+    for cat in range(N_CAT):
+        for seed in range(N_SEED):
+            rng = np.random.default_rng(hash((arm, cat, seed)) % (2**31))
+            starved = idx < starved_cells
+            # --- pick log: one row per click, `positives` of them positive ---
+            labels = np.zeros(N_STEP, dtype=int)
+            hits = rng.choice(N_STEP, size=positives, replace=False)
+            labels[hits] = 1
+            picks = pd.DataFrame(
+                {
+                    "seed": seed,
+                    "dataset": "ds",
+                    "category": f"cat{cat}",
+                    "startup_schedule": A.ARM_SCHEDULE[arm],
+                    "style": "whole_image",
+                    "t": np.arange(1, N_STEP + 1),
+                    "phase": ["s0"] * open_clicks + ["hard"] * (N_STEP - open_clicks),
+                    "startup_round": [0] * open_clicks + [-1] * (N_STEP - open_clicks),
+                    "startup_cut": depth,
+                    "startup_cut_percentile": [depth] * open_clicks + [np.nan] * (N_STEP - open_clicks),
+                    "picked_id": np.arange(N_STEP),
+                    "picked_label": labels,
+                    "picked_seed_rank": np.arange(N_STEP),
+                    "picked_seed_percentile": np.clip(rng.normal(depth, 0.01, N_STEP), 0, 1),
+                    "picked_seed_score": 0.5,
+                    "picked_detector_score": 0.5,
+                    "acq_threshold": 0.5,
+                    "n_good": labels.cumsum(),
+                    "n_bad": (1 - labels).cumsum(),
+                    "n_pool": N_STEP - np.arange(1, N_STEP + 1),
+                    "embedder": "siglip",
+                }
+            )
+            picks.to_csv(cells / f"task_{idx:04d}__picks.csv", index=False)
+            # --- main frame: absent for a starved cell (no detector trained) ---
+            main = pd.DataFrame(
+                {
+                    "seed": seed,
+                    "dataset": "ds",
+                    "category": f"cat{cat}",
+                    "t": np.arange(open_clicks + 1, N_STEP + 1),
+                    "n_good": 5,
+                    "n_bad": 5,
+                    "phase": "hard",
+                    "gmm_variant": "",
+                    "pool_variant": "max",
+                    "schedule": "",
+                    "cost": cost,
+                    "oracle_cost": cost - 0.02,
+                    "average_precision": 0.70 + (positives - 18) * 0.004,
+                    "embedder": "siglip",
+                }
+            )
+            if starved:
+                main = main.iloc[0:0]
+            main.to_csv(cells / f"task_{idx:04d}.csv", index=False)
+            idx += 1
+
+
+def _check(label: str, ok: bool, detail: str = "") -> bool:
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}{(' - ' + detail) if detail and not ok else ''}")
+    return ok
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="gm-selftest-"))
+    try:
+        root = tmp / "results"
+        for arm in A.ARMS:
+            _write_arm(root, arm, starved_cells=3 if arm == "deep_first" else 0)
+        summary = A.analyze(root, tmp / "analysis")
+
+        ok = True
+        print("planted-answer checks:")
+
+        # 1. The stuck lever is called out rather than reported as a null.
+        ok &= _check(
+            "incl_k is flagged as having measured nothing",
+            not summary["arms"]["incl_k"]["lever"]["moved"],
+            str(summary["arms"]["incl_k"]["lever"]),
+        )
+        ok &= _check(
+            "every arm that did move is recognised as having moved",
+            all(summary["arms"][a]["lever"]["moved"] for a in ("top_long", "easy_med_hard", "band_wide", "flat_mid")),
+        )
+
+        # 2. The planted winner is found, with the right sign on every leg.
+        emh = summary["arms"]["easy_med_hard"]
+        ok &= _check("easy_med_hard mines more positives", emh["positives_100"]["median_delta"] > 0)
+        ok &= _check("easy_med_hard holds cost", emh["final_cost"]["ci95_hi"] <= A.COST_REGRESSION_TOLERANCE)
+        ok &= _check(
+            "easy_med_hard beats the length-matched control",
+            emh["vs_length_control"]["positives_100"]["median_delta"] > 0,
+        )
+        ok &= _check("the verdict names it", "easy_med_hard" in summary["verdict"], summary["verdict"])
+
+        # 3. A click-budget win is not mistaken for a depth win.
+        bw = summary["arms"]["band_wide"]
+        ok &= _check("band_wide beats prod on positives", bw["positives_100"]["median_delta"] > 0)
+        ok &= _check(
+            "band_wide's edge over prod does NOT survive the length-matched control",
+            bw["vs_length_control"]["positives_100"]["median_delta"]
+            < emh["vs_length_control"]["positives_100"]["median_delta"],
+        )
+
+        # 4. Starved cells are counted, not dropped in silence.
+        ok &= _check(
+            "cells that trained no detector are counted",
+            len(summary["provenance"]["deep_first"]["main"]["no_positive_found"]) == 3,
+            str(summary["provenance"]["deep_first"]["main"]),
+        )
+
+        # 5. A falsifier that fails to falsify withholds the verdict.
+        broken = dict(summary)
+        broken["arms"] = dict(summary["arms"])
+        broken["arms"][A.FALSIFIER] = dict(summary["arms"][A.FALSIFIER])
+        broken["arms"][A.FALSIFIER]["positives_100"] = {"n_pairs": 24, "median_delta": +4.0}
+        ok &= _check("a non-falsifying falsifier withholds the verdict", A.verdict(broken).startswith("WITHHELD"))
+
+        # 6. The report is written and says what it found.
+        report = (tmp / "analysis" / "REPORT_startup.md").read_text()
+        ok &= _check("report names every arm", all(f"`{a}`" in report for a in A.ARMS))
+        ok &= _check("report flags the stuck lever", "**no**" in report)
+
+        print("\nSELFTEST", "PASSED" if ok else "FAILED")
+        return 0 if ok else 1
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/detectors/test_startup_schedule.py
+++ b/tests_lib/detectors/test_startup_schedule.py
@@ -1,0 +1,315 @@
+"""Parameterised Autopilot openings (issue #3267).
+
+Two things need pinning, and they pull against each other:
+
+* the **grammar and the state machine**, so an arm's spec means exactly what its
+  launch script says it means - a silently misparsed round would make a study
+  measure an opening nobody wrote; and
+* the **default**, so that :data:`~vtscore.eval.startup_schedule.
+  PRODUCTION_STARTUP` is not merely *similar* to the app's own opening but
+  reproduces it click for click.  That is what licenses reading a study's
+  control arm as "what users get today" (see "The Eval Default Arm IS the App"
+  in ``docs/EVAL.md``).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from vtscore.eval.autopilot_flow import BAD_TARGET, GOOD_TARGET, AutopilotFlow, app_has_detector
+from vtscore.eval.startup_schedule import (
+    PRODUCTION_STARTUP,
+    StartupRound,
+    StartupState,
+    is_startup_phase,
+    parse_startup_schedule,
+    round_cut,
+)
+from vtscore.eval.voting_iterations import _PICK_COLUMNS, simulate_voting_iterations
+
+DIM = 24
+
+
+def _seeded_dataset(n_pos=70, n_neg=200, seed=0):
+    """A single-vector dataset with a text-sortable query.
+
+    Positives sit near a planted centre and the query points at it, so the seed
+    sort is genuinely informative - which is the situation every schedule round
+    is defined against.  Returns ``(medias, seed_scores)``.
+    """
+    rng = np.random.default_rng(seed)
+    centre = rng.standard_normal(DIM).astype(np.float32)
+    medias: dict[int, dict] = {}
+    for i in range(n_pos + n_neg):
+        positive = i < n_pos
+        vec = centre * (1.2 if positive else 0.0) + rng.standard_normal(DIM).astype(np.float32) * 0.9
+        medias[i] = {
+            "id": i,
+            "category": "target" if positive else "other",
+            "embedding": vec,
+            "embeddings": {"stub": vec},
+        }
+    query = centre + rng.standard_normal(DIM).astype(np.float32) * 0.3
+
+    def cos(v):
+        return float(v @ query / (np.linalg.norm(v) * np.linalg.norm(query) + 1e-9))
+
+    return medias, {i: cos(m["embedding"]) for i, m in medias.items()}
+
+
+def _run(schedule, *, max_steps=24, seed=3):
+    medias, seed_scores = _seeded_dataset()
+    picks: list[dict] = []
+    rows = simulate_voting_iterations(
+        medias,
+        target_category="target",
+        seed=seed,
+        dataset_name="stub",
+        max_steps=max_steps,
+        seed_scores=seed_scores,
+        atlas_min_node_size=8,
+        startup_schedule=schedule,
+        pick_sink=picks,
+    )
+    return rows, picks
+
+
+# ---------------------------------------------------------------------------
+# The grammar
+# ---------------------------------------------------------------------------
+
+
+class TestParsing:
+    def test_production_spec_parses_to_the_apps_own_targets(self):
+        rounds = parse_startup_schedule(PRODUCTION_STARTUP)
+        assert rounds == (
+            StartupRound(stop="good", n=GOOD_TARGET, cut="top"),
+            StartupRound(stop="bad", n=BAD_TARGET, cut="mid"),
+        )
+
+    @pytest.mark.parametrize("spec", ["g3@top", "b4@mid", "n8@k-3", "n8@k0", "n8@k2", "n6@q0.05", "n6@q0.5"])
+    def test_round_trips_through_its_spec(self, spec):
+        (rnd,) = parse_startup_schedule(spec)
+        assert rnd.spec() == spec
+
+    @pytest.mark.parametrize(
+        "spec", ["", "g3", "g3@", "@top", "x3@top", "g0@top", "g3@k", "g3@warm", "n3@q", "g-1@top", "n3@k1.5"]
+    )
+    def test_junk_is_rejected_not_guessed_at(self, spec):
+        """A misparsed arm measures an opening nobody wrote."""
+        with pytest.raises(ValueError):
+            parse_startup_schedule(spec)
+
+    def test_whitespace_and_trailing_commas_are_tolerated(self):
+        assert parse_startup_schedule(" g3@top , b4@mid ,") == parse_startup_schedule(PRODUCTION_STARTUP)
+
+
+# ---------------------------------------------------------------------------
+# Where a round cuts
+# ---------------------------------------------------------------------------
+
+
+class TestRoundCut:
+    def setup_method(self):
+        _, self.scores = _seeded_dataset(seed=1)
+        self.values = list(self.scores.values())
+
+    def _cut(self, spec):
+        (rnd,) = parse_startup_schedule(f"n1@{spec}")
+        return round_cut(self.values, rnd)
+
+    def test_top_is_above_every_score(self):
+        """Not a sentinel: with the cut above the sort, rank 0 is the first row
+        at-or-below it, which is exactly what the Good phase's `top` select does."""
+        assert self._cut("top") == math.inf
+
+    def test_mid_is_the_shipped_cosine_sort_cut(self):
+        from vtscore.training.thresholds import calculate_gmm_threshold
+
+        assert self._cut("mid") == pytest.approx(calculate_gmm_threshold(self.values))
+
+    def test_more_negative_inclusion_raises_the_cut(self):
+        """The direction the whole study rests on: a negative inclusion prices a
+        false alarm higher, raises the cut, and moves the pick *up* the ranking."""
+        cuts = [self._cut(f"k{k}") for k in (4, 2, 0, -2, -4, -6)]
+        assert cuts == sorted(cuts), cuts
+
+    def test_quantile_names_a_rank_position_directly(self):
+        deep, shallow = self._cut("q0.4"), self._cut("q0.05")
+        assert shallow > deep
+        assert np.mean([s >= shallow for s in self.values]) == pytest.approx(0.05, abs=0.02)
+
+    def test_unfittable_distribution_falls_back_to_the_shipped_cut(self):
+        from vtscore.training.thresholds import calculate_gmm_threshold
+
+        (rnd,) = parse_startup_schedule("n1@k-3")
+        flat = [0.5]
+        assert round_cut(flat, rnd) == pytest.approx(calculate_gmm_threshold(flat))
+
+
+# ---------------------------------------------------------------------------
+# The round state machine
+# ---------------------------------------------------------------------------
+
+
+class TestStartupState:
+    def test_good_and_bad_stops_read_global_counts(self):
+        """The app's Good phase ends on the third *positive*, however many
+        negatives the top of the sort happened to hand back on the way."""
+        st = StartupState(parse_startup_schedule("g3@top,b4@mid"))
+        st.advance(good_count=2, bad_count=9, remaining_unlabeled=100)
+        assert st.index == 0
+        st.advance(good_count=3, bad_count=9, remaining_unlabeled=100)
+        assert st.done  # the bad target was already met by those nine
+
+    def test_click_stops_count_only_this_rounds_clicks(self):
+        st = StartupState(parse_startup_schedule("n2@top,n2@mid"))
+        for _ in range(2):
+            st.on_click()
+            st.advance(good_count=1, bad_count=1, remaining_unlabeled=100)
+        assert st.index == 1
+        assert st.clicks_in_round == 0
+
+    def test_stops_are_capped_by_what_the_pool_can_supply(self):
+        """A target the collection cannot meet must not strand the trajectory."""
+        st = StartupState(parse_startup_schedule("g9@top,b9@mid"))
+        st.advance(good_count=2, bad_count=1, remaining_unlabeled=0)
+        assert st.done
+
+    def test_schedule_will_not_finish_with_one_class_empty(self):
+        """Handing a learned sort a one-class labelset leaves the selector
+        picking at random, which would make the arm uninterpretable."""
+        st = StartupState(parse_startup_schedule("n1@top"))
+        st.on_click()
+        st.advance(good_count=4, bad_count=0, remaining_unlabeled=50)
+        assert not st.done
+        st.on_click()
+        assert st.extended_clicks == 1
+        st.advance(good_count=4, bad_count=1, remaining_unlabeled=49)
+        assert st.done
+
+    def test_an_exhausted_pool_ends_the_schedule_even_one_class_short(self):
+        st = StartupState(parse_startup_schedule("n1@top"))
+        st.on_click()
+        st.advance(good_count=4, bad_count=0, remaining_unlabeled=0)
+        assert st.done
+
+    def test_phase_names(self):
+        st = StartupState(parse_startup_schedule("n1@top,n1@mid"))
+        assert st.phase_name() == "s0"
+        st.on_click()
+        st.advance(1, 1, 10)
+        assert st.phase_name() == "s1"
+        assert is_startup_phase("s0") and is_startup_phase("s12")
+        assert not is_startup_phase("hard") and not is_startup_phase("s") and not is_startup_phase("")
+
+
+class TestFlowIntegration:
+    def test_no_detector_is_on_screen_during_a_round(self):
+        """A round is on the seed sort by construction, whatever the vote count."""
+        assert not app_has_detector("s0")
+        assert not app_has_detector("s3")
+
+    def test_the_apps_machine_resumes_once_the_schedule_is_spent(self):
+        flow = AutopilotFlow(startup=StartupState(parse_startup_schedule("n1@top")))
+        assert flow.phase == "s0"
+        flow.update(good_count=2, bad_count=2, remaining_unlabeled=50, span=None)
+        assert flow.phase == "hard"
+
+    def test_without_a_schedule_the_flow_is_untouched(self):
+        flow = AutopilotFlow()
+        assert flow.phase == "good"
+        assert flow.update(good_count=GOOD_TARGET, bad_count=0, remaining_unlabeled=50, span=None) == "bad"
+
+
+# ---------------------------------------------------------------------------
+# The default arm IS the app
+# ---------------------------------------------------------------------------
+
+
+class TestProductionScheduleIsTheDefault:
+    def test_it_reproduces_the_default_opening_click_for_click(self):
+        base_rows, base_picks = _run(None)
+        prod_rows, prod_picks = _run(PRODUCTION_STARTUP)
+        assert [p["picked_id"] for p in prod_picks] == [p["picked_id"] for p in base_picks]
+        assert [r["cost"] for r in prod_rows] == [r["cost"] for r in base_rows]
+
+    def test_only_the_phase_labels_differ(self):
+        _, base_picks = _run(None)
+        _, prod_picks = _run(PRODUCTION_STARTUP)
+        assert [p["phase"] for p in base_picks][:GOOD_TARGET] == ["good"] * GOOD_TARGET
+        assert [p["phase"] for p in prod_picks][:GOOD_TARGET] == ["s0"] * GOOD_TARGET
+        # And both hand over to the same learned phase at the same click.
+        tail = [(b["phase"], p["phase"]) for b, p in zip(base_picks, prod_picks) if b["phase"] == "hard"]
+        assert tail and all(p == "hard" for _, p in tail)
+
+    def test_a_default_run_leaves_the_column_blank(self):
+        rows, picks = _run(None)
+        assert {r["startup_schedule"] for r in rows} == {""}
+        assert {p["startup_round"] for p in picks} == {-1}
+
+
+# ---------------------------------------------------------------------------
+# What the study reads
+# ---------------------------------------------------------------------------
+
+
+class TestPickLog:
+    def test_records_every_click_including_the_untrainable_opening(self):
+        """The main frame starts at the first trainable step, so the opening -
+        the whole subject of #3267 - is exactly what it does not record."""
+        rows, picks = _run("n6@q0.02,n8@q0.25")
+        assert len(picks) == 24
+        assert len(rows) < len(picks)
+        assert [p["t"] for p in picks] == list(range(1, 25))
+
+    def test_every_declared_column_is_present(self):
+        _, picks = _run("n6@q0.02,n8@q0.25")
+        for row in picks:
+            assert set(row) == set(_PICK_COLUMNS)
+
+    def test_carries_where_on_the_seed_sort_each_click_came_from(self):
+        _, picks = _run("n6@q0.02,n8@q0.25")
+        opening = [p for p in picks if p["startup_round"] == 0]
+        assert opening
+        assert all(0.0 <= p["picked_seed_percentile"] <= 1.0 for p in opening)
+        # Round 0 cuts at the 2nd percentile, so its picks come off the top.
+        assert max(p["picked_seed_percentile"] for p in opening) < 0.2
+        assert all(p["startup_cut_percentile"] == pytest.approx(0.02, abs=0.01) for p in opening)
+
+    def test_the_arm_is_named_on_every_row(self):
+        rows, picks = _run("n6@q0.02,n8@q0.25")
+        assert {r["startup_schedule"] for r in rows} == {"n6@q0.02,n8@q0.25"}
+        assert {p["startup_schedule"] for p in picks} == {"n6@q0.02,n8@q0.25"}
+
+
+class TestTheLeverMoves:
+    def test_a_shallower_opening_mines_more_positives(self):
+        """The mechanism, stated as the study will read it: sampling nearer the
+        top of the seed sort returns more Goods per click."""
+        _, shallow = _run("n10@q0.03,n6@q0.4")
+        _, deep = _run("n10@q0.35,n6@q0.4")
+        assert sum(p["picked_label"] for p in shallow[:10]) > sum(p["picked_label"] for p in deep[:10])
+
+
+class TestGuards:
+    def test_a_schedule_needs_a_seed_sort(self):
+        medias, _ = _seeded_dataset()
+        with pytest.raises(ValueError, match="seed_scores"):
+            simulate_voting_iterations(medias, target_category="target", seed=1, max_steps=5, startup_schedule="n4@top")
+
+    def test_a_schedule_needs_the_apps_phase_machine(self):
+        medias, seed_scores = _seeded_dataset()
+        with pytest.raises(ValueError, match="autopilot_fidelity"):
+            simulate_voting_iterations(
+                medias,
+                target_category="target",
+                seed=1,
+                max_steps=5,
+                seed_scores=seed_scores,
+                autopilot_fidelity=False,
+                startup_schedule="n4@top",
+            )

--- a/vtscore/eval/al_strategies.py
+++ b/vtscore/eval/al_strategies.py
@@ -49,6 +49,8 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
+from vtscore.eval.startup_schedule import is_startup_phase
+
 if TYPE_CHECKING:
     from vtscore.state.coverage_atlas import CoverageAtlas
 
@@ -106,6 +108,11 @@ class ALContext:
             learned sort.  ``None`` selects the legacy behaviour (train from
             the first vote pair, parity-interleaved Hard/New), kept so
             published studies stay reproducible; see ``docs/EVAL.md``.
+        startup_cut: The cut a parameterised opening's current round samples
+            against (issue #3267), from
+            :func:`vtscore.eval.startup_schedule.round_cut`.  Read only while
+            :attr:`phase` names a schedule round (``s0``, ``s1``, ...);
+            ``None`` everywhere else, including on every default-arm run.
     """
 
     pool_ids: list[int]
@@ -119,6 +126,7 @@ class ALContext:
     pool_labels: Optional[dict[int, float]] = None
     seed_scores: Optional[dict[int, float]] = None
     phase: Optional[str] = None
+    startup_cut: Optional[float] = None
 
 
 # ------------------------------------------------------------------
@@ -279,6 +287,24 @@ def _pick_good_phase(ctx: ALContext) -> int:
     return _uniform_pick(ctx, positives or pool)
 
 
+def _pick_on_seed_sort(ctx: ALContext, cut: Optional[float]) -> int:
+    """Rank-space ``hard`` select on the text/example sort, against *cut*.
+
+    The one operation both pre-detector phases are made of: rank the seed sort,
+    find *cut*'s rank position, take the nearest unlabelled item.  ``None``
+    means the sort's own GMM line - the app's cutoff for every cosine sort.
+    """
+    ranking = ctx.seed_scores
+    if ranking is None:
+        ranking = _centroid_similarities(ctx, list(ctx.embeddings))
+    if ranking:
+        line = _sort_threshold(ranking) if cut is None else cut
+        pick = _hard_pick_by_index(ctx, ranking, line)
+        if pick is not None:
+            return pick
+    return _uniform_pick(ctx, ctx.pool_ids)
+
+
 def _pick_bad_phase(ctx: ALContext) -> int:
     """Bad phase: the cutoff of the text/example sort — never the detector.
 
@@ -289,14 +315,18 @@ def _pick_bad_phase(ctx: ALContext) -> int:
     Finding negatives is easy; the ones worth spending a vote on are the ones
     the query ranking cannot separate.
     """
-    ranking = ctx.seed_scores
-    if ranking is None:
-        ranking = _centroid_similarities(ctx, list(ctx.embeddings))
-    if ranking:
-        pick = _hard_pick_by_index(ctx, ranking, _sort_threshold(ranking))
-        if pick is not None:
-            return pick
-    return _uniform_pick(ctx, ctx.pool_ids)
+    return _pick_on_seed_sort(ctx, None)
+
+
+def _pick_startup_round(ctx: ALContext) -> int:
+    """A parameterised opening's round (issue #3267): the same seed-sort
+    ``hard`` select, against the cut its round names.
+
+    ``top`` arrives here as ``+inf`` and reproduces the Good phase's ``top``
+    select exactly; ``mid`` arrives as the sort's GMM line and reproduces the
+    Bad phase.  Everything between and beyond is the study's territory.
+    """
+    return _pick_on_seed_sort(ctx, ctx.startup_cut)
 
 
 def _select_phase_faithful(ctx: ALContext, phase: str) -> int:
@@ -313,7 +343,14 @@ def _select_phase_faithful(ctx: ALContext, phase: str) -> int:
     ``bad``     text / example         ``hard``
     ``hard``    learned                ``hard``
     ``new``     learned                ``new``
+    ``s``\ *i*   text / example         ``hard`` @ the round's cut
     ==========  =====================  =============
+
+    The ``s``\ *i* row is a parameterised opening's round (issue #3267), which
+    exists only when the harness was given a
+    :class:`~vtscore.eval.startup_schedule.StartupState`.  It generalises the
+    two rows above it: ``good`` is that select against a cut above every score,
+    ``bad`` against the sort's own GMM line.
 
     The load-bearing detail is that ``bad`` is still on the *text* sort: no
     detector is trained until the quorum is met, so the harness must not
@@ -321,6 +358,8 @@ def _select_phase_faithful(ctx: ALContext, phase: str) -> int:
     """
     pool = ctx.pool_ids
 
+    if is_startup_phase(phase):
+        return _pick_startup_round(ctx)
     if phase == "good":
         return _pick_good_phase(ctx)
     if phase == "bad":

--- a/vtscore/eval/autopilot_flow.py
+++ b/vtscore/eval/autopilot_flow.py
@@ -46,6 +46,8 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional
 
+from vtscore.eval.startup_schedule import StartupState, is_startup_phase
+
 Phase = Literal["idle", "good", "bad", "hard", "new", "done", "exhausted"]
 Status = Literal["red", "yellow", "green"]
 
@@ -206,6 +208,10 @@ def app_has_detector(phase: str) -> bool:
     about threshold quality (issue #2788) must filter on it rather than
     counting every simulated step.
     """
+    if is_startup_phase(phase):
+        # A schedule's rounds are on the seed sort by construction, so the app
+        # would have no detector on screen however many votes have been cast.
+        return False
     return phase in TRAINED_PHASES
 
 
@@ -226,11 +232,23 @@ class AutopilotFlow:
     confound model improvement with labelset growth (issue #2923).
     """
 
-    def __init__(self, *, good_target: int = GOOD_TARGET, bad_target: int = BAD_TARGET, span_green: int | None = None):
+    def __init__(
+        self,
+        *,
+        good_target: int = GOOD_TARGET,
+        bad_target: int = BAD_TARGET,
+        span_green: int | None = None,
+        startup: Optional[StartupState] = None,
+    ):
         self.good_target = good_target
         self.bad_target = bad_target
         self.span_green = SPAN_GREEN_DEFAULT if span_green is None else span_green
-        self.phase: Phase = "good"
+        #: A parameterised opening (issue #3267).  ``None`` - the default - is
+        #: the app's own: the Good/Bad targets above, resolved by
+        #: :func:`next_phase`.  When set, the schedule owns every phase until it
+        #: runs out and the app's machine takes over from ``hard``.
+        self.startup = startup
+        self.phase: Phase = "good" if startup is None else startup.phase_name()  # type: ignore[assignment]
         #: The most recent Smart window: the last :data:`SMART_WINDOW` models'
         #: costs, all against the *current* labelset.  Replaced, never appended.
         self.recent_error_costs: list[float] = []
@@ -261,7 +279,20 @@ class AutopilotFlow:
         self._prev_predictions = dict(predictions)
 
     def update(self, good_count: int, bad_count: int, remaining_unlabeled: float, span: dict[str, Any] | None) -> Phase:
-        """Recompute and return the phase after a vote."""
+        """Recompute and return the phase after a vote.
+
+        With a :class:`~vtscore.eval.startup_schedule.StartupState` attached the
+        opening is the schedule's, not :data:`GOOD_TARGET` / :data:`BAD_TARGET`;
+        once it is spent the app's machine resumes with both targets already
+        met, so the trajectory continues into ``hard`` / ``new`` / ``done``
+        exactly as it would have.
+        """
+        if self.startup is not None:
+            self.startup.on_click()
+            self.startup.advance(good_count, bad_count, remaining_unlabeled)
+            if not self.startup.done:
+                self.phase = self.startup.phase_name()  # type: ignore[assignment]
+                return self.phase
         smart = smart_status(self.recent_error_costs, good_count, bad_count)
         stable = stable_status(self.stability, good_count, bad_count)
         sp: Status = span_status(int(span["level"]), int(span["depth"]), self.span_green) if span is not None else "red"
@@ -272,7 +303,7 @@ class AutopilotFlow:
             smart=smart,
             stable=stable,
             span=sp,
-            good_target=self.good_target,
-            bad_target=self.bad_target,
+            good_target=0 if self.startup is not None else self.good_target,
+            bad_target=0 if self.startup is not None else self.bad_target,
         )
         return self.phase

--- a/vtscore/eval/startup_schedule.py
+++ b/vtscore/eval/startup_schedule.py
@@ -1,0 +1,280 @@
+"""Parameterised Autopilot **openings** for the voting-iterations harness (#3267).
+
+Autopilot's opening is what decides how many positives a run has when its first
+learned sort happens, and a Good-starved run is the one that fails.  Today the
+opening is fixed: vote the **top** of the seed sort until three positives exist,
+then vote that sort's **cutoff** until four negatives do, then hand over to the
+learned Hard sort forever.  This module makes that opening a *parameter* so a
+study can ask whether a different one mines better positives.
+
+**The unifying observation** (issue #3267) is that both of today's opening
+phases are the same operation - the app's rank-space ``hard`` select against a
+cut drawn on the seed sort - at two different cuts:
+
+* the Good phase's ``top`` select is a ``hard`` select against a cut placed
+  *above every score*, so the first at-or-below-cut rank is 0 and the pick is the
+  top of the sort;
+* the Bad phase's cut is that sort's own fitted 2-component GMM, split at the
+  production midpoint.
+
+So "Text-Good" really is "Text-Hard at a very exclusive cut", and the whole
+opening collapses to a list of rounds, each *how many clicks* to spend and
+*where on the seed sort* to spend them.
+
+**Where** is named the way the rest of the app names it: an **Inclusion**.  The
+seed sort ships an inclusion-independent cut (:func:`~vtscore.training.
+thresholds.calculate_gmm_threshold`, the midpoint of the fitted components), but
+the fit underneath it is the same object every inclusion-aware cut rule reads,
+so the sort *can* be split at an inclusion - the prior-agnostic split at ``k=0``
+and an inclusion-biased split either side of it (:func:`~vtscore.training.
+thresholds.gmm_cut_from_fit`'s ``rate`` rule at
+:func:`~vtscore.training.thresholds.inclusion_cost_weights`).  Negative ``k``
+prices a false alarm higher, raises the cut, and moves the pick **up** the
+ranking toward the positives - the same direction, and the same reason, as
+:data:`~vtscore.training.thresholds.ACQUISITION_INCLUSION_OFFSET` on the learned
+sort.  ``k`` far enough below zero converges on ``top``, which is the issue's
+"Text-Good is Text-Hard(-100)" made literal.
+
+**The spec.**  A schedule is a comma-separated list of ``<stop><n>@<cut>``
+rounds:
+
+==========  ====================================================================
+``g3``      stay until **3 goods** exist (a global count, as in the app)
+``b4``      stay until **4 bads** exist (likewise)
+``n8``      stay for **8 clicks**, whatever they turn out to be
+``@top``    cut above every score - the top of the sort (today's Good phase)
+``@mid``    the shipped GMM midpoint (today's Bad phase, and every cosine sort)
+``@k-3``    the fitted GMM split at inclusion ``-3``; ``@k0`` is prior-agnostic
+``@q0.05``  cut at the sort's own 5th percentile, by rank
+==========  ====================================================================
+
+**Why ``q`` exists next to ``k``.**  ``k`` is the arm that could *ship* - the app
+has an Inclusion knob and no rank-position knob - but how far a given ``k`` moves
+the pick is a property of the fitted mixture, not of ``k``.  On a steep sort the
+whole usable inclusion range can land inside a couple of rank percent, which
+makes an arm grid that looks well spread in ``k`` almost inert in the space the
+picks actually live in.  ``q`` names the rank position directly, so a study can
+establish whether *position* is the mechanism before asking whether ``k`` is a
+usable handle on it.  Read :data:`~vtscore.eval.voting_iterations._PICK_COLUMNS`'
+``startup_cut_percentile`` to see where each round's cut really landed; a ``k``
+family that does not separate there has not been tested, whatever its spec says.
+
+:data:`PRODUCTION_STARTUP` spells today's opening in that grammar, and
+``tests_lib/detectors/test_startup_schedule.py`` pins it against the ported
+phase machine: running it must reproduce the default flow pick for pick.  That
+pinning is the point - the default arm has to *be* the app (see "The Eval
+Default Arm IS the App" in ``docs/EVAL.md``), so a study measures deviations
+from what users get rather than from a second, drifting opening.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Literal, Optional, Sequence
+
+#: Today's opening, in the grammar above: the top of the seed sort until three
+#: positives, then that sort's midpoint cut until four negatives.  Equal by
+#: construction to ``GOOD_TARGET`` / ``BAD_TARGET`` and the Sort+Select pairing
+#: in :func:`vtscore.eval.al_strategies._select_phase_faithful`; pinned against
+#: both by ``tests_lib/detectors/test_startup_schedule.py`` and by
+#: ``scripts/check-eval-app-sync.py``'s ``autopilot.startup_default`` mirror.
+PRODUCTION_STARTUP = "g3@top,b4@mid"
+
+StopKind = Literal["good", "bad", "clicks"]
+CutKind = Literal["top", "mid", "rate", "quantile"]
+
+_ROUND_RE = re.compile(r"^([gbn])(\d+)@(top|mid|k-?\d+|q0?\.\d+|q1\.0+|q0|q1)$")
+
+#: Phase names a schedule produces: ``s0``, ``s1``, ...  Deliberately outside
+#: :data:`~vtscore.eval.autopilot_flow.TRAINED_PHASES` - a startup round is on
+#: the seed sort, so the app would have no detector on screen.
+_PHASE_PREFIX = "s"
+
+
+def is_startup_phase(phase: str) -> bool:
+    """Whether *phase* is one of a schedule's rounds (``s0``, ``s1``, ...)."""
+    return len(phase) > 1 and phase[0] == _PHASE_PREFIX and phase[1:].isdigit()
+
+
+@dataclass(frozen=True)
+class StartupRound:
+    """One round of an opening: how long to stay, and where on the seed sort."""
+
+    stop: StopKind
+    """What ends the round - ``good``/``bad`` count a **global** vote total (the
+    app's own rule: its Good phase ends on the third positive however many
+    negatives the top of the sort happened to hand back), ``clicks`` counts
+    votes spent **in this round**."""
+
+    n: int
+    """The count *stop* is compared against."""
+
+    cut: CutKind
+    """Which cut the round's rank-space ``hard`` select measures against."""
+
+    k: int = 0
+    """Inclusion for ``cut == "rate"``; ignored otherwise."""
+
+    q: float = 0.0
+    """Rank quantile of the seed sort for ``cut == "quantile"`` (0 = the top);
+    ignored otherwise."""
+
+    def spec(self) -> str:
+        """Round-trip this round back to its spec string."""
+        stop = {"good": "g", "bad": "b", "clicks": "n"}[self.stop]
+        if self.cut in ("top", "mid"):
+            cut = self.cut
+        elif self.cut == "rate":
+            cut = f"k{self.k}"
+        else:
+            cut = f"q{self.q}"
+        return f"{stop}{self.n}@{cut}"
+
+
+def parse_startup_schedule(spec: str) -> tuple[StartupRound, ...]:
+    """Parse a schedule *spec* into its rounds; raises ``ValueError`` on junk.
+
+    Deliberately strict.  A silently-misparsed arm is a study that measures
+    something other than what its launch script says it measures, and the
+    schedule is the only thing that distinguishes one arm from the next here.
+    """
+    rounds: list[StartupRound] = []
+    for raw in spec.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        m = _ROUND_RE.match(token)
+        if m is None:
+            raise ValueError(
+                f"bad startup round {token!r} in schedule {spec!r}; "
+                "expected <g|b|n><count>@<top|mid|k[-]N|q<frac>>, "
+                "e.g. 'g3@top', 'n8@k-3' or 'n8@q0.05'"
+            )
+        stop_letter, count, cut = m.group(1), int(m.group(2)), m.group(3)
+        if count <= 0:
+            raise ValueError(f"round {token!r} has a non-positive count")
+        stop: StopKind = {"g": "good", "b": "bad", "n": "clicks"}[stop_letter]  # type: ignore[assignment]
+        if cut.startswith("k"):
+            rounds.append(StartupRound(stop=stop, n=count, cut="rate", k=int(cut[1:])))
+        elif cut.startswith("q"):
+            rounds.append(StartupRound(stop=stop, n=count, cut="quantile", q=float(cut[1:])))
+        else:
+            rounds.append(StartupRound(stop=stop, n=count, cut=cut))  # type: ignore[arg-type]
+    if not rounds:
+        raise ValueError(f"empty startup schedule {spec!r}")
+    return tuple(rounds)
+
+
+def round_cut(scores: Sequence[float], rnd: StartupRound) -> float:
+    """The cut *rnd* samples against, over the seed sort's score distribution.
+
+    *scores* is the **whole** sort, labelled rows included: the app fits its
+    cosine-sort GMM over every score on screen and does not refit as votes
+    accumulate, so a schedule's cuts are constants of the run.
+
+    ``top`` returns ``+inf``, which is not a sentinel but the literal statement
+    of the rule: with the cut above every score, the first rank at-or-below it
+    is 0 and :func:`~vtscore.eval.al_strategies._hard_pick_by_index` returns the
+    top unlabelled item - exactly what the Good phase's ``top`` select does.
+    """
+    if rnd.cut == "top":
+        return math.inf
+    from vtscore.training.thresholds import (  # noqa: PLC0415
+        calculate_gmm_threshold,
+        fit_score_gmm,
+        gmm_cut_from_fit,
+        gmm_fit_array,
+        inclusion_cost_weights,
+    )
+
+    values = list(scores)
+    if rnd.cut == "quantile":
+        # A rank position, named directly.  Descending, so q=0 is the top of the
+        # sort and the cut is the score at that depth.
+        import numpy as np  # noqa: PLC0415
+
+        return float(np.quantile(np.asarray(values, dtype=np.float64), 1.0 - rnd.q))
+    if rnd.cut == "mid":
+        # The shipped cosine-sort cut, called rather than re-derived.
+        return float(calculate_gmm_threshold(values))
+    fit = fit_score_gmm(gmm_fit_array(values))
+    if fit is None:
+        # Same fallback the shipped cut takes on an unfittable distribution -
+        # there is no mixture to tilt, so an inclusion has nothing to price.
+        return float(calculate_gmm_threshold(values))
+    wf, wn = inclusion_cost_weights(rnd.k)
+    cut, _kind = gmm_cut_from_fit(fit, "rate", wf, wn)
+    return float(cut) if math.isfinite(cut) else float(calculate_gmm_threshold(values))
+
+
+class StartupState:
+    """Where a trajectory is in its opening, and what ends the current round.
+
+    Advanced once per vote by :class:`~vtscore.eval.autopilot_flow.AutopilotFlow`,
+    which owns the phase after the schedule runs out.
+    """
+
+    def __init__(self, rounds: Sequence[StartupRound]):
+        if not rounds:
+            raise ValueError("a startup schedule needs at least one round")
+        self.rounds: tuple[StartupRound, ...] = tuple(rounds)
+        self.index = 0
+        #: Clicks spent in the current round, for its ``clicks`` stop rule.
+        self.clicks_in_round = 0
+        #: Clicks spent past the end of the schedule because one vote class was
+        #: still empty (see :meth:`advance`).  A non-zero value on an arm is a
+        #: finding, not noise: the opening as written did not produce a
+        #: trainable pair and the harness had to keep voting to get one.
+        self.extended_clicks = 0
+        self._held_for_quorum = False
+
+    @property
+    def done(self) -> bool:
+        return self.index >= len(self.rounds)
+
+    def current(self) -> Optional[StartupRound]:
+        """The round now being voted, or ``None`` once the schedule is spent."""
+        return None if self.done else self.rounds[self.index]
+
+    def phase_name(self) -> str:
+        """``s0``, ``s1``, ... - the phase label rows carry for this round."""
+        return f"{_PHASE_PREFIX}{min(self.index, len(self.rounds) - 1)}"
+
+    def on_click(self) -> None:
+        """Record one vote against the current round's click budget."""
+        if self.done or self._held_for_quorum:
+            self.extended_clicks += 1
+        else:
+            self.clicks_in_round += 1
+
+    def advance(self, good_count: int, bad_count: int, remaining_unlabeled: float) -> None:
+        """Finish any rounds whose stop condition is now met.
+
+        Each stop is capped by what the pool could still supply, mirroring
+        :func:`~vtscore.eval.autopilot_flow.next_phase`'s target capping, so a
+        round can never strand a trajectory on a collection too small to satisfy
+        it.
+
+        The schedule as a whole will **not** finish while one vote class is
+        still empty and the pool could still fill it: the app's opening exists
+        to produce a trainable pair, and handing a learned Hard sort a
+        one-class labelset would leave the selector picking at random and make
+        the arm uninterpretable.  Those extra clicks stay on the last round and
+        are counted in :attr:`extended_clicks`.
+        """
+        while not self.done:
+            rnd = self.rounds[self.index]
+            if rnd.stop == "good" and good_count < min(rnd.n, good_count + remaining_unlabeled):
+                return
+            if rnd.stop == "bad" and bad_count < min(rnd.n, bad_count + remaining_unlabeled):
+                return
+            if rnd.stop == "clicks" and self.clicks_in_round < rnd.n and remaining_unlabeled > 0:
+                return
+            if self.index == len(self.rounds) - 1 and remaining_unlabeled > 0 and (good_count == 0 or bad_count == 0):
+                self._held_for_quorum = True
+                return
+            self._held_for_quorum = False
+            self.index += 1
+            self.clicks_in_round = 0

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.eval.al_strategies import ALContext, select_next
 from vtscore.eval.autopilot_flow import SMART_WINDOW, AutopilotFlow, app_has_detector
+from vtscore.eval.startup_schedule import StartupState, parse_startup_schedule, round_cut
 from vtscore.eval.labels import evaluable_pool, media_is_positive, region_box_for_category
 from vtscore.eval.score_dumps import maybe_dump_predictions
 from vtscore.eval.trainers import _cross_calibrated_threshold, _parse_trainer_spec
@@ -164,6 +165,11 @@ _IDENT_COLUMNS: tuple[str, ...] = (
     "n_bad",
     "phase",
     "app_trained",
+    #: The parameterised opening this run took (issue #3267), verbatim - so a
+    #: pooled frame says which arm each row came from without depending on the
+    #: directory it was read out of.  Empty on every run that took the app's
+    #: own opening, which is every study before #3267.
+    "startup_schedule",
     # --- Acquisition/reporting decoupling (docs/ML.md, threshold calibration).
     #: The threshold handed to the *selector* this step - cut
     #: ``acq_inclusion_offset`` inclusion steps below ``threshold``.  Equal to it
@@ -195,6 +201,54 @@ _VOTING_COLUMNS: tuple[str, ...] = (
     "backend",
     "device",
     "elapsed_seconds",
+)
+
+#: Column order for the per-click **pick log** (issue #3267): one row for every
+#: vote the simulated user casts, emitted only when the caller passes a
+#: ``pick_sink``.
+#:
+#: The main frame cannot answer the questions this study asks.  It starts at the
+#: first *trainable* step - before one Good and one Bad vote coexist there is no
+#: model, no threshold and no metrics row - so the opening, which is the whole
+#: subject here, is exactly the part it does not record.  This frame records
+#: every click instead: what was picked, whether it turned out to be a positive,
+#: and **where on the seed sort it came from**, which is what makes "why was this
+#: arm better" answerable rather than merely visible in the totals.
+_PICK_COLUMNS: tuple[str, ...] = (
+    "seed",
+    "dataset",
+    "category",
+    "startup_schedule",
+    "style",
+    "t",
+    "phase",
+    #: Index of the schedule round this click was spent in, or -1 outside one.
+    "startup_round",
+    #: The round's cut on the seed sort, and where that lands in the sort's own
+    #: score distribution - the sampling *position*, which is what the arms
+    #: actually differ by.  NaN / -1 outside a round.
+    "startup_cut",
+    "startup_cut_percentile",
+    "picked_id",
+    #: Ground truth for the click: 1 if the item was a positive.
+    "picked_label",
+    #: Where the picked item sat in the seed sort - as a 0-based rank over the
+    #: whole sort and as a percentile (0 = top).  Together with ``picked_label``
+    #: this is the mining record: how deep the arm had to reach for each
+    #: positive it found.
+    "picked_seed_rank",
+    "picked_seed_percentile",
+    #: The seed-sort similarity of the picked item.
+    "picked_seed_score",
+    #: The detector score the *previous* step's model gave this item, and the
+    #: acquisition cut it was picked against.  NaN before a model exists.
+    "picked_detector_score",
+    "acq_threshold",
+    #: Running vote totals **after** this click.
+    "n_good",
+    "n_bad",
+    #: Pool items still unlabelled after this click.
+    "n_pool",
 )
 
 #: Column order for the calibration study's main per-step frame (issue #2781),
@@ -552,6 +606,22 @@ def _pool_percentile(pool_scores: dict[int, float], threshold: float) -> float:
         return float("nan")
     arr = np.asarray(list(pool_scores.values()), dtype=np.float64)
     return round(float((arr < threshold).mean()), 6)
+
+
+def _sorted_percentile(descending: list[float], value: float) -> float:
+    """Where *value* cuts a **descending** score list, as a fraction from the top.
+
+    ``0`` = above every score, ``1`` = below every score.  Used for the pick
+    log's ``startup_cut_percentile``, so a round's cut is reported as the
+    sampling *position* it actually is rather than as a bare similarity whose
+    scale differs per category.  Infinite cuts (the ``top`` round) read 0.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    if not descending:
+        return float("nan")
+    idx = int(np.searchsorted(-np.asarray(descending, dtype=np.float64), -value, side="left"))
+    return _r(idx / len(descending))
 
 
 def _blend_xcal_input(threshold: float, details: dict[str, Any]) -> float:
@@ -2794,6 +2864,8 @@ def simulate_voting_iterations(  # noqa: C901
     cut_inclusion_qtilt_steps: Optional[list[float]] = None,
     acq_inclusion_offset: int = ACQUISITION_INCLUSION_OFFSET,
     acq_rank_percentile: Optional[float] = None,
+    startup_schedule: Optional[str] = None,
+    pick_sink: Optional[list[dict[str, Any]]] = None,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -2919,6 +2991,19 @@ def simulate_voting_iterations(  # noqa: C901
             ranking, and so returns *more* positives.  Requires a fold-anchored
             cut for the step; steps that fall back to the schedule blend keep
             the reporting threshold (the blend has no inclusion-aware form).
+        startup_schedule: A parameterised Autopilot **opening** (issue #3267),
+            e.g. ``"n6@k-6,n6@k-2,n6@k0"``; see
+            :mod:`vtscore.eval.startup_schedule` for the grammar.  ``None``
+            (default) is the **app's own** opening - three positives off the top
+            of the seed sort, four negatives at its cutoff - and leaves the
+            trajectory byte-for-byte what it was before the knob existed.  A
+            schedule replaces only the pre-detector phases; the learned Hard
+            sort that follows is unchanged and still samples at
+            *acq_inclusion_offset*.  Requires *seed_scores*: a schedule names
+            positions on the seed sort, so there has to be one.
+        pick_sink: List the per-click :data:`_PICK_COLUMNS` rows are appended
+            to - one per vote, including the opening's, which emit no main row
+            because no model exists yet.  ``None`` (default) = off.
         acq_rank_percentile: Alternative acquisition cut - place it at this
             quantile of the simulation-set score distribution directly, rather
             than by naming an inclusion.  This is the ``rank_pin`` arm: same
@@ -2999,6 +3084,17 @@ def simulate_voting_iterations(  # noqa: C901
     # These are pre-registered experiment knobs, so they are validated beside
     # the other argument checks rather than deep in the loop: a run that dies
     # forty minutes in on a typo has held a cluster slot for nothing.
+    startup_state: StartupState | None = None
+    if startup_schedule:
+        if seed_scores is None:
+            raise ValueError(
+                "startup_schedule needs seed_scores: a schedule names positions on the "
+                "seed sort, and there is no sort to name them on without one"
+            )
+        if not autopilot_fidelity or strategy != "autopilot":
+            raise ValueError("startup_schedule requires autopilot_fidelity and the autopilot strategy")
+        startup_state = StartupState(parse_startup_schedule(startup_schedule))
+
     if acq_rank_percentile is not None:
         if acq_inclusion_offset != 0:
             raise ValueError(
@@ -3182,7 +3278,20 @@ def simulate_voting_iterations(  # noqa: C901
     # selector on its legacy parity interleave.
     flow: Any = None
     if autopilot_fidelity and strategy == "autopilot":
-        flow = AutopilotFlow()
+        flow = AutopilotFlow(startup=startup_state)
+    # Each schedule round's cut on the seed sort, resolved once: the app fits a
+    # cosine sort's GMM over the whole sort and never refits it as votes come
+    # in, so these are constants of the run rather than per-step state.
+    startup_cuts: list[float] = []
+    if startup_state is not None and seed_scores is not None:
+        sort_values = list(seed_scores.values())
+        startup_cuts = [round_cut(sort_values, rnd) for rnd in startup_state.rounds]
+    # The seed sort as a ranking, for the pick log: where in the sort each click
+    # landed is the mining record the study reads.
+    seed_rank: dict[int, int] = {}
+    if pick_sink is not None and seed_scores is not None:
+        seed_rank = {cid: i for i, cid in enumerate(sorted(seed_scores, key=lambda c: seed_scores[c], reverse=True))}
+    seed_sorted_scores: list[float] = sorted(seed_scores.values(), reverse=True) if seed_scores else []
     # Recent per-step models (each with the threshold it was calibrated at),
     # re-scored every step against the *current* labelset so the Smart
     # indicator's slope regresses over one shared eval set - exactly what the
@@ -3193,6 +3302,8 @@ def simulate_voting_iterations(  # noqa: C901
         if not pool:
             break
         phase = flow.phase if flow is not None else None
+        startup_round = startup_state.index if (startup_state is not None and not startup_state.done) else -1
+        startup_cut = startup_cuts[startup_round] if startup_round >= 0 else None
         ctx = ALContext(
             pool_ids=pool,
             embeddings=sim_embeddings,
@@ -3207,6 +3318,7 @@ def simulate_voting_iterations(  # noqa: C901
             pool_labels=pool_labels,
             seed_scores=seed_scores,
             phase=phase,
+            startup_cut=startup_cut,
         )
         cid = select_next(strategy, ctx)
         pool.remove(cid)
@@ -3221,6 +3333,38 @@ def simulate_voting_iterations(  # noqa: C901
         # advances past covered regions (the app labels the atlas the same way).
         if atlas is not None and cid in atlas.vector_to_leaf:
             atlas.label(cid, good=is_positive)
+
+        if pick_sink is not None:
+            rank = seed_rank.get(cid, -1)
+            n_sorted = len(seed_rank)
+            pick_sink.append(
+                {
+                    "seed": seed,
+                    "dataset": dataset_name,
+                    "category": target_category,
+                    "startup_schedule": startup_schedule or "",
+                    "style": style or "",
+                    "t": t,
+                    "phase": phase or "",
+                    "startup_round": startup_round,
+                    "startup_cut": _r(startup_cut) if startup_cut is not None else float("nan"),
+                    "startup_cut_percentile": (
+                        _sorted_percentile(seed_sorted_scores, startup_cut) if startup_cut is not None else float("nan")
+                    ),
+                    "picked_id": cid,
+                    "picked_label": 1 if is_positive else 0,
+                    "picked_seed_rank": rank,
+                    "picked_seed_percentile": (
+                        _r(rank / (n_sorted - 1)) if n_sorted > 1 and rank >= 0 else float("nan")
+                    ),
+                    "picked_seed_score": _r(seed_scores[cid]) if seed_scores and cid in seed_scores else float("nan"),
+                    "picked_detector_score": _r(pool_scores[cid]) if cid in pool_scores else float("nan"),
+                    "acq_threshold": _r(acq_threshold),
+                    "n_good": len(good_votes),
+                    "n_bad": len(bad_votes),
+                    "n_pool": len(pool),
+                }
+            )
 
         # Need at least 1 good and 1 bad to train
         if not good_votes or not bad_votes:
@@ -3399,6 +3543,7 @@ def simulate_voting_iterations(  # noqa: C901
             "n_bad": len(bad_votes),
             "phase": flow.phase if flow is not None else "",
             "app_trained": 1 if (flow is None or app_has_detector(flow.phase)) else 0,
+            "startup_schedule": startup_schedule or "",
             "acq_threshold": round(float(acq_threshold), 6),
             # Measured against the pool the selector ranks, not the test set, so
             # the pair answers "how much did the sampling position move".
@@ -3552,6 +3697,7 @@ def run_voting_iterations_eval(
     prevalence_arms: Optional[list[Optional[float]]] = None,
     styles: Optional[list[Optional[str]]] = None,
     autopilot_fidelity: bool = True,
+    startup_schedule: Optional[str] = None,
 ) -> pd.DataFrame:
     """Run the voting-iterations evaluation over multiple seeds/datasets/categories.
 
@@ -3607,6 +3753,9 @@ def run_voting_iterations_eval(
             (default ``True``); see :func:`simulate_voting_iterations`.  Pass
             ``False`` to reproduce studies published before the flow was
             aligned.
+        startup_schedule: A parameterised Autopilot opening (issue #3267); see
+            :func:`simulate_voting_iterations`.  ``None`` (default) is the app's
+            own opening.  Requires a *seed_scores* entry for every cell run.
 
     Returns:
         A :class:`~pandas.DataFrame` with the columns listed in
@@ -3659,6 +3808,7 @@ def run_voting_iterations_eval(
                                     target_prevalence=arm,
                                     style=style,
                                     autopilot_fidelity=autopilot_fidelity,
+                                    startup_schedule=startup_schedule,
                                 )
                                 all_rows.extend(rows)
 
@@ -3683,6 +3833,7 @@ def run_voting_iterations_eval_from_pickles(
     prevalence_arms: Optional[list[Optional[float]]] = None,
     styles: Optional[list[Optional[str]]] = None,
     autopilot_fidelity: bool = True,
+    startup_schedule: Optional[str] = None,
 ) -> pd.DataFrame:
     """Convenience wrapper that loads datasets from pickle files.
 
@@ -3741,4 +3892,5 @@ def run_voting_iterations_eval_from_pickles(
         prevalence_arms=prevalence_arms,
         styles=styles,
         autopilot_fidelity=autopilot_fidelity,
+        startup_schedule=startup_schedule,
     )


### PR DESCRIPTION
Prep for the Good Mining experiment. The GRID run itself is still owed.

Refs #3267

## The observation this rests on

Today's opening is fixed: the top of the seed sort until 3 positives, that sort's cutoff until 4 negatives, then the learned Hard sort ever after. Both of those phases are the **same operation** — the app's rank-space `hard` select against a cut on the seed sort — at two different cuts:

- the Good phase's `top` select is that select against a cut placed *above every score*, so the first at-or-below-cut rank is 0;
- the Bad phase's cut is that sort's own fitted 2-component GMM, split at the production midpoint.

So "Text-Good is Text-Hard(-100)" is literally true, and the whole opening collapses to a list of rounds naming how many clicks to spend and where on the sort.

## What landed

**`vtscore/eval/startup_schedule.py`** — the opening as a parameter. Grammar: `<g|b|n><count>@<top|mid|k[-]N|q<frac>>`, comma-separated.

```
g3@top,b4@mid          today's opening, exactly
n5@k-6,n5@k-2,n6@k0    three rounds at inclusion-biased GMM splits
n5@q0.02,n5@q0.10,n6@mid   the same shape, by rank position
```

*Where* is named as an **Inclusion**, the way the app names it. The seed sort ships an inclusion-independent midpoint cut, but the fit under it is the same object every inclusion-aware rule reads, so the sort can be split at any `k` (`gmm_cut_from_fit`'s `rate` rule at `inclusion_cost_weights(k)` — `k=0` is the prior-agnostic split). Negative `k` prices a false alarm higher, raises the cut, and moves the pick up the ranking — same direction and same reason as `ACQUISITION_INCLUSION_OFFSET` on the learned sort.

A `q` spelling names the rank position directly, and it is not redundant: **how far a given `k` moves the pick is a property of the fitted mixture, not of `k`**. On a steep sort the whole usable inclusion range can land inside a couple of rank percent, which would make a grid that looks well spread in `k` nearly a point in the space the picks actually live in. `q` establishes whether *position* is the mechanism; `k` asks whether the app's existing knob is a usable handle on it.

**The default is untouched.** `startup_schedule=None` leaves every existing trajectory byte-for-byte what it was. The explicit production spec is *required* to reproduce a default run click for click, which the new tests assert directly.

**A per-click pick log** (`pick_sink` / `_PICK_COLUMNS`). The main frame starts at the first *trainable* step — before one Good and one Bad vote coexist there is no model and no metrics row — so the opening, the whole subject here, is exactly the part it does not record. The pick log records every click: what was picked, whether it turned out to be a positive, and where on the seed sort it came from.

**The study**, in `scripts/experiments/calibration/`: `launch_good_mining.sh` (8 arms, two stages), `analyze_startup.py`, and a planted-answer selftest for the analyzer. Arms are parsed before submission, so a typo fails at the terminal rather than four hours into the array.

Two arms are load-bearing. `deep_first` opens *below* the good mass and must mine fewer positives — if it does not, depth is not the mechanism and the analyzer withholds the verdict. `flat_mid` is the length-matched control: every banded arm spends 16 opening clicks against `prod`'s ~7, so without it a win could just be "spend more clicks before training".

## Eval/app sync

Two new pinned mirrors. `autopilot.startup_default` pins `PRODUCTION_STARTUP` against the app's `INITIAL_STATE`. `autopilot.phase_sort_select` pins the phase → Sort+Select table that `_select_phase_faithful` mirrors — **that was not pinned before**, and it is exactly the mapping this change generalises.

## Incidental

`docs/EVAL.md` said the acquisition-cut default was `-3`; PR #2891 cut it to `-1`. It now points at the constant rather than restating a number that goes stale.

## Still owed

The run: `GM_STAGE=live bash launch_good_mining.sh`, then the box-scale stage once a real cell has been timed, then `analyze_startup.py` and a report. The analyzer answers *whether* an opening mined better; the issue also asks **why**, which is a question about the items themselves — dump the opening's picks and render them as contact sheets, so a winning arm's extra positives can be looked at rather than counted.

`./run-tests.sh` — RUN PASSED (9149 passed, 6 skipped; all gates green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvUoMxXHS5AiyhSkbsb3cq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvUoMxXHS5AiyhSkbsb3cq)_