### PR TITLE
Read both eras of the VG box scan, and add a rebuildable canary

### DIFF
--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -10,6 +10,7 @@ source scripts/experiments/pile/pile_env.sh   # point a study at it
 python build_pile.py --list                   # what exists
 python build_pile.py                          # build whatever is missing
 python build_pile.py --verify                 # check every cell is usable
+python build_pile.py --rebuildable            # check every cell could be REBUILT
 python build_pile.py --bands                  # voted-box scale bands (boxed datasets)
 ```
 
@@ -193,6 +194,25 @@ which once substituted a partial re-download and produced a healthy-looking
 `visual_genome_m` cell holding 1662 of 4193 medias. `require_demo_source`
 blocks that, and `--verify` cross-checks that a dataset's cells agree on media
 count.
+
+**`--verify` does not tell you the pile is rebuildable; `--rebuildable` does.**
+The two paths share no code, so a cell can load perfectly while the code that
+would produce it again is broken. That is not hypothetical: `scan_vg_boxes.py`
+grew a `{"meta": …, "categories": …}` envelope on 2026-08-17, the scan file on
+scratch stayed pre-envelope, and every `vg_box_*` rebuild died with
+`KeyError: 'categories'` for eleven days behind a pile that verified clean
+(#3297). `--rebuildable` runs each dataset's *selection* step — really choosing
+`vg_box_*`'s categories, confirming everything else's sources are present and
+readable — and embeds nothing, so it costs seconds. Run it after changing
+anything a build reads, and before trusting scratch to be purgeable.
+
+The reader now accepts **both** scan shapes, which is deliberate: re-running
+`scan_vg_boxes.py` would produce a current-format file, but with per-image
+compact filtering (`10239c24e`) and per-band supply (`fb4f4ec03`) that qualify
+categories differently — silently redefining three datasets whose numbers are
+published in #3129 and #3156. The envelope was the only incompatibility; the
+selector reads `voted_area`, `n_images` and `union_inflation` and nothing else,
+all three present in the 2026-08-12 file.
 
 ## Building on the GRID
 

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -16,9 +16,17 @@ Usage::
     python build_pile.py --datasets coco_val         # just COCO's cells
     python build_pile.py --embedders siglip2,siglip2_l
     python build_pile.py --verify                    # load every cell, check geometry
+    python build_pile.py --rebuildable               # can every cell still be REBUILT?
     python build_pile.py --manifest                  # (re)write MANIFEST.{json,md}
     python build_pile.py --provenance                # which device built each cell
     python build_pile.py --backfill-provenance       # fingerprint the pre-#3160 cells
+
+``--rebuildable`` is the complement to ``--verify``, and the two answer
+different questions. ``--verify`` asks whether the cells on disk are usable;
+``--rebuildable`` asks whether they could be produced again. A cell that loads
+says nothing about whether it can be rebuilt -- the paths share no code -- which
+is how the ``vg_box_*`` rebuild sat broken for eleven days behind a pile that
+verified clean (#3297). Run it before trusting the pile to be purgeable.
 
 ``--verify`` is the guard the region-voting studies needed: it asserts that
 every cell whose ``(dataset, embedder)`` pair claims region capability actually
@@ -179,6 +187,60 @@ def _load_coco(medias: dict[int, dict], embedder_name: str) -> None:
 # --------------------------------------------------------------------------
 
 
+#: The only per-category fields :func:`_band_categories` reads. Named once so
+#: the tolerance check below stays honest: if the selector ever starts reading
+#: a field the pre-envelope scans do not carry, this list is what makes the old
+#: shape fail loudly instead of selecting from partial statistics.
+_SCAN_FIELDS = ("voted_area", "n_images", "union_inflation")
+
+
+def load_box_scan_categories() -> dict[str, dict]:
+    """Read the full-VG box scan, tolerating both eras of its file format.
+
+    Two shapes exist in the wild, and the reader accepts either:
+
+    * **Pre-2026-08-17** — the bare ``{category: stats}`` dict at top level.
+      This is what the published ``vg_box_*`` sets were selected from.
+    * **2026-08-17 and later** — ``fb4f4ec03`` wrapped that dict in
+      ``{"meta": {...}, "categories": {...}}`` so per-band supply could be
+      recorded alongside it.
+
+    Tolerating both is deliberate rather than lazy. The envelope was the *only*
+    incompatibility: the newer scan also carries ``bands``, ``bands_compact``,
+    ``n_compact`` and ``compact_frac`` per category, and
+    :func:`_band_categories` reads none of them -- only ``voted_area``,
+    ``n_images`` and ``union_inflation``, all three present in the old shape.
+    So an old scan still selects exactly what it always selected, and the
+    alternative repair (re-running ``scan_vg_boxes.py``) would *not*: the
+    current scanner applies per-image compact filtering (``10239c24e``) and
+    per-band supply (``fb4f4ec03``), which qualify categories differently and
+    would silently redefine three datasets whose numbers are published in
+    #3129 and #3156. Old scans also sit on other people's scratch, so the
+    reader is the right place to absorb this rather than the file.
+    """
+    scan_path = pc.PILE / "vg_box_scale.json"
+    if not scan_path.exists():
+        raise SystemExit(f"missing {scan_path}; run scan_vg_boxes.py first")
+    scan = json.loads(scan_path.read_text())
+    if not isinstance(scan, dict) or not scan:
+        raise SystemExit(f"{scan_path} is not a non-empty JSON object; re-run scan_vg_boxes.py")
+    # Discriminate on shape, not just on the key being present: a bare scan is
+    # keyed by VG's free-text vocabulary, so "categories" is a name it could in
+    # principle hold. An envelope's "categories" maps to the stats dict; a
+    # category of that name would map to a stats entry carrying `voted_area`.
+    envelope = isinstance(scan.get("categories"), dict) and "voted_area" not in scan["categories"]
+    stats = scan["categories"] if envelope else scan
+    if not isinstance(stats, dict) or not stats:
+        raise SystemExit(f"{scan_path} holds no categories; re-run scan_vg_boxes.py")
+    # Fail here rather than with a bare KeyError deep inside the comprehension:
+    # a scan missing a field the selector needs is a format problem, and saying
+    # so by name is what tells the next person which era the file is from.
+    missing = sorted({f for f in _SCAN_FIELDS for s in stats.values() if isinstance(s, dict) and f not in s})
+    if missing:
+        raise SystemExit(f"{scan_path} categories lack {', '.join(missing)}; re-run scan_vg_boxes.py")
+    return stats
+
+
 def _band_categories(band: str) -> list[str]:
     """Pick this band's categories from the full-VG scan, stratified within it.
 
@@ -188,10 +250,7 @@ def _band_categories(band: str) -> list[str]:
     voted-area rank and taking the best-supported category in each keeps the
     band spanning its own range.
     """
-    scan_path = pc.PILE / "vg_box_scale.json"
-    if not scan_path.exists():
-        raise SystemExit(f"missing {scan_path}; run scan_vg_boxes.py first")
-    stats = json.loads(scan_path.read_text())["categories"]
+    stats = load_box_scan_categories()
     lo, hi = pc.BOX_BANDS[band]
 
     pool = [
@@ -1338,6 +1397,78 @@ def verify() -> int:
     return 0
 
 
+def rebuildable(datasets: list[str] | None = None) -> int:
+    """Exercise every dataset's *selection* step without embedding anything.
+
+    The pile documents itself as purgeable -- ``pile_config``: "every cell must
+    be rebuildable from sources that are **not** on scratch". Nothing checked
+    that. ``--verify`` loads the built cells, and a cell that loads says
+    nothing about whether it can be rebuilt: the two paths share no code, so a
+    rebuild path can rot for months behind a pile that verifies clean. It did
+    (#3297): a scan-format change on 2026-08-17 outran the scan file the
+    ``vg_box_*`` cells were selected from, and the break surfaced only when
+    somebody asked for a rebuild eleven days later.
+
+    So this is the canary that would have caught it the same day, for a few
+    seconds. It runs the part of each build that reads sources and decides
+    *what goes in the cell*, and skips the part that costs GPU-hours. For a
+    banded dataset that means really running :func:`_band_categories` and
+    reporting what it chose; elsewhere it means confirming the sources a
+    rebuild would read are present and in a shape the current code accepts.
+
+    Deliberately does not parse the multi-GB sources (VG's ``objects.json``,
+    the COCO zip). A canary nobody runs is worth nothing, and the way to make
+    it run is to keep it cheap enough to sit in front of every build.
+    """
+    for bad in [d for d in (datasets or []) if d not in pc.DATASETS]:
+        raise SystemExit(f"unknown dataset {bad!r}; known: {sorted(pc.DATASETS)}")
+    wanted = list(datasets) if datasets else list(pc.DATASETS)
+
+    problems: list[str] = []
+
+    for ds in wanted:
+        spec = pc.DATASETS[ds]
+        kind = spec.get("kind")
+        try:
+            if kind == "demo":
+                pc.require_demo_source(ds)
+                log(f"  {ds:18s} ok       demo source staged")
+            elif kind == "coco":
+                for path in (pc.COCO_ANNOTATIONS, pc.COCO_IMAGES):
+                    if not path.exists():
+                        raise SystemExit(f"{ds}: missing {path}")
+                log(f"  {ds:18s} ok       annotations + images present")
+            elif kind == "vg_band":
+                chosen = _band_categories(spec["band"])
+                log(f"  {ds:18s} ok       {len(chosen)} categories selected")
+            elif kind == "vg_scale":
+                objects_json = pc.DEMO_CACHE / "visual_genome" / "objects.json"
+                if not objects_json.exists():
+                    raise SystemExit(f"{ds}: missing {objects_json}")
+                n_cells = len(pc.SCALE_CLASSES) * len(pc.BOX_BANDS)
+                roster = "roster present" if pc.ROSTER.exists() else "NO ROSTER (membership would be redrawn)"
+                log(f"  {ds:18s} ok       VG source present, {n_cells} cells, {roster}")
+            elif kind == "vg_scale_any":
+                # Derived from the built parent, so its "source" is a cell.
+                # Absent parents are not a problem here: a full run builds the
+                # parent first, and a purged pile rebuilds both in order.
+                built = [e for e in pc.EMBEDDERS if pc.cell_path("vg_scale", e).exists()]
+                log(f"  {ds:18s} ok       derives from vg_scale ({len(built)} parent cells built)")
+            else:
+                raise SystemExit(f"{ds}: unknown kind {kind!r}; this check needs teaching about it")
+        except SystemExit as exc:  # the loaders' own way of reporting a bad source
+            log(f"  {ds:18s} BROKEN   {exc}")
+            problems.append(f"{ds}: {exc}")
+
+    if problems:
+        log(f"{len(problems)} dataset(s) CANNOT be rebuilt from their sources:")
+        for p in problems:
+            log(f"REBUILD-BROKEN: {p}")
+        return 1
+    log("every dataset's selection step runs against its current sources")
+    return 0
+
+
 def report_bands() -> int:
     """Report voted-box scale-band populations for each boxed dataset.
 
@@ -1635,6 +1766,11 @@ def main() -> int:
     ap.add_argument("--force", action="store_true", help="rebuild cells that already exist")
     ap.add_argument("--list", action="store_true", help="show cell status and exit")
     ap.add_argument("--verify", action="store_true", help="load every cell and check geometry")
+    ap.add_argument(
+        "--rebuildable",
+        action="store_true",
+        help="run every dataset's selection step against its sources, embedding nothing",
+    )
     ap.add_argument("--bands", action="store_true", help="report voted-box scale bands for boxed datasets")
     ap.add_argument("--manifest", action="store_true", help="(re)write the manifest and exit")
     ap.add_argument("--provenance", action="store_true", help="show which device built each cell")
@@ -1653,6 +1789,8 @@ def main() -> int:
         return 0
     if args.verify:
         return verify()
+    if args.rebuildable:
+        return rebuildable(args.datasets.split(",") if args.datasets else None)
     if args.bands:
         return report_bands()
     if args.manifest:

--- a/tests_lib/core/test_pile_box_scan.py
+++ b/tests_lib/core/test_pile_box_scan.py
@@ -1,0 +1,197 @@
+"""The ``vg_box_*`` rebuild path must survive both eras of the box-scan file (#3297).
+
+``build_pile.py`` selects a band's categories from ``vg_box_scale.json``. That
+file changed shape on 2026-08-17 (``fb4f4ec03`` wrapped the stats dict in a
+``{"meta": ..., "categories": ...}`` envelope) while the file on scratch stayed
+pre-envelope, so every ``vg_box_*`` rebuild died with ``KeyError: 'categories'``
+for eleven days. Nothing caught it, because the *built* cells kept loading fine
+and the rebuild path shares no code with the load path.
+
+These tests run the real selector in a subprocess against synthetic scans of
+both shapes. The subprocess is not incidental: ``pile_config.setup_env()`` edits
+``os.environ`` and ``sys.meta_path`` at import, which is not something to do to
+the shared test process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+#: One synthetic category per slot, spread across the band so the stratified
+#: selector has a real range to work with rather than a single point.
+_N_CATEGORIES = 200
+
+
+def _stats(n: int = _N_CATEGORIES) -> dict[str, dict]:
+    """Categories that all qualify: inside the ``small`` band, well supported."""
+    return {
+        f"thing{i:03d}": {
+            "voted_area": 0.001 + i * 1e-5,
+            "n_images": 100 + i,
+            "union_inflation": 1.0,
+        }
+        for i in range(n)
+    }
+
+
+def _run(pile: Path, code: str) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "VTS_PILE": str(pile),
+        "VTSEARCH_DATA_DIR": str(pile / "datadir"),
+        "VTSEARCH_MODELS_DIR": str(pile / "models"),
+        "HF_HOME": str(pile / "models"),
+    }
+    return subprocess.run(  # noqa: S603  # interpreter + test-controlled source
+        [sys.executable, "-c", code],
+        cwd=str(_PILE_DIR),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+def _select(pile: Path, band: str = "small") -> subprocess.CompletedProcess:
+    """Run the real band selector and print what it chose, as JSON."""
+    return _run(
+        pile,
+        f"import json, build_pile; print(json.dumps(build_pile._band_categories({band!r})))",
+    )
+
+
+def _chosen(result: subprocess.CompletedProcess) -> list[str]:
+    assert result.returncode == 0, f"selector failed:\n{result.stdout}\n{result.stderr}"
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def _write_scan(pile: Path, payload: object) -> None:
+    pile.mkdir(parents=True, exist_ok=True)
+    (pile / "vg_box_scale.json").write_text(json.dumps(payload))
+
+
+class TestBothScanShapes:
+    def test_envelope_scan_selects(self, tmp_path: Path) -> None:
+        """The current shape: stats wrapped in an envelope."""
+        _write_scan(tmp_path, {"meta": {"n_images_scanned": 108000}, "categories": _stats()})
+        assert _chosen(_select(tmp_path))
+
+    def test_pre_envelope_scan_selects(self, tmp_path: Path) -> None:
+        """The 2026-08-12 shape: the bare stats dict. This is the #3297 regression."""
+        _write_scan(tmp_path, _stats())
+        assert _chosen(_select(tmp_path))
+
+    def test_both_shapes_choose_the_same_categories(self, tmp_path: Path) -> None:
+        """The point of tolerating the old shape rather than re-scanning.
+
+        Re-running ``scan_vg_boxes.py`` would regenerate the file in the current
+        format, but with per-image compact filtering and per-band supply, which
+        qualify categories differently -- silently redefining three datasets
+        whose numbers are published in #3129 and #3156. Reading the old file
+        instead has to select exactly what the envelope would from the same
+        statistics, and that is what this pins.
+        """
+        old, new = tmp_path / "old", tmp_path / "new"
+        stats = _stats()
+        _write_scan(old, stats)
+        _write_scan(new, {"meta": {"n_images_scanned": 108000}, "categories": stats})
+        assert _chosen(_select(old)) == _chosen(_select(new))
+
+
+class TestMalformedScansFailByName:
+    """A bad scan should say which era it is from, not raise a bare KeyError."""
+
+    def test_missing_field_is_named(self, tmp_path: Path) -> None:
+        stats = _stats()
+        for s in stats.values():
+            del s["union_inflation"]
+        _write_scan(tmp_path, stats)
+        result = _select(tmp_path)
+        assert result.returncode != 0
+        assert "union_inflation" in result.stderr
+        assert "KeyError" not in result.stderr
+
+    def test_empty_scan_is_named(self, tmp_path: Path) -> None:
+        _write_scan(tmp_path, {})
+        result = _select(tmp_path)
+        assert result.returncode != 0
+        assert "re-run scan_vg_boxes.py" in result.stderr
+
+    def test_a_category_named_categories_is_not_an_envelope(self, tmp_path: Path) -> None:
+        """VG's vocabulary is free text, so "categories" is a name it could hold.
+
+        The envelope is detected by shape rather than by the key being present,
+        so a bare scan carrying such a category is still read as a bare scan.
+        """
+        stats = _stats()
+        stats["categories"] = {"voted_area": 0.0015, "n_images": 500, "union_inflation": 1.0}
+        _write_scan(tmp_path, stats)
+        assert "categories" in _chosen(_select(tmp_path))
+
+
+class TestRebuildableCanary:
+    """``--rebuildable`` is what would have caught #3297 the day it landed."""
+
+    def _canary(self, pile: Path) -> subprocess.CompletedProcess:
+        return _run(
+            pile,
+            "import sys, build_pile; sys.exit(build_pile.rebuildable(['vg_box_small']))",
+        )
+
+    def test_passes_on_a_readable_scan(self, tmp_path: Path) -> None:
+        _write_scan(tmp_path, _stats())
+        result = self._canary(tmp_path)
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+        assert "categories selected" in result.stdout
+
+    def test_fails_on_the_break_it_exists_to_catch(self, tmp_path: Path) -> None:
+        """An envelope-era reader against a pre-envelope file: the #3297 shape."""
+        _write_scan(tmp_path, {"meta": {}, "categories": {}})
+        result = self._canary(tmp_path)
+        assert result.returncode == 1
+        assert "REBUILD-BROKEN" in result.stdout
+
+    def test_reports_every_broken_dataset_not_just_the_first(self, tmp_path: Path) -> None:
+        """One run should surface the whole list; a canary that stops at the
+        first problem costs a round trip per dataset."""
+        _write_scan(tmp_path, {"meta": {}, "categories": {}})
+        result = _run(
+            tmp_path,
+            "import sys, build_pile; "
+            "sys.exit(build_pile.rebuildable(['vg_box_small', 'vg_box_medium', 'vg_box_large']))",
+        )
+        assert result.returncode == 1
+        assert result.stdout.count("REBUILD-BROKEN") == 3
+
+    def test_unknown_dataset_is_rejected(self, tmp_path: Path) -> None:
+        _write_scan(tmp_path, _stats())
+        result = _run(tmp_path, "import build_pile; build_pile.rebuildable(['nope'])")
+        assert result.returncode != 0
+        assert "unknown dataset" in result.stderr
+
+
+def test_selector_reads_only_fields_the_pre_envelope_scan_carries() -> None:
+    """The tolerance above is only sound while this stays true.
+
+    ``fb4f4ec03`` added ``bands``, ``bands_compact``, ``n_compact`` and
+    ``compact_frac`` per category, none of which a 2026-08-12 scan has. Reading
+    an old scan is safe precisely because the selector wants none of them. If
+    someone teaches the selector a new field, the old shape must stop being
+    silently acceptable -- so this pins the fields it may touch, and fails when
+    a new one appears rather than when a rebuild does.
+    """
+    source = (_PILE_DIR / "build_pile.py").read_text()
+    body = source.split("def _band_categories(", 1)[1].split("\ndef ", 1)[0]
+    allowed = {"voted_area", "n_images", "union_inflation"}
+    read = set(re.findall(r'\["(\w+)"\]', body))
+    assert read <= allowed, (
+        f"_band_categories reads scan fields a pre-envelope file does not carry: "
+        f"{sorted(read - allowed)}. Either drop the read or stop accepting the bare shape."
+    )


### PR DESCRIPTION
Fixes the broken `vg_box_*` rebuild path, and adds the check that would have
caught it the day it broke.

## The bug

`build_pile.py` selects a `vg_box_*` band's categories from
`vg_box_scale.json`. `scan_vg_boxes.py` grew a `{"meta": …, "categories": …}`
envelope on 2026-08-17 (`fb4f4ec03`) while the scan file on scratch stayed
pre-envelope, so every `vg_box_*` rebuild has died with `KeyError: 'categories'`
since — embedder-independent, because selection runs before the embedder is
touched. The pile documents itself as purgeable; for three datasets it was not.

## Tolerate the old shape, rather than re-scan

The envelope was the only incompatibility. The selector reads `voted_area`,
`n_images` and `union_inflation` — all three present in the 2026-08-12 file — and
reads none of the four fields `fb4f4ec03` added. Re-running `scan_vg_boxes.py`
would instead produce a current-format file selected under per-image compact
filtering (`10239c24e`) and per-band supply (`fb4f4ec03`), which qualify
categories differently and would silently redefine three datasets whose numbers
are published in #3129 and #3156.

Envelope detection is by *shape*, not by the key being present: VG's vocabulary
is free text, so a bare scan could hold a category named `categories`. A scan
missing a field the selector needs now fails by name instead of raising a bare
KeyError deep inside a comprehension.

## The repair is verified, not assumed

The issue asked for this rather than an assumption, and it is answered
statically across all three bands rather than by sampling one. Every input to
selection is byte-identical to what built the cells on 2026-08-12:

| | |
|---|---|
| `BOX_BANDS`, `BAND_MIN_IMAGES`, `BAND_MAX_INFLATION`, `BAND_N_CATEGORIES` | unchanged |
| `is_object_category`, `NON_OBJECT_CATEGORIES` (127 entries) | unchanged |
| the stratified-slot algorithm in `_band_categories` | unchanged |
| the `["categories"]` subscript | **the only change on the whole path** |

So this is a bugfix, not a dataset change. `docs/experiments/gpu-node-3160/REPORT.md`
§6.1 corroborates it empirically: fed the archived scan, today's selector
reproduced all 40 categories per band and the rebuilt cells carried identical
media ids. Confirming it against the file actually on scratch needs the GRID and
is #3299.

## `--rebuildable`

`--verify` asks whether the cells on disk are usable. The two paths share no
code, so a pile can verify clean while the code that would produce it again is
broken — which is exactly how this sat unnoticed for eleven days. The new mode
runs each dataset's selection step against its real sources and embeds nothing
(really choosing `vg_box_*`'s categories; confirming everything else's sources
are present and readable), so it costs seconds. It reports every broken dataset
rather than stopping at the first.

## Tests

`tests_lib/core/test_pile_box_scan.py`, 11 tests, 0.8 s. They drive the real
selector in a subprocess — `pile_config.setup_env()` edits `os.environ` and
`sys.meta_path` at import, which is not something to do to the shared test
process. Checked against the pre-fix reader, they reproduce the issue's exact
`KeyError: 'categories'` and 5 fail.

They pin that both shapes choose the *same* categories, that malformed scans
fail by name, that a category named `categories` isn't mistaken for an envelope,
and that the selector never starts reading a field a pre-envelope scan does not
carry — the last is what keeps the tolerance honest as the selector evolves.

## Testing

Full `./run-tests.sh`: **9249 passed, 6 skipped, 2 xpassed**, all gates green
(pyright, pip-audit, npm audit, Vitest).

## Follow-up

#3299 covers what needs the GRID: building the six now-unblocked
`vg_box_* × {clip, clip_l}` cells, running `--rebuildable` against the real pile,
and confirming the band lists against the live cells.

Closes #3297

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX9iJZkMxWsXnRJXUkJwSa)_