### PR TITLE
deptry: declare coco_fixture as a slides-local module, unblocking the test gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ extend_exclude = [
 # Sibling modules that slides/figs/src/*.py import off their own directory
 # (they are scripts run by path, not an installed package, so deptry reads the
 # imports as third-party). Everything else under slides/ is still checked.
-known_first_party = ["report_svg", "slide_figure"]
+known_first_party = ["coco_fixture", "report_svg", "slide_figure"]
 
 # Module name → distribution name. Deptry needs these when the importable
 # module differs from the PyPI package.


### PR DESCRIPTION
**`./run-tests.sh` is currently blocked on `dev`**, and has been since a5e5ab591:

```
slides/figs/src/make-book-figs.py:46:1: DEP001 'coco_fixture' imported but missing from the dependency definitions
Found 1 dependency issue.
============================================================
TESTS BLOCKED: deptry found dependency issues
============================================================
```

`known_first_party` in `[tool.deptry]` is a hand-maintained list of the sibling modules that `slides/figs/src/*.py` import off their own directory — they're scripts run by path rather than an installed package, so deptry reads those imports as third-party. It listed `report_svg` and `slide_figure`; `coco_fixture.py` was added to that directory later and never joined them.

One word:

```diff
-known_first_party = ["report_svg", "slide_figure"]
+known_first_party = ["coco_fixture", "report_svg", "slide_figure"]
```

## Why this matters beyond slides

The gate fails **in 21 seconds, before a single test runs**, so it blocks every PR's test evidence — not just work under `slides/`.

## Verified pre-existing

| run | ref | result |
|---|---|---|
| job 564354 | a feature branch | FAILED 00:00:21, DEP001 |
| job 564357 | **`origin/dev` unchanged** | FAILED 00:00:21, identical message |
| after this change | — | `python -m deptry .` → `Success! No dependency issues found.` |

Found while running the #3267 GRID study, whose PR could not produce a passing suite for a reason that had nothing to do with it. Deliberately kept out of that PR: an unrelated repo fix does not belong inside an experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaTEg7ZzZvuHLMXvwqpCAc