### PR TITLE
Dither the Train/Calibrate split sizes instead of rounding them

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -65,7 +65,7 @@ The SVM head needs no such insurance and does not use it: the margin objective h
 
 A decision threshold separating "good" from "bad" predictions is computed via **cross-calibration**:
 
-1. Split labeled data into Train (1 − `calibration_fraction`) and Calibrate (`calibration_fraction`).
+1. Split labeled data into Train (1 − `calibration_fraction`) and Calibrate (`calibration_fraction`). The two sizes are **dithered rather than rounded**: a fractional split rounds up with probability equal to its fractional part, so the count is unbiased instead of pinned to whichever side `round` picks. At the default 0.5 this fires only on an odd label count — an exact tie, where "nearest" has no answer. It matters because `round` is round-half-to-**even**, which made the odd vote's destination alternate with the label count (Train at `n % 4 == 1`, Calibrate at `n % 4 == 3`); one user never notices, but the eval casts one vote per step, so that seesaw was phase-locked across every simulated run and survived averaging as a spurious 4-vote ripple on the learning curves (issue #3286). The tie-break RNG is seeded from a digest of the labelset itself, so a threshold stays a pure function of the votes that produced it.
 2. Train a fold model on Train **using the same head as the final model**, score the held-out Calibrate portion.
 3. Repeat for `calibrate_count` independent random splits.
 4. Pool every fold's held-out (score, label) pairs and apply the **conformal inclusion rule** (`conformal_threshold`) once. Pooling — rather than averaging per-fold thresholds — is deliberate: the knob's resolution is bounded by how many calibration scores the quantiles are taken over.

--- a/tests_lib/sorting/test_split_dither.py
+++ b/tests_lib/sorting/test_split_dither.py
@@ -1,0 +1,142 @@
+"""The Train/Calibrate split sizes are dithered, not rounded (issue #3286).
+
+``round`` is round-half-to-even, so at the shipped ``calibration_fraction`` of
+0.5 the odd vote's destination alternated with the vote count - Train at
+``n % 4 == 1``, Calibrate at ``n % 4 == 3``.  Every run of the eval casts one
+vote per step, so that seesaw was phase-locked across every trajectory and
+survived averaging as a visible 4-vote ripple on the learning curves.
+
+These tests pin the three properties the fix rests on: the count is unbiased,
+it is *stable* for a given labelset (the threshold must stay a pure function of
+the votes, or the calibration cache would serve stale orderings), and it is
+*decoherent* between two different labelsets that happen to be the same size,
+which is what makes the ripple average away.
+"""
+
+import numpy as np
+import pytest
+
+from vtscore.training.thresholds import (
+    NO_GOOD_THRESHOLD,
+    _dithered_count,
+    _split_dither_rng,
+    compute_fold_orderings,
+)
+
+
+def _labelset(rng, n, dim=8, n_pos=None):
+    """A random ``(X_list, y_list)`` of *n* votes with both classes present."""
+    n_pos = max(2, n // 3) if n_pos is None else n_pos
+    X = rng.standard_normal((n, dim)).astype(np.float32)
+    y = [1.0] * n_pos + [0.0] * (n - n_pos)
+    return list(X), y
+
+
+class TestDitheredCount:
+    def test_whole_numbers_pass_through(self):
+        rng = np.random.RandomState(0)
+        assert [_dithered_count(float(k), rng) for k in range(6)] == [0, 1, 2, 3, 4, 5]
+
+    def test_whole_number_consumes_no_randomness(self):
+        """An exact count must not advance the RNG, or it would shift later draws."""
+        rng = np.random.RandomState(0)
+        _dithered_count(7.0, rng)
+        after_exact = rng.random_sample()
+        assert after_exact == np.random.RandomState(0).random_sample()
+
+    def test_only_the_two_neighbours_are_reachable(self):
+        seen = {_dithered_count(10.5, np.random.RandomState(s)) for s in range(200)}
+        assert seen == {10, 11}
+
+    def test_unbiased_at_a_tie(self):
+        draws = [_dithered_count(10.5, np.random.RandomState(s)) for s in range(2000)]
+        assert np.mean(draws) == pytest.approx(10.5, abs=0.05)
+
+    def test_unbiased_off_a_tie(self):
+        """P(round up) tracks the fractional part, so a 0.8 remainder rounds up ~80%."""
+        draws = [_dithered_count(10.8, np.random.RandomState(s)) for s in range(2000)]
+        assert np.mean(draws) == pytest.approx(10.8, abs=0.05)
+
+
+class TestSplitDitherRng:
+    def test_same_labelset_gives_the_same_draw(self):
+        """The threshold stays a pure function of the votes - the cache relies on it."""
+        rng = np.random.RandomState(1)
+        X_list, y_list = _labelset(rng, 11)
+        X, y = np.array(X_list), np.array(y_list)
+        draws = {_dithered_count(5.5, _split_dither_rng(X, y)) for _ in range(25)}
+        assert len(draws) == 1
+
+    def test_different_embeddings_give_different_draws(self):
+        """Same shape, same labels, different vectors - the tie must not resolve alike."""
+        rng = np.random.RandomState(2)
+        y = np.array([1.0] * 4 + [0.0] * 7)
+        ups = sum(
+            _dithered_count(5.5, _split_dither_rng(rng.standard_normal((11, 8)).astype(np.float32), y))
+            for _ in range(300)
+        )
+        # Each draw is 5 or 6; ~half should round up.  The pre-#3286 code was a
+        # constant here, which is the failure this guards.
+        assert 300 * 5 + 90 < ups < 300 * 5 + 210
+
+    def test_the_draw_moves_as_a_session_accumulates_votes(self):
+        """A digest over a fixed prefix would freeze; this must keep moving."""
+        rng = np.random.RandomState(3)
+        X = rng.standard_normal((80, 8)).astype(np.float32)
+        odd_deviations = []
+        for n in range(9, 60, 2):  # odd n only: the tie cases
+            y = np.array([1.0] * (n // 3) + [0.0] * (n - n // 3))
+            odd_deviations.append(_dithered_count(n * 0.5, _split_dither_rng(X[:n], y)) - n // 2)
+        assert set(odd_deviations) == {0, 1}, "the tie must break both ways within one session"
+
+
+class TestNoPeriodFourStructure:
+    """The regression test: no vote count may resolve its tie the same way twice."""
+
+    def test_mean_split_has_no_mod_four_signature(self):
+        rng = np.random.RandomState(4)
+        # For each vote count, many independent labelsets - the eval's many runs.
+        by_n = {}
+        for n in range(9, 41):
+            ups = [
+                _dithered_count(n * 0.5, _split_dither_rng(rng.standard_normal((n, 8)).astype(np.float32), np.array(y)))
+                - n // 2
+                for y in ([1.0] * (n // 3) + [0.0] * (n - n // 3),) * 60
+            ]
+            by_n[n] = float(np.mean(ups))
+        # Under the old rule this was exactly 1.0 at n%4==1 and 0.0 at n%4==3
+        # (a full-amplitude square wave).  Dithered, every odd n sits near 0.5.
+        odd_means = [v for n, v in by_n.items() if n % 2 == 1]
+        assert min(odd_means) > 0.25, f"a tie is still resolving one way: {by_n}"
+        assert max(odd_means) < 0.75, f"a tie is still resolving one way: {by_n}"
+        # Even counts are exact - no draw, no spread.
+        assert all(v == 0.0 for n, v in by_n.items() if n % 2 == 0)
+
+
+class TestFoldOrderingsContract:
+    def test_repeated_calls_are_identical(self):
+        """Reproducibility: the same labelset must yield byte-identical folds."""
+        rng = np.random.RandomState(5)
+        X_list, y_list = _labelset(rng, 13)
+        first, _ = compute_fold_orderings(X_list, y_list, 8, rng=np.random.RandomState(42), hidden_dim=0)
+        second, _ = compute_fold_orderings(X_list, y_list, 8, rng=np.random.RandomState(42), hidden_dim=0)
+        assert first == second
+
+    def test_degenerate_fraction_still_returns_the_sentinel(self):
+        """n=4 at fraction 0.99 leaves too few training rows either way it rounds."""
+        rng = np.random.RandomState(6)
+        X_list, y_list = _labelset(rng, 4, n_pos=2)
+        orderings, fallback = compute_fold_orderings(
+            X_list, y_list, 8, rng=np.random.RandomState(42), calibration_fraction=0.99, hidden_dim=0
+        )
+        assert orderings == []
+        assert fallback == NO_GOOD_THRESHOLD
+
+    def test_tiny_fraction_still_keeps_one_calibration_item(self):
+        rng = np.random.RandomState(7)
+        X_list, y_list = _labelset(rng, 10)
+        orderings, fallback = compute_fold_orderings(
+            X_list, y_list, 8, rng=np.random.RandomState(42), calibration_fraction=0.01, hidden_dim=0
+        )
+        assert fallback is None
+        assert orderings

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -12,6 +12,23 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **Train/Calibrate split sizes are dithered rather than rounded.**
+  `calibration_folds` / `calibration_folds_cached` (and the grouped,
+  bag-aware path behind them) now round a fractional split size up with
+  probability equal to its fractional part, instead of calling `round`.
+  The count is unbiased either way; what changes is that a *tie* no longer
+  resolves the same way for every labelset of a given size. `round` is
+  round-half-to-even, so at the default `calibration_fraction=0.5` the odd
+  label's destination alternated with the label count - Train at
+  `n % 4 == 1`, Calibrate at `n % 4 == 3` - and every threshold read off
+  the fold models inherited that period-4 seesaw. Harmless for one
+  detector, but any study that advances one label at a time saw it
+  phase-locked across every run, where it survived averaging as a
+  spurious 4-label ripple (issue #3286). Thresholds remain a pure,
+  reproducible function of the labelset: the tie-break RNG is seeded from
+  a digest of the labels and training vectors, so the same votes still
+  give the same cut, and the calibration cache stays valid.
+
 - **Results exporters declare which payload kinds they handle, instead of
   sniffing the dict shape.** `LabelsetExporter` is now `ResultsExporter`
   (the old name stays as a permanent module-level alias), and it exposes

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -36,6 +36,11 @@ NO_GOOD_THRESHOLD = 2.0
 # shared global RNG state, making results order-dependent under concurrency.
 CALIBRATION_SPLIT_SEED = 42
 
+# Rows sampled from the training matrix when seeding the split-size dither (see
+# :func:`_split_dither_rng`).  Small on purpose: this only has to separate two
+# labelsets of equal size, not summarise them.
+_DITHER_SAMPLE_ROWS = 32
+
 # False-negative budget of the conformal inclusion rule at inclusion 0; each
 # +1 step of inclusion halves it (see :func:`conformal_threshold`).  0.25 means
 # the default cutoff may sacrifice at most ~25% of true matches to the
@@ -1696,6 +1701,73 @@ def _group_node_blocks(
     return [np.asarray([by_row[i] for i in rows_by_group[g]], dtype=np.float64) for g in cal_groups]
 
 
+def _split_dither_rng(X_np: np.ndarray, y_np: np.ndarray) -> "np.random.RandomState":
+    """A tie-break RNG for the Train/Calibrate split sizes, seeded from the labelset.
+
+    Deliberately **not** :data:`CALIBRATION_SPLIT_SEED`.  That seed is a
+    constant, so a draw from it is the same number on every call and would
+    replace one deterministic function of the vote count with another - which
+    is exactly the failure this dither exists to fix (issue #3286).  Seeding
+    from a digest of the training vectors and their labels instead gives a
+    draw that is *stable for a given labelset* - so the threshold stays a pure
+    function of the votes, and :func:`_calibration_cache_key` (which hashes the
+    same two arrays) stays valid - while differing between two labelsets that
+    merely happen to be the same size.
+
+    The digest is taken over the labels in full plus a **strided sample** of the
+    training rows, rather than the whole matrix.  Two reasons, and both are
+    requirements rather than optimisations:
+
+    * *Bounded cost.*  A flooded patch labelset reaches tens of thousands of
+      rows, so hashing all of it would add a ~100 MB pass to every step.  The
+      sample is capped at :data:`_DITHER_SAMPLE_ROWS` rows.
+    * *Sensitivity to the whole labelset.*  A fixed prefix would be useless: the
+      rows are laid out Good-then-Bad and the earliest votes never move, so a
+      prefix digest would barely change as a session accumulates votes and the
+      dither would freeze into a constant - a coherent pattern again, just a
+      different one.  Striding by ``len // k`` re-samples different rows at
+      every size, and the labels change length and composition on every vote.
+
+    Only slicing and ``tobytes`` are involved - no arithmetic over the
+    embeddings - so the digest is byte-exact across machines.  A reduction like
+    a column sum would not be: SIMD width changes the summation order, which is
+    how #3166 turned a sub-part-per-million difference into a moved threshold.
+    """
+    stride = max(1, len(X_np) // _DITHER_SAMPLE_ROWS)
+    h = hashlib.blake2b(np.ascontiguousarray(X_np[::stride], dtype=np.float32).tobytes(), digest_size=8)
+    h.update(np.ascontiguousarray(y_np, dtype=np.float32).tobytes())
+    return np.random.RandomState(int.from_bytes(h.digest()[:4], "little"))
+
+
+def _dithered_count(exact: float, rng: "np.random.RandomState") -> int:
+    """Round *exact* to an integer, breaking a fractional part at random.
+
+    Stochastic rounding: ``P(round up) = frac(exact)``, so the count is
+    **unbiased** (its expectation is *exact*) instead of being pinned to
+    whichever side ``round`` picks.  A whole number is returned unchanged and
+    draws nothing, so at the shipped ``calibration_fraction = 0.5`` this fires
+    on odd vote counts only - the exact ties, where "nearest" has no answer.
+
+    Why this is not just cosmetic (issue #3286).  ``round`` is round-half-to-
+    **even**, so at a 50/50 split the tie-break alternates with the vote count:
+    the odd vote joins Train at ``n % 4 == 1`` and Calibrate at ``n % 4 == 3``,
+    and ``n_train`` climbs 4, 5, 5, 5, 6, 7, 7, 7, 8 - stalling for two votes,
+    then jumping twice.  The fold models see a labelset share that seesaws with
+    period 4, and every threshold read off them inherits it.  One user never
+    notices; but the eval simulates one vote per step, so ``n`` tracks the step
+    index in *every* run and the seesaw is phase-locked across all of them.
+    Averaging hundreds of trajectories then cancels the noise and leaves the
+    artifact: a visible 4-vote ripple on the learning curves, big enough to
+    read as a real effect (see the #3286 investigation).  Randomising the tie
+    decoheres the runs, so the ripple averages away like the noise it is.
+    """
+    low = math.floor(exact)
+    frac = exact - low
+    if frac <= 0.0:
+        return int(low)
+    return int(low) + (1 if rng.random_sample() < frac else 0)
+
+
 def _grouped_folds(
     X_list: list[np.ndarray],
     y_list: list[float],
@@ -1748,13 +1820,16 @@ def _grouped_folds(
     if len(pos_groups) < 2 or len(neg_groups) < 2:
         return [], 0.5, X_np, rows_by_group, label_by_group
 
-    n_cal = max(1, round(n * calibration_fraction))
+    # Split sizes are dithered, not rounded, so a half-case does not resolve the
+    # same way for every labelset of the same size (issue #3286).
+    dither = _split_dither_rng(X_np, y_np)
+    n_cal = max(1, _dithered_count(n * calibration_fraction, dither))
     n_train = n - n_cal
     if n_train < 2 or n_cal < 1:
         return [], NO_GOOD_THRESHOLD, X_np, rows_by_group, label_by_group
 
     def _per_class_n_train(class_total: int) -> int:
-        target = round(class_total * n_train / n)
+        target = _dithered_count(class_total * n_train / n, dither)
         return max(1, min(class_total - 1, target))
 
     n_train_pos = _per_class_n_train(len(pos_groups))
@@ -1960,7 +2035,10 @@ def compute_fold_orderings(
     X_np = np.array(X_list)
     y_np = np.array(y_list)
 
-    n_cal = max(1, round(n * calibration_fraction))
+    # Split sizes are dithered, not rounded, so a half-case does not resolve the
+    # same way for every labelset of the same size (issue #3286).
+    dither = _split_dither_rng(X_np, y_np)
+    n_cal = max(1, _dithered_count(n * calibration_fraction, dither))
     n_train = n - n_cal
     if n_train < 2 or n_cal < 1:
         return [], NO_GOOD_THRESHOLD
@@ -1977,7 +2055,7 @@ def compute_fold_orderings(
     calibrate_count = max(1, calibrate_count)
 
     def _per_class_n_train(class_total: int) -> int:
-        target = round(class_total * n_train / n)
+        target = _dithered_count(class_total * n_train / n, dither)
         return max(1, min(class_total - 1, target))
 
     n_train_pos = _per_class_n_train(len(pos_idx))


### PR DESCRIPTION
Removes the period-4 ripple from averaged learning curves by breaking the split-size tie at random instead of always the same way.

Closes #3286.

## The bug

Both fold-split paths in `vtscore/training/thresholds.py` sized the Train/Calibrate split with

```python
n_cal = max(1, round(n * calibration_fraction))
```

`round` is round-half-to-**even**, so at the shipped `calibration_fraction = 0.5` every odd `n` is an exact tie and the tie-break alternates with the vote count: the odd vote joins Train at `n % 4 == 1` and Calibrate at `n % 4 == 3`. `n_train` therefore climbs `4, 5, 5, 5, 6, 7, 7, 7, 8` — stalling for two votes, then jumping twice — so the share of the labelset the fold models see seesaws with period 4, and every threshold read off those models inherits it.

One detector never notices. But the eval casts one vote per step, so `n` tracks the step index in **every** run and the seesaw is phase-locked across all of them. Averaging hundreds of trajectories cancels the noise and leaves the artifact: a 4-vote ripple on the learning curves, large enough to read as a real effect. The same clock drove the acquisition cut, so which item got voted next inherited it too, which is what sustained the ripple instead of letting it decay.

## The change

Round stochastically: `P(round up) = frac(exact)`. The count is unbiased (its expectation is exactly `n * calibration_fraction`) rather than pinned to whichever side `round` picks, and at the shipped 0.5 the draw fires **only on exact ties** — where "nearest" has no answer — so this is the minimal intervention. The same dither replaces the second rounding, `_per_class_n_train`.

The tie-break RNG is seeded from a digest of the labelset, deliberately **not** from `CALIBRATION_SPLIT_SEED`. That seed is a constant, so a draw from it would be the same number on every call and would just swap one deterministic function of `n` for another. Seeding from the data means a threshold stays a pure, reproducible function of the votes that produced it — so `_calibration_cache_key`, which hashes the same arrays, stays valid — while two labelsets that merely happen to be the same size resolve their tie independently.

The digest covers the labels in full plus a strided sample of the training rows, capped at 32. Hashing the whole matrix would add a ~100 MB pass per step on a flooded patch labelset; a fixed *prefix* would be worse than useless, since rows are laid out Good-then-Bad and the earliest votes never move, so the dither would freeze into a constant. Only slicing and `tobytes` are involved — no arithmetic over embeddings — so the digest is byte-exact across machines, which a column sum would not be (#3166).

## Measured effect

**On the split itself.** Decomposing the mod-4 structure into its period-4 contrast (`g1 − g3`, the seesaw) over 4000 labelsets per vote count:

| quantity | `round()` | dithered | removed |
|---|---|---|---|
| calibration size (`n_cal`) | −0.969 | +0.004 | 99.5% |
| pooled calibration total | −0.969 | +0.007 | 99.3% |
| calibration positives | −0.494 | −0.013 | 97% |
| calibration negatives | −0.506 | −0.011 | 98% |

The split is the only place the vote count enters the pipeline discretely, and its period-4 structure is gone.

**On the trained threshold**, over 200 labelsets per vote count, decomposed the same way:

| | period-4 (`g1 − g3`) | period-2 (even − odd) |
|---|---|---|
| `round()` | **+0.00821**, CI [+0.00416, +0.01240] | +0.00173, CI spans 0 |
| dithered | +0.00388, CI [−0.00004, +0.00806] | +0.00139, CI spans 0 |

The original ripple was **purely period-4** — the two odd classes sat at opposite extremes while the even classes were nearly equal — and after the fix it is no longer distinguishable from zero. (The +0.00388 point estimate is not evidence of a residual: its CI spans zero, and the 20×-more-precise split measurement above puts the true residual near 1%.)

**End to end**, re-running the 24-seed synthetic reproduction from the #3286 investigation:

| | before (`round`) | after (dither) |
|---|---|---|
| mod-4 cost amplitude | 0.00275 (2.3× noise) | 0.00121 (~1× noise) |
| cost residual at `n % 4 == 3` | **+0.00175** | −0.00025 |
| mean cost, t ≥ 20 | 0.2962 | 0.2947 |

The characteristic spike is gone, the residual sits inside ±1 SE, and mean cost does not regress.

## Compatibility

`calibration_folds` / `calibration_folds_cached` are public `vtscore` API and their numeric output changes on odd label counts, so this carries an `[Unreleased]` entry in `vtscore/CHANGELOG.md`. No signature changes; nothing to migrate. Thresholds remain deterministic per labelset, so nothing that caches or reloads a detector is affected.

## Tests

`tests_lib/sorting/test_split_dither.py` pins the three properties the fix rests on — unbiased, stable for a given labelset, decoherent between two labelsets of the same size — plus a regression test that no vote count resolves its tie the same way twice, and that the degenerate-fraction guards still return their sentinels. Full `./run-tests.sh` green: 9210 passed, every gate OK.