### PR TITLE
Assign the owner while an issue is being worked; clear it when solved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,13 +156,39 @@ is:issue is:open label:solved     # solved; waiting only on merges
 
 Three rules bind you directly:
 
-- **Apply it when you open the fix PR**, in the same motion as the `Addressed in #M` comment (see "Linking a fix PR to its GitHub issue" above). Pass `labels` explicitly with the issue's existing labels plus `solved` — `labels` *replaces* the whole set, so read the issue first if you don't already know them.
+- **Apply it when you open the fix PR**, in the same motion as the `Addressed in #M` comment (see "Linking a fix PR to its GitHub issue" above). Pass `labels` explicitly with the issue's existing labels plus `solved` — `labels` *replaces* the whole set, so read the issue first if you don't already know them. **Clear the assignee in the same write** — see "Assign the owner while you are working an issue" below.
 - **Take it back off if the fix falls through.** If your PR is closed without merging, or review concludes the fix is wrong and the issue needs solving again, strip `solved` — the issue belongs back in the human queue. This is the one removal a fix session does itself.
 - **Closing an issue strips `solved`.** Pass `labels` explicitly on a `completed` close, listing every label the issue keeps (`claude`, `experiment`, …) and omitting `solved`; passing `[]` would wipe the rest. A `PreToolUse` hook blocks a close that keeps the label or omits the array.
 
-`scripts/reconcile-solved-labels.py` is the backstop for all three — it catches issues a session forgot to label, issues whose fix PR was abandoned, and stale labels left behind by a close. It encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
+`scripts/reconcile-solved-labels.py` is the backstop for all three, and for the assignee — it catches issues a session forgot to label, issues whose fix PR was abandoned, stale labels left behind by a close, and solved or closed issues still showing an assignee. It encodes `docs/RELEASE.md` step 6's resolution logic — closing keywords vs. `Refs`, `Partially addressed in #M` vs. `Addressed in #M`, and the ambiguity of a comment posted *after* a fix pointer. It is a pure function from data to plan: the GitHub REST API is unreachable from a Claude session (`GITHUB_TOKEN` is present but 403s, since GitHub access is intermediated by the MCP server), so gather the PR and issue data with the `github` MCP tools and pipe it in. See `docs/RELEASE.md` for the recipe.
 
 **A comment after the fix pointer is never guessed at.** If someone comments below an `Addressed in #M` pointer, the script reports the issue as needing review rather than tagging or skipping it. The later comment might be a maintainer saying "thanks" or the reporter saying the fix doesn't work; tagging would bury a dispute (hiding an issue that still needs solving), and skipping would leave solved work in the human queue. Ambiguity gets surfaced, not resolved by a coin flip.
+
+## Assign the owner while you are working an issue
+
+**Assign `samggreenberg` to an issue the moment you start working it, and take the assignee off the moment the issue is solved.** Assignment answers a different question from the labels: not "is this solved?" but **"is somebody on it right now?"** Together they give the tracker two views instead of one:
+
+```
+is:issue is:open -label:solved              # nobody has solved this
+is:issue is:open -label:solved no:assignee  # ...and nobody is on it right now — free to pick up
+```
+
+That second view is the one that stops two sessions — or a session and a human — starting the same issue an hour apart. It only works if the assignee goes on *early* and comes off *promptly*; a stale assignee is worse than none, because it makes free work look taken.
+
+Assignment is writable exactly like labels: `issue_write` with `method: "update"` and an `assignees` array. Two mechanics matter, and they differ from the label rules:
+
+- **`assignees` replaces the whole set**, just as `labels` does. Pass `["samggreenberg"]` to assign and `[]` to clear.
+- **Omitting `assignees` leaves the existing assignees untouched.** So a label-only write never disturbs assignment, and an assignment-only write never disturbs labels — you do *not* need to read the issue first the way you do for labels. Pass only the field you mean to change.
+
+Three rules bind you directly:
+
+- **Assign at the start.** When you begin work on an issue — before the first edit, not after the PR — write `assignees: ["samggreenberg"]`. Do this even when you filed the issue yourself in the same session, and even for issues filed by someone else: the assignee names who is *doing* the work, not who reported it, and every Claude session here works through the owner's account.
+- **Unassign when you apply `solved`.** In the same motion as the `solved` label and the `Addressed in #M` comment, write `assignees: []`. Once the issue is solved, nobody is working it — only merges remain — so an assignee would assert something false. (These are two separate fields on one `issue_write` call; set both.)
+- **Re-assign if the fix falls through and you pick it back up.** Stripping `solved` (per the rule above) puts the issue back in the human queue. If you are the one resuming it, assign again; if you are walking away, leave it unassigned so someone else can take it.
+
+**Closing an issue clears the assignee too** — `docs/RELEASE.md` step 6 passes `assignees: []` alongside the label list, for the same reason it strips `solved`: a closed issue has nobody working it.
+
+`scripts/reconcile-solved-labels.py` backstops this, reporting a `CLEAR ASSIGNEE` bucket beside its label buckets. It reconciles in **one direction only** — it plans removals from solved and closed issues, and never invents an assignment, because "nobody is working on it" and "a session started five minutes ago" are the same JSON from its input. That asymmetry is why the *assign* half of the rule above has no safety net and has to be done by hand.
 
 ## Recommend a Claude model in every issue you file
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -87,6 +87,7 @@ Anything else stays open — a genuinely partial `Refs` is doing its job.
 - Skip it if it is already closed. Never reopen or re-close.
 - Close it with `state_reason: completed`.
 - **Strip the `solved` label in the same write.** `solved` means "the development is done; only merges remain" (see CLAUDE.md), and this close is the moment the last merge lands — so the label has nothing left to say. Pass `labels` explicitly with every label the issue keeps (`claude`, `experiment`, …) minus `solved`; `labels` *replaces* the whole set, so passing `[]` would wipe the rest. A `PreToolUse` hook blocks a `completed` close that keeps `solved` or omits the array.
+- **Clear the assignee in the same write.** Pass `assignees: []`. An assignee means "somebody is working this right now" (see CLAUDE.md), which a closed issue cannot be. Unlike `labels`, there is nothing to preserve here — the empty array is always the right value on a close.
 - Add a one-line comment noting it shipped to `main` in today's release and linking the fix PR (e.g. `Shipped to main in the 2026-07-14 release — fixed
   in #M.`). When the PR used a non-closing keyword, say so in that comment, so the mislabel is visible on the issue rather than silently corrected.
 
@@ -94,7 +95,7 @@ Anything else stays open — a genuinely partial `Refs` is doing its job.
 
 ## 6b. Audit the `solved` label
 
-`solved` means "the development is done; only merges remain", and the fix session applies it when it opens the PR (CLAUDE.md). So by the time you get here the label should already be right, and this step is an **audit**: `scripts/reconcile-solved-labels.py` catches issues a session forgot to label, issues whose fix PR was later abandoned, and stale labels left behind by step 6's closes.
+`solved` means "the development is done; only merges remain", and the fix session applies it when it opens the PR (CLAUDE.md). So by the time you get here the label should already be right, and this step is an **audit**: `scripts/reconcile-solved-labels.py` catches issues a session forgot to label, issues whose fix PR was later abandoned, and stale labels left behind by step 6's closes. It audits the **assignee** on the same pass, for the same reason — an assignee outlives its purpose exactly when `solved` does.
 
 Run it right after step 6 to confirm nothing was left behind. It is also worth running **between** releases — the views it keeps honest (`is:issue is:open -label:solved`, what a human should pick up next) matter most while the release is still weeks away.
 
@@ -102,7 +103,7 @@ The script is a pure function from data to plan — it does no network I/O, beca
 
 1. List the PRs merged into `dev` since the last release — the same `origin/main..origin/dev` window as step 3 — and read each one's **body**. These are `release_prs`.
 2. List the PRs currently **open** against `dev` (`open_prs`) and those **closed without merging** since the last release (`abandoned_prs`), with their bodies. The open ones are why an issue can be labelled before any merge; the abandoned ones are the only way a label comes off outside a close.
-3. List the repo's issues with their `labels` and `state`, and fetch each one's **comments** in chronological order (the API default).
+3. List the repo's issues with their `labels`, `state`, and `assignees`, and fetch each one's **comments** in chronological order (the API default).
 4. Assemble them into one JSON object and run the script:
 
 ```json
@@ -112,6 +113,7 @@ The script is a pure function from data to plan — it does no network I/O, beca
   "abandoned_prs": [{"number": 3155, "body": "... Closes #3090 ..."}],
   "issues": [
     {"number": 3077, "state": "open", "labels": ["claude"],
+     "assignees": ["samggreenberg"],
      "comments": [{"body": "Addressed in #3128"}]}
   ]
 }
@@ -121,13 +123,15 @@ The script is a pure function from data to plan — it does no network I/O, beca
 python scripts/reconcile-solved-labels.py --input plan-input.json
 ```
 
-It prints four buckets. **Apply `ADD` and `REMOVE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there for one of three reasons, all genuinely undecidable from the outside:
+It prints five buckets. **Apply `ADD`, `REMOVE`, and `CLEAR ASSIGNEE` directly** — they are unambiguous. **Do not apply `NEEDS REVIEW`**; read those issues yourself. An issue lands there for one of three reasons, all genuinely undecidable from the outside:
 
 - **A fix pointer is not the newest comment.** The later comment may be a maintainer saying "thanks" or the reporter saying the fix does not work. Tagging would bury a dispute — hiding an issue that still needs solving — while skipping would leave solved work in the human queue.
 - **A comment claims a fix by commit SHA** instead of `Addressed in #M`. The script has only the JSON you piped in, so it cannot map a commit to its PR — but the claim is real, so it is surfaced. Resolve it with `git log --ancestry-path <sha>..origin/dev --merges --oneline | tail -1` to find the merge that carried it, then re-run with a corrected pointer.
 - **The issue carries `solved` but nothing resolves it** — stale, or fixed in an earlier release.
 
 That is the same "not silently skipped" principle step 6 applies to non-closing references.
+
+`CLEAR ASSIGNEE` is orthogonal to the label buckets — an issue whose label is already correct can still owe an assignee removal, so it appears under `CLEAR ASSIGNEE` while also counting as "no change" for its label. The bucket only ever asks you to *remove* an assignee: the script cannot tell "nobody is working this" from "a session started five minutes ago", so it never proposes assigning anyone, and it leaves `NEEDS REVIEW` issues and fallen-through fixes alone.
 
 Add `--check` to make it exit non-zero when anything needs attention, and `--json` for machine-readable output.
 

--- a/scripts/reconcile-solved-labels.py
+++ b/scripts/reconcile-solved-labels.py
@@ -37,6 +37,30 @@ pointer naming a commit instead of a PR cannot be resolved here at all.
 Getting any of those subtly wrong silently corrupts both views above.
 Encoding it here makes it testable; see tests/core/test_reconcile_solved_labels.py.
 
+## The assignee half, and why it only ever removes
+
+Assignment carries a second status alongside the label: a session assigns the
+owner when it *starts* work on an issue, and takes them back off once the issue
+is solved (CLAUDE.md, "Assign the owner while you are working an issue"). So the
+open-issue queue reads:
+
+    is:issue is:open -label:solved             # nobody has solved this
+    is:issue is:open -label:solved no:assignee # ...and nobody is on it right now
+
+That second view is what stops two people picking up the same issue, and it
+only works if the assignee comes off again. Nothing observes the moment it
+should, which is the same gap that left `solved` unapplied for weeks -- hence
+this backstop.
+
+It reconciles in **one direction only**. An issue that is closed, or solved,
+must carry no assignee, and the script plans that removal. It never plans an
+*addition*, because from this input "nobody is working on it" and "a session
+started work on it a minute ago" are the same JSON: an unlabelled, unassigned
+issue. Guessing there would either evict a session mid-flight or fabricate work
+nobody is doing. For the same reason an issue whose label is ambiguous
+(`NEEDS REVIEW`) or whose fix fell through has its assignee left strictly
+alone -- the script has no opinion it can defend.
+
 ## Why it takes input instead of fetching
 
 The GitHub REST API is not reachable from a Claude session — `GITHUB_TOKEN` is
@@ -58,9 +82,13 @@ Input schema (unknown keys are ignored, so richer API payloads pipe in as-is):
       "abandoned_prs": [ {"number": 3155, "body": "... Closes #3090 ..."} ],
       "issues": [
         {"number": 3077, "state": "open", "labels": ["claude"],
+         "assignees": ["samggreenberg"],
          "comments": [ {"body": "Addressed in #3128"} ]}
       ]
     }
+
+`assignees` accepts either bare logins or the GitHub API's `{"login": ...}`
+objects, so both the MCP tools' output and a raw REST payload pipe in as-is.
 
 `release_prs` are the PRs merged into `dev` since the last release — the same
 `origin/main..origin/dev` window step 6 uses. `open_prs` are the PRs currently
@@ -191,6 +219,50 @@ def _sha_pointer(issue: dict) -> str | None:
     return None
 
 
+def _is_labelled(issue: dict) -> bool:
+    return SOLVED_LABEL in {str(item).strip().lower() for item in (issue.get("labels") or [])}
+
+
+def _is_open(issue: dict) -> bool:
+    return str(issue.get("state") or "open").lower() == "open"
+
+
+def _assignees(issue: dict) -> list[str]:
+    """Normalise an issue's assignees to logins.
+
+    The github MCP tools hand back bare strings (`["samggreenberg"]`) while the
+    REST API hands back objects (`[{"login": "samggreenberg"}]`); both forms
+    reach this script depending on who gathered the data, so both are accepted.
+    """
+    logins = []
+    for entry in issue.get("assignees") or []:
+        login = entry.get("login") if isinstance(entry, dict) else entry
+        if login:
+            logins.append(str(login))
+    return logins
+
+
+def _assignee_action(issue: dict, label_action: str, labelled: bool, is_open: bool) -> tuple[str, str]:
+    """Return (action, reason) for one issue's assignees. Action is unassign/none.
+
+    Removal only -- see the module docstring. The trigger is "this issue has no
+    problem-solving left in it", which is exactly the state the label already
+    encodes, so this reads that verdict rather than re-deriving it.
+    """
+    logins = _assignees(issue)
+    if not logins:
+        return "none", "no assignee"
+
+    who = ", ".join(f"@{login}" for login in logins)
+    if not is_open:
+        return "unassign", f"issue is closed but is still assigned to {who}"
+    if label_action == "add":
+        return "unassign", f"solved by this run's fix PR, but still assigned to {who}"
+    if labelled and label_action == "none":
+        return "unassign", f"already carries `{SOLVED_LABEL}` but is still assigned to {who}"
+    return "none", f"assigned to {who}; not solved, so the assignment stands"
+
+
 def _describe(pr_number: int, kind: str, issue_number: int) -> str:
     article = "open PR" if kind == "open" else "merged PR"
     return f"{article} #{pr_number} claims `Closes #{issue_number}`"
@@ -204,8 +276,8 @@ def _classify(
 ) -> tuple[str, str]:
     """Return (action, reason) for one issue. Action is add/remove/review/none."""
     number = issue.get("number")
-    labelled = SOLVED_LABEL in {str(item).strip().lower() for item in (issue.get("labels") or [])}
-    is_open = str(issue.get("state") or "open").lower() == "open"
+    labelled = _is_labelled(issue)
+    is_open = _is_open(issue)
 
     if not is_open:
         if labelled:
@@ -255,10 +327,17 @@ def reconcile(data: dict) -> dict[str, list[tuple[int, str]]]:
     live_numbers = {number for number, _, kind in prs if kind != DEAD_KIND}
     dead_numbers = {number for number, _, kind in prs if kind == DEAD_KIND}
 
-    plan: dict[str, list[tuple[int, str]]] = {"add": [], "remove": [], "review": [], "none": []}
+    plan: dict[str, list[tuple[int, str]]] = {"add": [], "remove": [], "review": [], "none": [], "unassign": []}
     for issue in data.get("issues") or []:
         action, reason = _classify(issue, closers, live_numbers, dead_numbers)
         plan[action].append((issue.get("number"), reason))
+
+        # Orthogonal to the label buckets: an issue can be `none` for its label
+        # (already correct) and still owe an assignee removal, so it lands in
+        # both rather than being moved out of one.
+        assignee_action, assignee_reason = _assignee_action(issue, action, _is_labelled(issue), _is_open(issue))
+        if assignee_action == "unassign":
+            plan["unassign"].append((issue.get("number"), assignee_reason))
     for bucket in plan.values():
         bucket.sort()
     return plan
@@ -269,6 +348,7 @@ def render(plan: dict[str, list[tuple[int, str]]]) -> str:
         ("add", f"ADD `{SOLVED_LABEL}`"),
         ("remove", f"REMOVE `{SOLVED_LABEL}`"),
         ("review", "NEEDS REVIEW (ambiguous — do not guess)"),
+        ("unassign", "CLEAR ASSIGNEE (solved or closed; nobody is working it)"),
     ]
     lines = ["", "solved-label reconciliation", "=" * 40]
     for key, heading in headings:
@@ -309,7 +389,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(render(plan))
 
-    if args.check and (plan["add"] or plan["remove"] or plan["review"]):
+    if args.check and (plan["add"] or plan["remove"] or plan["review"] or plan["unassign"]):
         return 1
     return 0
 

--- a/tests/core/test_reconcile_solved_labels.py
+++ b/tests/core/test_reconcile_solved_labels.py
@@ -16,6 +16,12 @@ are the point of testing it:
   tracks "solved", not "merged"), while a PR closed *without* merging un-solves
   it and must take the label back off.
 
+It also reconciles the *assignee*, which carries the companion status "a
+session is working this right now". That half removes only: a solved or closed
+issue must end up unassigned, but nothing in this input can distinguish "nobody
+is on it" from "a session just started", so an assignment is never invented and
+an ambiguous issue is never touched.
+
 Getting any of these wrong silently corrupts both views the label powers:
 `-label:solved` (what a human should pick up next) and `label:solved`
 (solved, waiting only on merges).
@@ -43,11 +49,19 @@ def _load():
 mod = _load()
 
 
-def issue(number: int, *, state: str = "open", labels: list[str] | None = None, comments: list[str] | None = None):
+def issue(
+    number: int,
+    *,
+    state: str = "open",
+    labels: list[str] | None = None,
+    comments: list[str] | None = None,
+    assignees: list | None = None,
+):
     return {
         "number": number,
         "state": state,
         "labels": labels or [],
+        "assignees": assignees or [],
         "comments": [{"body": body} for body in (comments or [])],
     }
 
@@ -384,3 +398,92 @@ class TestCommandLine:
 
     def test_empty_input_is_not_an_error(self):
         assert self.run({}).returncode == 0
+
+
+class TestAssigneeRemoval:
+    """The assignee comes off once an issue is solved or closed -- and only then."""
+
+    def test_issue_solved_by_this_run_is_unassigned(self):
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        plan = plan_for(prs, [issue(3077, assignees=["samggreenberg"])])
+        assert 3077 in plan["add"]
+        assert "@samggreenberg" in plan["unassign"][3077]
+
+    def test_already_solved_issue_still_assigned_is_unassigned(self):
+        """The label went on but the assignee was forgotten -- the common miss."""
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        plan = plan_for(prs, [issue(3077, labels=["claude", "solved"], assignees=["samggreenberg"])])
+        assert 3077 in plan["none"]  # label is already correct...
+        assert 3077 in plan["unassign"]  # ...but the assignee is not
+
+    def test_closed_issue_is_unassigned(self):
+        plan = plan_for([], [issue(3077, state="closed", assignees=["samggreenberg"])])
+        assert 3077 in plan["unassign"]
+
+    def test_unsolved_issue_keeps_its_assignee(self):
+        """An assignee on an unsolved issue means a session is working it now."""
+        plan = plan_for([], [issue(3077, assignees=["samggreenberg"])])
+        assert 3077 not in plan["unassign"]
+
+    def test_refs_only_issue_keeps_its_assignee(self):
+        prs = [{"number": 3128, "body": "Refs #3077"}]
+        assert 3077 not in plan_for(prs, [issue(3077, assignees=["samggreenberg"])])["unassign"]
+
+    def test_unassigned_issue_is_never_planned_for_assignment(self):
+        """The script only ever removes -- it cannot know who, if anyone, is working."""
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        plan = plan_for(prs, [issue(3077)])
+        assert plan["unassign"] == {}
+
+    def test_ambiguous_issue_is_left_alone(self):
+        """A `NEEDS REVIEW` label verdict must not drag the assignee with it."""
+        plan = plan_for([], [issue(3077, labels=["solved"], assignees=["samggreenberg"])])
+        assert 3077 in plan["review"]
+        assert 3077 not in plan["unassign"]
+
+    def test_fallen_through_fix_leaves_the_assignee_alone(self):
+        """The label comes off, but whoever is picking the work back up may be assigned."""
+        plan = plan_for(
+            [],
+            [issue(3077, labels=["solved"], assignees=["samggreenberg"])],
+            abandoned_prs=[{"number": 3155, "body": "Closes #3077"}],
+        )
+        assert 3077 in plan["remove"]
+        assert 3077 not in plan["unassign"]
+
+    @pytest.mark.parametrize(
+        "assignees", [["samggreenberg"], [{"login": "samggreenberg"}]], ids=["mcp-strings", "rest-objects"]
+    )
+    def test_both_assignee_payload_shapes_are_understood(self, assignees):
+        """MCP tools hand back logins; the REST API hands back objects."""
+        plan = plan_for([{"number": 3128, "body": "Closes #3077"}], [issue(3077, assignees=assignees)])
+        assert "@samggreenberg" in plan["unassign"][3077]
+
+    def test_multiple_assignees_are_all_named(self):
+        plan = plan_for(
+            [{"number": 3128, "body": "Closes #3077"}], [issue(3077, assignees=["samggreenberg", "Khamersk"])]
+        )
+        assert "@samggreenberg" in plan["unassign"][3077]
+        assert "@Khamersk" in plan["unassign"][3077]
+
+    def test_empty_and_missing_assignees_are_both_quiet(self):
+        prs = [{"number": 3128, "body": "Closes #3077"}]
+        assert plan_for(prs, [{"number": 3077, "state": "open", "labels": [], "comments": []}])["unassign"] == {}
+
+    def test_check_flags_an_owed_unassignment_alone(self):
+        """A tree whose labels are all correct still fails the gate on a stale assignee."""
+        data = {
+            "release_prs": [{"number": 3128, "body": "Closes #3077"}],
+            "issues": [issue(3077, labels=["solved"], assignees=["samggreenberg"])],
+        }
+        assert mod.reconcile(data)["add"] == []
+        assert mod.reconcile(data)["unassign"] != []
+
+    def test_render_names_the_bucket(self):
+        plan = mod.reconcile(
+            {
+                "release_prs": [{"number": 3128, "body": "Closes #3077"}],
+                "issues": [issue(3077, assignees=["samggreenberg"])],
+            }
+        )
+        assert "CLEAR ASSIGNEE" in mod.render(plan)


### PR DESCRIPTION
Adds GitHub issue **assignment** to the workflow, as a status that sits alongside the `solved` label.

Assignment answers a question the labels do not: not "is this solved?" but **"is somebody on it right now?"** Together they give the tracker a second view:

```
is:issue is:open -label:solved              # nobody has solved this
is:issue is:open -label:solved no:assignee  # ...and nobody is on it — free to pick up
```

That second view is what stops two sessions, or a session and a human, starting the same issue an hour apart. It only works if the assignee goes on early and comes off promptly — a stale assignee is worse than none, because it makes free work look taken.

## The rule (CLAUDE.md)

- **Assign at the start of work** — before the first edit, not at PR time. Including on issues filed by someone else: the assignee names who is *doing* the work, not who reported it.
- **Clear it in the same write that applies `solved`**, alongside the `Addressed in #M` comment.
- **Re-assign only if a fallen-through fix is picked back up.**

Two mechanics differ from the label rules and are documented: `assignees` replaces the whole set like `labels` does, but *omitting* it leaves assignment untouched — so unlike labels there is no need to read the issue first.

`docs/RELEASE.md` step 6 now clears the assignee alongside stripping `solved`, for the same reason: a closed issue has nobody working it.

## The backstop

`solved` went unapplied for weeks as a prose-only rule, because no session observes the moment it should go on. Assignment has the same gap, so it gets the same backstop: `scripts/reconcile-solved-labels.py` grows a `CLEAR ASSIGNEE` bucket beside its label buckets, orthogonal to them (an issue whose label is already correct can still owe a removal). `--check` fails on an owed unassignment.

**It reconciles in one direction only.** It plans removals from solved and closed issues and never invents an assignment, because "nobody is working on it" and "a session started five minutes ago" are the same JSON from its input — guessing would either evict a session mid-flight or fabricate work nobody is doing. Ambiguous (`NEEDS REVIEW`) issues and fallen-through fixes are left strictly alone, mirroring how the label half already declines to guess. That asymmetry is why the *assign* half of the rule has no safety net and must be done by hand.

## Backlog sweep

The tracker had accumulated stale assignments at scale: **356 issues** carried an assignee they no longer needed — essentially every closed issue in the repo, since assignment had been used as an implicit "who did this" record. All 356 were cleared via the MCP tools; all 378 closed issues now verify as `assignees: []`, and no open issue carries one.

This included a live instance of exactly the gap the rule closes: #3265 was closed by the in-flight release sweep partway through this session, `solved` stripped — and left assigned.

## Testing

- 13 new tests in `tests/core/test_reconcile_solved_labels.py` covering both payload shapes (MCP logins vs REST objects), the removal triggers, and every case that must be left alone.
- Full `./run-tests.sh`: **RUN PASSED**, 9166 passed / 6 skipped, all gates green (pyright, pip-audit, npm audit, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JN86MnvBkzakkFKUWeu8Q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN86MnvBkzakkFKUWeu8Q8)_