### PR TITLE
Build the last six pile cells, and make the canary and the GPU picker true (#3299)

### DIFF
--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -72,10 +72,12 @@ correct union of the two branches with no judgement involved.
 
 | Date | Lesson | Issue |
 |---|---|---|
+| 2026-08-28 | [a canary that checked a path the build never reads](lessons/2026-08-28-a-canary-that-checked-a-path-the-build-never-reads.md) | #3299 |
 | 2026-08-28 | [a committed figure is *output*, and git merged it clean](lessons/2026-08-28-a-committed-figure-is-output-not-a-file.md) | #3280 |
 | 2026-08-28 | [a detached worktree ate a commit, and `git push` said OK](lessons/2026-08-28-a-detached-worktree-ate-a-commit-and-the-push-said-ok.md) | #3292 |
 | 2026-08-28 | [a figure that hung, and three fixes that were not it](lessons/2026-08-28-a-figure-that-hung-and-three-fixes-that-were-not-it.md) | #3156 |
 | 2026-08-28 | [I nearly rebuilt a pile dataset another session was rebuilding (#3281, #3284)](lessons/2026-08-28-nearly-rebuilt-a-dataset-another-session-owned.md) | #3281, #3284 |
+| 2026-08-28 | [the GPU picker reported every GPU on the cluster as free](lessons/2026-08-28-the-gpu-picker-reported-every-gpu-free.md) | #3299 |
 | 2026-08-27 | [a box normalised twice](lessons/2026-08-27-a-box-normalised-twice.md) | #3281 |
 | 2026-08-27 | [a repair moves more than the defect](lessons/2026-08-27-a-repair-moves-more-than-the-defect.md) | #3281 |
 | 2026-08-27 | [The pick log was being concatenated into every analyzer's metric frame](lessons/2026-08-27-the-pick-log-was-in-every-metric-frame.md) | — |

--- a/scripts/experiments/lessons/2026-08-28-a-canary-that-checked-a-path-the-build-never-reads.md
+++ b/scripts/experiments/lessons/2026-08-28-a-canary-that-checked-a-path-the-build-never-reads.md
@@ -1,0 +1,50 @@
+# 2026-08-28 — a canary that checked a path the build never reads (#3299)
+
+**What broke.** `build_pile.py --rebuildable`, added the day before by #3300 to
+prove every pile dataset can still be rebuilt from off-scratch sources, ran for
+the first time against the real cluster and reported:
+
+```
+[pile]   coco_val           BROKEN   coco_val: missing /exp/scale26/datasets/external/COCO/images/val2017
+[pile] REBUILD-BROKEN: coco_val: ...
+```
+
+Nothing was broken. `_load_coco` reads
+`COCO_ROOT/images/**val2017.zip**` — 815 MB, present, staged in July and
+untouched. `val2017/` is an extracted directory the staging area has never
+held, and the README says so: *"COCO from the staged zip plus flattened
+annotations."* The canary checked `pc.COCO_IMAGES`; the builder spelled the zip
+path inline. Two names for one source, and the check took the one the build
+never opens.
+
+**Cost.** ~10 minutes of investigation, and it very nearly cost more: the issue
+that commissioned the run said anything reporting `REBUILD-BROKEN` "is a second
+purge-time landmine of the same kind as #3297 and wants its own issue". Filing
+that issue would have been the reasonable-looking wrong move. The check that
+settled it was two lines — read what `_load_coco` opens, then `ls` it.
+
+**The general form.** A canary is only as good as the identity between what it
+checks and what the real path does. Here the constant `COCO_IMAGES` existed and
+looked authoritative, so the new code used it without asking whether the builder
+did. **The builder had its own copy of the path**, which is what let the two
+disagree — and neither was wrong on its own terms.
+
+The consequence is worse than a plain bug. A false alarm costs exactly what a
+true alarm costs, and it is spent on nothing; a canary that cries wolf on its
+first real run is a canary people learn to skip, which is the one failure mode
+that makes it worthless. So a false positive here is not a milder version of a
+false negative. It is how you lose the check.
+
+**Prevented.** `pile_config.COCO_VAL_ZIP` now names the zip once; `_load_coco`
+and `rebuildable()` both go through it, and `COCO_IMAGES` is documented as the
+optional extracted directory that only `box_sheets.py` wants. Three tests in
+`tests_lib/core/test_pile_box_scan.py` cover the COCO branch of the canary,
+which had none: a staged-zip-only tree passes, a missing zip still fails, and a
+source-level assertion fails if the builder ever spells `val2017.zip` inline
+again. That last one is the real guard — it pins the *identity*, not the
+behaviour.
+
+**Related, and still only advice.** `box_sheets.py` reads COCO pixels from the
+same non-existent `COCO_IMAGES` directory. It does not error; `path_of` simply
+returns `None` for every media and the sheet comes out empty. Nobody has asked
+it for a COCO sheet yet. Filed separately.

--- a/scripts/experiments/lessons/2026-08-28-the-gpu-picker-reported-every-gpu-free.md
+++ b/scripts/experiments/lessons/2026-08-28-the-gpu-picker-reported-every-gpu-free.md
@@ -1,0 +1,59 @@
+# 2026-08-28 — the GPU picker reported every GPU on the cluster as free (#3299)
+
+**What broke.** `scripts/slurm/pick_gpu.py` measured usage from the `GresUsed=`
+field of `scontrol show node --oneliner`. This cluster (Slurm 23.11.6) writes
+that field on **zero** nodes — `scontrol show node --oneliner | grep -c GresUsed=`
+returns `0`, and the multi-line form does not carry it either. The reader
+flattened the missing field to an empty string, so `used = {}` and
+`free = total` on every node, on every type, always.
+
+The visible symptom was a picker that looked like it was working:
+
+```
+pick_gpu:   a100      23 free /  23 total
+pick_gpu:   l40s      14 free /  14 total
+pick_gpu:   v100     110 free / 110 total
+pick_gpu: a100 -- 23/23 free -- fastest type with 3 free to start on now
+```
+
+Every count is the node total. Read off `AllocTRES=` instead, the same moment
+was `a100 0/23`, `l40s 2/14`, `v100 109/110`. The three `vg_box_* × clip`
+build jobs went to A100 and came back `Reason=Priority`,
+`StartTime=2026-08-29T12:33` — **a 24-hour wait, with 109 V100s idle**.
+
+**Cost.** ~15 minutes, all of it noticing. Cancelled and resubmitted with
+`VTS_GPU=v100`; all three jobs started within 20 seconds and the six cells
+built in ~11 minutes. Had nobody looked at `squeue`, it would have been a day.
+Structurally the cost is larger and older: because `free == total` everywhere,
+rule 2 of the selection order ("fastest type with `--need` free") always
+matched the **first** candidate, so since 2026-08-17 the picker has returned
+`a100` unconditionally. It was a hardcoded `a100` wearing a query.
+
+**The general form.** The
+[predecessor lesson](2026-08-17-a-hardcoded-gpu-type-is-a-pin-that.md) replaced
+a hardcoded `v100` with "ask the scheduler", and the replacement did not ask —
+it read a field that does not exist here and could not tell that apart from a
+field that says zero. **A missing measurement must not be spellable as a
+measurement of zero.** Both are falsy, and the failure is silent in the
+direction that looks like good news: everything free, first choice wins, log
+line reads exactly like success.
+
+It survived a full test suite because **every fixture wrote a `GresUsed`
+field**. Twelve parser tests, all green, all describing a cluster the code
+never meets. A fixture is a claim about production, and this one was never
+checked against a real record.
+
+**Prevented.** `_node_gpus_used` now prefers `GresUsed` where a cluster writes
+it, falls back to `AllocTRES`'s `gres/gpu:<type>=<n>`, and returns `None` when
+**neither** field is present — a node whose usage cannot be read now contributes
+nothing at all, exactly like a drained one, so an unreadable cluster degrades to
+the fallback type instead of confidently claiming everything is free. The new
+tests in `tests_lib/core/test_pick_gpu.py` are built from records copied
+verbatim off `rack5n06` and `rack10n01` rather than composed, so the fixture
+cannot drift away from the machine again.
+
+**Still advice.** `VTS_GPU=v100` in `~/.bashrc` short-circuits the picker
+entirely (`pick_gpu: v100 (VTS_GPU is set; not querying the scheduler)`) and
+has silently pinned launches before — see
+[`grid-gpu-node-gotchas`](../GRID-PLAYBOOK.md). Today it would have been the
+*right* answer by accident, which is not a reason to keep it.

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -24,18 +24,27 @@ Embedders got re-run because the cache had no home of its own.
 
 ## The grid
 
-Three datasets x three embedders: `siglip` (the shipped default, 768-d),
-`siglip2_l` (the premium end, 1152-d) and `dinov3_patch` (768-d, the only
-patch-capable one). Differing dims mean galleries are **not** interchangeable
-between `siglip` and `siglip2_l`.
+Eight datasets x five embedders, complete — 40 of 40 cells built as of
+2026-08-28.
 
-The middle columns (`siglip_l`, `siglip2`) were deliberately dropped: a study
-learns little from interpolating between the endpoints, and the compute is
-better spent on more runs of the ones that matter. The cost is that
+| embedder | dim | note |
+|---|---:|---|
+| `siglip` | 768 | the shipped default |
+| `siglip2_l` | 1152 | the premium end |
+| `dinov3_patch` | 768 | the only patch-capable one, so the only region-voting column |
+| `clip` | 512 | a different pretraining *family*, at base capacity |
+| `clip_l` | 768 | the same family at large capacity |
+
+Differing dims mean galleries are **not** interchangeable across columns.
+
 `siglip` -> `siglip2_l` moves *generation* (1 -> 2) and *capacity* (base ->
-SO400M) together, so a difference between them cannot be attributed to either
-alone. `build_pile.py --embedders siglip2` rebuilds a middle column if a result
-ever needs that split.
+SO400M) together, so a difference between those two cannot be attributed to
+either alone. That is what the CLIP columns are for: `clip`/`clip_l` change the
+pretraining family at two capacities, which is the axis #3292 needed and could
+not get from the SigLIP pair. The middle SigLIP columns (`siglip_l`, `siglip2`)
+are still deliberately absent — a study learns little from interpolating
+between endpoints — and `build_pile.py --embedders siglip2` rebuilds one if a
+result ever needs that split.
 
 | dataset | medias | boxed | note |
 |---|---:|:--:|---|
@@ -45,6 +54,16 @@ ever needs that split.
 | `vg_box_small` | 12000 | yes | box-banded VG: union box **below one patch** |
 | `vg_box_medium` | 12000 | yes | box-banded VG: patch → HAC leaf |
 | `vg_box_large` | 12000 | yes | box-banded VG: leaf → 80% of the image |
+| `vg_scale` | 7747 | yes | one class list held fixed across every box-size band |
+| `vg_scale_any` | 7747 | yes | derived from `vg_scale`, band collapsed away (#3115) |
+
+The six `vg_box_* x {clip, clip_l}` cells were the last gap, and they were
+unbuildable rather than merely unbuilt: band selection died before the embedder
+was ever reached (#3297). They were built on 2026-08-28 once that was repaired.
+Unlike their `siglip2_l` siblings from 2026-08-12 they carry the
+`ATEN_CPU_CAPABILITY=avx2` pin, but no comparison rests on that: the CPU-dispatch
+divergence #3160 measured is in the **384px** resize, and both CLIP columns are
+224px models, where the resize is bit-identical either way.
 
 ### The box-banded VG sets
 
@@ -214,14 +233,33 @@ published in #3129 and #3156. The envelope was the only incompatibility; the
 selector reads `voted_area`, `n_images` and `union_inflation` and nothing else,
 all three present in the 2026-08-12 file.
 
+**Where a band is already built, `--rebuildable` also asks whether a rebuild
+would produce *that*.** "Selection runs" and "selection picks the same thing"
+come apart in the direction that hurts: both candidate repairs for #3297 made
+the selector run again, and only one kept choosing the categories the published
+sets hold — the other would have redefined three datasets with the right media
+count, the right vectors and nothing visible to say so. So the canary compares
+today's selection against the vocabulary the smallest built cell carries and
+reports `REBUILD-BROKEN` on any difference. Verified against the live pile on
+2026-08-28: all three bands reproduce exactly, 40/40 categories, agreeing
+across all three cells present at the time (#3299).
+
 ## Building on the GRID
 
 ```bash
-bash launch_pile.sh              # prefetch weights (CPU), then one GPU job per dataset
+bash launch_pile.sh              # canary + weights (CPU), then one GPU job per dataset
 bash launch_pile.sh coco_val     # just one dataset
 ```
 
-Weights are prefetched in a separate CPU stage because parallel GPU jobs would
+`--rebuildable` runs in front of every launch. That is the answer to "what runs
+the canary periodically": every build already touches the pile, the check costs
+a fraction of a second, and a purge is the worst possible moment to learn the
+rebuild path rotted. It reports **all** datasets — rot under one you are not
+building today still gets seen — but only the datasets being launched gate the
+submission, since a broken source under a dataset nobody asked for is news
+rather than grounds to refuse.
+
+Weights are prefetched in the same CPU stage because parallel GPU jobs would
 otherwise race on the shared HF cache, and because the embedders load with
 `cache_dir=<VTSEARCH_MODELS_DIR>` — prefetching to the HF default instead leaves
 weights the jobs cannot see.
@@ -234,3 +272,10 @@ hardcoded `v100`, which is why every cell built before 2026-08-17 was embedded o
 the slowest GPU on the cluster — 2.3× slower for `siglip2_l` than the L40S nodes
 sitting idle beside it. Set `VTS_GPU` to pin a type anyway; see
 [`docs/SETUP.md`](../../../docs/SETUP.md#which-gpu-type-gets-requested).
+
+Until 2026-08-28 that query was answering from a field this cluster does not
+emit, so it read every GPU as free and always returned the first candidate —
+a hardcoded `a100` wearing a query, which sent the #3299 build into a 24-hour
+queue with 109 V100s idle. It now reads `AllocTRES` where `GresUsed` is absent
+and refuses to count a node whose usage it cannot read; see
+[the lesson](../lessons/2026-08-28-the-gpu-picker-reported-every-gpu-free.md).

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -139,7 +139,7 @@ def _load_coco(medias: dict[int, dict], embedder_name: str) -> None:
     """
     if not pc.COCO_ANNOTATIONS.exists():
         raise SystemExit(f"missing COCO annotations: {pc.COCO_ANNOTATIONS}")
-    zip_path = pc.COCO_ROOT / "images" / "val2017.zip"
+    zip_path = pc.COCO_VAL_ZIP
     if not zip_path.exists():
         raise SystemExit(f"missing COCO images zip: {zip_path}")
 
@@ -1397,6 +1397,42 @@ def verify() -> int:
     return 0
 
 
+def _band_vocab_drift(dataset: str, chosen: list[str]) -> str:
+    """Would rebuilding this band reproduce the cells that already exist?
+
+    ``--rebuildable`` on its own answers a weaker question than it looks like it
+    answers: that selection *runs*, not that it selects the same thing. Those
+    come apart in the direction that hurts. #3297's two candidate repairs both
+    made the selector run again; only one of them kept picking the categories
+    the published ``vg_box_*`` sets were built from, and taking the other would
+    have silently redefined three datasets whose numbers are cited in #3129 and
+    #3156 -- with the right media count, the right vectors, and nothing to look
+    at that would say so.
+
+    So where a cell is already built, compare its vocabulary against what the
+    selector picks today. Reads the smallest present cell: every cell carries
+    ``categories``, so there is no reason to page in the multi-GB patch one.
+    Returns an empty string when they agree (or when nothing is built yet --
+    a purged pile has nothing to reproduce, which is not a failure).
+    """
+    present = [(pc.cell_path(dataset, e).stat().st_size, e) for e in pc.EMBEDDERS if pc.cell_path(dataset, e).exists()]
+    if not present:
+        return ""
+    _, emb = min(present)
+    medias = _cells_io().load_medias(pc.cell_path(dataset, emb))
+    live = {c for m in medias.values() for c in (m.get("categories") or [])}
+    gained = sorted(set(chosen) - live)
+    lost = sorted(live - set(chosen))
+    if not gained and not lost:
+        return ""
+    return (
+        f"{dataset}: a rebuild would NOT reproduce the built cells -- selection now differs "
+        f"from {dataset}__{emb}.pkl by {len(gained)} added and {len(lost)} dropped "
+        f"categories (added {gained[:5]}, dropped {lost[:5]}). That is a dataset change, "
+        f"not a rebuild; published numbers that cite this set would need re-examining."
+    )
+
+
 def rebuildable(datasets: list[str] | None = None) -> int:
     """Exercise every dataset's *selection* step without embedding anything.
 
@@ -1416,6 +1452,12 @@ def rebuildable(datasets: list[str] | None = None) -> int:
     reporting what it chose; elsewhere it means confirming the sources a
     rebuild would read are present and in a shape the current code accepts.
 
+    Where a banded dataset is already built it goes one question further, via
+    :func:`_band_vocab_drift`: not only "would a rebuild run?" but "would a
+    rebuild produce *this*?". A repair that restores the former while quietly
+    changing the latter is the expensive kind, and it is invisible from the
+    built cell.
+
     Deliberately does not parse the multi-GB sources (VG's ``objects.json``,
     the COCO zip). A canary nobody runs is worth nothing, and the way to make
     it run is to keep it cheap enough to sit in front of every build.
@@ -1434,12 +1476,19 @@ def rebuildable(datasets: list[str] | None = None) -> int:
                 pc.require_demo_source(ds)
                 log(f"  {ds:18s} ok       demo source staged")
             elif kind == "coco":
-                for path in (pc.COCO_ANNOTATIONS, pc.COCO_IMAGES):
+                # The *zip*, which is what `_load_coco` opens. Checking the
+                # extracted directory instead reported this dataset broken
+                # against sources that were entirely intact (#3299) -- a canary
+                # that names a different path than the build is not a canary.
+                for path in (pc.COCO_ANNOTATIONS, pc.COCO_VAL_ZIP):
                     if not path.exists():
                         raise SystemExit(f"{ds}: missing {path}")
-                log(f"  {ds:18s} ok       annotations + images present")
+                log(f"  {ds:18s} ok       annotations + image zip present")
             elif kind == "vg_band":
                 chosen = _band_categories(spec["band"])
+                drift = _band_vocab_drift(ds, chosen)
+                if drift:
+                    raise SystemExit(drift)
                 log(f"  {ds:18s} ok       {len(chosen)} categories selected")
             elif kind == "vg_scale":
                 objects_json = pc.DEMO_CACHE / "visual_genome" / "objects.json"

--- a/scripts/experiments/pile/launch_pile.sh
+++ b/scripts/experiments/pile/launch_pile.sh
@@ -52,15 +52,40 @@ BUILDENV="$ENVSET && export VTSEARCH_TORCH_THREADS=$CPUS OMP_NUM_THREADS=$CPUS M
 # so in their provenance.
 BUILDENV="$BUILDENV ATEN_CPU_CAPABILITY=${VTS_CPU_CAPABILITY:-avx2}"
 
-# --- Stage 1: weights (CPU, blocking) -------------------------------------
-echo "=== prefetching weights (CPU) ==="
-srun --job-name=pile-prefetch --partition=cpu --cpus-per-task=4 --mem=8G --time=2:00:00 \
-  bash -lc "$ENVSET && python prefetch_models.py" 2>&1 | tail -20
-
-# --- Stage 2: one GPU job per dataset -------------------------------------
 DATASETS=("${@:-visual_genome_m caltech101_m coco_val}")
 read -r -a DATASETS <<< "${DATASETS[@]}"
+DS_CSV="$(IFS=,; echo "${DATASETS[*]}")"
 
+# --- Stage 1: rebuild canary, then weights (CPU, blocking) ----------------
+# The canary runs in front of every launch because that is the only thing that
+# exercises the rebuild path on any schedule at all. `--verify` loads the built
+# cells and shares no code with the build, so a rebuild path can rot invisibly
+# behind a pile that verifies clean -- #3297 did, for eleven days, and surfaced
+# only when somebody asked for a rebuild. A purge is the worst possible moment
+# to discover that. It costs a fraction of a second, which is what makes here
+# the right place for it: a canary expensive enough to skip gets skipped.
+#
+# Two runs, on purpose. The first reports **every** dataset, so rot under one
+# you are not building today still gets seen. The second covers only the
+# datasets about to be built, and its exit code is what gates the launch: a
+# broken source under a dataset nobody asked for is news, not grounds to refuse
+# to submit. It runs inside the srun rather than on the login node because
+# build_pile.py asserts it is running against its own checkout's vtscore, which
+# needs the venv this ENVSET activates.
+echo "=== rebuild canary + weights (CPU) ==="
+if ! srun --job-name=pile-prefetch --partition=cpu --cpus-per-task=4 --mem=8G --time=2:00:00 \
+  bash -lc "$ENVSET \
+    && { python build_pile.py --rebuildable || true; } \
+    && python build_pile.py --rebuildable --datasets $DS_CSV >/dev/null \
+    && python prefetch_models.py"; then
+  echo >&2
+  echo "prelaunch FAILED -- nothing submitted." >&2
+  echo "  Either the rebuild canary found a source ${DATASETS[*]} cannot be built" >&2
+  echo "  from (look for REBUILD-BROKEN above), or the weight prefetch failed." >&2
+  exit 1
+fi
+
+# --- Stage 2: one GPU job per dataset -------------------------------------
 # Pick the GPU type from what is actually free, and do it *here* rather than at
 # the top of the script: stage 1 blocks on the queue, so availability measured
 # before the prefetch is stale by the time we submit. This used to be a

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -40,6 +40,15 @@ MODELS = PILE / "models"
 #: Shared, non-scratch sources the pile is rebuilt from.
 DEMO_CACHE = Path(os.environ.get("VTS_DEMO_CACHE", "/exp/scale26/datasets/external/vtsearch-demos"))
 COCO_ROOT = Path(os.environ.get("VTS_COCO_ROOT", "/exp/scale26/datasets/external/COCO"))
+#: The zip the builder reads pixels out of. This, not an extracted directory,
+#: is what a `coco_val` rebuild actually depends on -- the staging area holds
+#: `val2017.zip` and has never held `val2017/`. Named here because it was
+#: previously spelled inline in the builder while :data:`COCO_IMAGES` named the
+#: directory, and the rebuild canary checked the directory: it reported
+#: `coco_val` REBUILD-BROKEN against a source that was present and fine (#3299).
+COCO_VAL_ZIP = COCO_ROOT / "images" / "val2017.zip"
+#: Where the images live *if* somebody extracts them. Optional, and not part of
+#: the rebuild path; `box_sheets.py` looks here for pixels to draw.
 COCO_IMAGES = COCO_ROOT / "images" / "val2017"
 COCO_ANNOTATIONS = COCO_ROOT / "derived" / "objects_flat_val2017.jsonl.gz"
 

--- a/scripts/slurm/pick_gpu.py
+++ b/scripts/slurm/pick_gpu.py
@@ -20,7 +20,8 @@ fall back toward availability when the fast types are busy. Selection order:
    fast queue slot.
 4. Failing that (nothing free anywhere), the type with the largest total pool,
    since the biggest pool drains soonest.
-5. Failing that (``scontrol`` unreachable, or none of the candidates exist here),
+5. Failing that (``scontrol`` unreachable, none of the candidates exist here,
+   or no node reports its GPU usage in a form this can read),
    ``$VTS_GPU_FALLBACK``.
 
 The chosen type goes to **stdout**; the reason goes to **stderr**, so callers can
@@ -79,6 +80,11 @@ _UNUSABLE_STATE = re.compile(
 # candidate even when it is idle.
 _GRES_RE = re.compile(r"gpu:([A-Za-z0-9_.-]+):(\d+)")
 
+# The same counts as they appear in `AllocTRES=`: `gres/gpu:a100=4`. The untyped
+# `gres/gpu=4` alongside it is a total over types and deliberately does not
+# match, or every allocated GPU would be counted twice.
+_ALLOC_GPU_RE = re.compile(r"gres/gpu:([A-Za-z0-9_.-]+)=(\d+)")
+
 
 @dataclass(frozen=True)
 class Availability:
@@ -89,8 +95,14 @@ class Availability:
     total: int
 
 
-def _field(line: str, key: str) -> str:
-    """Read ``key=value`` out of one ``scontrol show node --oneliner`` record.
+def _field_opt(line: str, key: str) -> str | None:
+    """``key=value`` from one node record, or None if the key is absent.
+
+    The distinction matters: ``AllocTRES=`` is written *empty* on a node with
+    nothing allocated, which is a measurement ("zero used"), while a key that
+    does not appear at all is the absence of a measurement. Collapsing the two
+    is what let :func:`_node_gpus_used` read "no usage field" as "nothing is
+    used" and report a fully-booked cluster as fully free (#3299).
 
     Regex rather than splitting on whitespace because a few values on that line
     (``Reason=``, ``OS=``) contain spaces, which would shift every field after
@@ -98,7 +110,12 @@ def _field(line: str, key: str) -> str:
     ``GresUsed=``.
     """
     match = re.search(rf"(?:^|\s){re.escape(key)}=(\S*)", line)
-    return match.group(1) if match else ""
+    return match.group(1) if match else None
+
+
+def _field(line: str, key: str) -> str:
+    """``key=value``, with an absent key flattened to the empty string."""
+    return _field_opt(line, key) or ""
 
 
 def _gpu_counts(gres: str) -> dict[str, int]:
@@ -108,13 +125,46 @@ def _gpu_counts(gres: str) -> dict[str, int]:
     return counts
 
 
+def _node_gpus_used(line: str) -> dict[str, int] | None:
+    """How many GPUs of each type this node has allocated, or None if unknowable.
+
+    Two fields can answer it, and which one exists depends on the Slurm build:
+
+    * ``GresUsed=gpu:a100:4(IDX:0-3)`` -- the direct answer, when present.
+    * ``AllocTRES=cpu=32,mem=384G,gres/gpu=4,gres/gpu:a100=4`` -- the same
+      number by another route. Written **empty** on a node with nothing
+      allocated, which is still an answer: zero.
+
+    The cluster this runs on (Slurm 23.11.6) emits ``GresUsed`` on *no* node in
+    ``scontrol show node --oneliner``, so the original reader -- which looked
+    only there and treated a missing field as an empty string -- computed
+    ``free == total`` for every node on the cluster and always returned the
+    first candidate type. It reported "a100 23/23 free" against 23 allocated
+    A100s and 109 idle V100s, and the resulting job was told it would start in
+    24 hours (#3299). Every test fixture wrote a ``GresUsed`` field, so nothing
+    caught it: the fixtures described a cluster the code never met.
+
+    Returning None rather than ``{}`` when neither field is present is the
+    point of the repair. "I cannot measure usage" must not be spellable as
+    "nothing is used", because those two produce opposite launches.
+    """
+    used = _field_opt(line, "GresUsed")
+    if used is not None:
+        return _gpu_counts(used)
+    alloc = _field_opt(line, "AllocTRES")
+    if alloc is not None:
+        return {t: int(n) for t, n in _ALLOC_GPU_RE.findall(alloc)}
+    return None
+
+
 def parse_node_availability(scontrol_output: str, partition: str = DEFAULT_PARTITION) -> dict[str, Availability]:
     """Sum free/total GPUs per type over the usable nodes of ``partition``.
 
     ``scontrol_output`` is ``scontrol show node --oneliner`` (one node per line).
-    Nodes outside the partition, and nodes in an unusable state, contribute
-    nothing at all -- not even to ``total`` -- so a drained node full of idle
-    A100s never advertises itself as the shortest queue.
+    Nodes outside the partition, in an unusable state, or whose GPU usage
+    cannot be read at all contribute nothing -- not even to ``total`` -- so a
+    drained node full of idle A100s never advertises itself as the shortest
+    queue, and neither does a node this parser cannot understand.
     """
     free: dict[str, int] = {}
     total: dict[str, int] = {}
@@ -130,7 +180,12 @@ def parse_node_availability(scontrol_output: str, partition: str = DEFAULT_PARTI
             continue
 
         node_total = _gpu_counts(_field(line, "Gres"))
-        node_used = _gpu_counts(_field(line, "GresUsed"))
+        node_used = _node_gpus_used(line)
+        if node_used is None:
+            # Unmeasurable: contribute nothing at all, exactly as a drained node
+            # does. A node whose usage cannot be read is not evidence of a free
+            # GPU, and pretending otherwise is the #3299 failure.
+            continue
         for gpu_type, count in node_total.items():
             total[gpu_type] = total.get(gpu_type, 0) + count
             # A node can report more used than configured only if the two fields

--- a/tests_lib/core/test_pick_gpu.py
+++ b/tests_lib/core/test_pick_gpu.py
@@ -120,6 +120,76 @@ class TestParseNodeAvailability:
         assert pick_gpu.parse_node_availability("scontrol: error: Invalid node name\n") == {}
 
 
+class TestUsageWithoutGresUsed:
+    """The cluster does not write ``GresUsed``; usage has to come from ``AllocTRES``.
+
+    Every fixture above supplies a ``GresUsed`` field, which is why nothing
+    caught #3299: the HLTCOE cluster (Slurm 23.11.6) emits that field on **no**
+    node, so the reader saw an empty string, computed ``free == total``
+    everywhere and always returned the first candidate type. It advertised
+    "a100 23/23 free" while all 23 A100s were allocated and 109 V100s idled.
+    The records below are copied from that cluster rather than composed, so a
+    future reader cannot describe a machine the code never meets.
+    """
+
+    #: Verbatim `scontrol show node --oneliner` for rack5n06, 2026-08-28: four
+    #: A100s, all four allocated, and no GresUsed field anywhere on the line.
+    BUSY_A100 = (
+        "NodeName=rack5n06 Arch=x86_64 CoresPerSocket=24  CPUAlloc=32 CPUEfctv=96 CPUTot=96 CPULoad=5.06 "
+        "AvailableFeatures=a100,intel,40gb ActiveFeatures=a100,intel,40gb Gres=gpu:a100:4 NodeAddr=rack5n06 "
+        "NodeHostName=rack5n06 Version=23.11.6 OS=Linux 5.14.0-687.13.1.el9_8.x86_64 #1 SMP PREEMPT_DYNAMIC "
+        "Tue Jun 2 11:33:56 EDT 2026  RealMemory=750000 AllocMem=393216 FreeMem=8524 Sockets=2 Boards=1 "
+        "State=MIXED ThreadsPerCore=2 TmpDisk=6900000 Weight=1 Owner=N/A MCS_label=N/A Partitions=gpu  "
+        "BootTime=2026-06-25T09:05:36 SlurmdStartTime=2026-07-08T10:05:26 LastBusyTime=2026-08-24T02:01:17 "
+        "ResumeAfterTime=None CfgTRES=cpu=96,mem=750000M,billing=1950,gres/gpu=4,gres/gpu:a100=4 "
+        "AllocTRES=cpu=32,mem=384G,gres/gpu=4,gres/gpu:a100=4 CapWatts=n/a CurrentWatts=0 AveWatts=0 "
+        "ExtSensorsJoules=n/a ExtSensorsWatts=0 ExtSensorsTemp=n/a"
+    )
+
+    #: Same cluster, rack10n01: eight idle V100s. `AllocTRES=` is present and
+    #: **empty**, which is a real measurement (zero) and not a missing field.
+    IDLE_V100 = (
+        "NodeName=rack10n01 Arch=x86_64 CoresPerSocket=20 CPUAlloc=0 CPUEfctv=80 CPUTot=80 CPULoad=0.01 "
+        "AvailableFeatures=v100,intel ActiveFeatures=v100,intel Gres=gpu:v100:8 NodeAddr=rack10n01 "
+        "NodeHostName=rack10n01 Version=23.11.6 RealMemory=1000000 AllocMem=0 FreeMem=900000 Sockets=2 "
+        "Boards=1 State=IDLE ThreadsPerCore=2 TmpDisk=7100000 Weight=1 Owner=N/A MCS_label=N/A "
+        "Partitions=gpu  BootTime=2026-06-13T19:13:24 SlurmdStartTime=2026-07-08T10:05:26 "
+        "CfgTRES=cpu=80,mem=1000000M,billing=3208,gres/gpu=8,gres/gpu:v100=8 AllocTRES= "
+        "CapWatts=n/a CurrentWatts=0 AveWatts=0"
+    )
+
+    def test_a_fully_allocated_node_reports_zero_free(self):
+        avail = pick_gpu.parse_node_availability(self.BUSY_A100)
+        assert avail["a100"] == pick_gpu.Availability("a100", free=0, total=4)
+
+    def test_an_empty_alloctres_means_zero_used_not_unknown(self):
+        avail = pick_gpu.parse_node_availability(self.IDLE_V100)
+        assert avail["v100"] == pick_gpu.Availability("v100", free=8, total=8)
+
+    def test_the_slow_type_wins_when_the_fast_one_is_full(self):
+        """The whole point: this pair used to select a100 and pend for a day."""
+        avail = pick_gpu.parse_node_availability(self.BUSY_A100 + "\n" + self.IDLE_V100)
+        gpu_type, _ = pick_gpu.select_gpu_type(avail, need=3)
+        assert gpu_type == "v100"
+
+    def test_the_untyped_gres_gpu_total_is_not_double_counted(self):
+        """`AllocTRES` carries both `gres/gpu=4` and `gres/gpu:a100=4`."""
+        assert pick_gpu._node_gpus_used(self.BUSY_A100) == {"a100": 4}
+
+    def test_gres_used_still_wins_where_a_cluster_writes_it(self):
+        """Other Slurm builds do emit it; do not regress them onto AllocTRES."""
+        line = _node("n1", gres="gpu:l40s:8", used="gpu:l40s:3") + " AllocTRES=cpu=8,gres/gpu:l40s=7"
+        assert pick_gpu.parse_node_availability(line)["l40s"].free == 5
+
+    def test_a_node_with_no_usage_field_at_all_is_not_counted_as_free(self):
+        """Unmeasurable is not empty: it must not advertise a free GPU."""
+        line = (
+            "NodeName=n1 Arch=x86_64 Gres=gpu:a100:8 RealMemory=256000 State=MIXED Partitions=gpu "
+            "BootTime=2026-08-01T00:00:00"
+        )
+        assert pick_gpu.parse_node_availability(line) == {}
+
+
 class TestSelectGpuType:
     # No return annotation: pick_gpu is loaded by path, so its Availability is a
     # runtime attribute pyright cannot use in a type expression.

--- a/tests_lib/core/test_pile_box_scan.py
+++ b/tests_lib/core/test_pile_box_scan.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import pickle
 import re
 import subprocess
 import sys
@@ -41,13 +42,14 @@ def _stats(n: int = _N_CATEGORIES) -> dict[str, dict]:
     }
 
 
-def _run(pile: Path, code: str) -> subprocess.CompletedProcess:
+def _run(pile: Path, code: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
     env = {
         **os.environ,
         "VTS_PILE": str(pile),
         "VTSEARCH_DATA_DIR": str(pile / "datadir"),
         "VTSEARCH_MODELS_DIR": str(pile / "models"),
         "HF_HOME": str(pile / "models"),
+        **(extra_env or {}),
     }
     return subprocess.run(  # noqa: S603  # interpreter + test-controlled source
         [sys.executable, "-c", code],
@@ -175,6 +177,109 @@ class TestRebuildableCanary:
         result = _run(tmp_path, "import build_pile; build_pile.rebuildable(['nope'])")
         assert result.returncode != 0
         assert "unknown dataset" in result.stderr
+
+
+class TestCanaryCatchesASilentDatasetChange:
+    """ "Would a rebuild run?" is weaker than "would a rebuild produce *this*?".
+
+    #3297 had two candidate repairs and both made selection run again; only one
+    kept picking the categories the published ``vg_box_*`` sets hold. Taking the
+    other would have redefined three datasets with the right media count, the
+    right vectors and nothing visible to say so. #3299 checked that by hand
+    against the live cells; this is the same check, in the canary.
+    """
+
+    def _cell(self, pile: Path, categories: list[str], embedder: str = "siglip") -> None:
+        """Write a `vg_box_small` cell holding exactly *categories*."""
+        embeddings = pile / "datadir" / "embeddings"
+        embeddings.mkdir(parents=True, exist_ok=True)
+        medias = {i: {"id": i, "categories": [c]} for i, c in enumerate(categories)}
+        with (embeddings / f"vg_box_small__{embedder}.pkl").open("wb") as fh:
+            pickle.dump(medias, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+    def _canary(self, pile: Path) -> subprocess.CompletedProcess:
+        return _run(pile, "import sys, build_pile; sys.exit(build_pile.rebuildable(['vg_box_small']))")
+
+    def _selected(self, pile: Path) -> list[str]:
+        _write_scan(pile, _stats())
+        return _chosen(_select(pile))
+
+    def test_agreeing_cell_passes(self, tmp_path: Path) -> None:
+        self._cell(tmp_path, self._selected(tmp_path))
+        result = self._canary(tmp_path)
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+
+    def test_a_changed_vocabulary_is_reported_as_broken(self, tmp_path: Path) -> None:
+        chosen = self._selected(tmp_path)
+        self._cell(tmp_path, [*chosen[:-1], "something_else_entirely"])
+        result = self._canary(tmp_path)
+        assert result.returncode == 1
+        assert "REBUILD-BROKEN" in result.stdout
+        assert "would NOT reproduce" in result.stdout
+
+    def test_no_built_cell_is_not_a_failure(self, tmp_path: Path) -> None:
+        """A purged pile has nothing to reproduce; that is the rebuild case."""
+        _write_scan(tmp_path, _stats())
+        assert self._canary(tmp_path).returncode == 0
+
+
+class TestCanaryChecksThePathTheBuildReads:
+    """The canary must name the *same* source the builder opens (#3299).
+
+    Its first real run reported ``coco_val`` REBUILD-BROKEN. Nothing was
+    broken: ``_load_coco`` reads ``images/val2017.zip``, which was present,
+    while the canary checked ``images/val2017`` -- an extracted directory the
+    staging area has never held. A canary pointed at a path the build never
+    touches raises a false alarm exactly as loudly as a true one, which is the
+    fastest way to teach people to ignore it.
+    """
+
+    def _coco_canary(self, pile: Path, root: Path) -> subprocess.CompletedProcess:
+        return _run(
+            pile,
+            "import sys, build_pile; sys.exit(build_pile.rebuildable(['coco_val']))",
+            extra_env={"VTS_COCO_ROOT": str(root)},
+        )
+
+    def _stage(self, root: Path, *, zip_present: bool = True, extracted: bool = False) -> None:
+        (root / "images").mkdir(parents=True, exist_ok=True)
+        (root / "derived").mkdir(parents=True, exist_ok=True)
+        (root / "derived" / "objects_flat_val2017.jsonl.gz").write_bytes(b"")
+        if zip_present:
+            (root / "images" / "val2017.zip").write_bytes(b"")
+        if extracted:
+            (root / "images" / "val2017").mkdir(exist_ok=True)
+
+    def test_the_staged_zip_alone_is_a_rebuildable_source(self, tmp_path: Path) -> None:
+        """How the source actually sits on the cluster: a zip, never unpacked."""
+        _write_scan(tmp_path, _stats())
+        root = tmp_path / "COCO"
+        self._stage(root)
+        result = self._coco_canary(tmp_path, root)
+        assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+        assert "REBUILD-BROKEN" not in result.stdout
+
+    def test_a_missing_zip_is_still_reported(self, tmp_path: Path) -> None:
+        """Relaxing the check must not turn it off: an extracted directory is
+        not a substitute for the zip the builder opens."""
+        _write_scan(tmp_path, _stats())
+        root = tmp_path / "COCO"
+        self._stage(root, zip_present=False, extracted=True)
+        result = self._coco_canary(tmp_path, root)
+        assert result.returncode == 1
+        assert "REBUILD-BROKEN" in result.stdout
+        assert "val2017.zip" in result.stdout
+
+    def test_the_canary_and_the_builder_name_one_path(self, tmp_path: Path) -> None:
+        """Pins the repair itself: both sides go through ``pc.COCO_VAL_ZIP``.
+
+        Spelling the zip inline in the builder while a constant named the
+        directory is what let the two drift apart in the first place.
+        """
+        source = (_PILE_DIR / "build_pile.py").read_text()
+        loader = source.split("def _load_coco(", 1)[1].split("\ndef ", 1)[0]
+        assert "pc.COCO_VAL_ZIP" in loader
+        assert 'val2017.zip"' not in loader, "the builder is spelling the zip path inline again"
 
 
 def test_selector_reads_only_fields_the_pre_envelope_scan_carries() -> None:


### PR DESCRIPTION
Closes #3299.

The pile is complete: **40 of 40 cells**, `--verify` green on all of them. The six `vg_box_* × {clip, clip_l}` cells built on jobs `582384`–`582386`, 8m09s each, 0 failures — `clip` 136s embed per 12000 images, `clip_l` 229s.

The cells were the cheap part. Three things had to be repaired to get them, and each is worth more than the cells are.

## The GPU picker was reporting every GPU on the cluster as free

`pick_gpu.py` measured usage from `GresUsed=`. This cluster writes that field on **zero** nodes — `scontrol show node --oneliner | grep -c GresUsed=` returns `0` — and the reader flattened the missing field to an empty string, so `free == total` on every node, on every type, always. Rule 2 of its selection order ("fastest type with `--need` free") therefore always matched the **first** candidate. Since 2026-08-17 it has been a hardcoded `a100` wearing a query.

It looked like it was working:

```
pick_gpu:   a100      23 free /  23 total
pick_gpu:   l40s      14 free /  14 total
pick_gpu:   v100     110 free / 110 total
pick_gpu: a100 -- 23/23 free -- fastest type with 3 free to start on now
```

Every number there is the node total. Read off `AllocTRES` at the same moment: `a100 0/23`, `l40s 2/14`, `v100 109/110`. The three build jobs went to A100 and came back `Reason=Priority`, `StartTime=2026-08-29T12:33` — **a 24-hour wait, with 109 V100s idle**. Cancelled, resubmitted on V100, running in 20 seconds.

`_node_gpus_used` now prefers `GresUsed` where a cluster writes it, falls back to `AllocTRES`'s `gres/gpu:<type>=<n>`, and returns `None` when **neither** is present — an unmeasurable node contributes nothing at all, exactly like a drained one, so an unreadable cluster degrades to the fallback instead of confidently claiming everything is free. A missing measurement must not be spellable as a measurement of zero; both are falsy, and the failure is silent in the direction that reads like good news.

Verified on the cluster after the fix, picking `l40s` over `a100` for the first time ever:

```
pick_gpu:   a100       0 free /  23 total
pick_gpu:   l40s       1 free /  14 total
pick_gpu:   v100     110 free / 110 total
pick_gpu: l40s -- 1/14 free -- fastest type with 1 free to start on now
```

Twelve green parser tests missed this because **every fixture wrote a `GresUsed` field** — they described a cluster the code never meets. The new ones are copied verbatim off `rack5n06` and `rack10n01`.

## The canary's first real run was a false alarm

`--rebuildable` reported `coco_val` REBUILD-BROKEN against sources that were entirely intact. It checked `images/val2017`, an extracted directory the staging area has never held; `_load_coco` opens `images/val2017.zip`, 815 MB, present since July. The builder carried its own inline copy of that path while `COCO_IMAGES` named the directory, which is what let the two disagree.

`pile_config.COCO_VAL_ZIP` now names it once and both sides go through it. Three tests cover the COCO branch, which had none — including a source-level assertion that fails if the builder ever spells `val2017.zip` inline again, because the thing worth pinning is the *identity*, not the behaviour.

Worth stating plainly: **a false alarm costs exactly what a true alarm costs**, and it is spent on nothing. The issue instructed that any `REBUILD-BROKEN` "wants its own issue"; filing one would have been the reasonable-looking wrong move.

## The canary asked a weaker question than it looked like it asked

That selection *runs*, not that it selects the same thing. Those come apart in the direction that hurts: #3297 had two candidate repairs, both of which made the selector run again, and only one of which kept picking the categories the published `vg_box_*` sets hold. The other would have redefined three datasets with the right media count, the right vectors and nothing to look at that would say so.

So `--rebuildable` now compares today's selection against the vocabulary of the smallest built cell (`_band_vocab_drift`), and reports `REBUILD-BROKEN` on any difference. That is #3299's Part 3 answered by committed code rather than by hand — and against the live pile it passes:

| dataset | selector picks | live cell holds | cells compared | verdict |
|---|---:|---:|---|---|
| `vg_box_small` | 40 | 40 | `siglip`, `siglip2_l`, `dinov3_patch` | identical |
| `vg_box_medium` | 40 | 40 | `siglip`, `siglip2_l`, `dinov3_patch` | identical |
| `vg_box_large` | 40 | 40 | `siglip`, `siglip2_l`, `dinov3_patch` | identical |

Not just against `siglip`: all three present cells of each band agree with each other and with the selector, and every selected category is carried by at least 52 images in its cell. So the #3297 repair is confirmed to be a bugfix and not a dataset change, and #3129 / #3156 need no re-examination. Costs 0.93s for all eight datasets, up from 0.23s.

## Where the periodic canary runs

In front of every launch, inside `launch_pile.sh`'s existing blocking CPU stage. Every build already touches the pile, the check is sub-second, and a purge is the worst possible moment to learn the rebuild path rotted.

Two runs, deliberately: the first reports **all eight** datasets, so rot under something you are not building today still gets seen; the second covers only the datasets being submitted and its exit code gates the launch, because a broken source under a dataset nobody asked for is news rather than grounds to refuse. Both halves tested against the real launcher on the cluster:

- `VTS_COCO_ROOT=/tmp/nope bash launch_pile.sh coco_val` → `REBUILD-BROKEN`, `prelaunch FAILED -- nothing submitted`, exit 1, empty queue.
- `VTS_COCO_ROOT=/tmp/nope bash launch_pile.sh vg_box_small` → same report, launch proceeds, `submitted vg_box_small -> job 582411`, exit 0.

It runs inside the `srun` rather than on the login node because `build_pile.py` asserts it is running against its own checkout's `vtscore`, which needs the venv.

## Also here

- `README.md`'s grid section said "three datasets x three embedders" and listed six datasets. It is eight × five now, with a table, and a note on what the CLIP columns buy that the SigLIP pair cannot (family at fixed capacity, rather than generation and capacity moving together).
- Two lesson files, and `LESSONS.md` regenerated.
- #3305 filed: `box_sheets.py` is the other consumer of the non-existent `COCO_IMAGES` directory. It does not error — it draws an empty sheet. Not urgent (no COCO sheet has ever been asked for), not fixed here.

## Testing

`tests_lib/core/test_pick_gpu.py` 32 passed, `tests_lib/core/test_pile_box_scan.py` 17 passed. Full suite on the GRID: job `582413` — result added below.