### PR TITLE
Normalise a correction box once, and check boxes against the frame

### DIFF
--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -120,6 +120,13 @@ VTSearch supplies the loop with no new plugin code: a Good vote already carries
 import → vote → `server_json_file` export round-trip emits exactly the required
 record. The box fixes presence *and* band membership in one gesture.
 
+**But `region_box` is normalised and VG's shape is pixels**, so "VG's own shape"
+above is a claim about the *record*, not about the numbers. A correction row
+therefore declares `box_space` and the builder converts once; merging it
+unconverted normalises it twice and parks the box on the frame origin, taking
+its band with it (#3281). Both halves are checked at build time — see the pile
+[`README.md`](../../scripts/experiments/pile/README.md).
+
 **The negatives are the expensive half.** They are ~95% of *I* and rest on an
 absence claim, which is precisely what VG cannot support (`498326.jpg` is
 annotated `car, clouds` and has a bus front and centre). Review them in

--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -72,6 +72,7 @@ correct union of the two branches with no judgement involved.
 
 | Date | Lesson | Issue |
 |---|---|---|
+| 2026-08-27 | [a box normalised twice](lessons/2026-08-27-a-box-normalised-twice.md) | #3281 |
 | 2026-08-27 | [the region arm could not open the way the app does](lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md) | #3276 |
 | 2026-08-26 | [a completed grid reported "0 / 6480" cells](lessons/2026-08-26-a-completed-grid-reported-zero-cells.md) | #3156 |
 | 2026-08-26 | [a counter that never reached the rows, and a check that was a no-op](lessons/2026-08-26-a-counter-that-never-reached-the-rows.md) | #3267 |

--- a/scripts/experiments/lessons/2026-08-27-a-box-normalised-twice.md
+++ b/scripts/experiments/lessons/2026-08-27-a-box-normalised-twice.md
@@ -1,0 +1,56 @@
+# 2026-08-27 — a box normalised twice (#3281)
+
+**Study:** #3156 `vg_scale` overview, plus #3115's `vg_scale_any` and the #3276
+run in flight.
+**Cost:** every per-category and per-band claim touching `backpack@small`,
+`bird@small` or `bicycle@small` in three studies, and a "region voting is worse"
+reading of the #3276 region arm that was a broken box all along.
+
+**What broke.** `corrections.json` records a reviewer's redrawn box, and that box
+arrives from the app's `region_box` — already **normalised** to [0, 1]. VG's and
+COCO's boxes arrive in **pixels**. The builder merged all three into one dict
+and then normalised the lot on the way into the pickle, so a correction box was
+divided by ~500 a second time and landed on the frame origin: 130 boxes, all
+sub-pixel, all in the top-left corner.
+
+**Why nothing caught it.** `--verify` already recomputed each box's band and
+compared it against the band its cell name claims — the check written after the
+last coordinate-space mistake. It passed, because **the band is derived from the
+box**. Crush a box to the origin and its area lands in `small`, which is exactly
+what `@small` asserts; both sides move together and the cell stays perfectly
+self-consistent. A check that compares a value against something computed from
+that same value cannot fail. The frame is the only fixed reference, and nothing
+was comparing boxes to it.
+
+**The band damage was bigger than the box damage.** The corrupt box does not
+merely mis-pool a region vote (which only the region arm reads, which is why
+this presented as a voting-mode effect). It also *files the image*: 97 of the
+130 do not belong in `@small` at all once repaired — one is a macaw filling 45%
+of the frame — so the small band of three classes was partly a bucket of
+misfiled large objects, for **every** arm, on the one axis `vg_scale` exists to
+measure.
+
+**Prevented?** Code, four ways:
+
+- `corrections.json` rows declare `box_space`, and `build_pile.py` refuses a row
+  whose boxes contradict the declaration. The two spaces are indistinguishable
+  for a box in the top-left corner of a 1×1 image, which is why inference was
+  never going to work — the file has to say.
+- The correction box is converted to pixels **once**, against the same `(W, H)`
+  the region write divides by, so the stored box is the reviewer's box bit for
+  bit rather than approximately.
+- `region_geometry_problems` checks boxes against the **frame**: a sub-pixel
+  side fails outright (no drawn box is one), and the share crushed into the
+  top-left 1% of the frame fails as a *rate* (a real object can sit there — 1.2%
+  of healthy boxes do — but not 100% of a class). It runs at build time, before
+  the GPU hours, and again in `--verify`.
+- `vg_scale_any` is derived from the built `vg_scale` pickle and shares its
+  vectors, so it survived a parent rebuild carrying the parent's **previous**
+  labels with a healthy media count. It now stamps a digest of the parent's
+  labels, `--verify` compares it against the live parent, and a run that
+  rebuilds `vg_scale` pulls the derived dataset in with it.
+
+**The general form.** *A consistency check between two values derived from the
+same source is not a check.* It is worth asking, of any guard already in place,
+what independent thing it is comparing against — and if the answer is "itself, a
+step earlier", the guard is decoration.

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -114,6 +114,37 @@ COCO is built from the staged images rather than the #2790 vector cache, which
 stores HAC region vectors but not the raw patch grid and so can never carry a
 region arm.
 
+## Boxes arrive in two spaces, and the file has to say which
+
+VG's and COCO's boxes are in **pixels**. A correction box is the reviewer's
+`region_box` from the app, already **normalised** to [0, 1]. The builder merges
+all three and normalises on the way into the pickle, so a correction box merged
+unconverted is normalised *twice*: divided by ~500 a second time and parked on
+the frame origin. That is #3281 — 130 boxes, and with them 97 images filed into
+`@small` whose object is medium or large, on the one axis `vg_scale` exists to
+measure.
+
+Three things now stop it, because none of them alone would have:
+
+- `corrections.json` rows carry `box_space`, and `build_pile.py` refuses a row
+  whose boxes contradict it. Inference cannot do this job: a normalised box and
+  a pixel box are the same numbers for a box in the top-left corner of a 1×1
+  image, which is precisely the shape the bug produced.
+- The conversion happens **once**, against the same `(W, H)` the region write
+  divides by, so the round trip is exact rather than close.
+- `--verify` (and the build, before the GPU hours) checks boxes against the
+  **frame**: a sub-pixel side is a failure outright, and the share crushed into
+  the top-left 1% of the frame is a failure as a rate. The older check — box
+  against the band its cell name claims — passed happily through all of this,
+  because the band is *derived from* the box and moved with it. A consistency
+  check between two values computed from one source is not a check.
+
+`vg_scale_any` is a relabel of the built `vg_scale` pickle and shares its
+vectors, so a parent rebuild used to leave it holding the parent's previous
+labels with a perfectly healthy media count. It now stamps a digest of the
+parent's labels, `--verify` compares that against the live parent, and a run
+that rebuilds `vg_scale` pulls the derived dataset in with it.
+
 ## Voted-box scale bands (`--bands`)
 
 Orthogonal to the `_s`/`_m`/`_l` suffix, which is a **dataset size tier** (a

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -22,7 +22,11 @@ Usage::
 
 ``--verify`` is the guard the region-voting studies needed: it asserts that
 every cell whose ``(dataset, embedder)`` pair claims region capability actually
-carries ``patch_grid`` on its medias, and that no cell silently holds zero.
+carries ``patch_grid`` on its medias, and that no cell silently holds zero. It
+also checks the *geometry*: boxes against the band their cell name claims, and
+boxes against the frame -- the second because the first cannot see a box
+corrupted before banding, since the band is derived from that same box and moves
+with it (#3281).
 """
 
 from __future__ import annotations
@@ -374,6 +378,11 @@ def _load_corrections() -> dict[tuple[int, str], dict]:
 
     Written by ``ingest_slate.py``; absent until the first review lands, which
     is why this returns empty rather than failing.
+
+    **Boxes here are NORMALISED, unlike VG's and COCO's** -- they come from the
+    app's ``region_box``. The space is validated on the way in and converted to
+    pixels once, by :func:`_correction_boxes_px`, so that everything downstream
+    of this function is in one space. See ``pile_config.CORRECTION_BOX_SPACE``.
     """
     path = Path(os.environ.get("VTS_CORRECTIONS", pc.PILE / "corrections.json"))
     if not path.exists():
@@ -381,8 +390,131 @@ def _load_corrections() -> dict[tuple[int, str], dict]:
     rows = json.loads(path.read_text())
     out: dict[tuple[int, str], dict] = {}
     for r in rows:
+        _assert_correction_box_space(r, path)
         out[(int(r["image_id"]), r["class"])] = r
     return out
+
+
+def _assert_correction_box_space(row: dict, path: Path) -> None:
+    """Refuse a correction row whose boxes are not in the declared space.
+
+    The space is a *declaration*, not a guess: a pixel-space box handed to the
+    normalised path is undetectable once it has been divided by (W, H) -- the
+    result is a small, plausible, entirely wrong box, which is #3281 in the
+    other direction. Checking it here costs one comparison per row and is the
+    only point at which the two spaces are still distinguishable.
+    """
+    space = row.get("box_space", pc.CORRECTION_BOX_SPACE)
+    where = f"{path.name}: image {row.get('image_id')} / {row.get('class')!r}"
+    if space != pc.CORRECTION_BOX_SPACE:
+        raise SystemExit(f"{where}: box_space {space!r}, expected {pc.CORRECTION_BOX_SPACE!r}")
+    for b in row.get("boxes") or []:
+        if len(b) != 4:
+            raise SystemExit(f"{where}: box {b} is not [x0, y0, x1, y1]")
+        if not all(-1e-6 <= float(v) <= 1.0 + 1e-6 for v in b):
+            raise SystemExit(
+                f"{where}: box {b} has a coordinate outside [0, 1], so it is in PIXEL space "
+                f"while the file declares {pc.CORRECTION_BOX_SPACE!r}"
+            )
+        if float(b[2]) <= float(b[0]) or float(b[3]) <= float(b[1]):
+            raise SystemExit(f"{where}: box {b} is degenerate (x1 <= x0 or y1 <= y0)")
+
+
+def _correction_boxes_px(row: dict, W: int, H: int) -> list[list[float]]:
+    """A verdict's boxes in the pixel space of ``(W, H)``.
+
+    ``(W, H)`` is the space the image's *other* boxes were measured in -- the
+    COCO original for an anchored image, the VG copy otherwise -- because that
+    is what the region write later divides by. Scaling up here and dividing down
+    there is an exact round trip, so the stored box is the reviewer's box to the
+    last bit rather than merely close to it.
+    """
+    return [[float(b[0]) * W, float(b[1]) * H, float(b[2]) * W, float(b[3]) * H] for b in (row.get("boxes") or [])]
+
+
+def scale_label_digest(medias: dict[int, dict]) -> str:
+    """A hash of exactly what ``vg_scale_any`` copies out of ``vg_scale``.
+
+    ``vg_scale_any`` is a *relabel* of the built ``vg_scale`` pickle, so a fix to
+    ``vg_scale``'s labels, boxes or bands leaves the derived cell holding the old
+    ones -- with the right media count, the right vectors and a healthy-looking
+    ``--verify``. #3281 is the case: the box repair moves 97 images between
+    bands, and ``build_pile.py --force vg_scale`` alone would ship a
+    ``vg_scale_any`` still carrying the pre-repair regions.
+
+    Vectors are deliberately not in it: they are identical by construction (the
+    derived build never re-embeds) and ``cell_fingerprint`` already covers them.
+    What this pins is the half a rebuild of the parent can actually change.
+    """
+    h = hashlib.sha256()
+    for mid in sorted(medias):
+        m = medias[mid]
+        h.update(
+            json.dumps(
+                [
+                    mid,
+                    m.get("category"),
+                    m.get("categories"),
+                    m.get("evaluable_categories"),
+                    [
+                        [r.get("label"), [round(float(v), 9) for v in r.get("box") or []]]
+                        for r in m.get("regions") or []
+                    ],
+                ],
+                sort_keys=True,
+            ).encode()
+        )
+    return h.hexdigest()
+
+
+def region_geometry_problems(medias: dict[int, dict]) -> list[str]:
+    """Geometry no honest normalised region box can have (#3281).
+
+    The band check in :func:`verify` cannot see a coordinate-space mistake made
+    *before* banding, because the band is computed from the very box it would be
+    checking: crush a box to the origin and it is filed under ``@small``, where
+    a sub-pixel area is exactly what the band's name claims. Both sides move
+    together and the cell stays self-consistent. So the box has to be checked
+    against the frame rather than against its own label.
+
+    Two rules, and they are different in kind:
+
+    * **Sub-pixel** is absolute. A side below ``MIN_BOX_SIDE`` is under one pixel
+      on any image the pile holds, so no such box was ever drawn or annotated.
+      One is a failure.
+    * **Crushed to the origin** is a rate. A real small object can sit in the
+      top-left corner and 1.2% of healthy boxes do, so a single hit proves
+      nothing; a *population* of them is a double-normalise, which put 100% of
+      the affected images there.
+    """
+    problems: list[str] = []
+    n_boxes = 0
+    subpixel: list[str] = []
+    cornered = 0
+    edge = pc.CORNER_AREA_FRAC**0.5
+    for mid, m in medias.items():
+        for r in m.get("regions") or []:
+            b = r.get("box") or []
+            if len(b) != 4:
+                problems.append(f"media {mid} / {r.get('label')!r}: box {b} is not [x0, y0, x1, y1]")
+                continue
+            n_boxes += 1
+            if (b[2] - b[0]) < pc.MIN_BOX_SIDE or (b[3] - b[1]) < pc.MIN_BOX_SIDE:
+                subpixel.append(f"media {mid} / {r.get('label')!r} {[round(v, 6) for v in b]}")
+            if b[2] <= edge and b[3] <= edge:
+                cornered += 1
+    if subpixel:
+        problems.append(
+            f"{len(subpixel)} region boxes are sub-pixel (side < {pc.MIN_BOX_SIDE:g} of the frame), "
+            f"which no drawn or annotated box is -- e.g. {'; '.join(subpixel[:3])}"
+        )
+    if n_boxes and cornered / n_boxes > pc.MAX_CORNER_RATE:
+        problems.append(
+            f"{cornered}/{n_boxes} ({cornered / n_boxes:.1%}) of region boxes lie wholly inside the "
+            f"top-left {pc.CORNER_AREA_FRAC:.0%} of the frame, against a healthy rate near 1% -- "
+            f"the signature of a box normalised twice"
+        )
+    return problems
 
 
 def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
@@ -501,12 +633,20 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
     # a band is a claim about size, and no size was measured. It leaves every
     # cell of that class instead -- neither a positive nor a negative -- which
     # is precisely what the third value is for.
+    #
+    # The box, when there is one, is NORMALISED and everything in `labels` is in
+    # pixels, so it is converted here -- once, against the same (W, H) the region
+    # write divides by. Merging it unconverted is #3281: the region write then
+    # normalises a normalised coordinate, which divides it by ~500 and parks the
+    # box on the frame origin. Nothing downstream could see that, because the
+    # BAND is derived from the same corrupted box, so the cell name and its boxes
+    # stayed consistent with each other all the way into the study.
     unbanded: set[tuple[int, str]] = set()
     for (iid, name), verdict in corrections.items():
         if iid not in labels:
             continue
         if verdict.get("present"):
-            boxes = verdict.get("boxes") or []
+            boxes = _correction_boxes_px(verdict, *box_dims[iid])
             if boxes:
                 labels[iid][name] = boxes
             else:
@@ -674,6 +814,13 @@ def _load_vg_scale(medias: dict[int, dict], embedder_name: str) -> None:
             "origin_name": str(path),
         }
 
+    # Refuse to embed a pickle whose boxes are impossible. `--verify` runs the
+    # same check, but only after the GPU hours are spent and the cell is on
+    # disk; #3281 got as far as three published studies that way.
+    bad = region_geometry_problems(medias)
+    if bad:
+        raise SystemExit("vg_scale: " + "; ".join(bad))
+
 
 def _load_vg_scale_any(medias: dict[int, dict], embedder_name: str) -> None:
     """``vg_scale`` with the box-size band collapsed away (#3115).
@@ -725,7 +872,8 @@ def _load_vg_scale_any(medias: dict[int, dict], embedder_name: str) -> None:
         return list(dict.fromkeys(_base(c) for c in (labels or [])))
 
     loaded = _cells_io().load_medias(src)
-    log(f"  derived from {src.name}: {len(loaded)} medias")
+    parent_digest = scale_label_digest(loaded)
+    log(f"  derived from {src.name}: {len(loaded)} medias, parent labels {parent_digest[:12]}")
     for mid, media in loaded.items():
         d = dict(media)
         d["categories"] = _collapse(d.get("categories"))
@@ -736,7 +884,13 @@ def _load_vg_scale_any(medias: dict[int, dict], embedder_name: str) -> None:
         if d.get("category"):
             d["category"] = _base(d["category"])
         d["regions"] = [{**r, "label": _base(r["label"])} for r in (d.get("regions") or [])]
-        d["origin"] = {"importer": "vg_scale_any", "params": {"embedder": embedder_name, "derived_from": src.name}}
+        # The parent's label digest travels with every media, so `--verify` can
+        # tell a derived cell that is merely older than its parent from one that
+        # no longer agrees with it. Without it a stale derivation is invisible.
+        d["origin"] = {
+            "importer": "vg_scale_any",
+            "params": {"embedder": embedder_name, "derived_from": src.name, "parent_labels": parent_digest},
+        }
         medias[mid] = d
 
     n_pos = sum(1 for d in medias.values() if d["categories"])
@@ -1107,7 +1261,39 @@ def verify() -> int:
                 f"{ds} x {emb}: {bad}/{checked} region boxes fall outside the band their cell "
                 f"name claims -- boxes and bands were measured in different pixel spaces"
             )
+        # The band check above compares a box against its own label, so it is
+        # blind to a box corrupted BEFORE banding -- the band moves with it and
+        # the two stay consistent (#3281). This one compares the box against the
+        # frame, which nothing can drag along with it.
+        problems += [f"{ds} x {emb}: {g}" for g in region_geometry_problems(medias)]
         break  # one embedder is enough; the boxes are identical across cells
+
+    # A derived cell that no longer matches its parent. `vg_scale_any` is a
+    # relabel of the built `vg_scale` pickle and shares its vectors, so it
+    # survives a parent rebuild looking perfect while carrying the parent's
+    # PREVIOUS labels, boxes and bands -- which is how a box repair ships to one
+    # study and not the other.
+    live_digest: dict[Path, str] = {}  # one parent serves every derived cell built from it
+    for ds, emb in pc.cells():
+        if pc.DATASETS.get(ds, {}).get("kind") != "vg_scale_any":
+            continue
+        path, parent = pc.cell_path(ds, emb), pc.cell_path("vg_scale", emb)
+        if not path.exists() or not parent.exists():
+            continue
+        medias = io.load_medias(path)
+        problems += [f"{ds} x {emb}: {g}" for g in region_geometry_problems(medias)]
+        first = next(iter(medias.values()), None)
+        stamped = ((first or {}).get("origin") or {}).get("params", {}).get("parent_labels")
+        if parent not in live_digest:
+            live_digest[parent] = scale_label_digest(io.load_medias(parent))
+        live = live_digest[parent]
+        if stamped is None:
+            problems.append(f"{ds} x {emb}: no parent_labels stamp -- built before the staleness check, rebuild it")
+        elif stamped != live:
+            problems.append(
+                f"{ds} x {emb}: derived from a {parent.name} that has since changed "
+                f"({stamped[:12]} != {live[:12]}) -- rebuild it, --force on the parent alone leaves it stale"
+            )
 
     # A dataset's cells must all cover the same medias, or cross-embedder
     # comparisons silently compare different populations. This is not
@@ -1481,6 +1667,21 @@ def main() -> int:
         raise SystemExit(f"unknown dataset {bad!r}; known: {sorted(pc.DATASETS)}")
     for bad in [e for e in embedders if e not in pc.EMBEDDERS]:
         raise SystemExit(f"unknown embedder {bad!r}; known: {sorted(pc.EMBEDDERS)}")
+
+    # A derived dataset joins the run whenever its parent is in it. `vg_scale`
+    # rebuilt without `vg_scale_any` leaves the derived cell holding the
+    # parent's previous labels, boxes and bands -- with the right media count
+    # and the right vectors, so nothing looks wrong (#3281 shipped that way).
+    # Pulling it in costs a relabel and no embedding pass, and `--force` is what
+    # makes it actually happen: the derived cell already exists.
+    derived = [
+        d
+        for d, spec in pc.DATASETS.items()
+        if spec.get("kind") == "vg_scale_any" and d not in datasets and "vg_scale" in datasets
+    ]
+    if derived:
+        log(f"including {', '.join(derived)}: derived from vg_scale, and stale the moment it is rebuilt")
+        datasets += derived
 
     summaries = []
     for ds in datasets:

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -83,8 +83,13 @@ DATASETS: dict[str, dict] = {
     # and so it inherits whatever that cell currently holds.  #3252 changed how
     # `vg_scale` selects and corrects its cells, which means a `vg_scale_any`
     # built before that commit is NOT the same dataset as one built after it.
-    # Rebuild it whenever `vg_scale` is rebuilt; `build_pile.py --force` on
-    # `vg_scale` alone silently leaves this one stale.
+    # Rebuild it whenever `vg_scale` is rebuilt.  That used to be a rule nobody
+    # could check: `--force` on `vg_scale` alone left this cell holding the old
+    # labels with the right media count and the right vectors, so it looked
+    # healthy (#3281 shipped a box repair to one study and not the other).  It
+    # is now enforced twice -- `build_pile.py` pulls this dataset into any run
+    # that rebuilds its parent, and `--verify` compares the parent-label digest
+    # stamped on each derived media against the parent's live one.
     "vg_scale_any": {"boxed": True, "kind": "vg_scale_any"},
 }
 
@@ -298,6 +303,36 @@ SCALE_N_NEG_SPARE = int(os.environ.get("VTS_SCALE_N_NEG_SPARE", "300"))
 #: those -- small enough to ignore by accident, which is why it is a constant
 #: with a check rather than an assumption.
 MAX_ASPECT_DRIFT = float(os.environ.get("VTS_MAX_ASPECT_DRIFT", "0.01"))
+
+
+#: The coordinate space a correction box is recorded in. VG's and COCO's boxes
+#: arrive in **pixels**; a correction box comes from the app's ``region_box``,
+#: which is already **normalised** to [0, 1]. The builder divides every box by
+#: (W, H) on the way into the pickle, so a correction box merged in unconverted
+#: is normalised twice: it lands on the frame origin, sub-pixel, and takes its
+#: band with it (#3281 -- 130 boxes, and 97 images filed in ``@small`` whose
+#: object is medium or large). The space is therefore *declared* in the file and
+#: converted once at read, never inferred: the two spaces are indistinguishable
+#: for a box in the top-left corner of a 1x1 image, which is exactly the shape
+#: the bug produced.
+CORRECTION_BOX_SPACE = "normalised"
+
+#: Below this normalised side length a box is sub-pixel on any image the pile
+#: holds -- VG's largest copy is 1280 px wide -- so it cannot describe anything
+#: that was observed. Zero legitimate boxes are anywhere near it; the 130
+#: double-normalised ones were all under 1e-3.
+MIN_BOX_SIDE = float(os.environ.get("VTS_MIN_BOX_SIDE", "0.000244"))  # 1/4096
+
+#: "Crushed to the origin": both corners inside the top-left square holding this
+#: fraction of the frame area. Unlike the sub-pixel rule this one has genuine
+#: hits -- a small object really can sit in the top-left corner, 43 of 3470
+#: healthy boxes do -- so it gates on the *rate*, not on any single box.
+CORNER_AREA_FRAC = float(os.environ.get("VTS_CORNER_AREA_FRAC", "0.01"))
+
+#: The share of a cell's boxes that may be crushed to the origin before the
+#: build is refused. The measured healthy rate is 1.2% and the defect put it at
+#: 100% of the affected images, so anything in between separates them.
+MAX_CORNER_RATE = float(os.environ.get("VTS_MAX_CORNER_RATE", "0.05"))
 
 
 #: Which images each cell currently holds. Selection is hash-stable, but a

--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -9,6 +9,14 @@ Three sources feed one file, and they are *not* interchangeable:
 * **triage flags** -- a model pass over the ranked negatives, which finds
   contaminated negatives efficiently but draws no boxes.
 
+**Boxes are written NORMALISED, and say so.** A drawn box arrives as the app's
+`region_box`, which is already in [0, 1], while VG's and COCO's are in pixels.
+The builder normalises every box it merges, so an undeclared correction box was
+normalised twice and landed on the frame origin -- 130 of them, taking their
+band with them, invisible because the band is derived from the same box
+(#3281). Each row therefore carries `box_space`, and `build_pile.py` refuses a
+row whose boxes do not match what it declares.
+
 **A correction without a box excludes rather than promotes.** "There is a bus in
 this image" fixes a poisoned negative, but it cannot make the image a *positive*
 for any band, because a band is a claim about size and no size was measured. The
@@ -109,6 +117,7 @@ def main() -> int:
                     "class": key[1],
                     "present": True,
                     "boxes": [box] if box else [],
+                    "box_space": pc.CORRECTION_BOX_SPACE,
                     "source": "human_review",
                 }
                 stats["negative_fixed" if box else "negative_excluded"] += 1
@@ -122,6 +131,7 @@ def main() -> int:
                         "class": key[1],
                         "present": True,
                         "boxes": [box],
+                        "box_space": pc.CORRECTION_BOX_SPACE,
                         "source": "human_rebox",
                     }
                     stats["positive_reboxed"] += 1


### PR DESCRIPTION
Fixes the double-normalise behind #3281 and adds the checks that would have caught it. **Does not rebuild the pickles** — see "Still owed" below.

## The bug

`corrections.json` records the reviewer's redrawn box as the app's `region_box`, already normalised to [0, 1]. VG's and COCO's boxes arrive in pixels. `_load_vg_scale` merged all three into one dict and then normalised the lot on the way into the pickle, so a correction box was divided by ~500 a second time and landed on the frame origin — 130 boxes, all sub-pixel, all in the top-left corner.

## Why nothing caught it

`--verify` already recomputed each box's band and compared it against the band its cell name claims — the check written after the *last* coordinate-space mistake. It passed, because **the band is derived from the box**. Crush a box to the origin and its area lands in `small`, which is exactly what `@small` asserts; both sides move together and the cell stays perfectly self-consistent. A check that compares a value against something computed from that same value is not a check. The frame is the only fixed reference, and nothing was comparing boxes to it.

## What changed

- **`box_space` is declared, not inferred.** `verdicts_to_corrections.py` writes it on every row carrying a box; `build_pile.py` refuses a row whose boxes contradict the declaration (a coordinate outside [0, 1], a degenerate box, wrong arity). Inference cannot do this job — a normalised box and a pixel box are the same numbers for a box in the top-left corner of a 1×1 image, which is precisely the shape the bug produced.
- **Converted once**, against the same `(W, H)` the region write divides by — the COCO original for an anchored image, the VG copy otherwise. The round trip is bit-exact, so the stored box is the reviewer's box rather than approximately it.
- **`region_geometry_problems`** checks boxes against the frame. A sub-pixel side (< 1/4096 of the frame) fails outright: no drawn or annotated box is one. The share crushed into the top-left 1% of the frame fails as a *rate*, not per box — a real small object can sit there and 1.2% of healthy boxes do, but 100% of a class is a double-normalise. It runs at build time, before the GPU hours, and again in `--verify`.
- **`vg_scale_any` staleness is now visible.** It is a relabel of the built `vg_scale` pickle and shares its vectors, so a parent rebuild left it holding the parent's *previous* labels with a healthy media count and a clean `--verify`. It now stamps a digest of the parent's labels, `--verify` compares that against the live parent, and a run that rebuilds `vg_scale` pulls the derived dataset in with it.

Plus an incident entry in `scripts/experiments/lessons/`, and the box-space note in the pile README and the plan.

## Still owed (why this is `Refs`, not `Closes`)

Items 2 and 3 of the issue's fix list are a GRID operation, not a code change, and need the VG/COCO sources and the pile — neither of which exists in this container:

- Rebuild `vg_scale` **and `vg_scale_any` with it** (`--force`; no re-embed is needed either way).
- Re-band: 97 of the 130 images leave `@small` once their box is repaired, so the class lists move. The existing roster machinery carries this — reviewed images outrank unreviewed ones for a seat in whatever cell their repaired box now puts them in — but `check_review_coverage.py` should be read before trusting the rebuilt cells.

## Testing

Full `./run-tests.sh`: `RUN PASSED`, 9198 passed / 6 skipped, all gates green. The new pure functions were exercised directly against the issue's own numbers — a healthy population with one legitimate corner box passes; 20 crushed boxes in 100 trip both rules; the pixel-space, degenerate, wrong-arity and mis-declared rows are each rejected by name; and `[0.4719, 0.0166, 0.5961, 0.1824]` scaled by (500, 333) and divided back is exactly equal.

Refs #3281

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDdnf8GueiVr46kqZZgHMc

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDdnf8GueiVr46kqZZgHMc)_