### PR TITLE
Hold the #3156 scale grid to the opening it declares

### DIFF
--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -235,19 +235,27 @@ DATASET_EMBEDDERS: dict[str, list[str]] = {
     # produce cells with no trainable step at all.  Both embedders are in the
     # pile, so one dataset supplies BOTH voting modes and the mode contrast
     # stops being confounded with the dataset.
-    "vg_scale_any": os.environ.get("CALIB_VGSCALE_EMBEDDERS", "siglip,dinov3_patch").split(","),
+    # The region arm is the PAIR, for the reason spelled out on `vg_scale` below:
+    # bare `dinov3_patch` cannot open on a text sort, and `EXPERIMENT_QUERIES`
+    # gives this dataset a query for every category precisely so it can.
+    "vg_scale_any": os.environ.get("CALIB_VGSCALE_EMBEDDERS", "siglip,siglip+dinov3_patch").split(","),
     # The same-class-across-bands set (#3156): one class list at three box
     # scales, so a small-vs-large difference is about size rather than about
     # which words happen to live at which size. Its categories are
     # band-suffixed (`bus@small`), and every one of them is the experiment --
     # see CATEGORY_MODE "all".
     #
-    # The region-voting arm here is normally the PAIR `siglip+dinov3_patch`
-    # rather than bare `dinov3_patch`: DINOv3 has no text tower, so on its own
-    # it opens on three random known-goods while the whole-image arms open on a
-    # text sort, and the voting-mode contrast carries a seeding contrast inside
-    # it. See PAIR_SEP.
-    "vg_scale": os.environ.get("CALIB_VGSCALE_EMBEDDERS", "siglip,dinov3_patch").split(","),
+    # The region-voting arm is the PAIR `siglip+dinov3_patch` rather than bare
+    # `dinov3_patch`: DINOv3 has no text tower, so on its own it opens on three
+    # random known-goods while the whole-image arms open on a text sort, and the
+    # voting-mode contrast carries a seeding contrast inside it. See PAIR_SEP.
+    #
+    # The DEFAULT carries the pair, not just the launchers. Every caller that
+    # sets `CALIB_VGSCALE_EMBEDDERS` already names it, so the bare fallback was
+    # reachable only by the callers that name nothing -- a direct
+    # `run_cells.py --index`, a preflight run without the env -- which are
+    # exactly the ones with no launcher comment to warn them.
+    "vg_scale": os.environ.get("CALIB_VGSCALE_EMBEDDERS", "siglip,siglip+dinov3_patch").split(","),
 }
 
 #: Region voting (drag the ground-truth box) only makes sense on a boxed dataset.

--- a/scripts/experiments/calibration/launch_scale.sh
+++ b/scripts/experiments/calibration/launch_scale.sh
@@ -68,6 +68,18 @@ export CALIB_SCHEDULE_VARIANTS=""
 export CALIB_FOLD_COUNTS=""
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
 
+# Declare the opening this study is FOR (#3278), rather than leaving it to be
+# decided per cell by whether a query happens to exist.  The pair guards itself
+# -- `siglip+dinov3_patch` exists to take the text sort, so falling back raises
+# -- but the WHOLE-IMAGE arms have no such guard: a category with no typed query
+# would open on three random known-goods while the others opened on a sort, and
+# that is the same arm-dependent seeding confound the pair was added to remove,
+# entering from the other side.  `all` categories are designated here, so the
+# `REQUIRE_SEED_QUERY` filter drops nothing: EXPERIMENT_QUERIES["vg_scale"]
+# covers every `<class>@<band>` cell.  It is a guard, not a selection knob.
+export CALIB_REQUIRE_OPENING="${CALIB_REQUIRE_OPENING:-text}"
+export CALIB_REQUIRE_SEED_QUERY="${CALIB_REQUIRE_SEED_QUERY:-1}"
+
 LOGS="$CALIB_EXP/logs"
 mkdir -p "$LOGS" "$CALIB_RESULTS/cells"
 
@@ -132,6 +144,10 @@ ENVX="$ENVX CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_MAX_STEPS=$CALIB_MAX_STEPS"
 ENVX="$ENVX CALIB_CELL_ORDER=$CALIB_CELL_ORDER"
 ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
 ENVX="$ENVX CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES"
+# `REQUIRE_SEED_QUERY` filters CATEGORIES, so it reaches the cell list: it has to
+# travel with the rest or a task enumerates a different grid than the launcher
+# counted.  `REQUIRE_OPENING` is checked per cell and travels beside it.
+ENVX="$ENVX CALIB_REQUIRE_OPENING=$CALIB_REQUIRE_OPENING CALIB_REQUIRE_SEED_QUERY=$CALIB_REQUIRE_SEED_QUERY"
 
 # A submission is not a launch: --parsable returns an EMPTY id when the submit
 # filter refuses the job (#2897 lost both arms exactly this way).


### PR DESCRIPTION
Two ways the confounded region arm could still reach a `vg_scale` run, both silent. Neither is the run #3276 still owes; both are things you would want fixed *before* launching it.

## `launch_scale.sh` never declared its opening

Unlike every other post-#3278 launcher (`launch_folds_3115.sh:128,132`, `launch_calfrac_3287.sh:111`, …) it exported neither `CALIB_REQUIRE_OPENING` nor `CALIB_REQUIRE_SEED_QUERY`.

The paired arm guards itself — `siglip+dinov3_patch` exists *for* the text sort, so `run_cells.py` raises rather than running a cell that fell back — but the **whole-image arms have no such guard**. A category with no typed query would open on three random known-goods while the others opened on a sort: the same arm-dependent seeding confound the pair was added to remove, entering from the other side.

Both knobs now default to the declaration (`text`, `1`) and travel in `ENVX`. `REQUIRE_SEED_QUERY` filters *categories*, so it reaches the cell **list** — it has to be enumerated identically on both sides of the array or an index maps to a different cell, which is the failure mode the surrounding `ENVX` comment already warns about. It drops nothing here: `EXPERIMENT_QUERIES["vg_scale"]` covers all 36 `<class>@<band>` cells (verified).

## `DATASET_EMBEDDERS` still defaulted to the bare arm

`vg_scale` and `vg_scale_any` fell back to `"siglip,dinov3_patch"` — directly under a comment saying the region arm should be the pair. Every caller that sets `CALIB_VGSCALE_EMBEDDERS` already names the pair, so the stale default was reachable only by the callers that name *nothing*: a direct `run_cells.py --index`, a preflight run without the env. Those are exactly the ones with no launcher comment to warn them.

Now `"siglip,siglip+dinov3_patch"`. This keeps the arm *set* the launchers use for these datasets (`launch_folds_3115.sh:127`, `launch_calfrac_3287.sh:110`) rather than inventing a third arm in a shared fallback; `launch_scale.sh` continues to name its own three.

## Verification

```
vg_scale ['siglip', 'siglip+dinov3_patch']
  siglip+dinov3_patch | learn=dinov3_patch | text=siglip | paired=True | patch=True
     pkl=vg_scale__dinov3_patch.pkl  textpkl=vg_scale__siglip.pkl  styles=['max_patch', 'max_patch_pca_hac']
all 36 categories have a query: True
launch_scale.sh defaults: opening=text seedq=1
```

Full `./run-tests.sh`: `RUN PASSED`, 9238 passed / 6 skipped, every gate green.

Refs #3276 — the issue still owes the overview grid **re-run** itself (60 seeds, current head, paired region arm) and the report refresh; this only makes the launch configuration honest first.


---
_Generated by [Claude Code](https://claude.ai/code/session_0159vCL1LwhqPxc3NMkviE6E)_