### PR TITLE
experiments: two lessons from the #3280 backfill and the #3281 fallout

### DIFF
--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -72,6 +72,8 @@ correct union of the two branches with no judgement involved.
 
 | Date | Lesson | Issue |
 |---|---|---|
+| 2026-08-28 | [a committed figure is *output*, and git merged it clean](lessons/2026-08-28-a-committed-figure-is-output-not-a-file.md) | #3280 |
+| 2026-08-28 | [I nearly rebuilt a pile dataset another session was rebuilding (#3281, #3284)](lessons/2026-08-28-nearly-rebuilt-a-dataset-another-session-owned.md) | #3281, #3284 |
 | 2026-08-27 | [a box normalised twice](lessons/2026-08-27-a-box-normalised-twice.md) | #3281 |
 | 2026-08-27 | [the region arm could not open the way the app does](lessons/2026-08-27-the-region-arm-could-not-open-the-way-the-app-does.md) | #3276 |
 | 2026-08-26 | [a completed grid reported "0 / 6480" cells](lessons/2026-08-26-a-completed-grid-reported-zero-cells.md) | #3156 |

--- a/scripts/experiments/lessons/2026-08-28-a-committed-figure-is-output-not-a-file.md
+++ b/scripts/experiments/lessons/2026-08-28-a-committed-figure-is-output-not-a-file.md
@@ -1,0 +1,58 @@
+# 2026-08-28 — a committed figure is *output*, and git merged it clean (#3280)
+
+**Study:** #3280, backfilling #3267's quality-over-clicks figures.
+**Cost:** a rebase, a 12-minute regeneration of every figure and the viewer, and
+a second full `run-tests.sh`. Caught before merge, by reading the upstream
+commit rather than by any tool.
+
+**What happened.** #3280's branch was cut from #3279's branch, because the
+curve/viewer machinery it needed lived only there and not yet on `dev`. Mid-task
+#3279 merged — and it had gained a commit making the *same* change to the figures
+that this branch had made independently, by a different and better route (drop
+the dotted baseline rule *and* the separate marker; make click 0 each series' own
+leftmost point, with the dashed segment bridging to its first trained click).
+
+Dropping the superseded commit was easy. The trap was what came with it: this
+branch had **committed PNGs and a `viewer.html`**, and those are *output of the
+code that had just changed underneath them*. The two cherry-picks applied with no
+conflict at all, so at that moment the branch held figures drawn by a renderer
+that no longer existed in its own tree, plus a report caption describing a black
+dot the new renderer no longer drew.
+
+**Why nothing caught it.** Git compares *files*. A PNG that only one side edited
+merges clean by definition, and nothing in the repo records that
+`figures/cost_vs_clicks.png` is a function of `curves.py`. Every gate agreed:
+`ruff` and `pyright` do not read PNGs, `check-docs.py` verified the image link
+resolves — it did, to a stale image — and `run-tests.sh` passed against the
+stale figures without complaint. A conflict-free merge is evidence about text,
+not about whether an artifact still describes the code that made it.
+
+**The tell, when there is one.** The prose was the only thing that broke
+visibly: the report said "marked by the black dot at the far left" while the new
+renderer drew no such marker, and the analyzer's own `FIGURE_CAPTIONS` had been
+rewritten upstream to say something else. Two copies of the same caption, one
+generated and one hand-written into `REPORT.md`, disagreed — which is the same
+argument for generating the reading copy rather than hand-writing it.
+
+Regenerating was cheap insurance and also the check: every number came back
+**bit-identical** across the two renderings, so the rendering change was
+confirmed cosmetic rather than assumed to be.
+
+**Prevented?** No — still advice, and worth a control:
+
+- **If a branch is stacked on an open PR, expect that PR to move under it**, and
+  before resolving anything, read what upstream actually did. The right
+  resolution here was to *drop* a commit, not to merge two versions of one idea.
+  Rebasing onto a moved base is not finished when the conflicts are gone.
+- **Any commit that touches a generator must regenerate that generator's
+  committed output, or say why it need not.** `curves.py`, `viewer.py` and
+  `analyze_startup.py` all have artifacts in `docs/experiments/`.
+- A real control would record the generating commit beside the artifact — a line
+  in the study's `REPORT_generated.md` naming the SHA the figures were built
+  from — so a check can compare it against the last commit touching the
+  generator. That is mechanically checkable and does not exist yet.
+
+**See also:** [a fresh worktree ran the *other* worktree's
+code](2026-08-07-a-fresh-worktree-ran-the-other-worktrees-code.md) and [a stale
+base changed the default head](2026-08-26-a-stale-base-changed-the-default-head.md)
+— the same family: the code that ran was not the code you were reading.

--- a/scripts/experiments/lessons/2026-08-28-nearly-rebuilt-a-dataset-another-session-owned.md
+++ b/scripts/experiments/lessons/2026-08-28-nearly-rebuilt-a-dataset-another-session-owned.md
@@ -1,0 +1,53 @@
+# 2026-08-28 — I nearly rebuilt a pile dataset another session was rebuilding (#3281, #3284)
+
+**Study:** #3284, scoping the reruns owed after #3281's `vg_scale` box fix.
+**Cost:** none — averted. The user said *"Careful: The vg_scale experiment is
+still running."* one turn before I would have launched it. Recorded because the
+cost of the averted version is high and nothing prevents it.
+
+**What nearly happened.** #3281's fix had merged, so I checked whether the data
+it fixes had been rebuilt. It had not: the pickles still predated the fix, and
+`build_pile.py --verify` failed on them. Correct diagnosis, and I offered to run
+the rebuild — sized honestly from a measured 12m53s prior build.
+
+What I had not checked was **who else was working on it**. Another session was
+mid-repair on the same dataset: it launched `vgscale-rebuild` minutes later, then
+relaunched the whole grid against the repaired pickles. Two sessions rebuilding
+one shared pile dataset would have interleaved writes into the same
+`vts-cache/datadir/embeddings/*.pkl` — and the failure mode is not a crash but a
+pickle that is a mixture, which every downstream run would read without
+complaint. That is worse than either the stale data or the wait.
+
+**A second version of the same mistake, in the same hour.** To run the read-only
+`--verify` I needed a worktree carrying the fix, so I `git checkout --detach`ed
+`/exp/sgreenberg/projects/vts-pile` — a **shared** worktree — off the branch it
+was sitting on, without checking whether anything was using it. Nothing was, so
+it cost nothing; had a job been running from it, I would have swapped the code
+out from under a live run. I put it back on its branch afterwards.
+
+**Why nothing caught it.** The pile is a shared artifact under one Unix account,
+and nothing serialises access to it. `preflight.sh` guards a *results* directory
+against another grid's cells, which is the analogous check one level down, but
+there is no equivalent for the pile itself, and `build_pile.py --force` will
+happily start a second time. The signals were all there and all in `squeue`,
+which I had read minutes earlier for a different purpose and not re-read before
+proposing a write.
+
+**Prevented?** No — advice, plus two things that are mechanically checkable:
+
+- **Before writing any shared artifact, ask who owns it right now.** `squeue -u
+  $USER -o "%i %j %Z"` names every running job and its working directory; a job
+  named `*rebuild*`, or any job whose `WorkDir` is the worktree you are about to
+  move, is the answer. Reading the queue for *jobs of mine* is not the same
+  question as *is anyone touching this*.
+- **A worktree is shared state.** Do not `checkout` in one you did not create;
+  make your own, or use one no job's `WorkDir` names. If you do move one, put it
+  back on its branch — a detached shared worktree is the trap already recorded
+  for `suite.sbatch`.
+- A real control: a lockfile beside the pile that `build_pile.py --force` takes
+  and refuses to proceed without, naming the job id holding it. Cheap, and it
+  converts a silent corruption into a refusal.
+
+**The wider lesson.** Diagnosing correctly ("the data is stale, here is the
+proof") does not establish that *I* am the one who should fix it. Concurrency
+between sessions is invisible in the repo and visible in the queue.


### PR DESCRIPTION
Two entries for `scripts/experiments/lessons/`, written same-day per the `grid-experiments` skill, plus the regenerated `LESSONS.md` index.

Refs #3280, #3281, #3284

## 1. A committed figure is *output*, and git merged it clean

#3280's branch was stacked on #3279's, because the curve/viewer machinery it needed lived only there. #3279 merged mid-task — carrying its own, better version of the same figure change this branch had made independently.

Dropping the superseded commit was easy. The trap was that the branch also carried **committed PNGs and a `viewer.html`**, which are *output of the code that had just changed underneath them*. Both cherry-picks applied with **no conflict**, leaving figures drawn by a renderer no longer present in the tree and a report caption describing a marker it no longer drew.

Nothing caught it, and the reason is general: git compares *files*, and nothing in the repo records that `figures/cost_vs_clicks.png` is a function of `curves.py`. `check-docs.py` confirmed the image link resolved — to a stale image. `run-tests.sh` passed.

Regenerating was also the check: every number came back **bit-identical** across the two renderings, so "the change was cosmetic" is measured rather than assumed.

## 2. I nearly rebuilt a pile dataset another session was rebuilding

A near-miss, recorded with its averted cost because nothing prevents it — the log already carries near-misses (`a login-node timing nearly cut an arm`, `a five-seed check nearly produced a wrong negative`).

The diagnosis was right — the data #3281 fixes had not been rebuilt, and `build_pile.py --verify` proved it on the actual files rather than from mtimes. The wrong step was concluding I should be the one to fix it. Another session was mid-repair and launched `vgscale-rebuild` minutes later. Two concurrent `--force` builds do not crash; they leave a pickle that is a *mixture*, which every downstream run reads without complaint.

Same shape twice in one hour: I also `checkout --detach`ed a **shared** worktree to run that read-only check without asking whether a job was using it. Nothing was, so it cost nothing.

The signals were entirely in `squeue`, which I had read minutes earlier for a different question. "Are any jobs mine?" is not the same question as "is anyone touching this?".

## Controls proposed, not implemented

Both entries say plainly that they are advice, and name the check that would make them not-advice:

- record the generating commit beside a study's figures, so a check can compare it against the last commit touching the generator;
- a lockfile beside the pile that `build_pile.py --force` must take, naming the job id holding it — converting a silent corruption into a refusal.

I have not built either; they belong to whoever picks up the pile tooling next.

## Testing

`check-docs.py` OK (250 markdown files), `gen-docs-inventories.py --check` clean, `codespell` clean. The index was regenerated by the script, not hand-edited. Docs-only change: no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)