### PR TITLE
Every launcher with a DINOv3 arm now says how it opens — and is held to it

### DIFF
--- a/.claude/skills/grid-experiments/SKILL.md
+++ b/.claude/skills/grid-experiments/SKILL.md
@@ -36,7 +36,25 @@ already using**, which silently breaks the per-name completion waiter below.
 Add `--reuse-prepare "$PREPARE_DIR"` when you are skipping a GPU prepare stage by
 reusing a finished study's output. It checks that every `crops/` entry still
 resolves — the links point into the study that generated them, and `readlink -f`
-recreates them happily after that study is archived (#2881).
+recreates them happily after that study is archived (#2881) — and it is where the
+grid-vs-prepare check reads from when the run has not copied `prepare_info.json`
+in yet.
+
+**Declare the opening.** `export CALIB_REQUIRE_OPENING=text` (or `known_good`, or
+`mixed`) in the launcher. Autopilot has two real starts and which one a cell takes
+is decided silently, by whether its category has a typed query and whether its
+embedder has a text tower — so a grid holding a SigLIP arm and a bare
+`dinov3_patch` one opens two ways along one axis, and nothing says so (#3278).
+The declaration is asserted per grid by preflight and per cell by `run_cells.py`,
+and `_cells_io.assert_one_opening` refuses to pool two openings at analysis time.
+An arm that must region-vote *and* open on a query is the pair
+`siglip+dinov3_patch` (#3276): SigLIP ranks the query, DINOv3 does the learning.
+
+Renaming an arm — pairing one included — means **re-running prepare**, even when
+every pickle is cached. `prepare_info.json` is keyed by embedder name and the grid
+enumerates from it, so an arm with no entry contributes zero cells silently and
+every later array index means a different cell. Preflight check 15 is what says
+whether you did.
 
 It refuses to pass when the results dir already holds another grid's cells,
 when the *actual* mount is low on space, when zero-byte cells from a previous

--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -72,6 +72,7 @@ correct union of the two branches with no judgement involved.
 
 | Date | Lesson | Issue |
 |---|---|---|
+| 2026-08-27 | [the region arm could not open the way the app does](lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md) | #3276 |
 | 2026-08-26 | [a completed grid reported "0 / 6480" cells](lessons/2026-08-26-a-completed-grid-reported-zero-cells.md) | #3156 |
 | 2026-08-26 | [a counter that never reached the rows, and a check that was a no-op](lessons/2026-08-26-a-counter-that-never-reached-the-rows.md) | #3267 |
 | 2026-08-26 | [a fixture dataset has no query, so it seeds from somewhere else](lessons/2026-08-26-a-fixture-dataset-has-no-query.md) | #3267 |

--- a/scripts/experiments/calibration/_cells_io.py
+++ b/scripts/experiments/calibration/_cells_io.py
@@ -91,3 +91,74 @@ def load_medias(path: str | Path) -> dict[int, dict[str, Any]]:
     with Path(path).open("rb") as fh:
         # S301 - our own prepare-written cache, not untrusted input.
         return _StaleClassUnpickler(fh).load()  # noqa: S301
+
+
+#: Columns ``run_cells.py`` writes to record **how each cell opened**: the app's
+#: two real starts are a text sort and three random known-goods, and since #3276
+#: a paired arm's text sort can run in a different embedding space than the arm
+#: it is labelled with.
+OPENING_COLUMNS = ("seed_mode", "seed_embedder")
+
+
+def assert_one_opening(frame, where: str = "") -> None:
+    """Refuse to pool cells of one environment that did not open the same way.
+
+    ``region_voting_for`` made the *voting mode* a per-cell premise rather than a
+    flag, because a run that requests region voting and silently gets whole-image
+    training reads as the experiment it is not (#2877).  The **opening** has
+    exactly that shape and was the last piece of it left unasserted (#3278): a
+    cell records ``seed_mode`` and ``seed_embedder``, and cells of one
+    ``(dataset, embedder, category)`` split across a text sort and a known-good
+    start are two experiments averaged into one number.
+
+    The way to land there is a **resume**.  Cells are skipped when their CSV
+    already exists, so re-running a grid across the #3269 seeding fix -- or after
+    an arm was paired -- leaves the old cells in place and writes the new ones
+    beside them.  Every column is populated, every count says "N/N cells", and
+    the mean is over two openings.
+
+    **Grouped by environment, not by arm**, and the difference is the whole
+    argument of the #3278 lesson.  A *category* with no typed query takes the
+    known-good start on **every** arm, so it shifts them all together and cancels
+    in any contrast between them -- that is a legitimate grid, and a study that
+    wants it gone sets ``CALIB_REQUIRE_SEED_QUERY=1``.  An *arm* that opens
+    differently from its neighbours does not cancel, and that is what
+    ``CALIB_REQUIRE_OPENING`` and preflight check 14 refuse before the array
+    rather than after it.  What is left for the analyzer is the case neither can
+    see: one environment holding both, which no launcher ever declared and only a
+    resume can produce.  Style is not in the key either -- one cell writes every
+    style from one opening.
+
+    Cells written before the columns existed carry no value at all; that reads as
+    ``unrecorded`` so a mix of old and new fails here rather than averaging
+    quietly.  A frame with neither column is entirely pre-#3269 and has nothing
+    to compare.
+
+    :raises ValueError: if any ``(dataset, embedder, category)`` holds more than
+        one opening.
+    """
+    if frame is None or len(frame) == 0:
+        return
+    present = [c for c in OPENING_COLUMNS if c in frame.columns]
+    key = ["dataset", "embedder", "category"]
+    if not present or not set(key) <= set(frame.columns):
+        return
+    mixed = []
+    for group_key, group in frame.groupby(key, dropna=False):
+        openings = {
+            tuple(str(row[c]) if row[c] == row[c] and row[c] != "" else "unrecorded" for c in present)
+            for _, row in group[present].drop_duplicates().iterrows()
+        }
+        if len(openings) > 1:
+            got = ", ".join(sorted("/".join(o) for o in openings))
+            mixed.append(f"{' x '.join(str(k) for k in group_key)}: {got}")
+    if mixed:
+        raise ValueError(
+            (f"{where}: " if where else "")
+            + "these environments pooled cells that opened differently -- "
+            + "; ".join(mixed[:8])
+            + (f" (and {len(mixed) - 8} more)" if len(mixed) > 8 else "")
+            + ".  A text sort and a known-good start are different rankings, so their cells are "
+            + "not seeds of one experiment; delete the stale cells and re-run them, or analyse "
+            + "the two runs separately."
+        )

--- a/scripts/experiments/calibration/analyze.py
+++ b/scripts/experiments/calibration/analyze.py
@@ -29,7 +29,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files, side_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files, side_frame_files  # noqa: E402
 
 import experiment_config as cfg  # noqa: E402
 
@@ -56,6 +56,7 @@ def load_all(cells_dir: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
     sweep = pd.concat([pd.read_csv(p) for p in sweep_files], ignore_index=True) if sweep_files else pd.DataFrame()
     if not main.empty:
         main["arm"] = main.apply(_arm, axis=1)
+    assert_one_opening(main, "analyze.py")
     common.log(f"loaded {len(main)} main rows from {len(main_files)} cells, {len(sweep)} sweep rows")
     return main, sweep
 

--- a/scripts/experiments/calibration/analyze_ab.py
+++ b/scripts/experiments/calibration/analyze_ab.py
@@ -38,7 +38,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 
 #: Vote-count windows the comparison aggregates over.  Below 6 votes the blend
 #: is pure GMM (full authority), 6-20 is the ramp, above 20 it is pure
@@ -88,6 +88,7 @@ def load_base_rows(results_dir: Path, label: str) -> pd.DataFrame:
     if not files:
         return pd.DataFrame()
     df = pd.concat([pd.read_csv(p) for p in files], ignore_index=True)
+    assert_one_opening(df, f"analyze_ab.py ({label})")
     if "gmm_variant" in df.columns:
         df["gmm_variant"] = df["gmm_variant"].fillna("")
         df = df[df["gmm_variant"] == ""]

--- a/scripts/experiments/calibration/analyze_anchored.py
+++ b/scripts/experiments/calibration/analyze_anchored.py
@@ -37,7 +37,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 
 import experiment_config as cfg  # noqa: E402
 
@@ -65,6 +65,7 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     if not files:
         return pd.DataFrame()
     df = pd.concat([pd.read_csv(p) for p in files], ignore_index=True)
+    assert_one_opening(df, "analyze_anchored.py")
     df["gmm_variant"] = df["gmm_variant"].fillna("")
     df["arm"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
     df["n_votes"] = df["n_good"] + df["n_bad"]

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -46,7 +46,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 
 from vtscore.eval.cut_rules import TAIL_ALPHA_PREREGISTERED, TAIL_RULES  # noqa: E402
 from vtscore.eval.transfer_rules import BAGGED_FIT_RULES, TRANSFER_ORACLE_RULES  # noqa: E402
@@ -200,6 +200,7 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     df["arm"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
     df["n_votes"] = df["n_good"] + df["n_bad"]
     common.log(f"loaded {len(df)} variant rows from {len(files)} cells")
+    assert_one_opening(df, "analyze_cut.py")
     return df
 
 

--- a/scripts/experiments/calibration/analyze_folds.py
+++ b/scripts/experiments/calibration/analyze_folds.py
@@ -24,7 +24,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from _cells_io import main_frame_files
+from _cells_io import assert_one_opening, main_frame_files
 from scipy.stats import mannwhitneyu, wilcoxon
 
 FOLD_RE = re.compile(r"^fold_anchored_w(?P<w>[\d.]+)_(?P<rule>mid|rate)_(?P<combine>\w+)$")
@@ -37,6 +37,7 @@ def load(results: Path) -> pd.DataFrame:
     files = main_frame_files(results)
     frames = [pd.read_csv(p) for p in files if p.stat().st_size > 0]
     df = pd.concat(frames, ignore_index=True)
+    assert_one_opening(df, "analyze_folds.py")
     df["gmm_variant"] = df["gmm_variant"].fillna("")
     df["env"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
     df = df[df["env"] == ENV]

--- a/scripts/experiments/calibration/analyze_folds_2897.py
+++ b/scripts/experiments/calibration/analyze_folds_2897.py
@@ -55,7 +55,7 @@ common.setup_env()
 from experiment_config import region_voting_for  # noqa: E402
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 from scipy.stats import mannwhitneyu, wilcoxon  # noqa: E402
 
 #: The arms this analyzer owns.  ``xcal`` / ``blend`` / ``anchored`` are the
@@ -147,6 +147,7 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     if not frames:
         return pd.DataFrame()
     df = pd.concat(frames, ignore_index=True)
+    assert_one_opening(df, "analyze_folds_2897.py")
     df["gmm_variant"] = df["gmm_variant"].fillna("")
     df["env"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
     df["n_votes"] = df["n_good"] + df["n_bad"]

--- a/scripts/experiments/calibration/analyze_mixin.py
+++ b/scripts/experiments/calibration/analyze_mixin.py
@@ -31,7 +31,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 
 #: The window every headline number is computed over: the app's first trained
 #: detector appears at 7 votes, and the production ramp ends at 20.  Below 7 no
@@ -77,6 +77,7 @@ def load_cells(results: Path) -> pd.DataFrame:
     if not frames:
         raise SystemExit(f"every cell CSV under {results / 'cells'} was unreadable")
     df = pd.concat([f for f in frames if len(f)], ignore_index=True)
+    assert_one_opening(df, f"analyze_mixin.py ({results.name})")
     for col in ("schedule", "gmm_variant"):
         df[col] = df[col].fillna("")
     df["n_votes"] = df["n_good"] + df["n_bad"]

--- a/scripts/experiments/calibration/analyze_overview.py
+++ b/scripts/experiments/calibration/analyze_overview.py
@@ -1,8 +1,15 @@
 """What is VTSearch good at, what is it bad at, and why — descriptively.
 
 No arms, no winners. Three modes a real user could pick (`siglip` whole-image,
-`siglip2_l` whole-image, `dinov3_patch` region voting) run many times under
-shipped defaults, characterised rather than ranked.
+`siglip2_l` whole-image, `siglip+dinov3_patch` region voting) run many times
+under shipped defaults, characterised rather than ranked.
+
+The region mode is a **pair** (#3276): SigLIP embeds the typed query and ranks
+the opening, DINOv3 does the learning. DINOv3 has no text tower, so bare
+`dinov3_patch` cannot open on a text sort at all -- it falls back to three
+random known-goods, which would put a seeding difference inside the voting-mode
+comparison this file draws. All three modes now open the same way and differ
+only in the space the detector learns in.
 
 The "why" comes from a decomposition the harness already emits per step:
 

--- a/scripts/experiments/calibration/analyze_overview.py
+++ b/scripts/experiments/calibration/analyze_overview.py
@@ -119,7 +119,18 @@ def main() -> int:
     def mode(r: dict) -> str:
         return f"{r.get('embedder', '')}/{r.get('style', '')}".strip("/")
 
+    def mode_w(names, floor: int = 26) -> int:
+        """Width of the mode column, from the widest name actually present.
+
+        A constant 26 was wide enough for `dinov3_patch/max_patch` and is two
+        short of `siglip+dinov3_patch/max_patch`, so the by-band table printed
+        `...max_patchsmall` -- the band welded onto the arm. Tables are how this
+        study is read, so the width follows the data.
+        """
+        return max(floor, max((len(str(n)) for n in names), default=floor) + 2)
+
     modes = sorted({mode(r) for r in rows})
+    MW = mode_w(modes)
     cats = sorted({r["category"] for r in rows})
     seeds = sorted({r["seed"] for r in rows})
     expected = args.expect or len(cats) * len(modes) * len(seeds)
@@ -155,26 +166,28 @@ def main() -> int:
     deep = {k: v for k, v in snap.items() if k[3] == DEEP}
 
     print("=== what a run looks like: cost distribution (lower is better) ===")
-    print(f"{'mode':<26}{'votes':>6}{'p10':>7}{'median':>8}{'p90':>7}{'worst':>7}{'n':>6}")
-    print("-" * 67)
+    hdr = f"{'mode':<{MW}}{'votes':>6}{'p10':>7}{'median':>8}{'p90':>7}{'worst':>7}{'n':>6}"
+    print(hdr)
+    print("-" * len(hdr))
     for m in modes:
         for s in STEPS:
             xs = [fnum(v, "cost") for k, v in snap.items() if k[0] == m and k[3] == s]
             xs = [x for x in xs if x == x]
             print(
-                f"{m:<26}{s:>6}{f(q(xs, 0.1)):>7}{f(q(xs, 0.5)):>8}"
+                f"{m:<{MW}}{s:>6}{f(q(xs, 0.1)):>7}{f(q(xs, 0.5)):>8}"
                 f"{f(q(xs, 0.9)):>7}{f(max(xs)) if xs else 'n/a':>7}{len(xs):>6}"
             )
         print()
 
     print(f"=== runs that never got going (cost >= {args.floor} at {DEEP} votes) ===")
-    print(f"{'mode':<26}{'stuck':>7}{'of':>6}{'rate':>8}")
-    print("-" * 47)
+    hdr = f"{'mode':<{MW}}{'stuck':>7}{'of':>6}{'rate':>8}"
+    print(hdr)
+    print("-" * len(hdr))
     for m in modes:
         xs = [fnum(v, "cost") for k, v in deep.items() if k[0] == m]
         xs = [x for x in xs if x == x]
         stuck = [x for x in xs if x >= args.floor]
-        print(f"{m:<26}{len(stuck):>7}{len(xs):>6}{f(len(stuck) / len(xs)) if xs else 'n/a':>8}")
+        print(f"{m:<{MW}}{len(stuck):>7}{len(xs):>6}{f(len(stuck) / len(xs)) if xs else 'n/a':>8}")
 
     # --- the profile of a stuck run -----------------------------------------
     print()
@@ -182,8 +195,9 @@ def main() -> int:
     metrics = ("n_good", "n_bad", "average_precision", "auroc", "oracle_cost", "regret")
     bad = [v for k, v in deep.items() if fnum(v, "cost") >= args.floor]
     good = [v for k, v in deep.items() if fnum(v, "cost") < args.floor]
-    print(f"{'metric':<22}{'stuck':>14}{'healthy':>14}   n={len(bad)} vs {len(good)}")
-    print("-" * 62)
+    hdr = f"{'metric':<22}{'stuck':>14}{'healthy':>14}   n={len(bad)} vs {len(good)}"
+    print(hdr)
+    print("-" * len(hdr))
     for met in metrics:
         b = [x for x in (fnum(v, met) for v in bad) if x == x]
         g = [x for x in (fnum(v, met) for v in good) if x == x]
@@ -199,8 +213,9 @@ def main() -> int:
         ph_bad[v.get("phase", "?")] += 1
     for v in good:
         ph_good[v.get("phase", "?")] += 1
-    print(f"{'phase':<12}{'stuck':>8}{'healthy':>9}   what it means")
-    print("-" * 72)
+    hdr = f"{'phase':<12}{'stuck':>8}{'healthy':>9}   what it means"
+    print(hdr)
+    print("-" * len(hdr))
     meaning = {
         "good": "never found GOOD_TARGET positives — still on the text sort",
         "bad": "still collecting the initial negatives",
@@ -215,8 +230,9 @@ def main() -> int:
     print()
     print("=== why: is the ranking the limit, or the cut rule? ===")
     print("cost = oracle_cost (the ranking's own limit) + regret (what the cut gives away)")
-    print(f"{'mode':<26}{'cost':>13}{'oracle':>13}{'regret':>13}{'regret share':>14}")
-    print("-" * 79)
+    hdr = f"{'mode':<{MW}}{'cost':>13}{'oracle':>13}{'regret':>13}{'regret share':>14}"
+    print(hdr)
+    print("-" * len(hdr))
     for m in modes:
         sel = [v for k, v in deep.items() if k[0] == m]
         c = [x for x in (fnum(v, "cost") for v in sel) if x == x]
@@ -224,22 +240,24 @@ def main() -> int:
         g = [x for x in (fnum(v, "regret") for v in sel) if x == x]
         mc = mean_se(c)[0]
         share = mean_se(g)[0] / mc if mc else float("nan")
-        print(f"{m:<26}{pm(c):>13}{pm(o):>13}{pm(g):>13}{f(share):>14}")
+        print(f"{m:<{MW}}{pm(c):>13}{pm(o):>13}{pm(g):>13}{f(share):>14}")
 
     print()
     print("=== and inside regret: a bad rule, or a shifted calibration? ===")
-    print(f"{'mode':<26}{'regret':>13}{'rule_ineff':>13}{'cal_shift':>13}")
-    print("-" * 66)
+    hdr = f"{'mode':<{MW}}{'regret':>13}{'rule_ineff':>13}{'cal_shift':>13}"
+    print(hdr)
+    print("-" * len(hdr))
     for m in modes:
         sel = [v for k, v in deep.items() if k[0] == m]
         cols = ("regret", "rule_inefficiency", "calibration_shift")
         vals = [[x for x in (fnum(v, c) for v in sel) if x == x] for c in cols]
-        print(f"{m:<26}" + "".join(f"{pm(v):>13}" for v in vals))
+        print(f"{m:<{MW}}" + "".join(f"{pm(v):>13}" for v in vals))
 
     print()
     print("=== the same split, by target size ===")
-    print(f"{'mode':<26}{'band':<8}{'cost':>13}{'oracle':>13}{'regret':>13}{'stuck':>8}")
-    print("-" * 82)
+    hdr = f"{'mode':<{MW}}{'band':<8}{'cost':>13}{'oracle':>13}{'regret':>13}{'stuck':>8}"
+    print(hdr)
+    print("-" * len(hdr))
     for m in modes:
         for b in BANDS:
             sel = [v for k, v in deep.items() if k[0] == m and k[1].endswith("@" + b)]
@@ -247,7 +265,7 @@ def main() -> int:
             o = [x for x in (fnum(v, "oracle_cost") for v in sel) if x == x]
             g = [x for x in (fnum(v, "regret") for v in sel) if x == x]
             rate = (sum(1 for x in c if x >= args.floor) / len(c)) if c else float("nan")
-            print(f"{m:<26}{b:<8}{pm(c):>13}{pm(o):>13}{pm(g):>13}{f(rate):>8}")
+            print(f"{m:<{MW}}{b:<8}{pm(c):>13}{pm(o):>13}{pm(g):>13}{f(rate):>8}")
         print()
 
     # --- per-cell reliability ------------------------------------------------
@@ -270,7 +288,7 @@ def main() -> int:
         print(f"({skipped} cell x mode combinations had < {args.min_seeds} runs and are not rated)")
     for cat, m, rate, med, n in sorted(scored, key=lambda r: -r[2])[: args.top]:
         bar = "#" * int(round(rate * 20))
-        print(f"{cat:<20}{m:<26}rate {rate:>5.2f}  median {med:>5.2f}  n={n:<4} {bar}")
+        print(f"{cat:<20}{m:<{MW}}rate {rate:>5.2f}  median {med:>5.2f}  n={n:<4} {bar}")
 
     print()
     print("=== hard for everyone, or hard for one mode? ===")

--- a/scripts/experiments/calibration/analyze_rate.py
+++ b/scripts/experiments/calibration/analyze_rate.py
@@ -48,7 +48,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 
 import experiment_config as cfg  # noqa: E402
 
@@ -99,6 +99,7 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     if not frames:
         return pd.DataFrame()
     df = pd.concat(frames, ignore_index=True)
+    assert_one_opening(df, "analyze_rate.py")
     df["gmm_variant"] = df["gmm_variant"].fillna("")
     df["schedule"] = df["schedule"].fillna("")
     # A schedule row is the shipped blend under an alternative mix-in curve; it

--- a/scripts/experiments/calibration/analyze_safe.py
+++ b/scripts/experiments/calibration/analyze_safe.py
@@ -32,7 +32,7 @@ common.setup_env()
 
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
-from _cells_io import main_frame_files  # noqa: E402
+from _cells_io import assert_one_opening, main_frame_files  # noqa: E402
 
 #: Vote-count windows (inclusive) the deliverables aggregate over.  Below 6
 #: votes the blend is pure GMM; 6-20 is the ramp; above 20 the blend is pure
@@ -63,6 +63,7 @@ def load_cells(cells_dir: Path) -> pd.DataFrame:
     if not files:
         return pd.DataFrame()
     df = pd.concat([pd.read_csv(p) for p in files], ignore_index=True)
+    assert_one_opening(df, "analyze_safe.py")
     df["gmm_variant"] = df["gmm_variant"].fillna("")
     df["arm"] = df["dataset"] + "/" + df["embedder"] + "/" + df["style"]
     df["n_votes"] = df["n_good"] + df["n_bad"]

--- a/scripts/experiments/calibration/analyze_scale.py
+++ b/scripts/experiments/calibration/analyze_scale.py
@@ -203,7 +203,11 @@ def main() -> int:
         print("=== region voting vs the SAME encoder with geometry off, per band ===")
         print(f"{'band':<10}{'max_patch':>14}{'whole_image':>14}{'paired diff':>18}{'n':>5}")
         print("-" * 62)
-        live = next((a for a in styles if a.startswith("dinov3") and "(control)" not in a), None)
+        # Identify the region arm by its STYLE, not by its embedder's name: the
+        # region arm is `siglip+dinov3_patch/max_patch` since #3276, and a
+        # `startswith("dinov3")` test silently finds nothing and prints an empty
+        # control table rather than failing.
+        live = next((a for a in styles if a.endswith("/max_patch") and "(control)" not in a), None)
         base = ctrl[0]
         for b in BANDS:
             diffs = []

--- a/scripts/experiments/calibration/analyze_tail_overlap.py
+++ b/scripts/experiments/calibration/analyze_tail_overlap.py
@@ -1,0 +1,183 @@
+"""When a run ends badly, is it the same run for every mode?
+
+The tail is the product problem — the per-run figures show a bottom decile that
+never leaves the floor whichever mode you pick — but "a bad tail" has two very
+different causes and the same appearance:
+
+* **a property of the mode.** Region voting fails a tenth of runs that
+  whole-image handles. Then the fix is the mode, and switching mode helps those
+  users.
+* **a property of the data.** The same images defeat every mode. Then the fix is
+  the dataset or the query, no mode switch helps anyone, and reporting it as a
+  mode difference sends the next study after a ghost.
+
+#3156 got this wrong once already, by eye: two "stuck exemplars" that survived a
+change of representation were taken as evidence of hard images, and the
+heuristic behind that shortlist — *a model failure should not survive a change
+of representation* — turned out to be false (one image was correctly labelled
+and genuinely hard, one was a mislabel, and both were seeding artefacts anyway).
+Cross-mode persistence is a **shortlist generator, not a verdict.**
+
+So this measures the persistence instead of asserting it, and it is careful in
+two ways that matter:
+
+* each mode's tail is cut at **its own** decile, not at a shared cost. Cutting
+  at a shared threshold hands every bad run to the worst mode by construction
+  and measures nothing.
+* the overlap is quoted against **chance**, because two decile sets over the
+  same runs overlap ~10% for free. A Jaccard of 0.05 is what independence looks
+  like here, not a weak signal.
+
+Usage::
+
+    python analyze_tail_overlap.py --exp /expscratch/$USER/scale-3156-pair
+    python analyze_tail_overlap.py --exp ... --metric cost --quantile 0.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import os
+from collections import defaultdict
+from pathlib import Path
+
+from figures_overview import band_of, class_of
+
+#: For each metric, whether a LARGE value is the bad end.
+BAD_IS_HIGH = {"cost": True, "regret": True, "average_precision": False, "auroc": False}
+
+
+def final_values(exp: str, metric: str, step: int) -> dict[str, dict[tuple[str, str], float]]:
+    """``mode -> {(category, seed): value at the deepest row <= step}``."""
+    best: dict[str, dict[tuple[str, str], tuple[int, float]]] = defaultdict(dict)
+    for path in sorted(glob.glob(str(Path(exp) / "results" / "cells" / "task_*.csv"))):
+        if "__" in Path(path).name:
+            continue
+        try:
+            with open(path, newline="") as fh:
+                for r in csv.DictReader(fh):
+                    try:
+                        t, v = int(r["t"]), float(r[metric])
+                    except (KeyError, ValueError, TypeError):
+                        continue
+                    if t > step:
+                        continue
+                    mode = f"{r.get('embedder', '')}/{r.get('style', '')}".strip("/")
+                    key = (r["category"], r["seed"])
+                    prev = best[mode].get(key)
+                    if prev is None or prev[0] < t:
+                        best[mode][key] = (t, v)
+        except (OSError, csv.Error):
+            continue
+    return {m: {k: v for k, (_, v) in d.items()} for m, d in best.items()}
+
+
+def tail_set(values: dict[tuple[str, str], float], q: float, bad_high: bool) -> set[tuple[str, str]]:
+    """The worst *q* fraction of runs, by this mode's own distribution."""
+    if not values:
+        return set()
+    ordered = sorted(values, key=lambda k: values[k], reverse=bad_high)
+    return set(ordered[: max(1, int(round(q * len(ordered))))])
+
+
+def spearman(a: list[float], b: list[float]) -> float:
+    """Rank correlation, ties averaged — no scipy in this environment."""
+
+    def ranks(xs):
+        order = sorted(range(len(xs)), key=lambda i: xs[i])
+        out = [0.0] * len(xs)
+        i = 0
+        while i < len(order):
+            j = i
+            while j + 1 < len(order) and xs[order[j + 1]] == xs[order[i]]:
+                j += 1
+            avg = (i + j) / 2 + 1
+            for k in range(i, j + 1):
+                out[order[k]] = avg
+            i = j + 1
+        return out
+
+    if len(a) < 3:
+        return float("nan")
+    ra, rb = ranks(a), ranks(b)
+    n = len(ra)
+    ma, mb = sum(ra) / n, sum(rb) / n
+    num = sum((x - ma) * (y - mb) for x, y in zip(ra, rb))
+    da = sum((x - ma) ** 2 for x in ra) ** 0.5
+    db = sum((y - mb) ** 2 for y in rb) ** 0.5
+    return num / (da * db) if da and db else float("nan")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--exp", default=f"/expscratch/{os.environ.get('USER', 'sgreenberg')}/scale-3156-pair")
+    ap.add_argument("--metric", default="average_precision")
+    ap.add_argument("--step", type=int, default=150)
+    ap.add_argument("--quantile", type=float, default=0.10)
+    args = ap.parse_args(argv)
+
+    bad_high = BAD_IS_HIGH.get(args.metric, True)
+    per_mode = final_values(args.exp, args.metric, args.step)
+    if not per_mode:
+        print(f"no rows under {args.exp}")
+        return 1
+    modes = sorted(per_mode)
+    shared = set.intersection(*(set(per_mode[m]) for m in modes))
+    print(f"metric={args.metric}  step<={args.step}  tail=worst {args.quantile:.0%} of each mode's OWN runs")
+    print(f"{len(shared)} runs present in all {len(modes)} modes (of {max(len(per_mode[m]) for m in modes)} max)\n")
+
+    tails = {m: tail_set({k: v for k, v in per_mode[m].items() if k in shared}, args.quantile, bad_high) for m in modes}
+
+    print("=== do the modes fail the SAME runs? ===")
+    print("Jaccard of the two tail sets, against what independence would give.")
+    hdr = f"{'pair':<62}{'|A&B|':>7}{'jaccard':>9}{'chance':>8}{'ratio':>7}"
+    print(hdr)
+    print("-" * len(hdr))
+    q = args.quantile
+    chance_j = q / (2 - q)  # two independent q-fractions of one population
+    for i, a in enumerate(modes):
+        for b in modes[i + 1 :]:
+            inter = len(tails[a] & tails[b])
+            union = len(tails[a] | tails[b])
+            j = inter / union if union else float("nan")
+            print(f"{a + '  vs  ' + b:<62}{inter:>7}{j:>9.2f}{chance_j:>8.2f}{j / chance_j:>7.1f}x")
+    all_three = set.intersection(*(tails[m] for m in modes))
+    print(f"\nin EVERY mode's tail: {len(all_three)} runs  (chance ~{q ** (len(modes) - 1) * len(shared):.0f})")
+
+    print("\n=== is it the CATEGORY, or the seed? ===")
+    print("Each mode's per-category tail rate, and how those rates rank together.")
+    cats = sorted({c for c, _ in shared})
+    rate = {m: {c: 0.0 for c in cats} for m in modes}
+    for m in modes:
+        n_by_cat: dict[str, int] = defaultdict(int)
+        bad_by_cat: dict[str, int] = defaultdict(int)
+        for key in shared:
+            n_by_cat[key[0]] += 1
+            if key in tails[m]:
+                bad_by_cat[key[0]] += 1
+        for c in cats:
+            rate[m][c] = bad_by_cat[c] / n_by_cat[c] if n_by_cat[c] else float("nan")
+    hdr2 = f"{'modes compared':<62}{'spearman rho':>14}"
+    print(hdr2)
+    print("-" * len(hdr2))
+    for i, a in enumerate(modes):
+        for b in modes[i + 1 :]:
+            rho = spearman([rate[a][c] for c in cats], [rate[b][c] for c in cats])
+            print(f"{a + '  vs  ' + b:<62}{rho:>14.2f}")
+
+    worst = sorted(cats, key=lambda c: -sum(rate[m][c] for m in modes))[:10]
+    print(f"\n{'category':<20}{'band':<8}" + "".join(f"{m.split('/')[0][:14]:>16}" for m in modes))
+    print("-" * (28 + 16 * len(modes)))
+    for c in worst:
+        print(f"{class_of(c):<20}{band_of(c):<8}" + "".join(f"{rate[m][c]:>16.2f}" for m in modes))
+    covered = sum(1 for key in all_three if key[0] in set(worst))
+    print(f"\n{covered}/{len(all_three)} of the universally-bad runs fall in those 10 categories.")
+    print("A tail concentrated in a few categories is a DATA problem; one spread")
+    print("evenly across categories but shared across modes is a HARNESS one.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/bench_cells.py
+++ b/scripts/experiments/calibration/bench_cells.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from _cells_io import assert_one_opening
+
 #: Identifies one run of the loop: a (dataset, embedder, category, seed) cell.
 CELL_KEY = ["dataset", "embedder", "category", "seed"]
 _SIDECARS = ("sweep", "cutdiag", "cutincl")
@@ -50,6 +52,7 @@ def load_cells(results: Path, embedder_suffix: str = "", quiet: bool = False) ->
             continue
         frames.append(df)
     out = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    assert_one_opening(out, f"bench_cells.load_cells({results})")
     if embedder_suffix and not out.empty:
         out["embedder"] = out["embedder"] + embedder_suffix
     prov = {

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -3,7 +3,9 @@
 One place the prepare stage, the SLURM array indexer, and the analyzer all agree
 on.  See ``docs/plans/calibration-experiment.md`` for the design.
 
-Arms (each an ``(embedder, style)`` pair):
+Arms (each an ``(embedder, style)`` pair).  An embedder is either a single
+registered name or a **paired** ``"<text>+<learn>"`` name (see :data:`PAIR_SEP`),
+which opens on one space's text sort and learns in another's:
 
 * ``visual_genome_m`` (boxed; ground-truth regions):
   ``siglip`` / ``siglip_l`` × ``whole_image`` (row-wise conformal), and
@@ -233,6 +235,12 @@ DATASET_EMBEDDERS: dict[str, list[str]] = {
     # which words happen to live at which size. Its categories are
     # band-suffixed (`bus@small`), and every one of them is the experiment --
     # see CATEGORY_MODE "all".
+    #
+    # The region-voting arm here is normally the PAIR `siglip+dinov3_patch`
+    # rather than bare `dinov3_patch`: DINOv3 has no text tower, so on its own
+    # it opens on three random known-goods while the whole-image arms open on a
+    # text sort, and the voting-mode contrast carries a seeding contrast inside
+    # it. See PAIR_SEP.
     "vg_scale": os.environ.get("CALIB_VGSCALE_EMBEDDERS", "siglip,dinov3_patch").split(","),
 }
 
@@ -501,9 +509,64 @@ SCALE_BANDS: list[tuple[str, float, float]] = [
 ]
 
 
+#: Separator in a **paired embedder** name, ``"<text>+<learn>"``.
+#:
+#: Autopilot asks an embedding space for two different things, and nothing says
+#: they must be the same space:
+#:
+#: * the **opening** is a text sort - the user types a query and votes down the
+#:   cosine ranking - which needs a *text tower*;
+#: * everything after it - training the detector, pooling a dragged box, and
+#:   re-sorting by the trained model - happens in the *media* space, which needs
+#:   a *patch grid* for region voting and no text tower at all.
+#:
+#: ``dinov3_patch`` is the only patch-capable embedder in the pile and it has no
+#: text tower, so on its own it can never take the app's real opening: every
+#: DINOv3 cell falls back to the three-random-known-goods start.  That made the
+#: voting-mode contrast a *seeding* contrast as well - the binary arms opened on
+#: a text sort and the region arm did not - which is a confound in the axis the
+#: study exists to measure, not a detail.
+#:
+#: ``siglip+dinov3_patch`` removes it: SigLIP (the shipped default embedder, and
+#: the one whose text sort users actually see) ranks the typed query, and DINOv3
+#: does every piece of learning - vector learning, region learning, and the
+#: learn-sort.  Production would have to keep two vectors per image to ship it;
+#: the pile already does, which is why it is measurable here first.
+PAIR_SEP = "+"
+
+
+def split_embedder(embedder: str) -> tuple[str, str]:
+    """``"<text>+<learn>"`` -> ``(text_embedder, learn_embedder)``.
+
+    A plain name is both of its own halves, so callers can split
+    unconditionally instead of branching on whether a name is paired.
+    """
+    text, sep, learn = embedder.partition(PAIR_SEP)
+    return (text, learn) if sep else (embedder, embedder)
+
+
+def learn_embedder(embedder: str) -> str:
+    """The space the detector trains, scores and sorts in - i.e. which pickle."""
+    return split_embedder(embedder)[1]
+
+
+def text_embedder(embedder: str) -> str:
+    """The space the typed query is embedded in - i.e. which opening."""
+    return split_embedder(embedder)[0]
+
+
+def is_paired(embedder: str) -> bool:
+    """True when the opening and the learning run in *different* spaces."""
+    return PAIR_SEP in embedder
+
+
 def is_patch_embedder(embedder: str) -> bool:
-    """True for embedders that produce a patch grid + HAC tree."""
-    return embedder.endswith("_patch")
+    """True for embedders that produce a patch grid + HAC tree.
+
+    Reads the **learn** half: ``siglip+dinov3_patch`` region-votes because
+    DINOv3 supplies the patches, whatever supplies the opening.
+    """
+    return learn_embedder(embedder).endswith("_patch")
 
 
 def styles_for_embedder(embedder: str) -> list[str]:
@@ -536,11 +599,27 @@ def embedders_for_dataset(dataset: str) -> list[str]:
 
 
 def pickle_name(dataset: str, embedder: str) -> str:
-    return f"{dataset}__{embedder}.pkl"
+    """The cell pickle an arm loads its medias from.
+
+    A paired arm loads the **learn** half's pickle, because that is where the
+    vectors the detector is trained and scored on live.  The text half's pickle
+    is opened separately, once, and only to rank the opening - see
+    :func:`text_pickle_name` and ``run_cells._text_seed_scores``.
+    """
+    return f"{dataset}__{learn_embedder(embedder)}.pkl"
+
+
+def text_pickle_name(dataset: str, embedder: str) -> str:
+    """The pickle whose vectors the typed query is ranked against.
+
+    Equal to :func:`pickle_name` for an unpaired embedder, which is what makes
+    the paired path a generalisation of the ordinary one rather than a branch.
+    """
+    return f"{dataset}__{text_embedder(embedder)}.pkl"
 
 
 def crops_basename(dataset: str, embedder: str) -> str:
-    return f"{dataset}__{embedder}__crops"
+    return f"{dataset}__{learn_embedder(embedder)}__crops"
 
 
 def category_rng_seed(category: str) -> int:

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -168,6 +168,12 @@ EXPERIMENT_QUERIES: dict[str, dict[str, str]] = {
         f"{cls}@{band}": text for cls, text in _VG_SCALE_TEXTS.items() for band in ("small", "medium", "large")
     },
     "coco_val": _COCO_TEXTS,
+    # `vg_scale` with the band collapsed away (#3115): the same verified images
+    # under the bare class name, so the same twelve texts serve it.  Without this
+    # entry every `vg_scale_any` cell falls back to the known-good start -- which
+    # is what it silently did until #3278 paired its region arm and the pair's
+    # own guard refused to run, since a pair exists FOR the text sort.
+    "vg_scale_any": dict(_VG_SCALE_TEXTS),
     # The box-size bands are built from the FULL Visual Genome vocabulary, so
     # their categories are VG's, not COCO's.  A band is a property of the cell -
     # someone hunting a small bus and someone hunting a large one both type
@@ -706,6 +712,39 @@ CATEGORY_MODE = os.environ.get("CALIB_CATEGORY_MODE", "").strip().lower()
 #: replaced by the next eligible one instead of shrinking the grid.  0 (the
 #: default) is the behaviour of every run before #3267.
 REQUIRE_SEED_QUERY = os.environ.get("CALIB_REQUIRE_SEED_QUERY", "0") == "1"
+
+
+#: The opening this study **declares**, asserted per cell (#3278).
+#:
+#: Autopilot has two real starts and which one a cell takes is decided silently:
+#: a text sort when the (dataset, category) has a query *and* the embedder's text
+#: half has a tower, three random known-goods otherwise.  Since #3269 the harness
+#: takes the first wherever it can, which means a grid mixing SigLIP and DINOv3
+#: arms now opens two different ways along one axis - the confound
+#: ``lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md``
+#: describes, and the reason :data:`PAIR_SEP` exists.
+#:
+#: Values, all of them a *declaration* rather than a switch - none of them
+#: changes how a cell seeds, only what it is allowed to have seeded from:
+#:
+#: * ``"text"`` - every cell must open on a typed query.  A cell that falls back
+#:   raises instead of running, for the reason the paired-arm guard in
+#:   ``run_cells`` does: a mislabelled cell is invisible where a missing one is
+#:   not.
+#: * ``"known_good"`` - every cell must open on three random known-goods.  This
+#:   is the pin for a study whose subject *is* that flow (or one re-running a
+#:   finished grid that took it), and it fails if an arm silently gains a text
+#:   tower or a query.
+#: * ``"mixed"`` - the grid deliberately holds both openings, e.g. a re-runner
+#:   mirroring a completed study's arms.  Nothing is asserted per cell; the
+#:   declaration is what stops the mix reading as an oversight, and the analyzer
+#:   guard (``_cells_io.assert_one_opening``) is what stops two openings being
+#:   pooled into one number.
+#: * ``""`` (unset) - no assertion, the behaviour of every run before #3278.
+REQUIRE_OPENING = os.environ.get("CALIB_REQUIRE_OPENING", "").strip().lower()
+_OPENINGS = ("", "text", "known_good", "mixed")
+if REQUIRE_OPENING not in _OPENINGS:
+    raise ValueError(f"CALIB_REQUIRE_OPENING={REQUIRE_OPENING!r} is not one of {_OPENINGS[1:]}")
 
 
 def select_categories(

--- a/scripts/experiments/calibration/figures_overview.py
+++ b/scripts/experiments/calibration/figures_overview.py
@@ -34,7 +34,11 @@ from pathlib import Path
 BANDS = ("small", "medium", "large")
 BAND_COLORS = {"small": "#c2410c", "medium": "#0f766e", "large": "#3730a3"}
 MODE_COLORS = {
-    "dinov3_patch/max_patch": "#7c3aed",
+    # The region arm is the SigLIP+DINOv3 pair since #3276; the bare-DINOv3 key
+    # stays so a figure re-made from an older grid keeps its colour and the two
+    # are not confusable across reports.
+    "siglip+dinov3_patch/max_patch": "#7c3aed",
+    "dinov3_patch/max_patch": "#a78bfa",
     "siglip/whole_image": "#0891b2",
     "siglip2_l/whole_image": "#b45309",
 }

--- a/scripts/experiments/calibration/figures_trajectory.py
+++ b/scripts/experiments/calibration/figures_trajectory.py
@@ -1,0 +1,319 @@
+"""Learning curves: how the simulated user's detector improves as they click.
+
+The question these answer is the one a user actually asks — *if I keep voting,
+does this get better, and how fast?* — and it is asked twice, because the two
+readings want different pictures:
+
+1. **Averaged** (``learning_<metric>.png``, and ``_by_band``): one line per arm,
+   the mean over every run on the dataset, with a ±SE ribbon. This is "how does
+   this arm TEND to do", and it is the picture for comparing arms.
+2. **Individual** (``learning_<metric>_runs.png``, and ``_by_band``): one PANEL
+   per arm, every run on the dataset drawn as its own thin line, with the median
+   and the 10–90% band over the top. This is "what actually happens to people",
+   and it is the picture a mean cannot show: an arm whose median is fine and
+   whose bottom decile never leaves the floor fails those users completely.
+
+Splitting the runs into one panel per arm rather than overlaying every arm's
+spaghetti in one is deliberate — at 60 seeds x 36 categories an overlay is 2160
+lines in three hues, which encodes nothing.
+
+Both are drawn per *band* as well, because band is this study's axis: a curve
+pooled over `small`, `medium` and `large` is an average over the very thing the
+grid was built to separate.
+
+Colours, band names and the run-splitting helpers come from
+:mod:`figures_overview` rather than being restated here — an arm's hue has to
+mean the same thing in every figure of the report, and two copies of a colour
+table is how it stops.
+
+Usage::
+
+    python figures_trajectory.py --exp /expscratch/$USER/scale-3156-pair
+    python figures_trajectory.py --exp ... --metric average_precision
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import os
+from collections import defaultdict
+from pathlib import Path
+
+from figures_overview import BANDS, MODE_COLORS, band_of, mean_se
+
+#: Metrics worth a curve, and which direction is good.  ``cost`` is the study's
+#: headline (the harness's operating-point cost); ``average_precision`` is the
+#: ranking's own quality, which is what improves first when the detector learns
+#: something the cut cannot yet exploit.
+METRICS = {
+    "cost": ("detection cost (lower is better)", False),
+    "average_precision": ("average precision (higher is better)", True),
+    "auroc": ("AUROC (higher is better)", True),
+    "oracle_cost": ("oracle cost — the ranking's own limit (lower is better)", False),
+}
+
+
+def load_runs(exp: str, metric: str) -> dict[tuple, list[tuple[int, float]]]:
+    """``(mode, category, seed) -> [(t, value), ...]`` sorted by t.
+
+    Side frames (``task_*__sweep.csv`` and friends) are excluded by the ``__``
+    test, the same guard ``_cells_io.SIDE_FRAME_SUFFIXES`` exists to centralise:
+    they are separate long-format tables and concatenating them yields a ragged
+    frame whose extra rows enter every aggregate silently.
+    """
+    runs: dict[tuple, list[tuple[int, float]]] = defaultdict(list)
+    for path in sorted(glob.glob(str(Path(exp) / "results" / "cells" / "task_*.csv"))):
+        if "__" in Path(path).name:
+            continue
+        try:
+            with open(path, newline="") as fh:
+                for r in csv.DictReader(fh):
+                    try:
+                        t, v = int(r["t"]), float(r[metric])
+                    except (KeyError, ValueError, TypeError):
+                        continue
+                    mode = f"{r.get('embedder', '')}/{r.get('style', '')}".strip("/")
+                    runs[(mode, r["category"], r["seed"])].append((t, v))
+        except (OSError, csv.Error):
+            continue
+    for v in runs.values():
+        v.sort()
+    return runs
+
+
+def value_at(series: list[tuple[int, float]], step: int) -> float | None:
+    """The run's value as of *step*, carried forward from its last recorded row.
+
+    A run does not emit a row at every t — the harness skips steps with too few
+    votes to train — so sampling "the row where t == step" silently drops runs
+    from the average at exactly the steps where runs differ most.  Carrying the
+    last value forward is what a user would see on screen: the detector does not
+    stop existing between votes.
+    """
+    best = None
+    for t, v in series:
+        if t <= step:
+            best = v
+        else:
+            break
+    return best
+
+
+def q(xs: list[float], p: float) -> float:
+    s = sorted(xs)
+    return s[min(len(s) - 1, max(0, int(round(p * (len(s) - 1)))))]
+
+
+def _style_axes(ax, xlabel: str, ylabel: str) -> None:
+    """Hairline, solid, recessive — grid and axes are chrome, not data."""
+    ax.grid(True, color="#e6e4e0", linewidth=0.6, zorder=0)
+    ax.set_axisbelow(True)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+    for side in ("left", "bottom"):
+        ax.spines[side].set_color("#c9c6c1")
+        ax.spines[side].set_linewidth(0.8)
+    ax.tick_params(colors="#57534e", labelsize=8, length=3, width=0.8)
+    ax.set_xlabel(xlabel, fontsize=9, color="#44403c")
+    ax.set_ylabel(ylabel, fontsize=9, color="#44403c")
+
+
+def _subset(runs, modes, band):
+    """Runs restricted to one band, or all of them when *band* is None."""
+    return {k: v for k, v in runs.items() if k[0] in modes and (band is None or band_of(k[1]) == band)}
+
+
+def _mean_curve(runs, mode, steps):
+    """(steps, mean, se, n) for one arm — the ±SE is the mean's own uncertainty."""
+    xs, ms, ses, ns = [], [], [], []
+    for s in steps:
+        vals = [v for k, series in runs.items() if k[0] == mode for v in (value_at(series, s),) if v is not None]
+        if len(vals) < 2:
+            continue
+        m, se = mean_se(vals)
+        xs.append(s)
+        ms.append(m)
+        ses.append(se)
+        ns.append(len(vals))
+    return xs, ms, ses, ns
+
+
+def _stamp(fig, note: str) -> None:
+    """Say so, on the picture, when the data behind it is not the whole run."""
+    if note:
+        fig.text(0.01, 0.005, note, fontsize=7.5, color="#a8a29e", ha="left", va="bottom")
+
+
+def figure_average(
+    runs, modes, steps, out: Path, metric: str, label: str, band: str | None, plt, note: str = ""
+) -> None:
+    """One panel: every arm's mean curve on one axis."""
+    sub = _subset(runs, modes, band)
+    fig, ax = plt.subplots(figsize=(7.4, 4.6))
+    n_by_mode = {}
+    ends: list[tuple[float, float, str]] = []
+    for m in modes:
+        xs, ms, ses, ns = _mean_curve(sub, m, steps)
+        if not xs:
+            continue
+        n_by_mode[m] = max(ns)
+        colour = MODE_COLORS.get(m, "#57534e")
+        ax.fill_between(
+            xs,
+            [a - b for a, b in zip(ms, ses)],
+            [a + b for a, b in zip(ms, ses)],
+            color=colour,
+            alpha=0.18,
+            linewidth=0,
+            zorder=2,
+        )
+        ax.plot(xs, ms, color=colour, linewidth=2.0, zorder=3, label=f"{m}  (n={max(ns)})")
+        ends.append((ms[-1], xs[-1], colour))
+    # Direct-label the endpoints -- three series, so identity never rests on the
+    # legend alone -- but de-collide them first.  Two arms that FINISH IN A TIE
+    # is the most interesting thing this figure can show, and it is exactly the
+    # case where two labels land on the same pixel and render as mush.
+    ends.sort()
+    # The gap has to be a TEXT height, so it is measured against the axis range,
+    # not against the spread of the endpoints. Two arms finishing 0.003 apart is
+    # the interesting case, and scaling the gap by that spread reproduces the
+    # collision it exists to prevent.
+    lo_y, hi_y = ax.get_ylim()
+    gap = (hi_y - lo_y) * 0.038
+    placed: list[float] = []
+    for value, x, colour in ends:
+        y = value
+        while placed and abs(y - placed[-1]) < gap:
+            y = placed[-1] + gap
+        placed.append(y)
+        ax.annotate(
+            f"{value:.2f}",
+            (x, y),
+            xytext=(8, 0),
+            textcoords="offset points",
+            fontsize=8,
+            color=colour,
+            va="center",
+            annotation_clip=False,
+        )
+        if abs(y - value) > 1e-12:
+            # A displaced label needs a leader back to the line it belongs to,
+            # or it reads as a value the curve never had.
+            ax.annotate(
+                "",
+                (x, y),
+                xytext=(x, value),
+                textcoords="data",
+                annotation_clip=False,
+                arrowprops=dict(arrowstyle="-", color=colour, linewidth=0.7, alpha=0.7),
+            )
+    _style_axes(ax, "votes spent (clicks)", label)
+    title = f"How the detector improves with clicking — {band or 'all bands'}"
+    ax.set_title(title, fontsize=11, color="#292524", loc="left", pad=10)
+    ax.legend(frameon=False, fontsize=8, loc="best")
+    fig.tight_layout()
+    _stamp(fig, note)
+    name = f"learning_{metric}{'_' + band if band else ''}.png"
+    fig.savefig(out / name, dpi=160)
+    plt.close(fig)
+    counts = ", ".join(f"{k} n={v}" for k, v in n_by_mode.items())
+    print(f"  wrote {name}  ({counts})")
+
+
+def figure_runs(runs, modes, steps, out: Path, metric: str, label: str, band: str | None, plt, note: str = "") -> None:
+    """One panel per arm: every run, with the median and the 10-90% band."""
+    sub = _subset(runs, modes, band)
+    fig, axes = plt.subplots(1, len(modes), figsize=(4.6 * len(modes), 4.4), sharey=True, sharex=True)
+    if len(modes) == 1:
+        axes = [axes]
+    for ax, m in zip(axes, modes):
+        colour = MODE_COLORS.get(m, "#57534e")
+        series = [v for k, v in sub.items() if k[0] == m]
+        for run in series:
+            xs = [t for t, _ in run]
+            ys = [v for _, v in run]
+            ax.plot(xs, ys, color=colour, linewidth=0.3, alpha=0.05, zorder=2)
+        lo, mid, hi, xs = [], [], [], []
+        for s in steps:
+            vals = [v for run in series for v in (value_at(run, s),) if v is not None]
+            if len(vals) < 2:
+                continue
+            xs.append(s)
+            lo.append(q(vals, 0.10))
+            mid.append(q(vals, 0.50))
+            hi.append(q(vals, 0.90))
+        if xs:
+            # The band has to read THROUGH the spaghetti it summarises, so it
+            # carries hairline edges rather than relying on fill alpha alone,
+            # and the median gets a surface-coloured halo -- the same trick as a
+            # 2px surface ring on overlapping marks.
+            ax.fill_between(xs, lo, hi, color=colour, alpha=0.20, linewidth=0, zorder=3)
+            for edge in (lo, hi):
+                ax.plot(xs, edge, color=colour, linewidth=0.9, alpha=0.85, zorder=4)
+            ax.plot(xs, mid, color="#fcfcfb", linewidth=3.6, zorder=5)
+            ax.plot(xs, mid, color=colour, linewidth=2.0, zorder=6)
+        _style_axes(ax, "votes spent (clicks)", label if ax is axes[0] else "")
+        ax.set_title(f"{m}\n{len(series)} runs", fontsize=9.5, color="#292524", loc="left", pad=8)
+    fig.suptitle(
+        f"Every run, one line each — {band or 'all bands'}  (band = 10–90%, line = median)",
+        fontsize=11,
+        color="#292524",
+        x=0.01,
+        ha="left",
+    )
+    fig.tight_layout(rect=(0, 0.02, 1, 0.94))
+    _stamp(fig, note)
+    name = f"learning_{metric}_runs{'_' + band if band else ''}.png"
+    fig.savefig(out / name, dpi=160)
+    plt.close(fig)
+    print(f"  wrote {name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--exp", default=f"/expscratch/{os.environ.get('USER', 'sgreenberg')}/scale-3156-pair")
+    ap.add_argument("--out", default="")
+    ap.add_argument("--metric", default="cost,average_precision", help="comma-separated; see METRICS")
+    ap.add_argument(
+        "--note",
+        default="",
+        help="stamped on every figure -- use it to say a run is still in flight, "
+        "since a partial figure that looks final is how a preview becomes a fact",
+    )
+    ap.add_argument("--by-band", action="store_true", default=True)
+    ap.add_argument("--no-by-band", dest="by_band", action="store_false")
+    args = ap.parse_args(argv)
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    out = Path(args.out or (Path(args.exp) / "figures"))
+    out.mkdir(parents=True, exist_ok=True)
+
+    for metric in [m.strip() for m in args.metric.split(",") if m.strip()]:
+        label = METRICS.get(metric, (metric, False))[0]
+        runs = load_runs(args.exp, metric)
+        if not runs:
+            print(f"{metric}: no rows under {args.exp}")
+            continue
+        modes = sorted({k[0] for k in runs})
+        seeds = sorted({k[2] for k in runs}, key=lambda s: int(s) if s.isdigit() else s)
+        steps = sorted({t for v in runs.values() for t, _ in v})
+        print(f"{metric}: {len(runs)} runs, {len(modes)} arms, {len(seeds)} seeds present")
+        note = args.note or f"{len(seeds)} seeds present, {len(runs)} runs"
+        figure_average(runs, modes, steps, out, metric, label, None, plt, note)
+        figure_runs(runs, modes, steps, out, metric, label, None, plt, note)
+        if args.by_band:
+            for band in BANDS:
+                if any(band_of(k[1]) == band for k in runs):
+                    figure_average(runs, modes, steps, out, metric, label, band, plt, note)
+                    figure_runs(runs, modes, steps, out, metric, label, band, plt, note)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/launch_acq_region_2905.sh
+++ b/scripts/experiments/calibration/launch_acq_region_2905.sh
@@ -123,7 +123,14 @@ export CALIB_REPOOL_VARIANTS=
 export CALIB_SCHEDULE_VARIANTS=
 export CALIB_MAX_STEPS=100
 export CALIB_N_SEEDS=48   # DECLARED; see the header. The study runs --seeds 24.
-export CALIB_HEAD=linear
+# The head a live detector actually has, because the acquisition offset is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD=linear_svm
 export CALIB_SAFE_THRESHOLDS=1
 export CALIB_ANCHORED=0
 # CALIB_BLEND_SCHEDULE deliberately unset: the run must live under whatever

--- a/scripts/experiments/calibration/launch_acq_region_2905.sh
+++ b/scripts/experiments/calibration/launch_acq_region_2905.sh
@@ -56,12 +56,25 @@
 # `--seeds 24-47` and every cell already on disk still counts — the mistake
 # #2877 could not undo becomes a second submission.
 #
+# "Still counts" is about the INDEX mapping, and it stops at the seeding fix:
+# cells written before #3269 seeded from a crop, and cells written now open on a
+# text sort (see the environment note below), so the two cannot be pooled into
+# one number however stable the indices are.  `_cells_io.assert_one_opening`
+# refuses that pooling at analysis time rather than leaving it to be noticed.
+#
 # A seed's trajectory does not depend on the declared count: `seed` is passed
 # to the simulator directly and the exemplar is `candidates[seed % len]`.  Only
 # the index mapping moves, which is exactly what this pins.
 #
 # Prepare is REUSED (no GPU stage): the dinov3_patch pickle and exemplar crops
-# from the #2861 anchor-rate run, so the categories are the same 23.
+# from the #2861 anchor-rate run, so the categories are the same 23.  The pair
+# reads that same pickle (`pickle_name` resolves the LEARN half) and opens the
+# `visual_genome_m__siglip.pkl` beside it, which that run also embedded.  What
+# it cannot reuse is a prepare_info.json keyed by the old bare name: the grid
+# enumerates by embedder, so a missing key means the arm contributes ZERO cells
+# rather than failing.  Re-run prepare for the paired name -- it reuses the
+# cached pickles, so it costs no encoder time -- and preflight check 15 is what
+# says whether you did.
 #
 # Usage:
 #   bash launch_acq_region_2905.sh --seeds 24                  # the study
@@ -88,8 +101,23 @@ HERE="$WT/scripts/experiments/calibration"
 export CALIB_EXP="${CALIB_EXP:-/home/hltcoe/$USER/experiments/acq-region-2905}"
 
 # --- environment: the one VG arm that genuinely region-votes ---
+# ...as the PAIR `siglip+dinov3_patch` (#3278).  This study has a single
+# environment, so nothing inside it can be confounded -- but its whole purpose
+# is a COMPARISON ACROSS environments: k_acq=-3 ships on COCO-siglip and fails
+# its own rule on VG-siglip, and this run is the third, region-voting reading
+# that decides whether the offset should be gated by voting mode.  The other two
+# were measured on siglip, which since #3269 opens on a typed query; bare
+# `dinov3_patch` has no text tower and would open on three random known-goods,
+# so the environment that breaks the tie would have differed from both of them
+# in two ways at once.  k_acq is an offset applied to a RANK POSITION in the
+# acquisition ranking, which is precisely the object the opening creates.
 export CALIB_DATASETS=visual_genome_m
-export CALIB_VG_EMBEDDERS=dinov3_patch
+export CALIB_VG_EMBEDDERS=siglip+dinov3_patch
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES=max_patch
 export CALIB_REPOOL_VARIANTS=
 export CALIB_SCHEDULE_VARIANTS=

--- a/scripts/experiments/calibration/launch_all.sh
+++ b/scripts/experiments/calibration/launch_all.sh
@@ -15,6 +15,36 @@ HERE="$WT/scripts/experiments/calibration"
 MAXPATCH="/exp/$USER/max-patch"
 export CALIB_EXP="${CALIB_EXP:-/exp/$USER/calibration}"
 export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
+
+# --- the opening every arm of this chain takes (#3278) -----------------------
+# Region voting arrives as the PAIR `siglip+dinov3_patch` rather than bare
+# `dinov3_patch`.  DINOv3 has no text tower, so since #3269 a bare DINOv3 arm
+# opens on three random known-goods while every SigLIP arm opens on a typed
+# query -- an arm-dependent difference, which unlike the seeding fix itself does
+# NOT cancel in a contrast.  This chain's studies all read a patch arm against a
+# whole-image one, so that difference would sit inside their headline axis.
+#
+# `:-` throughout: every wrapper (launch_safe.sh, launch_cut.sh,
+# launch_anchored.sh, launch_folds_2897.sh, launch_tail_2881.sh) sets its own
+# grid before exec'ing this, and each carries the same declaration with its own
+# reason.  These defaults are for `launch_all.sh` run directly, i.e. the #2781
+# study itself.
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip2_l,siglip+dinov3_patch}"
+export CALIB_CALTECH_EMBEDDERS="${CALIB_CALTECH_EMBEDDERS:-siglip,siglip2_l,siglip+dinov3_patch}"
+# The array is submitted from the `cal-launch` grid job below, where no
+# preflight runs, so `run_cells.py`'s per-cell assertion is the enforcement
+# point here; `--export=ALL` is what carries this to it.
+export CALIB_REQUIRE_OPENING="${CALIB_REQUIRE_OPENING:-text}"
+# ...and the other half of that declaration, which pairing makes mandatory rather
+# than tidy: a paired arm has no known-good fallback (falling back would run bare
+# `dinov3_patch` under the pair's name, so `run_cells.py` raises instead), and
+# category selection here runs over the dataset's FULL vocabulary while the query
+# tables cover part of it.  `CALIB_REQUIRE_SEED_QUERY=1` filters the ineligible
+# categories out BEFORE selection, so each is replaced by the next eligible one
+# rather than shrinking the grid.  It does move the selected set: that is the
+# price of every cell opening the way a user would, and the alternative is cells
+# that die one at a time deep inside the array.
+export CALIB_REQUIRE_SEED_QUERY="${CALIB_REQUIRE_SEED_QUERY:-1}"
 # Reuse the Max-Patch datadir (demo data + embeddings pickles + models) directly;
 # siglip_l pickles land alongside them, harmlessly.
 export VTSEARCH_DATA_DIR="${VTSEARCH_DATA_DIR:-$MAXPATCH/datadir}"
@@ -24,7 +54,8 @@ LOGS="$CALIB_EXP/logs"
 mkdir -p "$LOGS" "$CALIB_RESULTS/crops" "$CALIB_RESULTS/cells"
 
 # --- Symlink the reusable Max-Patch crops (embeddings pickles are read in place
-# from the shared datadir). ---
+# from the shared datadir).  A paired arm's crops are its LEARN half's
+# (`crops_basename` resolves it), so these names are unchanged by #3278. ---
 for base in visual_genome_m__siglip__crops visual_genome_m__dinov3_patch__crops; do
   for ext in npz json; do
     src="$MAXPATCH/results/crops/$base.$ext"

--- a/scripts/experiments/calibration/launch_anchored.sh
+++ b/scripts/experiments/calibration/launch_anchored.sh
@@ -26,9 +26,14 @@ export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 export CALIB_SAFE_THRESHOLDS=1
 export CALIB_ANCHORED=1
 export CALIB_ANALYZE=analyze_anchored.py
-# The head the live detector ships since #2790/#2809 - the estimator is only
-# worth measuring on the model users actually get.
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because the anchored estimator is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 
 # Visual Genome region voting; production patch arm + single-vector control.
 # The region arm is the PAIR `siglip+dinov3_patch` (#3278): the anchored

--- a/scripts/experiments/calibration/launch_anchored.sh
+++ b/scripts/experiments/calibration/launch_anchored.sh
@@ -31,8 +31,25 @@ export CALIB_ANALYZE=analyze_anchored.py
 export CALIB_HEAD="${CALIB_HEAD:-linear}"
 
 # Visual Genome region voting; production patch arm + single-vector control.
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278): the anchored
+# estimator is characterised HERE against the whole-image control, and bare
+# `dinov3_patch` cannot open the way that control does -- no text tower means
+# three random known-goods where the control gets a typed query.  An anchored
+# mixture is fitted to the score distribution the votes produce, and the opening
+# is what produces the first of them, so a per-mode reading of this study would
+# have been part voting mode and part start.  The pair holds the opening fixed
+# and leaves the geometry as the only difference.
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+# Asserted per cell by run_cells.py, and by preflight check 14 wherever this
+# chain reaches a preflight with prepare already staged.  `launch_all.sh`
+# submits the array from a grid job, so the per-cell guard is the one that
+# always runs; --export=ALL carries this to it.
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 # No raw-patch tree arm -> nothing to re-pool.
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"

--- a/scripts/experiments/calibration/launch_bench.sh
+++ b/scripts/experiments/calibration/launch_bench.sh
@@ -25,9 +25,40 @@ export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
 # --- the grid (sizing only) ------------------------------------------------
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m,caltech101_m,coco_val}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip2_l,dinov3_patch}"
-export CALIB_CALTECH_EMBEDDERS="${CALIB_CALTECH_EMBEDDERS:-siglip,siglip2_l,dinov3_patch}"
-export CALIB_COCO_EMBEDDERS="${CALIB_COCO_EMBEDDERS:-siglip,siglip2_l,dinov3_patch}"
+# The region arm is the PAIR `siglip+dinov3_patch`, not bare `dinov3_patch`
+# (#3278).  DINOv3 has no text tower, so on its own it opens on three random
+# known-goods while both SigLIP arms open on a typed query -- and this benchmark
+# reads its three arms SIDE BY SIDE per dataset, which is precisely where an
+# arm-dependent difference in the opening stops cancelling.  The pair holds the
+# opening fixed (SigLIP ranks the query for every arm) and lets the arms differ
+# only in what the detector learns in, which is the axis being reported.
+#
+# The honest caveat, because this study's charter is "what does a current
+# VTSearch user get?": the app cannot pair two spaces today (#3276 "Not in
+# scope"), so a real user with a DINOv3 detector *does* get the known-good
+# start.  The paired arm therefore prices REGION VOTING rather than today's
+# DINOv3 flow end to end.  That is the right trade for a table whose rows are
+# compared against each other -- the alternative measures voting mode and
+# opening at once and can separate neither -- but it is a divergence, not a
+# default, which is why it is written down here.
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip2_l,siglip+dinov3_patch}"
+export CALIB_CALTECH_EMBEDDERS="${CALIB_CALTECH_EMBEDDERS:-siglip,siglip2_l,siglip+dinov3_patch}"
+export CALIB_COCO_EMBEDDERS="${CALIB_COCO_EMBEDDERS:-siglip,siglip2_l,siglip+dinov3_patch}"
+# One declaration, two enforcement points: preflight check 14 refuses the array
+# if any selected cell would take the other start, and run_cells.py raises on a
+# cell that did.  Either alone leaves a hole -- preflight cannot see a cell that
+# resumes months later, and a per-cell raise costs a queue slot per cell.
+export CALIB_REQUIRE_OPENING=text
+# ...and the other half of that declaration, which pairing makes mandatory rather
+# than tidy: a paired arm has no known-good fallback (falling back would run bare
+# `dinov3_patch` under the pair's name, so `run_cells.py` raises instead), and
+# category selection here runs over the dataset's FULL vocabulary while the query
+# tables cover part of it.  `CALIB_REQUIRE_SEED_QUERY=1` filters the ineligible
+# categories out BEFORE selection, so each is replaced by the next eligible one
+# rather than shrinking the grid.  It does move the selected set: that is the
+# price of every cell opening the way a user would, and the alternative is cells
+# that die one at a time deep inside the array.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_N_SEEDS="${CALIB_N_SEEDS:-3}"
 export CALIB_N_PER_BAND="${CALIB_N_PER_BAND:-2}"
 export CALIB_N_CATEGORIES="${CALIB_N_CATEGORIES:-6}"
@@ -67,6 +98,10 @@ ENVX="$ENVX VTS_REPO=$VTS_REPO"
 ENVX="$ENVX CALIB_DATASETS=$CALIB_DATASETS"
 ENVX="$ENVX CALIB_VG_EMBEDDERS=$CALIB_VG_EMBEDDERS CALIB_CALTECH_EMBEDDERS=$CALIB_CALTECH_EMBEDDERS"
 ENVX="$ENVX CALIB_COCO_EMBEDDERS=$CALIB_COCO_EMBEDDERS"
+# Named explicitly for the same reason CALIB_PATCH_STYLES is below: it decides
+# what the run is allowed to have measured, so it must not depend on the
+# submitting shell's environment surviving into the job.
+ENVX="$ENVX CALIB_REQUIRE_OPENING=$CALIB_REQUIRE_OPENING CALIB_REQUIRE_SEED_QUERY=$CALIB_REQUIRE_SEED_QUERY"
 ENVX="$ENVX CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_N_PER_BAND=$CALIB_N_PER_BAND"
 ENVX="$ENVX CALIB_N_CATEGORIES=$CALIB_N_CATEGORIES CALIB_MAX_STEPS=$CALIB_MAX_STEPS"
 ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="

--- a/scripts/experiments/calibration/launch_cut.sh
+++ b/scripts/experiments/calibration/launch_cut.sh
@@ -34,7 +34,19 @@ export CALIB_HEAD="${CALIB_HEAD:-linear}"
 # The control is not decoration here: `calculate_gmm_threshold` also backs the
 # cosine/text sort, so a winning rule has to not regress the no-max-pool geometry.
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278).  A cut rule is a
+# statement about a score distribution, and the control above is here because
+# `calculate_gmm_threshold` also backs the cosine/text sort -- so the two arms
+# have to differ in the pooling geometry and in NOTHING ELSE.  Bare
+# `dinov3_patch` has no text tower and would open on three random known-goods
+# against the control's typed query, which moves the early score distribution
+# the 6-20-vote window is entirely about.
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 # No raw-patch tree arm -> nothing to re-pool.
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"

--- a/scripts/experiments/calibration/launch_cut.sh
+++ b/scripts/experiments/calibration/launch_cut.sh
@@ -26,9 +26,14 @@ export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
 export CALIB_SAFE_THRESHOLDS=1
 export CALIB_ANALYZE=analyze_cut.py
-# The head the live detector ships since #2790/#2809 - the cut's authority is
-# only worth measuring on the model users actually get.
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because the cut's authority is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 
 # Visual Genome region voting only; production patch arm + single-vector control.
 # The control is not decoration here: `calculate_gmm_threshold` also backs the

--- a/scripts/experiments/calibration/launch_errdump.sh
+++ b/scripts/experiments/calibration/launch_errdump.sh
@@ -16,6 +16,25 @@
 # The profile must reproduce the source run's grid exactly, because the index
 # is a position in an enumerated list.  A profile that sets a different dataset
 # or embedder list silently dumps a DIFFERENT cell under the tag you asked for.
+#
+# THE OPENING IS PINNED BY THAT, NOT CHOSEN (#3278).  Sixteen launchers carried
+# a bare `dinov3_patch` arm that opens on three random known-goods where every
+# SigLIP arm opens on a typed query; most of them are now the pair
+# `siglip+dinov3_patch`, which holds the opening fixed across the arms of one
+# study.  These profiles are not a study.  They re-run named cells of a
+# COMPLETED grid, against that grid's own `prepare_info.json` by symlink -- and
+# prepare_info is keyed by embedder name, so renaming an arm here drops it from
+# the enumeration entirely (zero categories -> zero cells) and every index after
+# it means a different cell.  So each profile keeps its source run's arms
+# verbatim, and each declares what it therefore gets: `CALIB_REQUIRE_OPENING`
+# is `mixed` for the two profiles whose source grid holds both openings and
+# `known_good` for the all-DINOv3 `binary` one.  Change a profile only when its
+# SOURCE run is re-launched with a new grid, and change it to match.
+#
+# One thing the source runs no longer promise: a cell re-run today opens on a
+# text sort wherever it can (#3269), while the wave1/vgbox/binary runs on disk
+# were crop-seeded.  A dump is therefore a reading of the same CELL, not a replay
+# of the same TRAJECTORY, until the source grid is re-run.
 set -euo pipefail
 
 WT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -37,6 +56,9 @@ case "$PROFILE" in
 text) ;;  # resolved below, after the source run is known
 wave1)
   SRC=/expscratch/$USER/bench-overview
+  # Both openings, because the source grid holds SigLIP arms (typed query) and a
+  # bare DINOv3 arm (three random known-goods) side by side.
+  OPENING=mixed
   GRID="CALIB_DATASETS=visual_genome_m,caltech101_m,coco_val"
   GRID="$GRID CALIB_VG_EMBEDDERS=siglip,siglip2_l,dinov3_patch"
   GRID="$GRID CALIB_CALTECH_EMBEDDERS=siglip,siglip2_l,dinov3_patch"
@@ -46,6 +68,7 @@ wave1)
   ;;
 vgbox)
   SRC=/expscratch/$USER/bench-vgbox2
+  OPENING=mixed
   GRID="CALIB_DATASETS=vg_box_small,vg_box_medium,vg_box_large"
   GRID="$GRID CALIB_VGBOX_EMBEDDERS=siglip,siglip2_l,dinov3_patch"
   GRID="$GRID CALIB_N_SEEDS=3 CALIB_N_CATEGORIES=10"
@@ -55,6 +78,10 @@ binary)
   # The box-averse arm: dinov3_patch forced through the whole-image style, so
   # the only difference from its boxed twin is whether a box is dragged.
   SRC=/expscratch/$USER/bench-binary
+  # This one IS uniform: every arm is bare DINOv3, so every cell takes the
+  # known-good start.  Pinned rather than left implicit, so a future edit that
+  # pairs an arm here fails instead of quietly re-seeding a dump.
+  OPENING=known_good
   GRID="CALIB_DATASETS=visual_genome_m,coco_val"
   GRID="$GRID CALIB_VG_EMBEDDERS=dinov3_patch CALIB_COCO_EMBEDDERS=dinov3_patch"
   GRID="$GRID CALIB_N_SEEDS=3 CALIB_N_PER_BAND=2 CALIB_N_CATEGORIES=6"
@@ -98,6 +125,11 @@ ENVX="export CALIB_EXP=$EXP CALIB_RESULTS=$EXP/results"
 ENVX="$ENVX VTSEARCH_DATA_DIR=$VTSEARCH_DATA_DIR VTSEARCH_MODELS_DIR=$VTSEARCH_MODELS_DIR HF_HOME=$HF_HOME"
 ENVX="$ENVX VTS_REPO=$WT"
 ENVX="$ENVX $GRID CALIB_MAX_STEPS=150"
+# Declared, not inherited (#3278).  A mirrored grid that holds a text-seeded
+# SigLIP arm and a known-good-seeded DINOv3 arm at once is `mixed` -- neither
+# uniform assertion is true of it, and saying so keeps `run_cells.py` from
+# raising on a cell that is doing exactly what was asked.
+ENVX="$ENVX CALIB_REQUIRE_OPENING=$OPENING"
 ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
 ENVX="$ENVX VTS_DUMP_TEST_SCORES=$DUMP"
 

--- a/scripts/experiments/calibration/launch_folds_2897.sh
+++ b/scripts/experiments/calibration/launch_folds_2897.sh
@@ -30,11 +30,18 @@ set -uo pipefail
 export CALIB_EXP="${CALIB_EXP:-/exp/$USER/calibration-folds-2897}"
 export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
-# The shipped path: safe thresholds on, production linear head.  The fold count
+# The shipped path: safe thresholds on, the production head.  The fold count
 # is a knob on the cross-calibration term, but what a user gets is that term
 # after the blend, so both arms are emitted per K (folds_k{K}_xcal / _blend).
 export CALIB_SAFE_THRESHOLDS="${CALIB_SAFE_THRESHOLDS:-1}"
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because regret(K) is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 export CALIB_BLEND_SCHEDULE="${CALIB_BLEND_SCHEDULE:-prod}"
 export CALIB_ANALYZE=analyze_folds_2897.py
 

--- a/scripts/experiments/calibration/launch_folds_2897.sh
+++ b/scripts/experiments/calibration/launch_folds_2897.sh
@@ -53,9 +53,23 @@ export CALIB_CALIBRATE_COUNT="${CALIB_CALIBRATE_COUNT:-2}"
 # the Kmax fold budget goes into seeds and steps instead of arms.  The region
 # side additionally runs the production patch arm, which is where the bag-aware
 # calibrator (and its much smaller effective calibration set) lives.
+# The region side is the PAIR `siglip+dinov3_patch` (#3278).  This study reports
+# per voting mode because the calibrators differ (bag-aware vs row-wise), and
+# with bare `dinov3_patch` the region side would also have been the only side
+# opening on three random known-goods -- DINOv3 has no text tower.  regret(K) is
+# read across the cold start, where the calibration set is a handful of scores
+# and therefore most sensitive to which items the opening put in front of the
+# user, so the difference lands squarely inside the deliverable.
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m,caltech101_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
 export CALIB_CALTECH_EMBEDDERS="${CALIB_CALTECH_EMBEDDERS:-siglip}"
+# The preflight below runs BEFORE prepare (this is a full chain), so check 14
+# reports itself skipped there and run_cells.py is what asserts this per cell.
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
 

--- a/scripts/experiments/calibration/launch_folds_3115.sh
+++ b/scripts/experiments/calibration/launch_folds_3115.sh
@@ -114,7 +114,22 @@ export CALIB_CALIBRATE_COUNT=2
 # dataset collapsed, so there is no scale axis left to stratify on.  With 12
 # categories of identical count, `prevalence` mode returns all of them.
 export CALIB_DATASETS="${CALIB_DATASETS:-vg_scale_any}"
-export CALIB_VGSCALE_EMBEDDERS="${CALIB_VGSCALE_EMBEDDERS:-siglip,dinov3_patch}"
+# The region half is the PAIR `siglip+dinov3_patch` (#3278).  This grid exists
+# to SEPARATE the embedder from the voting mode -- `siglip/whole` vs
+# `dinov3/whole` is the embedder at fixed mode, `dinov3/whole` vs
+# `dinov3/max_patch` is the mode at fixed embedder -- and bare `dinov3_patch`
+# would have put a third axis through both of them: DINOv3 has no text tower, so
+# every DINOv3 cell (in EITHER style) opens on three random known-goods while
+# every SigLIP cell opens on a typed query.  The first contrast would then be
+# "embedder AND opening" and the second would be clean, which is worse than both
+# being dirty because only one of them looks confounded.  With the pair all four
+# corners open on the same SigLIP text sort of the same 12 classes.
+export CALIB_VGSCALE_EMBEDDERS="${CALIB_VGSCALE_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_CATEGORY_MODE="${CALIB_CATEGORY_MODE:-prevalence}"
 export CALIB_N_CATEGORIES="${CALIB_N_CATEGORIES:-12}"
 # BOTH styles on the patch embedder, which is what breaks the mode-vs-embedder
@@ -295,7 +310,7 @@ case "$MODE" in
       # class has exactly 300 - so it is a tripwire for a future edit that
       # repoints the run at a thinner dataset, not a constraint on this one.
       bash "$WT/scripts/experiments/preflight.sh" --exp "$CALIB_EXP" --need-gb 20 \
-        --require-region-voting vg_scale_any:dinov3_patch \
+        --require-region-voting vg_scale_any:siglip+dinov3_patch \
         --require-min-positives 100 \
         --contrasts-voting-modes \
         --job-name cal-cells --mem "$CALIB_MEM" --conc "$CALIB_CONC" || {

--- a/scripts/experiments/calibration/launch_horizon.sh
+++ b/scripts/experiments/calibration/launch_horizon.sh
@@ -14,6 +14,23 @@
 # the check, because "the same cells, longer" is a premise worth asserting rather
 # than assuming.
 #
+# That premise is also why the arms here are NOT paired (#3278).  Most launchers
+# with a bare `dinov3_patch` arm now run `siglip+dinov3_patch`, so that every arm
+# of one study opens the same way; this is not a study but a continuation of one,
+# read against cells the source run already wrote.  Its grid is keyed to that
+# run's `prepare_info.json` (renaming an arm drops it from the enumeration and
+# shifts every later index), so each profile keeps the source's arms verbatim and
+# declares the mix with `CALIB_REQUIRE_OPENING` instead.  Re-pair a profile only
+# when its SOURCE study is re-launched paired.
+#
+# Note the bit-for-bit claim has a seam of its own: cells re-run today open on a
+# text sort wherever they can (#3269), and the runs on disk were crop-seeded.  So
+# until a source grid is re-run, `status`'s reproduction check is comparing across
+# that fix and will not match -- the horizon run is the same CELLS, not the same
+# trajectory.  Its own cells stay internally consistent (they land in this
+# profile's results dir, not the source's), which is what keeps
+# `_cells_io.assert_one_opening` quiet about them.
+#
 # Per-step cost RISES with the vote count (each Good vote adds patch rows to the
 # training set): measured at 3.7 s/step early against 7.3 s/step at vote 150 for a
 # patch cell, so a horizon extension is superlinear in wall time and has to be
@@ -38,6 +55,9 @@ profile_env() {
   case "$1" in
   wave1)
     SRC=/expscratch/$USER/bench-overview
+    # Both openings: SigLIP arms take a typed query, the bare DINOv3 arm takes
+    # three random known-goods.  Declared so the mix reads as the mirror it is.
+    OPENING=mixed
     GRID="CALIB_DATASETS=visual_genome_m,caltech101_m,coco_val"
     GRID="$GRID CALIB_VG_EMBEDDERS=siglip,siglip2_l,dinov3_patch"
     GRID="$GRID CALIB_CALTECH_EMBEDDERS=siglip,siglip2_l,dinov3_patch"
@@ -47,6 +67,7 @@ profile_env() {
     ;;
   vgbox)
     SRC=/expscratch/$USER/bench-vgbox2
+    OPENING=mixed
     GRID="CALIB_DATASETS=vg_box_small,vg_box_medium,vg_box_large"
     GRID="$GRID CALIB_VGBOX_EMBEDDERS=siglip,siglip2_l,dinov3_patch"
     GRID="$GRID CALIB_N_SEEDS=3 CALIB_N_CATEGORIES=10"
@@ -54,6 +75,10 @@ profile_env() {
     ;;
   binary)
     SRC=/expscratch/$USER/bench-binary
+    # Uniform: every arm is bare DINOv3, so every cell takes the known-good
+    # start.  Pinned, so pairing an arm here fails instead of re-seeding a
+    # continuation of cells that started the other way.
+    OPENING=known_good
     GRID="CALIB_DATASETS=visual_genome_m,coco_val"
     GRID="$GRID CALIB_VG_EMBEDDERS=dinov3_patch CALIB_COCO_EMBEDDERS=dinov3_patch"
     GRID="$GRID CALIB_N_SEEDS=3 CALIB_N_PER_BAND=2 CALIB_N_CATEGORIES=6"
@@ -68,6 +93,7 @@ profile_env() {
   ENVX="$ENVX VTSEARCH_DATA_DIR=$VTSEARCH_DATA_DIR VTSEARCH_MODELS_DIR=$VTSEARCH_MODELS_DIR HF_HOME=$HF_HOME"
   ENVX="$ENVX VTS_REPO=$WT $GRID CALIB_MAX_STEPS=$HORIZON"
   ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
+  ENVX="$ENVX CALIB_REQUIRE_OPENING=$OPENING"
 }
 
 link_prepare() {

--- a/scripts/experiments/calibration/launch_incl_2865.sh
+++ b/scripts/experiments/calibration/launch_incl_2865.sh
@@ -65,9 +65,22 @@ export CALIB_ANALYZE=analyze_cutincl.py
 # it is the shipped default embedder.
 # Order matters: the array enumerates dataset -> embedder -> category -> seed,
 # so the long dinov3 arms are listed first and start in the first wave.
+#
+# Both region arms are the PAIR `siglip+dinov3_patch` (#3278).  The ship rule
+# above is a CROSS-MODE one -- a rule that restores the knob on region voting
+# while wrecking binary voting is not shippable -- so the two modes have to be
+# comparable, and bare `dinov3_patch` is not: with no text tower it opens on
+# three random known-goods while both siglip arms open on a typed query.  The
+# knob is a cost weight applied to a cut, so its measured effect rides on the
+# score distribution the opening starts building.
 export CALIB_DATASETS=visual_genome_m,coco_val
-export CALIB_VG_EMBEDDERS=dinov3_patch,siglip
-export CALIB_COCO_EMBEDDERS=dinov3_patch,siglip
+export CALIB_VG_EMBEDDERS=siglip+dinov3_patch,siglip
+export CALIB_COCO_EMBEDDERS=siglip+dinov3_patch,siglip
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 # `max_patch` only: it *is* the production patch pipeline.  The HAC hybrids are
 # experiment-only arms and #2886 removed the tree from ingest, so scoring them
 # here would double the run to price geometry no user gets.
@@ -186,7 +199,7 @@ case "$MODE" in
     # is a REQUEST, and a boxed dataset on a single-vector embedder silently runs
     # binary (#2877).  Preflight takes one arm at a time, so it runs twice.
     if [[ -x "$WT/scripts/experiments/preflight.sh" ]]; then
-      for arm in visual_genome_m:dinov3_patch coco_val:dinov3_patch; do
+      for arm in visual_genome_m:siglip+dinov3_patch coco_val:siglip+dinov3_patch; do
         # No `--diverges`: this run pins nothing off-production.  The cut rule
         # is the axis it sweeps, and the shipped rule is one of the arms, so
         # even that is not a divergence - it is a comparison.

--- a/scripts/experiments/calibration/launch_mixin.sh
+++ b/scripts/experiments/calibration/launch_mixin.sh
@@ -38,8 +38,20 @@ LOGS="$CALIB_EXP/logs"; mkdir -p "$LOGS"
 
 # --- the pre-registered grid (identical across both phases) ---
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m,coco_val}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278).  #2841 explicitly
+# allows region and binary voting to want DIFFERENT mix-in curves, so the
+# per-mode split is the deliverable rather than a slice of it -- and bare
+# `dinov3_patch` would have made "region" mean "region voting AND a known-good
+# start", since DINOv3 has no text tower.  The mix-in schedule governs the first
+# ~20 votes, which is the stretch the opening determines, so the two would not
+# have been separable afterwards.
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
 export CALIB_COCO_EMBEDDERS="${CALIB_COCO_EMBEDDERS:-siglip,siglip2}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 # Tree-free MaxPatch only: #2749 shipped it and dropped the HAC tree, so the
 # HAC styles would measure a path no user is on.
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
@@ -61,7 +73,8 @@ BASE_ENV="export VTS_REPO=$WT CALIB_EXP=$CALIB_EXP \
 CALIB_DATASETS=$CALIB_DATASETS CALIB_VG_EMBEDDERS=$CALIB_VG_EMBEDDERS \
 CALIB_COCO_EMBEDDERS=$CALIB_COCO_EMBEDDERS CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES \
 CALIB_SAFE_THRESHOLDS=1 CALIB_HEAD=$CALIB_HEAD CALIB_MAX_STEPS=$CALIB_MAX_STEPS \
-CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_SWEEP_KS=$CALIB_SWEEP_KS"
+CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_SWEEP_KS=$CALIB_SWEEP_KS \
+CALIB_REQUIRE_OPENING=$CALIB_REQUIRE_OPENING CALIB_REQUIRE_SEED_QUERY=$CALIB_REQUIRE_SEED_QUERY"
 
 cell_count() {
   local envx="$1"

--- a/scripts/experiments/calibration/launch_mixin.sh
+++ b/scripts/experiments/calibration/launch_mixin.sh
@@ -56,7 +56,14 @@ export CALIB_REQUIRE_SEED_QUERY=1
 # HAC styles would measure a path no user is on.
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 export CALIB_SAFE_THRESHOLDS=1
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because the mix-in schedule's effect is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-30}"
 export CALIB_N_SEEDS="${CALIB_N_SEEDS:-12}"
 export CALIB_SWEEP_KS="${CALIB_SWEEP_KS:-0}"

--- a/scripts/experiments/calibration/launch_rate_2861.sh
+++ b/scripts/experiments/calibration/launch_rate_2861.sh
@@ -36,8 +36,19 @@ export CALIB_HEAD=linear
 # Six environments.  Order matters: the array is enumerated
 # dataset -> embedder -> category -> seed, so the LONG arm (VG dinov3 max_patch,
 # ~75 min/cell) is listed first and starts in the first concurrency wave.
+# The region environment is the PAIR `siglip+dinov3_patch` (#3278).  "kappa* is
+# stable across six environments" is a claim about ENVIRONMENTS, so an
+# environment has to differ from its neighbours in the things that name it --
+# dataset, embedder, voting mode -- and not also in how the run started.  Bare
+# `dinov3_patch` has no text tower, which would have made the single region
+# environment the only one of the six opening on three random known-goods.
 export CALIB_DATASETS=visual_genome_m,coco_val,caltech101_m
-export CALIB_VG_EMBEDDERS=dinov3_patch,siglip
+export CALIB_VG_EMBEDDERS=siglip+dinov3_patch,siglip
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_COCO_EMBEDDERS=siglip,siglip2
 export CALIB_CALTECH_EMBEDDERS=siglip,siglip_l
 export CALIB_PATCH_STYLES=max_patch

--- a/scripts/experiments/calibration/launch_rate_2861.sh
+++ b/scripts/experiments/calibration/launch_rate_2861.sh
@@ -31,7 +31,14 @@ export CALIB_RESULTS="$CALIB_EXP/results"
 export CALIB_SAFE_THRESHOLDS=1
 export CALIB_ANCHORED=1
 export CALIB_ANALYZE=analyze_anchored.py
-export CALIB_HEAD=linear
+# The head a live detector actually has, because kappa*'s stability is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD=linear_svm
 
 # Six environments.  Order matters: the array is enumerated
 # dataset -> embedder -> category -> seed, so the LONG arm (VG dinov3 max_patch,

--- a/scripts/experiments/calibration/launch_safe.sh
+++ b/scripts/experiments/calibration/launch_safe.sh
@@ -22,8 +22,20 @@ export CALIB_ANALYZE=analyze_safe.py
 export CALIB_HEAD="${CALIB_HEAD:-linear}"
 
 # Visual Genome region voting only; production patch arm + single-vector control.
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278).  The control is what
+# says a winning GMM variant does not regress the no-max-pool geometry, and a
+# control that opens differently from the arm it controls is not one: DINOv3 has
+# no text tower, so bare `dinov3_patch` starts on three random known-goods while
+# the SigLIP control starts on a typed query.  The blend this study measures has
+# authority only in the first ~20 votes, which is exactly the stretch the
+# opening determines.
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 # No raw-patch tree arm -> nothing to re-pool.
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"

--- a/scripts/experiments/calibration/launch_safe.sh
+++ b/scripts/experiments/calibration/launch_safe.sh
@@ -17,9 +17,14 @@ export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
 export CALIB_SAFE_THRESHOLDS=1
 export CALIB_ANALYZE=analyze_safe.py
-# The head the live detector ships since #2790/#2809 - the blend's authority is
-# only worth measuring on the model users actually get.
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because the blend's authority is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 
 # Visual Genome region voting only; production patch arm + single-vector control.
 # The region arm is the PAIR `siglip+dinov3_patch` (#3278).  The control is what

--- a/scripts/experiments/calibration/launch_safe_ab.sh
+++ b/scripts/experiments/calibration/launch_safe_ab.sh
@@ -46,7 +46,14 @@ export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
 export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-30}"
 export CALIB_N_SEEDS="${CALIB_N_SEEDS:-8}"
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because a ship/no-ship decision is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 # The inclusion-budget sweep is #2781's question, not this one: keep one k so
 # the side CSVs stay tiny (/exp is a shared 50G volume).
 export CALIB_SWEEP_KS="${CALIB_SWEEP_KS:-0}"

--- a/scripts/experiments/calibration/launch_safe_ab.sh
+++ b/scripts/experiments/calibration/launch_safe_ab.sh
@@ -29,8 +29,19 @@ export CALIB_AB_OFF_EXP="${CALIB_AB_OFF_EXP:-/exp/$USER/calibration-off-linear}"
 # Shared pre-registered knobs.
 # Visual Genome region voting only: the production max_patch arm plus a
 # single-vector whole_image control.
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278).  The ON/OFF pairing
+# is per (arm, category, seed) and would survive any opening, but the deployment
+# question this answers -- "should safe_thresholds be forced on for EVERY
+# user?" -- is answered by reading the region arm against the whole-image
+# control, and bare `dinov3_patch` cannot open the way that control does (no
+# text tower, so three random known-goods against the control's typed query).
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
 export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-30}"
@@ -65,7 +76,8 @@ CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES CALIB_REPOOL_VARIANTS='$CALIB_REPOOL_VARI
 CALIB_MAX_STEPS=$CALIB_MAX_STEPS CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_HEAD=$CALIB_HEAD \
 CALIB_SWEEP_KS=$CALIB_SWEEP_KS VTSEARCH_DATA_DIR=$VTSEARCH_DATA_DIR \
 VTSEARCH_MODELS_DIR=$VTSEARCH_MODELS_DIR HF_HOME=$HF_HOME \
-CALIB_AB_ON_EXP=$CALIB_AB_ON_EXP CALIB_AB_OFF_EXP=$CALIB_AB_OFF_EXP VTS_REPO=$WT"
+CALIB_AB_ON_EXP=$CALIB_AB_ON_EXP CALIB_AB_OFF_EXP=$CALIB_AB_OFF_EXP VTS_REPO=$WT \
+CALIB_REQUIRE_OPENING=$CALIB_REQUIRE_OPENING CALIB_REQUIRE_SEED_QUERY=$CALIB_REQUIRE_SEED_QUERY"
 
 # --- Stage 0: prepare, once, into the ON run's results dir (the OFF run copies
 # its prepare_info.json so both enumerate the identical cells). ---

--- a/scripts/experiments/calibration/launch_scale.sh
+++ b/scripts/experiments/calibration/launch_scale.sh
@@ -106,13 +106,18 @@ mkdir -p "$LOGS" "$CALIB_RESULTS/cells"
 #   measured 5.02G AND is preflight check 7b's floor for patch cells, which
 #   exists because UNDER-sizing killed 74 of 108 cells in #3156.
 #
-# CONC 85 sits just under both caps (170 CPUs, 1020G) with margin for the
-# whole-image cells, which need 0.5G and hold a 12G slot regardless.
+# CONC is then bounded by preflight check 8, not by the raw cap: an array may
+# claim at most 90% of the ~1074G allowance before your OWN later jobs -- the
+# analyzer, a `redo`, a diagnostic -- start queueing behind it in
+# QOSMaxMemoryPerUser. 85 asks for 1020G (95%) and is refused, correctly; 70
+# asks for 840G (78%, 140 CPUs) and leaves 234G free for exactly those jobs.
+# Note the whole-image cells hold a 12G slot while needing 0.5G, which is the
+# price of running one array over a grid with two cost classes.
 MEM="${CALIB_MEM:-12G}"
 CPUS="${CALIB_CPUS:-2}"
 TIME="${CALIB_TIME:-6:00:00}"
 PARTITION="${CALIB_PARTITION:-cpu}"
-CONC="${CALIB_CONC:-85}"
+CONC="${CALIB_CONC:-70}"
 JOB_NAME="${CALIB_JOB_NAME:-scale-$(basename "$CALIB_EXP")}"
 
 ENVX="export CALIB_EXP=$CALIB_EXP CALIB_RESULTS=$CALIB_RESULTS"

--- a/scripts/experiments/calibration/launch_scale.sh
+++ b/scripts/experiments/calibration/launch_scale.sh
@@ -29,22 +29,38 @@ export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
 export CALIB_DATASETS="${CALIB_DATASETS:-vg_scale}"
 # siglip is the shipped default and votes binary; siglip2_l is the premium
-# whole-image end; dinov3_patch is the only patch-capable embedder in the pile
-# and is what makes region voting real.
+# whole-image end; the region arm is the PAIR `siglip+dinov3_patch` -- DINOv3
+# supplies the patch grid that makes region voting real, SigLIP supplies the
+# text sort the run opens on.
 #
-# All three cells are already embedded in the pile, so a column costs training
-# and inference only -- no encoder time. And the encoder here is a BLOCKING
-# factor, not the contrast: the question is whether the band effect holds
-# across encoders, so a second whole-image encoder replicates the finding
-# rather than competing with the first. ("siglip vs siglip2_l is unresolvable
-# on cost at three seeds" is a fact about comparing the two encoders, and says
-# nothing about whether each one shows the same size penalty.)
-export CALIB_VGSCALE_EMBEDDERS="${CALIB_VGSCALE_EMBEDDERS:-siglip,siglip2_l,dinov3_patch}"
+# Bare `dinov3_patch` was the region arm until #3276 and it could not open the
+# way the app does: DINOv3 has no text tower, so its cells fell back to the
+# three-random-known-goods start while both whole-image arms opened on a typed
+# query. The study's headline axis is VOTING MODE, and a seeding difference sat
+# inside it -- an arm-dependent difference, so unlike the #3156 seeding fix it
+# does not cancel in a contrast. The pair removes it: all three arms now open on
+# the same SigLIP text sort of the same 7749 medias, and only the space the
+# detector learns in differs.
+#
+# All three columns are already embedded in the pile, so a column costs training
+# and inference only -- no encoder time; the pair adds one 26 MB pickle open per
+# cell. And the encoder here is a BLOCKING factor, not the contrast: the
+# question is whether the band effect holds across encoders, so a second
+# whole-image encoder replicates the finding rather than competing with the
+# first. ("siglip vs siglip2_l is unresolvable on cost at three seeds" is a fact
+# about comparing the two encoders, and says nothing about whether each one
+# shows the same size penalty.)
+export CALIB_VGSCALE_EMBEDDERS="${CALIB_VGSCALE_EMBEDDERS:-siglip,siglip2_l,siglip+dinov3_patch}"
 # Every category is a designated cell; selecting a subset would discard the
 # design, and prevalence-spreading is meaningless when prevalence is 0.0250
 # everywhere by construction.
 export CALIB_CATEGORY_MODE=all
 export CALIB_N_SEEDS="${CALIB_N_SEEDS:-3}"
+# Walk every environment at seed 0, then every environment at seed 1, and so on.
+# A SLURM array dispatches roughly in index order, so if this run is cut short
+# it loses SEEDS uniformly rather than whole categories: the design stays intact
+# and only the standard errors widen, which a report can simply state.
+export CALIB_CELL_ORDER="${CALIB_CELL_ORDER:-seed}"
 export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-150}"
 
 export CALIB_REPOOL_VARIANTS=""
@@ -75,6 +91,11 @@ ENVX="$ENVX VTSEARCH_DATA_DIR=$VTSEARCH_DATA_DIR VTSEARCH_MODELS_DIR=$VTSEARCH_M
 ENVX="$ENVX VTS_REPO=$VTS_REPO CALIB_DATASETS=$CALIB_DATASETS"
 ENVX="$ENVX CALIB_VGSCALE_EMBEDDERS=$CALIB_VGSCALE_EMBEDDERS CALIB_CATEGORY_MODE=$CALIB_CATEGORY_MODE"
 ENVX="$ENVX CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_MAX_STEPS=$CALIB_MAX_STEPS"
+# Named explicitly rather than left to --export=ALL: the launcher computes the
+# cell COUNT and each task computes the cell LIST, and the two must enumerate
+# the same grid.  A knob that reaches one but not the other maps an index to a
+# different cell.
+ENVX="$ENVX CALIB_CELL_ORDER=$CALIB_CELL_ORDER"
 ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
 ENVX="$ENVX CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES"
 
@@ -115,7 +136,8 @@ if bad:
     print(f"  {ds}: patch embedders {bad} would run whole_image", file=sys.stderr)
     raise SystemExit(1)
 for e in cfg.embedders_for_dataset(ds):
-    print(f"  {ds} x {e}: styles={cfg.styles_for(ds, e)} region_voting={cfg.region_voting_for(ds, e)}")
+    print(f"  {ds} x {e}: styles={cfg.styles_for(ds, e)} region_voting={cfg.region_voting_for(ds, e)} "
+          f"learn={cfg.learn_embedder(e)} text={cfg.text_embedder(e)}")
 PYCHK
   echo "CALIB_EXP=$CALIB_EXP  datasets=$CALIB_DATASETS  embedders=$CALIB_VGSCALE_EMBEDDERS  seeds=$CALIB_N_SEEDS"
   submit prepare --job-name=scale-prep --mem=96G --cpus-per-task=8 \
@@ -146,8 +168,19 @@ cells)
   echo "cells: $N (array 0-$((N-1))%$CONC on $PARTITION)"
   PATCH_FLAG=""
   case "$CALIB_VGSCALE_EMBEDDERS" in *_patch*) PATCH_FLAG="--patch" ;; esac
+  # Both premises this study now rests on, asserted before the array rather
+  # than discovered in the rows afterwards: every cell opens on a TYPED QUERY
+  # (check 14, which for a paired arm probes the text half's tower and the text
+  # pickle's coverage), and the region arm really region-votes (check 6, which
+  # reads the learn half's pickle for a patch grid).
+  REGION_FLAG=""
+  case "$CALIB_VGSCALE_EMBEDDERS" in
+    *_patch*) REGION_FLAG="--require-region-voting ${CALIB_DATASETS%%,*}:$(
+      tr ',' '\n' <<<"$CALIB_VGSCALE_EMBEDDERS" | grep -- '_patch' | head -1)" ;;
+  esac
   bash "$WT/scripts/experiments/preflight.sh" --exp "$CALIB_EXP" --arms prod \
-    --job-name "$JOB_NAME" --mem "$MEM" --conc "$CONC" $PATCH_FLAG || {
+    --job-name "$JOB_NAME" --mem "$MEM" --conc "$CONC" $PATCH_FLAG \
+    --require-text-seed $REGION_FLAG || {
     echo "PREFLIGHT FAILED" >&2; exit 2; }
   submit cells --job-name="$JOB_NAME" --array="0-$((N-1))%$CONC" \
     --mem="$MEM" --cpus-per-task="$CPUS" --time="$TIME" \

--- a/scripts/experiments/calibration/launch_scale.sh
+++ b/scripts/experiments/calibration/launch_scale.sh
@@ -72,12 +72,26 @@ LOGS="$CALIB_EXP/logs"
 mkdir -p "$LOGS" "$CALIB_RESULTS/cells"
 
 # Sized from `size 0,72` on THIS configuration -- the text-seeded, paired grid --
-# rather than from an earlier one. A cell's cost moved when its opening did:
-# finding positives immediately means training on more of them, and the region
-# cell went from ~5 min typical (crop-seeded, job 549465) to 18m02s.
+# and cross-checked against the SAME cell in the crop-seeded run it replaces
+# (job 549465 index 4320: backpack@large, seed 0, max_patch).
 #
-#   whole_image cell (index 0)   47s    MaxRSS 0.50 G   0.7 cores
-#   max_patch   cell (index 72)  18m02s MaxRSS 5.02 G   1.0 cores
+#   whole_image cell (index 0)   47s     MaxRSS 0.50 G   0.7 cores
+#   max_patch   cell (index 72)  18m02s  MaxRSS 5.02 G   1.0 cores
+#   ...the same cell, crop-seeded: 11m28s MaxRSS 10.36 G
+#
+# The opening moved BOTH numbers, in opposite directions. Slower, because a text
+# sort finds positives immediately and the detector then trains on more of them.
+# Cheaper, because the crop path scored the query against every PATCH of every
+# media (7749 x ~197 x 768) where a text sort scores whole-image vectors only.
+#
+# For the array's shape, what matters is the whole region arm, not one cell.
+# Across the 532 region cells that finished in job 549465:
+#
+#   elapsed  p50 627s   p90 1206s  max 1345s
+#   MaxRSS   p50 4.9 G  p90 7.8 G  max 9.9 G
+#
+# So 12G clears the worst region cell ever observed on this grid, on a path that
+# has since become the cheaper of the two.
 #
 # Two things follow, and both were wrong before:
 #

--- a/scripts/experiments/calibration/launch_scale.sh
+++ b/scripts/experiments/calibration/launch_scale.sh
@@ -71,19 +71,34 @@ export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 LOGS="$CALIB_EXP/logs"
 mkdir -p "$LOGS" "$CALIB_RESULTS/cells"
 
-# Sized from the array that actually ran this grid (job 539790, 324 tasks):
-# MaxRSS peaked at 8.73G, typical ~7G, on the dinov3_patch/max_patch cells that
-# dominate the memory profile. 64G was a guess carried over from a different
-# study and it is 7x the measured peak -- which is not free: memory is the
-# binding per-user quota here (cpu_limit, ~1074G), so an oversized --mem caps
-# concurrency and parks your own later jobs behind the array in
-# QOSMaxMemoryPerUser. 16G keeps ~2x headroom over the measured peak and stays
-# above preflight's 12G floor for patch cells.
-MEM="${CALIB_MEM:-16G}"
-CPUS="${CALIB_CPUS:-6}"
+# Sized from `size 0,72` on THIS configuration -- the text-seeded, paired grid --
+# rather than from an earlier one. A cell's cost moved when its opening did:
+# finding positives immediately means training on more of them, and the region
+# cell went from ~5 min typical (crop-seeded, job 549465) to 18m02s.
+#
+#   whole_image cell (index 0)   47s    MaxRSS 0.50 G   0.7 cores
+#   max_patch   cell (index 72)  18m02s MaxRSS 5.02 G   1.0 cores
+#
+# Two things follow, and both were wrong before:
+#
+# * 6 CPUs was waste. user+sys is 17m47s against 18m02s wall -- the cell is
+#   effectively SINGLE-THREADED, so the extra cores bought nothing and cost
+#   quota. `cpu_limit` is cpu=240, so 6 CPUs/task caps the array at 40 tasks;
+#   2 CPUs/task lifts that to 120 and lets memory be the binding constraint
+#   instead, which is the one that reflects real usage.
+# * 16G was 3.2x the measured peak. Memory is the other half of `cpu_limit`
+#   (~1074G), so an oversized --mem is a direct concurrency cut: 12G allows 89
+#   concurrent tasks where 16G allows 67. 12G keeps 2.4x headroom over the
+#   measured 5.02G AND is preflight check 7b's floor for patch cells, which
+#   exists because UNDER-sizing killed 74 of 108 cells in #3156.
+#
+# CONC 85 sits just under both caps (170 CPUs, 1020G) with margin for the
+# whole-image cells, which need 0.5G and hold a 12G slot regardless.
+MEM="${CALIB_MEM:-12G}"
+CPUS="${CALIB_CPUS:-2}"
 TIME="${CALIB_TIME:-6:00:00}"
 PARTITION="${CALIB_PARTITION:-cpu}"
-CONC="${CALIB_CONC:-24}"
+CONC="${CALIB_CONC:-85}"
 JOB_NAME="${CALIB_JOB_NAME:-scale-$(basename "$CALIB_EXP")}"
 
 ENVX="export CALIB_EXP=$CALIB_EXP CALIB_RESULTS=$CALIB_RESULTS"

--- a/scripts/experiments/calibration/launch_tail_2881.sh
+++ b/scripts/experiments/calibration/launch_tail_2881.sh
@@ -31,7 +31,14 @@ export CALIB_RESULTS="${CALIB_RESULTS:-$CALIB_EXP/results}"
 
 export CALIB_SAFE_THRESHOLDS=1
 export CALIB_ANALYZE=analyze_cut.py
-export CALIB_HEAD="${CALIB_HEAD:-linear}"
+# The head a live detector actually has, because the tail rules' ship gate is only worth
+# measuring on the model users actually get.  NOT `linear`: that was production
+# when this launcher was written, and PR #3198 moved `PRODUCTION_HEAD` to the
+# linear SVM, so the pin outlived the thing it was pinning -- preflight check 12
+# has been failing on it since.  Named rather than left unset, which is what
+# `launch_transfer_2883.sh` settled on: the run's head is then readable from the
+# launcher instead of from a default three modules away.
+export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 
 # Visual Genome region voting; production patch arm + the single-vector control.
 # The control is the ship gate's other half: `calculate_gmm_threshold` also backs

--- a/scripts/experiments/calibration/launch_tail_2881.sh
+++ b/scripts/experiments/calibration/launch_tail_2881.sh
@@ -37,7 +37,19 @@ export CALIB_HEAD="${CALIB_HEAD:-linear}"
 # The control is the ship gate's other half: `calculate_gmm_threshold` also backs
 # the cosine/text sort, which has no max-pool and so no extreme-value tail at all.
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278).  The ship gate here
+# is literally "the tail rules must not regress the arm with no extreme-value
+# tail", so the control and the arm have to be the same run under two
+# geometries; bare `dinov3_patch` cannot be, because with no text tower it opens
+# on three random known-goods while the control opens on a typed query.  An EVT
+# fit is a statement about the top of a score distribution, and the opening
+# decides what is at the top when the first fit is taken.
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
 export CALIB_SWEEP_KS="${CALIB_SWEEP_KS:-0}"
@@ -74,7 +86,7 @@ REUSE="${TAIL_REUSE_PREPARE:-/exp/$USER/calibration-safe-linear/results}"
 # that only *changes* behaviour (this one adds seven rules, so it would in fact
 # have been caught by the missing-symbol crash, but the next one may not) would
 # otherwise produce a clean, plausible, wrong table.
-PREFLIGHT_ARGS=(--exp "$CALIB_EXP" --arms siglip,dinov3_patch)
+PREFLIGHT_ARGS=(--exp "$CALIB_EXP" --arms siglip,siglip+dinov3_patch)
 [[ -d "$REUSE" ]] && PREFLIGHT_ARGS+=(--reuse-prepare "$REUSE")
 bash "$WT/scripts/experiments/preflight.sh" "${PREFLIGHT_ARGS[@]}" || exit 1
 

--- a/scripts/experiments/calibration/launch_transfer_2883.sh
+++ b/scripts/experiments/calibration/launch_transfer_2883.sh
@@ -50,7 +50,18 @@ export CALIB_HEAD="${CALIB_HEAD:-linear_svm}"
 # max-pool, so if the transfer story is really about a max-pooled Bad tail rather
 # than about sample size, the two arms have to disagree.
 export CALIB_DATASETS="${CALIB_DATASETS:-visual_genome_m}"
-export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,dinov3_patch}"
+# The region arm is the PAIR `siglip+dinov3_patch` (#3278).  Every claim here is
+# "the two arms have to disagree" -- if transfer is about a max-pooled Bad tail
+# rather than about sample size, the whole_image control must not show it -- and
+# a disagreement is only evidence when the arms differ in one thing.  Bare
+# `dinov3_patch` has no text tower, so it would also differ in how it started,
+# and #3267 puts the largest measured effects in exactly that.
+export CALIB_VG_EMBEDDERS="${CALIB_VG_EMBEDDERS:-siglip,siglip+dinov3_patch}"
+export CALIB_REQUIRE_OPENING=text
+# A paired arm cannot fall back to the known-good start (`run_cells.py` raises),
+# so every selected category must have a typed query.  Selection filters to the
+# eligible ones before it picks, replacing rather than dropping.
+export CALIB_REQUIRE_SEED_QUERY=1
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 export CALIB_REPOOL_VARIANTS="${CALIB_REPOOL_VARIANTS:-}"
 export CALIB_SWEEP_KS="${CALIB_SWEEP_KS:-0}"
@@ -93,7 +104,7 @@ REUSE="${TRANSFER_REUSE_PREPARE:-/exp/$USER/tail2881-prepare/results}"
 # crops are symlinks into whichever study generated them, `readlink -f` will
 # happily recreate a dangling link, and a study that is archived between runs
 # leaves exactly that behind (#2881).
-PREFLIGHT_ARGS=(--exp "$CALIB_EXP" --arms siglip,dinov3_patch
+PREFLIGHT_ARGS=(--exp "$CALIB_EXP" --arms siglip,siglip+dinov3_patch
                 --job-name cal-cells --mem "$CALIB_MEM" --conc "$CALIB_CONC")
 [[ -d "$REUSE" ]] && PREFLIGHT_ARGS+=(--reuse-prepare "$REUSE")
 bash "$WT/scripts/experiments/preflight.sh" "${PREFLIGHT_ARGS[@]}" || exit 1

--- a/scripts/experiments/calibration/prepare_data.py
+++ b/scripts/experiments/calibration/prepare_data.py
@@ -125,6 +125,12 @@ def _prepare_pair(ds: str, emb_name: str, info: dict) -> None:
 
     from _cells_io import dump_medias, load_medias  # noqa: PLC0415
 
+    # A paired arm (`siglip+dinov3_patch`) prepares the LEARN half: that is the
+    # pickle its cells load and the space its detector lives in.  The text half
+    # contributes only the opening, so it needs no crops and no selection - but
+    # it does need to EXIST, and to cover the same medias, or every cell will
+    # die one at a time deep inside the array instead of here, once.
+    learn_name = cfg.learn_embedder(emb_name)
     pkl = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb_name)
     crops_np = common.RESULTS / "crops" / f"{cfg.crops_basename(ds, emb_name)}.npz"
     crops_js = crops_np.with_suffix(".json")
@@ -138,21 +144,37 @@ def _prepare_pair(ds: str, emb_name: str, info: dict) -> None:
         with common.timed(f"load_cache:{ds}:{emb_name}", timings):
             medias = load_medias(pkl)
     else:
-        common.log(f"\n=== {ds} x {emb_name} === (embedding fresh)")
-        if emb_name.startswith("dinov3") and not os.environ.get("HF_TOKEN"):
-            common.log(f"SKIPPING {emb_name}: HF_TOKEN not set (DINOv3 weights are licence-gated).")
+        common.log(f"\n=== {ds} x {emb_name} === (embedding fresh as {learn_name})")
+        if learn_name.startswith("dinov3") and not os.environ.get("HF_TOKEN"):
+            common.log(f"SKIPPING {learn_name}: HF_TOKEN not set (DINOv3 weights are licence-gated).")
             info.setdefault("failed", []).append(f"{ds}:{emb_name}")
             return
         from vtscore.datasets.loader_demo import load_demo_dataset  # noqa: PLC0415
         from vtscore.datasets.stages.embedding import embed_missing  # noqa: PLC0415
         from vtscore.media import get_embedder  # noqa: PLC0415
 
-        embedder = get_embedder(emb_name)
+        embedder = get_embedder(learn_name)
         with common.timed(f"load:{ds}:{emb_name}", timings):
-            load_demo_dataset(ds, medias, embedder_name=emb_name)
-            embed_missing(medias, emb_name)
+            load_demo_dataset(ds, medias, embedder_name=learn_name)
+            embed_missing(medias, learn_name)
         nbytes = dump_medias(medias, pkl)
         common.log(f"  wrote cell pickle {pkl.name}: {nbytes / 1e6:.0f} MB")
+
+    text_pickle = None
+    if cfg.is_paired(emb_name):
+        text_pkl = _loader.EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb_name)
+        if not text_pkl.exists():
+            raise FileNotFoundError(f"{emb_name}: text half's pickle {text_pkl.name} does not exist")
+        text_medias = load_medias(text_pkl)
+        missing = set(medias) - set(text_medias)
+        if missing:
+            raise ValueError(
+                f"{emb_name}: {text_pkl.name} is missing {len(missing)} of {len(medias)} medias "
+                f"(e.g. {sorted(missing)[:5]}); the opening would rank a different set than the run walks"
+            )
+        text_pickle = text_pkl.name
+        common.log(f"  paired opening: {text_pkl.name} covers all {len(medias)} medias")
+        del text_medias
 
     cats = _category_counts(medias)
     selected, sel_report = cfg.select_categories(medias, cats, dataset=ds)
@@ -204,6 +226,9 @@ def _prepare_pair(ds: str, emb_name: str, info: dict) -> None:
         "selected_categories": selected,
         "category_selection": sel_report,
         "reused_pickle": pkl.exists() and embedder is None,
+        "learn_embedder": learn_name,
+        "text_embedder": cfg.text_embedder(emb_name),
+        "text_pickle": text_pickle,
         "load_seconds": timings.get(f"load:{ds}:{emb_name}") or timings.get(f"load_cache:{ds}:{emb_name}"),
         "crops_seconds": timings.get(f"crops:{ds}:{emb_name}"),
         "pickle": cfg.pickle_name(ds, emb_name),

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -49,6 +49,65 @@ def _seed_query_text(ds: str, cat: str) -> str:
     return cfg.seed_query_text(ds, cat)
 
 
+def _text_seed_vectors(ds: str, emb: str, medias: dict) -> tuple[dict, str]:
+    """``(medias_to_rank, provenance)`` for the opening's cosine sort.
+
+    For an ordinary embedder that is the cell's own medias -- one pickle, one
+    space.  For a **paired** embedder (``siglip+dinov3_patch``) the opening runs
+    in the text half's space, and there are two ways to have those vectors:
+
+    * the media already carries them.  ``media["embeddings"]`` is a dict keyed
+      by embedder name (three-slot embedders, ``docs/plans/patch-embedder.md``),
+      so one media can hold a SigLIP vector and a DINOv3 vector at once.  This
+      is the shape production would ship, and it needs no second file.
+    * the pile stores one embedder per cell pickle, which is what it actually
+      does today -- so the text half's pickle is opened and its vectors used.
+
+    Preferring the first means the harness reads a multi-vector media correctly
+    the day the pile writes one, instead of silently ranking against a stale
+    side file.
+
+    Either way the two must describe the same medias.  A seed sort covering a
+    different set than the run walks is not the app's opening at all: the ids it
+    ranks are the ids the autopilot steps through, so a media missing from the
+    text side is a media the opening can never reach -- silently, in every
+    column.  It is asserted per cell rather than assumed, because "the flag you
+    passed is not the property you got" is how #2877, #2897 and #2905 each went
+    wrong.
+    """
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    if not cfg.is_paired(emb):
+        return medias, "cell"
+
+    text_emb = cfg.text_embedder(emb)
+    probe = next(iter(medias.values()), None)
+    if probe is not None and media_embedding(probe, text_emb) is not None:
+        common.log(f"  paired opening: {text_emb} vectors already on the cell's medias")
+        return medias, "multi_vector"
+
+    from vtscore.datasets import loader as _loader  # noqa: PLC0415
+
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    text_pkl = _loader.EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb)
+    if not text_pkl.exists():
+        raise FileNotFoundError(
+            f"paired embedder {emb!r} needs {text_emb} vectors: neither the cell's medias nor "
+            f"{text_pkl.name} (which does not exist) supplies them"
+        )
+    text_medias = load_medias(text_pkl)
+    missing = sorted(set(medias) - set(text_medias))
+    if missing:
+        raise ValueError(
+            f"{text_pkl.name} is missing {len(missing)} of {len(medias)} medias in "
+            f"{cfg.pickle_name(ds, emb)} (e.g. {missing[:5]}); the opening would rank "
+            "a different set than the run walks"
+        )
+    common.log(f"  paired opening: ranked in {text_emb} space from {text_pkl.name}")
+    return text_medias, text_pkl.name
+
+
 def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, float] | None":
     """The app's text sort: cosine from the typed query to every media.
 
@@ -57,10 +116,15 @@ def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, f
     (``al_strategies``, ``EVAL.md``, ``voting_iterations`` all say "similarity to
     the typed query").
 
-    Returns ``None`` when no query is defined for the cell, or when the embedder
-    has no text tower -- DINOv3 does not, so ``embed_text`` is the base class's
-    ``return None`` and ``embed_text_query`` yields nothing.  ``None`` is the
-    signal for the autopilot to seed from *three random known-good examples*
+    The query is embedded by the **text half** of the embedder name and scored
+    against that half's media vectors, while the ids returned are the *cell's*
+    ids -- so a paired arm hands the autopilot a SigLIP ranking of exactly the
+    medias it will then learn about in DINOv3 space.
+
+    Returns ``None`` when no query is defined for the cell, or when the text
+    embedder has no text tower -- DINOv3 does not, so ``embed_text`` is the base
+    class's ``return None`` and ``embed_text_query`` yields nothing.  ``None`` is
+    the signal for the autopilot to seed from *three random known-good examples*
     instead, the app's other real start ("3 random examples pulled from the
     Good").  Both are things a user does; ranking by cosine to a cropped box is
     not, which is why this no longer seeds from crops.
@@ -68,10 +132,11 @@ def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, f
     from vtscore.embedding.helpers import embed_text_query  # noqa: PLC0415
     from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
 
+    text_emb = cfg.text_embedder(emb)
     text = _seed_query_text(ds, cat)
     if not text:
         return None
-    qvec = embed_text_query(text, "image", embedder_name=emb)
+    qvec = embed_text_query(text, "image", embedder_name=text_emb)
     if qvec is None:
         return None
 
@@ -83,7 +148,17 @@ def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, f
     ids = list(medias.keys())
     if not ids:
         return None
-    matrix = np.stack([_unit(media_embedding(medias[c])) for c in ids])
+    vectors, _provenance = _text_seed_vectors(ds, emb, medias)
+    # Named on the paired path, primary on the ordinary one.  Asking for the
+    # name is what makes a wrong-space vector a KeyError-shaped None rather than
+    # a plausible ranking built from the wrong embedder.
+    rows = []
+    for c in ids:
+        vec = media_embedding(vectors[c], text_emb) if cfg.is_paired(emb) else media_embedding(vectors[c])
+        if vec is None:
+            raise ValueError(f"media {c} carries no {text_emb} vector for the opening of {ds}:{cat}")
+        rows.append(_unit(vec))
+    matrix = np.stack(rows)
     cos = matrix @ _unit(qvec)
     return {ids[k]: float(cos[k]) for k in range(len(ids))}
 
@@ -111,7 +186,8 @@ def main(argv: list[str] | None = None) -> int:
     styles = cfg.styles_for(ds, emb)
     region_voting = cfg.region_voting_for(ds, emb)
     common.log(
-        f"cell {idx}/{len(cells)}: dataset={ds} embedder={emb} category={cat} seed={seed} "
+        f"cell {idx}/{len(cells)}: dataset={ds} embedder={emb} "
+        f"(learn={cfg.learn_embedder(emb)} text={cfg.text_embedder(emb)}) category={cat} seed={seed} "
         f"styles={styles} head={cfg.HEAD or 'default (production)'} safe_thresholds={cfg.SAFE_THRESHOLDS} "
         f"calibrate_count={cfg.CALIBRATE_COUNT} fold_counts={cfg.FOLD_COUNTS or 'off'} "
         f"cut_incl_ks={cfg.CUT_INCLUSION_KS or 'off'} "
@@ -141,7 +217,18 @@ def main(argv: list[str] | None = None) -> int:
     seed_scores = _text_seed_scores(ds, emb, cat, medias)
     seed_mode = "text" if seed_scores is not None else "known_good"
     seed_query = _seed_query_text(ds, cat) if seed_scores is not None else ""
-    common.log(f"seed: mode={seed_mode} query={seed_query!r}")
+    seed_embedder = cfg.text_embedder(emb) if seed_scores is not None else ""
+    if cfg.is_paired(emb) and seed_mode != "text":
+        # A pair exists FOR the text sort.  Falling back to known-goods here
+        # would run an arm that is identical to the bare learn embedder while
+        # being labelled as something else -- a cell that looks like the
+        # experiment and is not it.  Fail the cell instead: a missing cell is
+        # visible and a mislabelled one is not.
+        raise RuntimeError(
+            f"paired embedder {emb!r} fell back to the known-good start for {ds}:{cat} "
+            f"(query={_seed_query_text(ds, cat)!r}); the pair exists to take the text sort"
+        )
+    common.log(f"seed: mode={seed_mode} embedder={seed_embedder or '-'} query={seed_query!r}")
 
     all_rows: list[dict] = []
     all_sweep: list[dict] = []
@@ -196,6 +283,7 @@ def main(argv: list[str] | None = None) -> int:
             r["embedder"] = emb
             r["seed_mode"] = seed_mode
             r["seed_query"] = seed_query
+            r["seed_embedder"] = seed_embedder
         for sr in sweep_local:
             sr["embedder"] = emb
         for dr in cutdiag_local:
@@ -216,7 +304,11 @@ def main(argv: list[str] | None = None) -> int:
 
     outdir = common.Path(args.outdir)
     outdir.mkdir(parents=True, exist_ok=True)
-    main_cols = [*_CALIBRATION_COLUMNS, "embedder", "seed_mode", "seed_query"]
+    # `seed_embedder` joins `seed_mode`/`seed_query` for the same reason those
+    # two exist: the #3156 rerun's root cause was that how a run started was
+    # unnameable after the fact.  A paired arm's opening lives in a different
+    # space than its `embedder` column implies, so the space has to be a column.
+    main_cols = [*_CALIBRATION_COLUMNS, "embedder", "seed_mode", "seed_query", "seed_embedder"]
     out = outdir / f"task_{idx:04d}.csv"
     pd.DataFrame(all_rows, columns=pd.Index(main_cols)).to_csv(out, index=False)
     sweep_cols = [*_INCLUSION_SWEEP_COLUMNS, "embedder"]

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -163,6 +163,32 @@ def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, f
     return {ids[k]: float(cos[k]) for k in range(len(ids))}
 
 
+def check_declared_opening(ds: str, emb: str, cat: str, seed_mode: str) -> None:
+    """Raise unless this cell opened the way the study said it would (#3278).
+
+    Which start a cell takes is decided silently, by whether its (dataset,
+    category) has a query and whether its embedder's text half has a tower.  So
+    a grid mixing SigLIP and DINOv3 arms opens two different ways along one axis
+    and nothing anywhere says so -- the confound
+    ``lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md``
+    describes.  ``CALIB_REQUIRE_OPENING`` is the study saying which opening it
+    means; this is the per-cell half of enforcing it, beside preflight check 14's
+    per-grid half.
+
+    It raises rather than warning for the reason the paired-arm guard in
+    :func:`main` does: a cell missing from the array is visible in any count of
+    it, and a cell that ran under the wrong opening is not.  ``mixed`` (and unset) assert
+    nothing -- a re-runner mirroring a completed grid legitimately holds both.
+    """
+    if cfg.REQUIRE_OPENING not in ("text", "known_good") or seed_mode == cfg.REQUIRE_OPENING:
+        return
+    raise RuntimeError(
+        f"cell {ds}x{emb}:{cat} opened on {seed_mode!r} but this study declares "
+        f"CALIB_REQUIRE_OPENING={cfg.REQUIRE_OPENING!r} "
+        f"(query={_seed_query_text(ds, cat)!r}, text half={cfg.text_embedder(emb)})"
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Calibration: one cell (dataset,embedder,category,seed).")
     parser.add_argument("--index", type=int, default=None, help="Cell index; defaults to $SLURM_ARRAY_TASK_ID.")
@@ -228,7 +254,13 @@ def main(argv: list[str] | None = None) -> int:
             f"paired embedder {emb!r} fell back to the known-good start for {ds}:{cat} "
             f"(query={_seed_query_text(ds, cat)!r}); the pair exists to take the text sort"
         )
-    common.log(f"seed: mode={seed_mode} embedder={seed_embedder or '-'} query={seed_query!r}")
+    # After the pair guard, which says the same thing about a paired arm in more
+    # useful words.
+    check_declared_opening(ds, emb, cat, seed_mode)
+    common.log(
+        f"seed: mode={seed_mode} embedder={seed_embedder or '-'} query={seed_query!r} "
+        f"declared={cfg.REQUIRE_OPENING or 'nothing'}"
+    )
 
     all_rows: list[dict] = []
     all_sweep: list[dict] = []

--- a/scripts/experiments/lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md
+++ b/scripts/experiments/lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md
@@ -68,15 +68,41 @@ caller builds, so the simulator needed no change at all.
   `--require-region-voting`, so both premises are asserted before the array
   instead of read out of the rows afterwards.
 
-**This is not fixed everywhere, and deliberately so.** Sixteen other launchers
-carry a DINOv3 arm and none passes `--require-text-seed` (#3278). Their existing
-results are fine — they all ran before #3269, so every arm seeded from a crop and
-the shift was shared. It is their *next* run that inherits this. The right answer
-differs per launcher: a mode-contrast study wants the pair, a single-arm region
-study has no contrast to confound but still would not open the way the app does,
-and a study whose subject *is* the known-good start should pin that choice rather
-than inherit it. Sweeping all sixteen would have replaced one unexamined default
-with another.
+**This was not fixed everywhere at first, and deliberately so.** Sixteen other
+launchers carried a DINOv3 arm and none passed `--require-text-seed`. Their
+existing results are fine — they all ran before #3269, so every arm seeded from a
+crop and the shift was shared. It was their *next* run that inherited this.
+Sweeping all sixteen in one edit would have replaced one unexamined default with
+another, so #3278 went through them one at a time; the answers did differ.
+Fourteen pair the region arm, because every one of them reads a patch arm against
+a whole-image control, contrasts voting modes, or compares environments — and one
+of those (#2905) is a *single-arm* study whose entire purpose is a comparison
+against two SigLIP environments, which is the case that shows "no contrast inside
+the grid" is not the same as "no contrast". Two are not studies at all
+(`launch_errdump.sh`, `launch_horizon.sh`): they re-run named cells of a
+completed grid against its own `prepare_info.json`, so their arms are pinned by
+that grid and renaming one would drop it from the enumeration and shift every
+later index.
+
+**What made the pins worth more than a comment.** Two of the sixteen keep an
+opening the rest do not, and a pin nobody can check reads exactly like an
+oversight a year later. So the opening became a *declaration* — `run_cells.py`
+raises on a cell that opened differently from `CALIB_REQUIRE_OPENING`, preflight
+check 14 refuses the array in either direction, and `assert_one_opening` refuses
+to pool two openings at analysis time. The third one is not redundant: cells are
+skipped when their CSV exists, so a resume across this fix leaves old cells
+beside new ones *inside one arm*, where every count still reads N/N.
+
+**And the rename needed a check of its own.** `array_cells` enumerates
+`DATASETS x embedders x the categories PREPARE selected`, so an arm prepare never
+wrote an entry for contributes **zero cells** — silently, with every later index
+meaning a different cell. Most of these launchers reuse a finished study's
+`prepare_info.json` to skip a GPU stage, and it is keyed by embedder name, so
+`dinov3_patch` -> `siglip+dinov3_patch` is exactly the rename that lands there.
+Preflight check 15 compares the configured grid against prepare's own entries;
+re-running prepare for the new name reuses the cached pickle and costs no encoder
+time, which is the point — the expensive thing was never the fix, it was not
+knowing you needed one.
 
 **One thing worth keeping beyond this study.** `media["embeddings"]` is already
 a dict keyed by embedder name, so one media *can* carry both vectors — that is

--- a/scripts/experiments/lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md
+++ b/scripts/experiments/lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md
@@ -1,0 +1,77 @@
+# 2026-08-27 — the region arm could not open the way the app does (#3276)
+
+**Study:** #3156 `vg_scale` overview, on its second rerun.
+**Cost:** nothing yet — caught before the array. It would have cost the
+headline: the study's whole point is the voting-mode axis, and a second axis was
+riding inside it.
+
+The day before, [the harness seeded from a crop](2026-08-26-the-harness-seeded-from-a-crop.md)
+was fixed: every cell now opens on a **text sort**, the way Autopilot does.
+`_text_seed_scores` returns `None` when the embedder has no text tower, and
+`None` is the documented signal to take the app's *other* real start — three
+random known-goods. That is a correct fallback and it was written deliberately.
+
+It is also the entire region arm. `dinov3_patch` is the only patch-capable
+embedder in the pile, and DINOv3 has no text tower — `embed_text` is the base
+class's `return None`. So after the fix:
+
+| arm | opening |
+|---|---|
+| `siglip` × `whole_image` | text sort |
+| `siglip2_l` × `whole_image` | text sort |
+| `dinov3_patch` × `max_patch` | **three random known-goods** |
+
+Both whole-image arms opened on a typed query and the region arm did not.
+
+**The shape, and why it is worse than the bug it came from.** The crop-seeding
+bug was a *shared baseline shift*: every arm seeded the same wrong way, so the
+28 stamped reports could keep their within-study contrasts and only lose claims
+about how a run starts. This one is **arm-dependent**. It does not cancel. Any
+sentence of the form "region voting costs X less than whole-image" would have
+been part voting mode and part opening, in unknown proportion — and #3267 puts
+the largest measured effects in the opening.
+
+The general form is one this repo keeps meeting: **a fallback that is correct in
+isolation becomes a confound when it fires on one arm of a contrast.** Nothing
+errors, nothing is mis-set, and the arm that took the fallback is the one the
+study is about. The 2026-08-25 lesson
+([a mode contrast that was an embedder contrast](2026-08-25-a-mode-contrast-that-was-an-embedder-contrast.md))
+is the same shape with the axes swapped.
+
+**The fix is not to disable the fallback.** A known-good start is a real user
+flow and bare `dinov3_patch` should keep it. What was missing is that *the two
+things an embedding space is asked for need not be the same space*: Autopilot
+wants a **text tower** to open on and a **media space** to learn in, and only
+the second one has to be DINOv3. Hence the paired name `siglip+dinov3_patch` —
+SigLIP ranks the query, DINOv3 does the vector learning, the region learning and
+the learn-sort. `seed_scores` is already just a `{media_id: similarity}` map the
+caller builds, so the simulator needed no change at all.
+
+**Controls added, rather than a paragraph:**
+
+- A paired arm that falls back to the known-good start **raises** instead of
+  running. Falling back would produce a cell identical to bare `dinov3_patch`
+  while labelled as the pair — and a missing cell is visible where a
+  mislabelled one is not.
+- `seed_embedder` is now a **column** beside `seed_mode` and `seed_query`, for
+  the reason those exist: the #3156 root cause was that how a run started was
+  unnameable after the fact. A paired arm's opening lives in a different space
+  than its `embedder` column implies, so the space has to be recorded.
+- preflight check 14 probes the **text half's** tower (probing the arm name
+  would ask the registry for an embedder called `siglip+dinov3_patch` and report
+  a working pair as broken), and refuses a pair whose text pickle does not cover
+  the run's medias.
+- preflight check 6 resolves the region-voting premise through
+  `cfg.pickle_name`, so it reads the learn half's pickle rather than a filename
+  that has never existed.
+- `launch_scale.sh` now passes `--require-text-seed` and
+  `--require-region-voting`, so both premises are asserted before the array
+  instead of read out of the rows afterwards.
+
+**One thing worth keeping beyond this study.** `media["embeddings"]` is already
+a dict keyed by embedder name, so one media *can* carry both vectors — that is
+production's three-slot design, not a harness trick. The pile happens to store
+one embedder per cell pickle, so the harness opens the text half's pickle; but
+it checks the media first, and will use an on-media vector the day the pile
+writes one. A helper that reaches for the side file *first* would silently keep
+ranking against a stale one forever after.

--- a/scripts/experiments/lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md
+++ b/scripts/experiments/lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md
@@ -68,6 +68,16 @@ caller builds, so the simulator needed no change at all.
   `--require-region-voting`, so both premises are asserted before the array
   instead of read out of the rows afterwards.
 
+**This is not fixed everywhere, and deliberately so.** Sixteen other launchers
+carry a DINOv3 arm and none passes `--require-text-seed` (#3278). Their existing
+results are fine — they all ran before #3269, so every arm seeded from a crop and
+the shift was shared. It is their *next* run that inherits this. The right answer
+differs per launcher: a mode-contrast study wants the pair, a single-arm region
+study has no contrast to confound but still would not open the way the app does,
+and a study whose subject *is* the known-good start should pin that choice rather
+than inherit it. Sweeping all sixteen would have replaced one unexamined default
+with another.
+
 **One thing worth keeping beyond this study.** `media["embeddings"]` is already
 a dict keyed by embedder name, so one media *can* carry both vectors — that is
 production's three-slot design, not a harness trick. The pile happens to store

--- a/scripts/experiments/preflight.sh
+++ b/scripts/experiments/preflight.sh
@@ -309,10 +309,14 @@ repo, ds, emb = sys.argv[1], sys.argv[2], sys.argv[3]
 sys.path.insert(0, str(pathlib.Path(repo) / "scripts" / "experiments" / "calibration"))
 import common
 common.setup_env()
+import experiment_config as cfg
 from _cells_io import load_medias
 from vtscore.datasets import loader as _loader
 
-pkl = _loader.EMBEDDINGS_DIR / f"{ds}__{emb}.pkl"
+# A paired arm (`siglip+dinov3_patch`) carries its patch grid in the LEARN
+# half's pickle; naming the file by hand here would look for a pickle that has
+# never existed and report the premise as MISSING rather than as held.
+pkl = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
 if not pkl.exists():
     print(f"MISSING {pkl}")
     raise SystemExit(0)
@@ -786,21 +790,32 @@ no_tower = set()
 for ds, embs in info.get("datasets", {}).items():
     for emb, d in embs.items():
         # The other half of the seed mode: an embedder with no text tower can
-        # never produce a text sort however good the query is (DINOv3).
+        # never produce a text sort however good the query is (DINOv3).  For a
+        # PAIRED arm the tower that matters is the text half's, which is the
+        # whole point of pairing - probing the arm name itself would ask the
+        # registry for an embedder called "siglip+dinov3_patch" and report a
+        # working pair as a broken one.
+        text_emb = cfg.text_embedder(emb)
         try:
-            has_tower = get_embedder(emb).embed_text("probe") is not None
+            has_tower = get_embedder(text_emb).embed_text("probe") is not None
         except Exception as exc:  # noqa: BLE001
-            bad.append(f"{ds}x{emb}: embedder failed to load ({type(exc).__name__})")
+            bad.append(f"{ds}x{emb}: embedder {text_emb} failed to load ({type(exc).__name__})")
             continue
         if not has_tower:
-            no_tower.add(emb)
+            no_tower.add(text_emb)
+        # And a pair can only rank the run's own medias if the text half's
+        # pickle holds them.  prepare_data checks this too; checking it again
+        # here is what stops an array of thousands of cells from being submitted
+        # against a pickle that cannot serve them.
+        if cfg.is_paired(emb) and d.get("text_pickle") is None:
+            bad.append(f"{ds}x{emb}: prepare recorded no text_pickle (rerun prepare on this branch)")
         for cat in d.get("selected_categories") or []:
             seen += 1
             text = cfg.seed_query_text(ds, cat)
             if not text:
                 bad.append(f"{ds}x{emb}:{cat}=no query")
             elif not has_tower:
-                bad.append(f"{ds}x{emb}:{cat}=no text tower on {emb}")
+                bad.append(f"{ds}x{emb}:{cat}=no text tower on {text_emb}")
             else:
                 texts += 1
 print(("FAILS " + "; ".join(sorted(bad)[:12])) if bad else f"HOLDS {texts}/{seen} selected cells seed from a typed query")

--- a/scripts/experiments/preflight.sh
+++ b/scripts/experiments/preflight.sh
@@ -54,11 +54,32 @@ done
   echo "usage: preflight.sh --exp DIR [--arms a,b,c] [--need-gb N]" >&2
   echo "                    [--require-region-voting DATASET:EMBEDDER]" >&2
   echo "                    [--require-text-seed]      # every cell must seed from a TYPED QUERY" >&2
+  echo "                    (or declare it once with CALIB_REQUIRE_OPENING=text|known_good|mixed," >&2
+  echo "                     which run_cells.py also asserts per cell)" >&2
   echo "                    [--reuse-prepare RESULTS_DIR]" >&2
   echo "                    [--job-name NAME] [--mem 64G] [--conc N] [--patch]" >&2
   echo "                    [--diverges knob1,knob2]   # knobs this study MEANS to pin off-production" >&2
   exit 2
 }
+
+# The opening this run asserts, from either half of one declaration: the flag a
+# launcher passes here, or `CALIB_REQUIRE_OPENING` -- which `run_cells.py`
+# asserts per CELL as well, so the pre-array gate and the per-cell guard cannot
+# disagree about what the study meant (#3278).  `mixed` declares a grid that
+# deliberately holds both openings, so there is nothing uniform to check here.
+WANT_OPENING=""
+[[ -n "$REQUIRE_TEXT_SEED" ]] && WANT_OPENING="text"
+case "${CALIB_REQUIRE_OPENING:-}" in
+  text) WANT_OPENING="text" ;;
+  known_good)
+    if [[ "$WANT_OPENING" == "text" ]]; then
+      echo "--require-text-seed contradicts CALIB_REQUIRE_OPENING=known_good; pick one" >&2
+      exit 2
+    fi
+    WANT_OPENING="known_good" ;;
+  mixed|"") ;;
+  *) echo "CALIB_REQUIRE_OPENING=${CALIB_REQUIRE_OPENING} is not text|known_good|mixed" >&2; exit 2 ;;
+esac
 
 FAILED=0
 say_fail() {
@@ -749,7 +770,7 @@ PY
   fi
 fi
 
-# --- 14. Every cell seeds from a TYPED QUERY, not from known-goods ------------
+# --- 14. Every cell takes the opening this study DECLARED ---------------------
 # The autopilot has two documented starts, and which one a cell takes is decided
 # silently by whether a query text happens to exist for its (dataset, category)
 # and whether its embedder has a text tower.  With a query the seed sort is
@@ -766,16 +787,49 @@ fi
 # for `vg_scale` and left it open for `coco_val` and `vg_box_*` in as many words
 # ("Still only advice ... config-only to fix"). This is the control.
 #
+# Both directions are checkable, because both are real choices (#3278).  A study
+# that pins the known-good start - because that flow IS its subject, or because
+# it re-runs a completed grid that took it - declares
+# `CALIB_REQUIRE_OPENING=known_good`, and this check then fails on a cell that
+# *would* text-seed.  A pin nobody can check is a comment, and the sixteen
+# launchers #3278 went through are what a comment was worth.
+#
 # Reads `prepare_info.json` for the categories actually selected, so it sees the
-# grid that will run rather than the one the launcher asked for.
-if [[ -n "$REQUIRE_TEXT_SEED" ]]; then
-  INFO="${CALIB_RESULTS:-$EXP/results}/prepare_info.json"
-  if [[ ! -f "$INFO" ]]; then
-    say_fail "--require-text-seed: no prepare_info.json at $INFO (run prepare first)"
+# grid that will run rather than the one the launcher asked for.  `run_cells.py`
+# asserts the same declaration per cell, which is what covers a study whose
+# array is submitted from a job where no preflight runs.
+
+# The prepare output this check and check 15 read: this run's own, or - when the study
+# has not copied it in yet - the one it declared it will reuse.  A launcher that
+# preflights BEFORE staging its reused prepare (launch_tail_2881.sh,
+# launch_transfer_2883.sh) would otherwise be checking a file that does not exist
+# yet, which is the moment its checks are most worth running.
+resolve_info() {
+  local own="${CALIB_RESULTS:-$EXP/results}/prepare_info.json"
+  if [[ -f "$own" ]]; then echo "$own"
+  elif [[ -n "$REUSE_PREPARE" && -f "$REUSE_PREPARE/prepare_info.json" ]]; then
+    echo "$REUSE_PREPARE/prepare_info.json"
+  fi
+}
+
+if [[ -n "$WANT_OPENING" ]]; then
+  INFO="$(resolve_info)"
+  if [[ -z "$INFO" ]]; then
+    # An explicit --require-text-seed is a caller asking for the check NOW, so a
+    # missing prepare is a failure.  A study-wide `CALIB_REQUIRE_OPENING` is a
+    # declaration that `run_cells.py` also asserts per cell, so a launcher that
+    # preflights before prepare has run has not lost the guarantee - it has only
+    # moved it later.  Saying which of the two happened matters: a skipped check
+    # is not a passed one.
+    if [[ -n "$REQUIRE_TEXT_SEED" ]]; then
+      say_fail "--require-text-seed: no prepare_info.json under ${CALIB_RESULTS:-$EXP/results} (run prepare first)"
+    else
+      say_note "opening check skipped: no prepare_info.json yet; run_cells.py asserts CALIB_REQUIRE_OPENING=$WANT_OPENING per cell"
+    fi
   elif [[ "$PY_USABLE" == "0" ]]; then
     say_fail "seed mode NOT checked: python cannot import the tree (see above)"
   else
-    SEEDCHK=$(cd "$REPO/scripts/experiments/calibration" && python - "$INFO" <<'PY' 2>&1
+    SEEDCHK=$(cd "$REPO/scripts/experiments/calibration" && python - "$INFO" "$WANT_OPENING" <<'PY' 2>&1
 import json
 import sys
 
@@ -784,9 +838,8 @@ import experiment_config as cfg  # noqa: E402
 
 from vtscore.media import get_embedder  # noqa: E402
 
-info = json.load(open(sys.argv[1]))
-bad, seen, texts = [], 0, 0
-no_tower = set()
+info, want = json.load(open(sys.argv[1])), sys.argv[2]
+bad, seen, held = [], 0, 0
 for ds, embs in info.get("datasets", {}).items():
     for emb, d in embs.items():
         # The other half of the seed mode: an embedder with no text tower can
@@ -801,8 +854,6 @@ for ds, embs in info.get("datasets", {}).items():
         except Exception as exc:  # noqa: BLE001
             bad.append(f"{ds}x{emb}: embedder {text_emb} failed to load ({type(exc).__name__})")
             continue
-        if not has_tower:
-            no_tower.add(text_emb)
         # And a pair can only rank the run's own medias if the text half's
         # pickle holds them.  prepare_data checks this too; checking it again
         # here is what stops an array of thousands of cells from being submitted
@@ -812,13 +863,14 @@ for ds, embs in info.get("datasets", {}).items():
         for cat in d.get("selected_categories") or []:
             seen += 1
             text = cfg.seed_query_text(ds, cat)
-            if not text:
-                bad.append(f"{ds}x{emb}:{cat}=no query")
-            elif not has_tower:
-                bad.append(f"{ds}x{emb}:{cat}=no text tower on {text_emb}")
+            got = "text" if (text and has_tower) else "known_good"
+            if got == want:
+                held += 1
+            elif want == "text":
+                bad.append(f"{ds}x{emb}:{cat}=" + ("no query" if not text else f"no text tower on {text_emb}"))
             else:
-                texts += 1
-print(("FAILS " + "; ".join(sorted(bad)[:12])) if bad else f"HOLDS {texts}/{seen} selected cells seed from a typed query")
+                bad.append(f"{ds}x{emb}:{cat}=would text-seed on {text_emb} ({text!r})")
+print(("FAILS " + "; ".join(sorted(bad)[:12])) if bad else f"HOLDS {held}/{seen} selected cells open on {want}")
 PY
     )
     # Keep the LAST line only.  Loading a SigLIP text tower prints transformers'
@@ -830,14 +882,80 @@ PY
     case "$SEEDCHK" in
       HOLDS*) say_ok "seed mode: ${SEEDCHK#HOLDS }" ;;
       FAILS*)
-        say_fail "cells that would NOT seed from a text sort: ${SEEDCHK#FAILS }"
-        echo "        -> these take the known-good start instead, so their seed sort is a"
-        echo "           different ranking; add the query to EXPERIMENT_QUERIES, or set"
-        echo "           CALIB_REQUIRE_SEED_QUERY=1 so prepare never selects them"
+        if [[ "$WANT_OPENING" == "text" ]]; then
+          say_fail "cells that would NOT seed from a text sort: ${SEEDCHK#FAILS }"
+          echo "        -> these take the known-good start instead, so their seed sort is a"
+          echo "           different ranking; add the query to EXPERIMENT_QUERIES, pair the arm"
+          echo "           with a text tower (siglip+dinov3_patch), or set"
+          echo "           CALIB_REQUIRE_SEED_QUERY=1 so prepare never selects them"
+        else
+          say_fail "cells that would NOT take the known-good start: ${SEEDCHK#FAILS }"
+          echo "        -> this study PINS the known-good opening, and these cells can open on"
+          echo "           a typed query instead; drop the pin if the text sort is now wanted"
+        fi
         ;;
       *) say_fail "could not check seed mode: $SEEDCHK" ;;
     esac
   fi
+fi
+
+# --- 15. Every arm in the grid has a prepare entry ----------------------------
+# `array_cells` enumerates the grid as `DATASETS x embedders_for_dataset(ds) x
+# the categories PREPARE selected for that (dataset, embedder)`.  So an arm with
+# no prepare entry contributes **zero cells**, silently: the array is that many
+# indices shorter, every index past the gap maps to a different cell than the
+# launcher's log says, and the run still comes back complete.
+#
+# The way to land there is ordinary: reuse a finished study's prepare_info.json
+# (the standard way to skip a GPU stage) after renaming an arm.  `dinov3_patch`
+# -> `siglip+dinov3_patch` is exactly that rename - #3278 made it in fourteen
+# launchers, most of which copy a `$REUSE/prepare_info.json` keyed by the old
+# bare name.  Prepare has to run again for the new key; it reuses the cached
+# pickle, so it costs no encoder time, and this check is what says so instead of
+# an array that quietly drops its region arm.  A skipped or failed embedder
+# (`prepare_info["failed"]`, e.g. DINOv3 without HF_TOKEN) lands here too.
+INFO15="$(resolve_info)"
+if [[ -z "$INFO15" ]]; then
+  say_note "grid-vs-prepare check skipped: no prepare_info.json under ${CALIB_RESULTS:-$EXP/results} yet"
+elif [[ -z "$REPO" ]]; then
+  say_note "grid-vs-prepare check skipped: VTS_REPO unset"
+elif [[ "$PY_USABLE" == "0" ]]; then
+  say_fail "grid vs prepare NOT checked: python cannot import the tree (see above)"
+else
+  GRIDCHK=$(cd "$REPO/scripts/experiments/calibration" && python - "$INFO15" <<'PY' 2>&1
+import json
+import sys
+
+sys.path.insert(0, ".")
+import experiment_config as cfg  # noqa: E402
+
+info = json.load(open(sys.argv[1]))
+prepared = info.get("datasets", {})
+failed = set(info.get("failed") or [])
+missing, seen = [], 0
+for ds in cfg.DATASETS:
+    for emb in cfg.embedders_for_dataset(ds):
+        seen += 1
+        if emb in prepared.get(ds, {}):
+            continue
+        why = "prepare FAILED it" if f"{ds}:{emb}" in failed else "prepare has no entry"
+        have = ", ".join(sorted(prepared.get(ds, {}))) or "nothing"
+        missing.append(f"{ds}x{emb} ({why}; prepared: {have})")
+print(("FAILS " + "; ".join(missing[:8])) if missing else f"HOLDS all {seen} grid arms are in prepare_info")
+PY
+  )
+  GRIDCHK=$(printf '%s\n' "$GRIDCHK" | tail -1)
+  case "$GRIDCHK" in
+    HOLDS*) say_ok "grid vs prepare: ${GRIDCHK#HOLDS }" ;;
+    FAILS*)
+      say_fail "arms in the grid that prepare never wrote: ${GRIDCHK#FAILS }"
+      echo "        -> each contributes ZERO cells, so the array is short and every index"
+      echo "           after the gap means a different cell than the launcher printed"
+      echo "        -> re-run prepare_data.py for this grid (a cached pickle is reused,"
+      echo "           so a renamed arm costs no encoder time), or fix the arm name"
+      ;;
+    *) say_fail "could not check the grid against prepare: $GRIDCHK" ;;
+  esac
 fi
 
 echo

--- a/tests_lib/detectors/test_declared_opening.py
+++ b/tests_lib/detectors/test_declared_opening.py
@@ -1,0 +1,227 @@
+"""Tests for the declared opening and the guards that enforce it (#3278).
+
+Autopilot has two real starts -- a text sort of a typed query, and three random
+known-good examples -- and which one a cell takes is decided silently, by
+whether its (dataset, category) has a query and whether its embedder has a text
+tower.  Since #3269 the harness takes the first wherever it can, so a grid
+holding SigLIP and DINOv3 arms opens two different ways along one axis with
+nothing anywhere recording it.
+
+``CALIB_REQUIRE_OPENING`` is the study saying which opening it means, and it is
+enforced at three places that do not overlap:
+
+* ``run_cells.check_declared_opening`` -- per cell, which is the only guard that
+  runs when the array is submitted from a grid job with no preflight;
+* ``preflight.sh`` check 14 -- per grid, before thousands of cells are queued
+  (not exercised here; it is bash);
+* ``_cells_io.assert_one_opening`` -- at analysis time, which is what catches a
+  RESUME that left cells from before the fix beside cells from after it.
+
+The calibration modules are loose scripts rather than package members, so they
+are loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+_CALIB = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "calibration"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def cells_io():
+    return _load("_calib_cells_io", _CALIB / "_cells_io.py")
+
+
+def _config(monkeypatch, declared: str | None):
+    """``experiment_config`` re-imported with ``CALIB_REQUIRE_OPENING`` set.
+
+    The declaration is read at import time, like every other knob in that module,
+    so a test that wants a different value has to load the module again.
+    """
+    if declared is None:
+        monkeypatch.delenv("CALIB_REQUIRE_OPENING", raising=False)
+    else:
+        monkeypatch.setenv("CALIB_REQUIRE_OPENING", declared)
+    return _load("_calib_experiment_config", _CALIB / "experiment_config.py")
+
+
+def _run_cells(cfg):
+    """``run_cells`` bound to *cfg*, with a stub ``common`` so import is inert."""
+    stub: Any = types.ModuleType("common")
+    stub.setup_env = lambda: None
+    stub.log = lambda _msg: None
+    stub.Path = Path
+    stub.RESULTS = Path(".")
+    saved = {k: sys.modules.get(k) for k in ("common", "experiment_config")}
+    sys.modules["common"] = stub
+    sys.modules["experiment_config"] = cfg
+    try:
+        return _load("_calib_run_cells", _CALIB / "run_cells.py")
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+# --- The declaration itself --------------------------------------------------
+
+
+@pytest.mark.parametrize("declared", ["text", "known_good", "mixed"])
+def test_every_documented_value_is_accepted(monkeypatch, declared):
+    assert _config(monkeypatch, declared).REQUIRE_OPENING == declared
+
+
+def test_unset_declares_nothing(monkeypatch):
+    assert _config(monkeypatch, None).REQUIRE_OPENING == ""
+
+
+def test_a_misspelt_declaration_fails_at_import(monkeypatch):
+    """`known-good` and `text_seed` are the plausible near-misses.
+
+    A declaration nobody validates is worse than none: the launcher reads as
+    though the opening were pinned while every cell asserts nothing.
+    """
+    with pytest.raises(ValueError, match="CALIB_REQUIRE_OPENING"):
+        _config(monkeypatch, "known-good")
+
+
+# --- The per-cell guard ------------------------------------------------------
+
+
+@pytest.mark.parametrize("declared,got", [("text", "text"), ("known_good", "known_good")])
+def test_a_cell_that_got_what_was_declared_runs(monkeypatch, declared, got):
+    cfg = _config(monkeypatch, declared)
+    _run_cells(cfg).check_declared_opening("vg_scale", "siglip", "boat@small", got)
+
+
+def test_a_text_study_refuses_a_known_good_cell(monkeypatch):
+    """The #3278 case: a DINOv3 arm silently taking the app's other start."""
+    cfg = _config(monkeypatch, "text")
+    with pytest.raises(RuntimeError, match="opened on 'known_good'"):
+        _run_cells(cfg).check_declared_opening("vg_scale", "dinov3_patch", "boat@small", "known_good")
+
+
+def test_a_pinned_known_good_study_refuses_a_text_cell(monkeypatch):
+    """The mirror: a pin is only a pin if it fails when it stops holding."""
+    cfg = _config(monkeypatch, "known_good")
+    with pytest.raises(RuntimeError, match="opened on 'text'"):
+        _run_cells(cfg).check_declared_opening("vg_scale", "siglip", "boat@small", "text")
+
+
+@pytest.mark.parametrize("declared", [None, "mixed"])
+def test_mixed_and_unset_assert_nothing(monkeypatch, declared):
+    """A re-runner mirroring a completed grid legitimately holds both openings."""
+    run_cells = _run_cells(_config(monkeypatch, declared))
+    run_cells.check_declared_opening("vg_scale", "siglip", "boat@small", "text")
+    run_cells.check_declared_opening("vg_scale", "dinov3_patch", "boat@small", "known_good")
+
+
+def test_the_message_names_the_arm_and_its_text_half(monkeypatch):
+    """A paired arm's opening lives in a different space than its name implies."""
+    cfg = _config(monkeypatch, "text")
+    with pytest.raises(RuntimeError, match="text half=siglip"):
+        _run_cells(cfg).check_declared_opening("vg_scale", "siglip+dinov3_patch", "boat@small", "known_good")
+
+
+# --- The analysis-time guard -------------------------------------------------
+
+
+def _rows(*specs: tuple[str, str, str, str, str]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [{"dataset": d, "embedder": e, "category": c, "seed_mode": m, "seed_embedder": s} for d, e, c, m, s in specs]
+    )
+
+
+def test_one_opening_per_environment_pools(cells_io):
+    frame = _rows(
+        ("vg_scale", "siglip", "boat", "text", "siglip"),
+        ("vg_scale", "siglip", "boat", "text", "siglip"),
+        ("vg_scale", "siglip+dinov3_patch", "boat", "text", "siglip"),
+    )
+    cells_io.assert_one_opening(frame)
+
+
+def test_two_openings_inside_one_environment_are_refused(cells_io):
+    """The resume case: cells from before the seeding fix beside cells from after."""
+    frame = _rows(
+        ("vg_scale", "dinov3_patch", "boat", "known_good", ""),
+        ("vg_scale", "dinov3_patch", "boat", "text", "siglip"),
+    )
+    with pytest.raises(ValueError, match="vg_scale x dinov3_patch x boat"):
+        cells_io.assert_one_opening(frame)
+
+
+def test_a_category_with_no_query_shifts_every_arm_together(cells_io):
+    """Not the analyzer's business: a shared shift cancels in every contrast.
+
+    `bus` has no typed query here, so it takes the known-good start on the SigLIP
+    arm and the DINOv3 one alike.  That is a legitimate grid -- the study that
+    wants it gone sets `CALIB_REQUIRE_SEED_QUERY=1` -- and refusing it would fire
+    on most Visual Genome runs while catching nothing.
+    """
+    frame = _rows(
+        ("visual_genome_m", "siglip", "boat", "text", "siglip"),
+        ("visual_genome_m", "siglip", "bus", "known_good", ""),
+        ("visual_genome_m", "siglip+dinov3_patch", "boat", "text", "siglip"),
+        ("visual_genome_m", "siglip+dinov3_patch", "bus", "known_good", ""),
+    )
+    cells_io.assert_one_opening(frame)
+
+
+def test_the_same_environment_opening_in_two_spaces_is_refused(cells_io):
+    """`seed_mode` alone would call these identical; the space is the difference."""
+    frame = _rows(
+        ("vg_scale", "siglip+dinov3_patch", "boat", "text", "siglip"),
+        ("vg_scale", "siglip+dinov3_patch", "boat", "text", "siglip2_l"),
+    )
+    with pytest.raises(ValueError, match="siglip2_l"):
+        cells_io.assert_one_opening(frame)
+
+
+def test_cells_written_before_the_columns_existed_read_as_unrecorded(cells_io):
+    """A pre-#3269 cell has no value at all, and mixing it in is the same fault."""
+    frame = _rows(("vg_scale", "dinov3_patch", "boat", "known_good", ""))
+    frame = pd.concat(
+        [frame, pd.DataFrame([{"dataset": "vg_scale", "embedder": "dinov3_patch", "category": "boat"}])],
+        ignore_index=True,
+    )
+    with pytest.raises(ValueError, match="unrecorded"):
+        cells_io.assert_one_opening(frame)
+
+
+def test_a_frame_with_no_opening_columns_is_entirely_old(cells_io):
+    """Every cell predates #3269, so they agree; there is nothing to compare."""
+    frame = pd.DataFrame([{"dataset": "vg_scale", "embedder": "siglip", "category": "boat", "t": 1}])
+    cells_io.assert_one_opening(frame)
+
+
+def test_an_empty_frame_is_not_an_error(cells_io):
+    cells_io.assert_one_opening(pd.DataFrame())
+    cells_io.assert_one_opening(None)
+
+
+def test_the_message_says_where_it_came_from(cells_io):
+    frame = _rows(
+        ("vg_scale", "dinov3_patch", "boat", "known_good", ""),
+        ("vg_scale", "dinov3_patch", "boat", "text", "siglip"),
+    )
+    with pytest.raises(ValueError, match="analyze_cut.py"):
+        cells_io.assert_one_opening(frame, "analyze_cut.py")

--- a/tests_lib/detectors/test_paired_embedder_seeding.py
+++ b/tests_lib/detectors/test_paired_embedder_seeding.py
@@ -1,0 +1,250 @@
+"""Tests for the paired ``"<text>+<learn>"`` embedder (#3276).
+
+Autopilot asks an embedding space for two unrelated things: a **text sort** to
+open on, and a **media space** to learn in.  ``dinov3_patch`` is the only
+patch-capable embedder in the pile and it has no text tower, so on its own it
+can never take the app's real opening — every DINOv3 cell fell back to the
+three-random-known-goods start while the whole-image arms opened on a typed
+query, putting a seeding difference *inside* the voting-mode axis the #3156
+scale study exists to measure.
+
+``siglip+dinov3_patch`` splits the two: SigLIP ranks the query, DINOv3 does the
+learning.  These tests pin the two halves of that — which half each config
+lookup reads, and that the opening really is built from the *text* half's
+vectors over the *learn* half's media ids.
+
+Both modules are loose scripts, not package members, so they are loaded by
+path.  ``run_cells`` is executed against a stub ``common``: the real one mutates
+``sys.meta_path`` and mkdirs an experiment tree at import time, neither of which
+belongs in a unit test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_CALIB = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "calibration"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def cfg():
+    return _load("_calib_experiment_config", _CALIB / "experiment_config.py")
+
+
+@pytest.fixture(scope="module")
+def run_cells(cfg):
+    """``run_cells`` with a stub ``common`` so importing it has no side effects."""
+    stub = types.ModuleType("common")
+    stub.setup_env = lambda: None
+    stub.log = lambda _msg: None
+    stub.Path = Path
+    stub.RESULTS = Path(".")
+    saved = {k: sys.modules.get(k) for k in ("common", "experiment_config")}
+    sys.modules["common"] = stub
+    sys.modules["experiment_config"] = cfg
+    try:
+        return _load("_calib_run_cells", _CALIB / "run_cells.py")
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = value
+
+
+PAIR = "siglip+dinov3_patch"
+
+
+# --- Which half each lookup reads -------------------------------------------
+
+
+def test_split_embedder_plain_name_is_both_halves(cfg):
+    assert cfg.split_embedder("siglip") == ("siglip", "siglip")
+    assert not cfg.is_paired("siglip")
+
+
+def test_split_embedder_pair(cfg):
+    assert cfg.split_embedder(PAIR) == ("siglip", "dinov3_patch")
+    assert cfg.text_embedder(PAIR) == "siglip"
+    assert cfg.learn_embedder(PAIR) == "dinov3_patch"
+    assert cfg.is_paired(PAIR)
+
+
+def test_patchness_is_decided_by_the_learn_half(cfg):
+    """The patch grid comes from the space the detector learns in, not the sort."""
+    assert cfg.is_patch_embedder(PAIR)
+    # Reversed, the pair learns in SigLIP space and has no patches to pool.
+    assert not cfg.is_patch_embedder("dinov3_patch+siglip")
+
+
+def test_pickles_split_by_role(cfg):
+    assert cfg.pickle_name("vg_scale", PAIR) == "vg_scale__dinov3_patch.pkl"
+    assert cfg.text_pickle_name("vg_scale", PAIR) == "vg_scale__siglip.pkl"
+    assert cfg.crops_basename("vg_scale", PAIR) == "vg_scale__dinov3_patch__crops"
+
+
+def test_unpaired_pickle_names_are_unchanged(cfg):
+    """The paired path is a generalisation, not a branch: plain names still work."""
+    assert cfg.pickle_name("vg_scale", "siglip") == "vg_scale__siglip.pkl"
+    assert cfg.text_pickle_name("vg_scale", "siglip") == "vg_scale__siglip.pkl"
+    assert cfg.crops_basename("vg_scale", "siglip") == "vg_scale__siglip__crops"
+
+
+def test_pair_region_votes_on_a_boxed_dataset(cfg):
+    assert cfg.region_voting_for("vg_scale", PAIR)
+    assert cfg.styles_for("vg_scale", PAIR) == cfg.PATCH_STYLES
+    # Both halves of the premise still required: no boxes, no region voting.
+    assert not cfg.region_voting_for("caltech101_m", PAIR)
+    assert cfg.styles_for("caltech101_m", PAIR) == cfg.SINGLE_STYLES
+
+
+# --- The opening itself ------------------------------------------------------
+
+_DS = "_paired_fixture"
+_CAT = "boat"
+_QUERY = "a boat on the water"
+
+
+def _media(vectors: dict[str, list[float]], primary: str) -> dict:
+    return {
+        "embeddings": {k: np.asarray(v, dtype=np.float32) for k, v in vectors.items()},
+        "embedder": primary,
+    }
+
+
+@pytest.fixture
+def queried(cfg, monkeypatch):
+    """A dataset the query table knows about, so ``seed_query_text`` resolves."""
+    monkeypatch.setitem(cfg.EXPERIMENT_QUERIES, _DS, {_CAT: _QUERY})
+
+
+@pytest.fixture
+def text_tower(monkeypatch):
+    """``embed_text_query`` answering only for SigLIP, as the real towers do."""
+    import vtscore.embedding.helpers as helpers
+
+    calls: list[tuple[str, str]] = []
+
+    def _embed(text, media_type, embedder_name=None):  # noqa: ARG001
+        calls.append((text, embedder_name))
+        if embedder_name != "siglip":
+            return None  # DINOv3 has no text tower
+        return np.asarray([1.0, 0.0], dtype=np.float32)
+
+    monkeypatch.setattr(helpers, "embed_text_query", _embed)
+    return calls
+
+
+#: SigLIP says media 1 is the best match; DINOv3 says the exact opposite.  Any
+#: implementation that ranks in the wrong space inverts the order, so the
+#: assertion below is a real discriminator rather than a smoke test.
+_SIGLIP = {1: [1.0, 0.0], 2: [0.0, 1.0]}
+_DINOV3 = {1: [0.0, 1.0], 2: [1.0, 0.0]}
+
+
+def test_pair_ranks_in_the_text_space_over_the_learn_ids(run_cells, queried, text_tower, monkeypatch, tmp_path):
+    """SigLIP orders the opening; the ids are the DINOv3 cell's own."""
+    learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
+    text = {cid: _media({"siglip": v}, "siglip") for cid, v in _SIGLIP.items()}
+
+    from vtscore.datasets import loader as _loader
+
+    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    (tmp_path / "_paired_fixture__siglip.pkl").write_bytes(b"")  # existence only
+    monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(text))
+
+    scores = run_cells._text_seed_scores(_DS, PAIR, _CAT, learn)
+
+    assert set(scores) == set(learn)
+    assert scores[1] > scores[2], "the opening must follow SigLIP, not DINOv3"
+    assert ("a boat on the water", "siglip") in text_tower
+
+
+def test_pair_prefers_vectors_already_on_the_media(run_cells, queried, text_tower, monkeypatch, tmp_path):
+    """A multi-vector media needs no second pickle — the production shape."""
+    both = {cid: _media({"dinov3_patch": _DINOV3[cid], "siglip": _SIGLIP[cid]}, "dinov3_patch") for cid in _DINOV3}
+
+    from vtscore.datasets import loader as _loader
+
+    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)  # empty: no side pickle exists
+    monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(None))
+
+    vectors, provenance = run_cells._text_seed_vectors(_DS, PAIR, both)
+
+    assert provenance == "multi_vector"
+    assert vectors is both
+    scores = run_cells._text_seed_scores(_DS, PAIR, _CAT, both)
+    assert scores[1] > scores[2]
+
+
+def test_pair_refuses_a_text_side_that_misses_medias(run_cells, monkeypatch, tmp_path):
+    """A partial opening is a different experiment, so it fails rather than runs."""
+    learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
+    partial = {1: _media({"siglip": _SIGLIP[1]}, "siglip")}
+
+    from vtscore.datasets import loader as _loader
+
+    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    (tmp_path / "_paired_fixture__siglip.pkl").write_bytes(b"")
+    monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(partial))
+
+    with pytest.raises(ValueError, match="missing 1 of 2 medias"):
+        run_cells._text_seed_vectors(_DS, PAIR, learn)
+
+
+def test_pair_reports_a_missing_text_pickle_by_name(run_cells, monkeypatch, tmp_path):
+    learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
+
+    from vtscore.datasets import loader as _loader
+
+    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(None))
+
+    with pytest.raises(FileNotFoundError, match="_paired_fixture__siglip.pkl"):
+        run_cells._text_seed_vectors(_DS, PAIR, learn)
+
+
+def test_unpaired_embedder_still_ranks_on_its_own_medias(run_cells, queried, text_tower, monkeypatch):
+    """No pickle is opened and the primary vector is used — the pre-#3276 path."""
+    medias = {cid: _media({"siglip": v}, "siglip") for cid, v in _SIGLIP.items()}
+    monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(None))
+
+    vectors, provenance = run_cells._text_seed_vectors(_DS, "siglip", medias)
+    assert provenance == "cell"
+    assert vectors is medias
+
+    scores = run_cells._text_seed_scores(_DS, "siglip", _CAT, medias)
+    assert scores[1] > scores[2]
+
+
+def test_no_text_tower_means_no_text_sort(run_cells, queried, text_tower):
+    """Bare DINOv3 still falls back to the known-good start rather than pretending."""
+    medias = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
+    assert run_cells._text_seed_scores(_DS, "dinov3_patch", _CAT, medias) is None
+
+
+def _cells_io_stub(text_medias):
+    """A ``_cells_io`` whose ``load_medias`` returns *text_medias* (or refuses)."""
+    module = types.ModuleType("_cells_io")
+
+    def load_medias(_path):
+        if text_medias is None:
+            raise AssertionError("load_medias must not be called on this path")
+        return text_medias
+
+    module.load_medias = load_medias
+    return module

--- a/tests_lib/detectors/test_paired_embedder_seeding.py
+++ b/tests_lib/detectors/test_paired_embedder_seeding.py
@@ -25,6 +25,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
@@ -48,7 +49,10 @@ def cfg():
 @pytest.fixture(scope="module")
 def run_cells(cfg):
     """``run_cells`` with a stub ``common`` so importing it has no side effects."""
-    stub = types.ModuleType("common")
+    # `Any` rather than `ModuleType`: a stub module is built by assigning
+    # attributes that the type does not declare, and pyright is right to object
+    # to that on a real ModuleType.
+    stub: Any = types.ModuleType("common")
     stub.setup_env = lambda: None
     stub.log = lambda _msg: None
     stub.Path = Path
@@ -137,7 +141,7 @@ def text_tower(monkeypatch):
     """``embed_text_query`` answering only for SigLIP, as the real towers do."""
     import vtscore.embedding.helpers as helpers
 
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str | None]] = []
 
     def _embed(text, media_type, embedder_name=None):  # noqa: ARG001
         calls.append((text, embedder_name))
@@ -239,7 +243,7 @@ def test_no_text_tower_means_no_text_sort(run_cells, queried, text_tower):
 
 def _cells_io_stub(text_medias):
     """A ``_cells_io`` whose ``load_medias`` returns *text_medias* (or refuses)."""
-    module = types.ModuleType("_cells_io")
+    module: Any = types.ModuleType("_cells_io")
 
     def load_medias(_path):
         if text_medias is None:


### PR DESCRIPTION
Closes #3278

> **Stacked on #3277.** The paired embedder (`siglip+dinov3_patch`), the
> `seed_embedder` column and preflight's pair-aware checks live there and are not
> on `dev` yet, so this branch is cut from `claude/siglip-dinov3-pair`. Merge
> #3277 first; this diff shrinks to its own four commits once it lands
> (`836781f2`, `0373f3f0`, `ed0ffccf`, `c7dfc704`).

## What was wrong

#3276 fixed one study. Sixteen other launchers carried a bare `dinov3_patch` arm
and none asserted an opening, so their **next** run would have opened that one
arm on three random known-goods while every SigLIP arm opened on a typed query.
That difference is arm-dependent, so unlike the #3269 seeding fix it does not
cancel in a contrast. Existing results are unaffected — they all ran before
#3269, when every arm seeded from a crop and the shift was shared.

## The per-launcher judgement

Decided one at a time, in each launcher's own header, because the answers differ.

| Launcher | Decision | Why |
|---|---|---|
| `bench`, `folds_2897`, `folds_3115`, `mixin`, `incl_2865` | pair + `text` | contrast voting modes; the mode axis would carry a seeding axis |
| `safe`, `safe_ab`, `cut`, `tail_2881`, `transfer_2883`, `anchored` | pair + `text` | a patch arm read against a whole-image control that must differ in geometry and nothing else |
| `rate_2861` | pair + `text` | "kappa\* is stable across six environments" is a claim about environments |
| `all` | pair + `text` | the shared chain, and the #2781 study's own grid |
| `acq_region_2905` | pair + `text` | single-arm, but it exists **only** to be compared against two SigLIP environments — "no contrast inside the grid" is not "no contrast" |
| `errdump`, `horizon` | arms kept verbatim, `mixed` / `known_good` declared | not studies: they re-run named cells of a completed grid against its own `prepare_info` by symlink, so renaming an arm drops it from the enumeration and shifts every later index |

Both re-runners' headers now also say what their source runs no longer promise:
a cell re-run today opens on a text sort, so a dump or a horizon extension is the
same **cells**, not the same trajectory, until the source grid is re-run.

## What makes a pin worth more than a comment

`CALIB_REQUIRE_OPENING` is the declaration, enforced at three points that do not
overlap:

- **`run_cells.check_declared_opening`**, per cell — the only guard that runs
  when the array is submitted from a grid job where no preflight does.
- **preflight check 14**, per grid, now in **both** directions: a study that pins
  the known-good start fails on a cell that would text-seed.
- **`_cells_io.assert_one_opening`**, at analysis time, for the case neither can
  see — a **resume** leaving cells from before the fix beside cells from after it
  inside one environment, where every count still reads N/N.

That last one groups by `(dataset, embedder, category)`, not by arm, and the
distinction is the lesson's own argument: a *category* with no query shifts every
arm together and cancels; an *arm* that opens differently does not, and that is
what the declaration and preflight refuse before the array.

## Two things the rename forced

- **preflight check 15** — every arm in the grid has a prepare entry. `array_cells`
  enumerates from prepare's own entries, so an arm prepare never wrote contributes
  **zero cells** silently. Most of these launchers reuse a finished study's
  `prepare_info.json`, which is keyed by embedder name, so `dinov3_patch` →
  `siglip+dinov3_patch` is exactly the rename that lands there. Re-running prepare
  reuses the cached pickle and costs no encoder time.
- **`CALIB_REQUIRE_SEED_QUERY=1`** on every launcher that declares `text`. A
  paired arm has no known-good fallback, and category selection runs over the
  dataset's full vocabulary while the query tables cover part of it. The filter
  runs *before* selection, so an ineligible category is replaced rather than
  dropped — but it does move the selected set, which is the one science-visible
  consequence here and is stated in each launcher.

`vg_scale_any` also gains a query table: neither `EXPERIMENT_QUERIES` nor the
app's demo table knew it, so every cell of #3115 was taking the known-good start.

## The stale head pin, found on the way through

Nine of these launchers pinned `CALIB_HEAD=linear` under a comment saying that is
"the head the live detector ships" and that the thing being measured "is only
worth measuring on the model users actually get". #3198 moved `PRODUCTION_HEAD`
to the linear SVM, so the pin has been asserting the opposite of its own comment
since, and preflight check 12 fails on it today for the ones that run preflight.
The last commit names `linear_svm` instead — which is what
`launch_transfer_2883.sh` already settled on when it met the same thing, and its
comment is what flagged `launch_cut.sh` and `launch_tail_2881.sh` in as many
words. `launch_acq_incl.sh`, `launch_acq_incl_vg.sh` and `launch_folds_2861.sh`
carry the same pin and are deliberately **not** touched: they are not among the
sixteen, so nothing here has looked at what their studies measure.

## Worth knowing

`launch_bench.sh` describes itself as measuring shipped defaults, and the app
cannot pair two spaces today (#3276 "not in scope"). Its paired arm therefore
prices **region voting** rather than today's DINOv3 flow end to end. That is the
right trade for a table whose rows are read against each other, but it is a
divergence and is written down in the launcher.

## Testing

Full `./run-tests.sh`: **9198 passed, 6 skipped**, all gates green (pyright,
pip-audit, npm audit, Vitest). 20 new tests in
`tests_lib/detectors/test_declared_opening.py` cover the declaration's parsing,
both directions of the per-cell guard, and the pooling guard's environment
grouping. Preflight's new paths were exercised by hand against a fabricated
`prepare_info.json` (check 15 firing on a missing arm, the contradiction and
invalid-value exits, and the skip-vs-fail split when prepare has not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhMve1rysyjKqf3PS1DEmt