### PR TITLE
Add torchvision to requirements/labbench.txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ extend_exclude = [
 # Sibling modules that slides/figs/src/*.py import off their own directory
 # (they are scripts run by path, not an installed package, so deptry reads the
 # imports as third-party). Everything else under slides/ is still checked.
-known_first_party = ["report_svg", "slide_figure"]
+known_first_party = ["coco_fixture", "report_svg", "slide_figure"]
 
 # Module name → distribution name. Deptry needs these when the importable
 # module differs from the PyPI package.

--- a/requirements/labbench.txt
+++ b/requirements/labbench.txt
@@ -34,6 +34,14 @@ umap-learn
 # ── PyTorch (CPU) ────────────────────────────────────────────────────
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch>=2.0.0
+# SigLIP's image processor is requested by backend name rather than
+# inheriting a default (#3173), and the name we ask for is `torchvision`
+# — so torchvision is a hard requirement of the preprocessing path, not
+# an optional accelerator. `torch` does not pull it in and neither does
+# `transformers`, so without this line the processor import raises
+# ImportError the first time an image is embedded. Listed under `torch`
+# so it resolves against the CPU wheel index above.
+torchvision
 
 # ── Image media type ─────────────────────────────────────────────────
 Pillow

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -47,6 +47,17 @@ _ALWAYS_REQUIRED: frozenset[str] = frozenset(
 )
 
 
+# Packages that any slim file shipping an *image* embedder requires. The
+# image-processor backend is now requested by name (`torchvision`) rather than
+# inherited from a transformers default (#3173), so torchvision is part of the
+# preprocessing path itself and not an optional accelerator. Nothing carries it
+# transitively — `torch` does not pull it in and neither does `transformers` —
+# which is how issue #3264 (LabBench image built without torchvision) happened.
+# Keyed off Pillow, the dep every image-capable variant declares.
+_IMAGE_MARKER = "pillow"
+_IMAGE_REQUIRED: frozenset[str] = frozenset({"torchvision"})
+
+
 def _normalise(name: str) -> str:
     return re.sub(r"[-_.]+", "-", name).lower()
 
@@ -80,4 +91,17 @@ def test_slim_requirements_include_core_deps(req_file: Path) -> None:
         f"{req_file.name} is missing deps every deployment needs: {sorted(missing)}\n"
         "Add them to that file (core framework / numeric stack entries near the top; "
         "umap-learn under the '── VTSBrowse projection ──' heading)."
+    )
+
+
+@pytest.mark.parametrize("req_file", _SLIM_FILES, ids=[p.name for p in _SLIM_FILES])
+def test_slim_requirements_include_image_deps(req_file: Path) -> None:
+    declared = _parse_packages(req_file)
+    if _IMAGE_MARKER not in declared:
+        pytest.skip(f"{req_file.name} ships no image media type")
+    missing = {_normalise(p) for p in _IMAGE_REQUIRED} - declared
+    assert not missing, (
+        f"{req_file.name} ships image embedders but is missing: {sorted(missing)}\n"
+        "Add them to that file under the PyTorch heading so they resolve against "
+        "the same wheel index as torch."
     )


### PR DESCRIPTION
Closes #3264

## What broke

`requirements/labbench.txt` is a standalone hand-edited list (it does not forward to `pyproject.toml`), and it never listed `torchvision`. That was harmless while SigLIP's image processor picked its backend from a `transformers` default, but #3173 made every image embedder request the `torchvision` backend **by name** — so torchvision became part of the preprocessing path rather than an optional accelerator, and the processor import now raises `ImportError`. Nothing carries it transitively: `torch` does not pull it in and neither does `transformers`. `requirements/image-embedders.txt` and `image-embedders-gpu.txt` were updated at the time; `labbench.txt` was missed.

## Changes

- **`requirements/labbench.txt`** — add `torchvision` directly under `torch>=2.0.0`, below the `--extra-index-url https://download.pytorch.org/whl/cpu` line already in the file, so it resolves against the CPU wheel index. Mirrors the placement and rationale comment in `requirements/image-embedders.txt`.
- **`tests/core/test_requirements.py`** — new guard alongside the existing core-deps one: any non-forwarding slim requirements file that declares `Pillow` (the marker for an image-capable variant) must also declare `torchvision`. Same class of check that caught the umap-learn gap in #2843, so the next image variant cannot ship without it.
- **`pyproject.toml`** — register `coco_fixture` in `[tool.deptry] known_first_party` alongside `report_svg` / `slide_figure`. `slides/figs/src/coco_fixture.py` landed as a new sibling of those two without being added to the list, so deptry read the by-path sibling import in `make-book-figs.py` as an undeclared third-party package and the gate was failing on `dev`. Unrelated to the torchvision fix, fixed here because it blocked the test run.

## Testing

Full `./run-tests.sh`: `RUN PASSED` — 9152 passed, 6 skipped, 2 xpassed; pyright, pip-audit, npm audit and the Vitest suite all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpZyGkhsE9Yxjx9XnpgWqv)_