### PR TITLE
Eval: supervised-skyline arm and the training-regret decomposition

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -327,6 +327,33 @@ Each metric row carries the operating point at that step's threshold — `cost` 
 
 `DETECTION_METRICS` in the same module carries each metric's label and its **direction**, and is what the report figures and the interactive viewer read — so nothing downstream decides for itself which way is "better".
 
+#### The supervised skyline and training regret (`skyline_arms`)
+
+`cost = oracle_cost + regret` splits a step's cost into "the ranking" and "the cut", but `oracle_cost` still conflates two causes that call for opposite fixes: **no linear head in this embedding can separate the class**, and **a head could, but 10–200 clicks did not find it**. Pass `skyline_arms=["skyline_train_full"]` (requires `emit_calibration_metrics`) to split them:
+
+```
+cost = skyline_oracle_cost   (learnability floor: embedding + head capacity)
+     + training_regret       (headroom the interactive loop left on the table)
+     + regret                (what the cut rule gave away on the ranking it got)
+```
+
+`skyline_train_full` is the standard supervised-skyline arm: the **same head, through the same trainer**, trained on the entire simulation split with **full ground-truth labels** and evaluated on the untouched test split — same hypothesis class, same features, full supervision, disjoint eval. It delegates to `_train_and_calibrate` rather than fitting an estimator of its own, so the gap it measures is "fewer labels" and not "a different trainer" (and so it needs no `Mirror(...)` entry to stay drift-proof).
+
+`training_regret` is defined on **rankings** — `oracle_cost(mortal) − oracle_cost(skyline)` — which is what makes the telescope exact. Routing the skyline through a calibrated cut would re-mix in the term `regret` already isolates, so the skyline's own threshold is the test oracle's: `cost == oracle_cost` and `regret == 0` on a skyline row **by construction**. Read its `oracle_cost`, never its `regret`.
+
+Four things to know before reading the numbers:
+
+- **The row is per *run*, not per step.** A skyline is vote-independent, so it is emitted once per `(cell, seed)` at `t = 0` with `app_trained = 0`, tagged in `gmm_variant` like every other variant family. The four decomposition columns (`skyline_oracle_cost`, `skyline_oracle_cost_honest`, `training_regret`, `training_regret_honest`) are then filled on *every* row of the run, so the identity holds within a row. Cost: one extra fit per arm per cell, not per click.
+- **Negative `training_regret` is legal.** Unlike the threshold oracle, the skyline is not a per-run optimum over the same object — region votes carry box information an image-labelled skyline lacks, and small samples get lucky. Nothing clamps it.
+- **The terms are sum-pinned**, so the same caution `_operating_metrics` documents for `rule_inefficiency` / `calibration_shift` applies verbatim: they share noise by construction, so don't read one half moving as an effect when the knob also moves the yardstick.
+- **The gap bundles several causes** — how many labels, *which* labels (the acquisition policy), and the full split's imbalance. Read it as "headroom left by the interactive loop", not as one cause.
+
+`skyline_test_xfit` is the optional bracket partner, and it is **cross-fitted**: the test split is partitioned into folds and each item is scored by a head that never saw it. A naive train-on-test fit is not an option — a ~769-parameter linear head on a test set of comparable size can shatter near-arbitrary labelings, so it would report near-zero cost on a genuinely unlearnable class and its "regret" would measure `d / n_test` rather than learnability. It is the SVM analogue of `honest_test_oracle`, which does the same thing one level down for the *cut*; its pooled scores share a ranking but not a calibrated scale, so read it for `oracle_cost` / `auroc` / `average_precision` only.
+
+**v1 is the whole-image column.** Full supervision hands out *image* labels, but the mortal `max_patch` flow trains on GT-box-pooled vectors, so a patch column's skyline is a design decision — "oracle boxes + all images", or the multiple-instance problem of which patch of a positive image is the positive — and issue #3321 holds it open. The harness warns and skips on a patch style rather than improvising one, so a sweep over both columns still gets the decomposition on the column that has one.
+
+Set `CALIB_SKYLINE_ARMS=skyline_train_full` to turn the arm on in the calibration experiment runner.
+
 #### The pick log (`pick_sink`)
 
 Pass a list as `pick_sink` to get one row per **click** (columns: `_PICK_COLUMNS`) — what was picked, whether it was a positive, and where on the seed sort it came from. The main frame starts at the first *trainable* step, because before one Good and one Bad vote coexist there is no model, no threshold and no metrics row; so the opening is exactly the part it does not record. An opening that never finds both classes emits **no main row at all**, which is a result about that opening rather than a missing cell.

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -214,6 +214,46 @@ Not to be confused with the older `analyze_folds.py` / `launch_folds_2861.sh`,
 which moved the fold count to 4 only to unlock the anchored `qmean`/`qmedian`
 combine question — it measures no cost and covers region voting only.
 
+## Supervised skyline / training regret (issue #3322)
+
+```bash
+CALIB_SKYLINE_ARMS=skyline_train_full ./launch_cells.sh
+```
+
+Splits the frame's `oracle_cost` into a **learnability floor** and the headroom
+the interactive loop left on the table:
+
+```
+cost = skyline_oracle_cost + training_regret + regret
+```
+
+`skyline_train_full` trains the same head, through the same trainer, on the
+**entire sim split with full ground-truth labels**, and scores the untouched
+test split. That answers the routing question no other column answers: when a
+cell is expensive, buy a better *embedder* (high floor) or a better
+*acquisition loop* (high `training_regret`)? A stuck run with a low floor was a
+findable class the loop missed; one with a high floor was never learnable in
+that space.
+
+Add `skyline_test_xfit` for the cross-fitted test-side bracket partner. It is
+**never** a naive train-on-test fit — a ~769-parameter head on a test set of
+comparable size shatters near-arbitrary labelings and would report `d / n_test`
+under the name "learnability" — so it folds the test split and scores each item
+with a head that never saw it, the SVM analogue of `honest_test_oracle`.
+
+Nearly free: the skyline is vote-independent, so it costs **one extra fit per
+arm per cell**, not one per click. Both arms emit a single `t = 0` row tagged in
+`gmm_variant`, and the four decomposition columns
+(`skyline_oracle_cost{,_honest}`, `training_regret{,_honest}`) are filled on
+every row of the run so the identity holds within a row.
+
+Scoped to the **whole-image** column in v1: a patch column's skyline needs a
+supervision decision (GT boxes vs. a multiple-instance problem) that is still
+open on #3321, so the harness warns and skips there rather than improvising one.
+See [`docs/EVAL.md`](../../../docs/EVAL.md) for the full read, and
+`tests_lib/detectors/test_skyline_arm.py` for the telescope, vote-independence
+and cross-fitting checks.
+
 ## Voted-media exclusion floor (issue #3312)
 
 ```bash

--- a/scripts/experiments/calibration/analyze_cut.py
+++ b/scripts/experiments/calibration/analyze_cut.py
@@ -141,7 +141,10 @@ def tail_alpha_of(variant: str) -> float | None:
 #: telling the analyzer, and :func:`unclassified_variants` says so — see there
 #: for why that has to be loud rather than silent.
 NON_CANDIDATES: tuple[str, ...] = ("xcal_only",)
-NON_CANDIDATE_PREFIXES: tuple[str, ...] = ("image_",)
+#: ``skyline_`` is here for the same reason ``ORACLE_VARIANTS`` exists: the #3322
+#: skyline arms read ground-truth labels the app can never see, so they are
+#: diagnostics that decompose the cost rather than rules competing to ship.
+NON_CANDIDATE_PREFIXES: tuple[str, ...] = ("image_", "skyline_")
 
 #: The variant that *reconstructs* the production rule of #2836's era.  Kept as
 #: the historical contrast, but it is a reconstruction and reconstructions go

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -517,6 +517,20 @@ FOLD_COUNTS = [int(k) for k in os.environ.get("CALIB_FOLD_COUNTS", "").split(","
 #: :data:`CALIBRATE_COUNT` itself - the screen cannot see it.
 FOLD_COUNT_SCHEDULE = os.environ.get("CALIB_FOLD_COUNT_SCHEDULE", "").strip() or None
 
+#: **Supervised-skyline** arms to measure once per run (issue #3322), splitting
+#: ``oracle_cost`` into a learnability floor plus the headroom the interactive
+#: loop left on the table.  Empty (the default) = off, and every other study runs
+#: exactly as before.
+#:
+#: ``CALIB_SKYLINE_ARMS=skyline_train_full`` is the headline: the same head,
+#: through the same trainer, on the entire sim split with full ground-truth
+#: labels.  Add ``skyline_test_xfit`` for the cross-fitted test-side bracket
+#: partner.  Both are vote-independent, so the price is one extra fit per arm per
+#: cell rather than one per click - and both are scoped to the whole-image column
+#: in v1 (a patch column's skyline needs a supervision decision that is still
+#: open on #3321; the harness warns and skips there rather than improvising one).
+SKYLINE_ARMS = [a.strip() for a in os.environ.get("CALIB_SKYLINE_ARMS", "").split(",") if a.strip()]
+
 #: Which head each step trains (``vtscore.eval.voting_iterations.HEADS``).
 #: Unset (the default) hands ``head=None`` to the harness, which resolves it to
 #: the head the live detector actually trains — ``linear_svm``.  That is the

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -219,6 +219,7 @@ def main(argv: list[str] | None = None) -> int:
         f"fold_count_schedule={cfg.FOLD_COUNT_SCHEDULE or 'off'} "
         f"sim_fraction={cfg.SIM_FRACTION} exclusion={cfg.exclusion_arm_name()} "
         f"cut_incl_ks={cfg.CUT_INCLUSION_KS or 'off'} "
+        f"skyline_arms={cfg.SKYLINE_ARMS or 'off'} "
         f"acq_inclusion_offset={cfg.ACQ_INCLUSION_OFFSET} acq_rank_percentile={cfg.ACQ_RANK_PERCENTILE} "
         f"startup_schedule={cfg.STARTUP_SCHEDULE or 'app default'}"
     )
@@ -306,6 +307,7 @@ def main(argv: list[str] | None = None) -> int:
             anchored_fold_arms=cfg.ANCHORED_FOLD_ARMS,
             anchored_fold_combines=cfg.ANCHORED_FOLD_COMBINES,
             fold_count_variants=cfg.FOLD_COUNTS or None,
+            skyline_arms=cfg.SKYLINE_ARMS or None,
             fold_count_schedule=cfg.FOLD_COUNT_SCHEDULE,
             cut_inclusion_ks=cfg.CUT_INCLUSION_KS or None,
             cut_inclusion_sink=cutincl_local,

--- a/tests_lib/detectors/test_skyline_arm.py
+++ b/tests_lib/detectors/test_skyline_arm.py
@@ -1,0 +1,356 @@
+"""The supervised-skyline arms and the training-regret decomposition (issue #3322).
+
+``oracle_cost`` conflates two very different causes: no linear head in this
+embedding can separate the class (the **floor**), and a head could but 10-200
+clicks did not find it (the **shortfall**).  The skyline arm splits them, so
+``cost = skyline_oracle_cost + training_regret + regret``.
+
+These tests pin the three properties that make that split mean anything: the
+telescope is *exact*, the skyline is *vote-independent* (one row per run, and
+turning it on cannot move a single vote), and the bracket arm is genuinely
+**cross-fitted** rather than a train-on-test fit wearing the word "skyline".
+
+Everything runs on small synthetic single-vector datasets - no model downloads.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.eval.patch_styles import WholeImageStyle
+from vtscore.eval.voting_iterations import (
+    _CALIBRATION_COLUMNS,
+    _SKYLINE_COLUMNS,
+    _WHOLE_IMAGE_STYLE,
+    SKYLINE_ARMS,
+    SKYLINE_PROVENANCE,
+    SKYLINE_TEST_XFIT,
+    SKYLINE_TRAIN_FULL,
+    TIMING_COLUMNS,
+    _skyline_arm_rows,
+    _skyline_fit_and_score,
+    simulate_voting_iterations,
+)
+
+from .test_max_patch_style import _planted_dataset
+
+DIM = 64
+
+
+def _blob_dataset(n_per_cat=30, seed=0, separation=3.0, dim=DIM):
+    """Two Gaussian blobs, linearly separable at *separation* - a learnable class."""
+    rng = np.random.default_rng(seed)
+    direction = np.zeros(dim, dtype=np.float32)
+    direction[0] = 1.0
+    medias: dict[int, dict] = {}
+    mid = 1
+    for cat, sign in (("cat0", 1.0), ("cat1", -1.0)):
+        for _ in range(n_per_cat):
+            vec = rng.normal(0, 1.0, dim).astype(np.float32) + sign * separation * direction
+            medias[mid] = {"id": mid, "category": cat, "embeddings": {"emb": vec}}
+            mid += 1
+    return medias
+
+
+def _noise_dataset(n_per_cat=25, seed=0, dim=DIM):
+    """Labels independent of features, with ``dim`` comparable to the sample size.
+
+    This is the fixture the cross-fitting check needs: a linear head with ``dim``
+    free parameters shatters near-arbitrary labelings of a sample this size, so a
+    naive train-on-test skyline reports near-zero cost on a class nothing can
+    learn.  A cross-fitted one cannot.
+    """
+    rng = np.random.default_rng(seed)
+    medias: dict[int, dict] = {}
+    mid = 1
+    for cat in ("cat0", "cat1"):
+        for _ in range(n_per_cat):
+            vec = rng.normal(0, 1.0, dim).astype(np.float32)
+            medias[mid] = {"id": mid, "category": cat, "embeddings": {"emb": vec}}
+            mid += 1
+    return medias
+
+
+def _run(medias, *, arms=(SKYLINE_TRAIN_FULL,), seed=0, max_steps=14, **kw):
+    return simulate_voting_iterations(
+        medias,
+        target_category="cat0",
+        seed=seed,
+        dataset_name="synthetic",
+        inclusion=0,
+        safe_thresholds=False,
+        max_steps=max_steps,
+        style="whole_image",
+        emit_calibration_metrics=True,
+        skyline_arms=list(arms),
+        **kw,
+    )
+
+
+def _split(rows):
+    """``(mortal rows, skyline rows)``."""
+    return (
+        [r for r in rows if not r["gmm_variant"]],
+        [r for r in rows if r["gmm_variant"] in SKYLINE_ARMS],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Emission shape
+# ---------------------------------------------------------------------------
+
+
+def test_style_constant_matches_the_style_registry():
+    """The spelled-out name is pinned against the class it stands for."""
+    assert _WHOLE_IMAGE_STYLE == WholeImageStyle.name
+
+
+def test_one_row_per_arm_per_run_at_step_zero():
+    rows = _run(_blob_dataset(), arms=SKYLINE_ARMS)
+    mortal, skyline = _split(rows)
+    assert mortal, "no mortal rows produced"
+    assert [r["gmm_variant"] for r in skyline] == [SKYLINE_TRAIN_FULL, SKYLINE_TEST_XFIT]
+    for r in skyline:
+        # A skyline belongs to no step, so it is given a step index no
+        # trajectory can occupy rather than being duplicated onto all of them.
+        assert r["t"] == 0
+        assert r["app_trained"] == 0
+        assert r["threshold_provenance"] == SKYLINE_PROVENANCE
+        assert set(_CALIBRATION_COLUMNS).issubset(r.keys())
+    assert all(r["t"] >= 1 for r in mortal)
+
+
+def test_full_supervision_is_the_whole_simulation_split():
+    medias = _blob_dataset(n_per_cat=30)
+    rows = _run(medias)
+    _mortal, skyline = _split(rows)
+    row = skyline[0]
+    assert row["n_good"] + row["n_bad"] == row["n_haystack"]
+    # Full supervision leaves nothing in the haystack unlabelled.
+    assert row["n_remainder"] == 0
+
+
+def test_skyline_is_vote_independent():
+    """The decomposition columns are one constant of the run, not a per-step number."""
+    rows = _run(_blob_dataset())
+    mortal, skyline = _split(rows)
+    floor = skyline[0]["oracle_cost"]
+    assert {r["skyline_oracle_cost"] for r in mortal} == {floor}
+    assert len({r["skyline_oracle_cost_honest"] for r in mortal}) == 1
+
+
+def test_learnable_class_has_a_low_floor():
+    """A separable blob is learnable, so the floor is near zero and the loop's shortfall is the rest."""
+    rows = _run(_blob_dataset(separation=4.0))
+    _mortal, skyline = _split(rows)
+    assert skyline[0]["oracle_cost"] < 0.05
+    assert skyline[0]["average_precision"] > 0.95
+
+
+def test_columns_are_nan_without_the_arm():
+    rows = _run(_blob_dataset(), arms=())
+    assert rows
+    assert all(not r["gmm_variant"].startswith("skyline") for r in rows)
+    for r in rows:
+        for col in _SKYLINE_COLUMNS:
+            assert np.isnan(r[col])
+
+
+# ---------------------------------------------------------------------------
+# The telescope
+# ---------------------------------------------------------------------------
+
+
+def test_three_term_decomposition_telescopes_exactly():
+    rows = _run(_blob_dataset(), arms=SKYLINE_ARMS)
+    assert rows
+    for r in rows:
+        assert r["skyline_oracle_cost"] + r["training_regret"] + r["regret"] == pytest.approx(r["cost"], abs=1e-5)
+        # #3116's honest reference re-bases the same split, and telescopes too.
+        assert r["skyline_oracle_cost_honest"] + r["training_regret_honest"] + r["regret_honest"] == pytest.approx(
+            r["cost"], abs=1e-5
+        )
+        # `training_regret` is defined on RANKINGS - a difference of oracle
+        # costs - which is exactly what makes the identity above exact.  Routing
+        # the skyline through a calibrated cut would re-mix in `regret`.
+        assert r["training_regret"] == pytest.approx(r["oracle_cost"] - r["skyline_oracle_cost"], abs=1e-5)
+
+
+def test_primary_arm_is_its_own_reference():
+    rows = _run(_blob_dataset(), arms=SKYLINE_ARMS)
+    _mortal, skyline = _split(rows)
+    ref = next(r for r in skyline if r["gmm_variant"] == SKYLINE_TRAIN_FULL)
+    assert ref["training_regret"] == pytest.approx(0.0, abs=1e-9)
+    # A skyline row is a statement about a ranking: its cut is the test oracle's,
+    # so `cost == oracle_cost` and `regret == 0` BY CONSTRUCTION on that row.
+    assert ref["cost"] == pytest.approx(ref["oracle_cost"], abs=1e-6)
+    assert ref["regret"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_negative_training_regret_is_not_clamped():
+    """A mortal step that out-ranks the skyline is information, not a bug."""
+    # The whole-image column of a planted-PATCH dataset: the CLS vector averages
+    # the signal away, so the image-labelled skyline is genuinely weak and some
+    # step beats it.  Nothing in the harness may clamp that to zero.
+    medias, _ = _planted_dataset(n_per_cat=30, seed=0)
+    rows = _run(medias, region_voting=True)
+    mortal, skyline = _split(rows)
+    assert skyline, "no skyline row"
+    assert any(r["training_regret"] < 0 for r in mortal), "fixture no longer produces a negative regret"
+
+
+# ---------------------------------------------------------------------------
+# The arm cannot move the run it describes
+# ---------------------------------------------------------------------------
+
+
+def test_skyline_does_not_perturb_the_trajectory():
+    """Turning the arm on must not move a single vote, threshold or metric."""
+    medias = _blob_dataset()
+    without, _ = _split(_run(medias, arms=()))
+    with_sky, _ = _split(_run(medias, arms=SKYLINE_ARMS))
+    assert len(without) == len(with_sky)
+    ignore = TIMING_COLUMNS | set(_SKYLINE_COLUMNS)
+    for a, b in zip(without, with_sky, strict=True):
+        for key in set(a) | set(b):
+            if key in ignore:
+                continue
+            va, vb = a[key], b[key]
+            if isinstance(va, float) and np.isnan(va):
+                assert isinstance(vb, float) and np.isnan(vb), key
+            else:
+                assert va == vb, key
+
+
+# ---------------------------------------------------------------------------
+# Cross-fitting
+# ---------------------------------------------------------------------------
+
+
+def _xfit_row(medias, seed=0):
+    """Run the bracket arm alone, straight through the helper, on *medias*' test half."""
+    # Interleaved, not sliced: the fixtures lay one category out after the
+    # other, so a contiguous halving would hand the arm a single-class test set.
+    ids = sorted(medias)
+    sim_ids, test_ids = ids[0::2], ids[1::2]
+    rows = _skyline_arm_rows(
+        [SKYLINE_TEST_XFIT],
+        medias,
+        "cat0",
+        sim_ids,
+        test_ids,
+        0,
+        trainer="mlp",
+        head="linear_svm",
+        style_obj=WholeImageStyle(),
+        region_voting=False,
+        input_dim=DIM,
+        calibrate_count=2,
+        calibration_fraction=0.5,
+        seed=seed,
+    )
+    return rows, test_ids
+
+
+def test_bracket_arm_is_cross_fitted_not_trained_on_test():
+    """A naive test-side fit shatters random labels; the shipped arm must not.
+
+    This is the failure the arm exists to avoid: a ~d-parameter linear head on a
+    test set of comparable size reports near-zero cost on a class nothing can
+    learn, so its "regret" would measure ``d / n_test`` rather than learnability.
+    """
+    medias = _noise_dataset(n_per_cat=25)
+    rows, test_ids = _xfit_row(medias)
+    assert len(rows) == 1
+    xfit_cost = rows[0]["oracle_cost"]
+
+    # The naive cheat, built here so the comparison is against a measured number
+    # rather than an asserted constant: fit on the whole test set, score it.
+    pos = [c for c in test_ids if medias[c]["category"] == "cat0"]
+    neg = [c for c in test_ids if c not in set(pos)]
+    score_map, _step, _timings, _secs = _skyline_fit_and_score(
+        pos,
+        neg,
+        test_ids,
+        medias,
+        "cat0",
+        trainer="mlp",
+        head="linear_svm",
+        style_obj=WholeImageStyle(),
+        region_voting=False,
+        input_dim=DIM,
+        inclusion=0,
+        calibrate_count=2,
+        calibration_fraction=0.5,
+    )
+    from vtscore.eval.calibration_metrics import inclusion_weights, oracle_cut
+
+    wf, wn = inclusion_weights(0)
+    scores = np.array([score_map[c] for c in test_ids], dtype=np.float64)
+    labels = np.array([1.0 if medias[c]["category"] == "cat0" else 0.0 for c in test_ids])
+    _thr, naive_cost, _f, _fn = oracle_cut(scores, labels, wf, wn)
+
+    assert naive_cost < 0.1, "fixture no longer shatters in-sample; the leak check would be vacuous"
+    assert xfit_cost > naive_cost + 0.25, (
+        f"cross-fitted cost {xfit_cost} is too close to the in-sample cheat {naive_cost}: "
+        "the bracket arm looks like it is scoring items its head was trained on"
+    )
+
+
+def test_bracket_arm_ranks_a_learnable_class():
+    """Cross-fitting is honest, not blind: real signal still comes through."""
+    rows, _ = _xfit_row(_blob_dataset(n_per_cat=30, separation=4.0))
+    assert len(rows) == 1
+    assert rows[0]["average_precision"] > 0.9
+
+
+def test_bracket_arm_is_dropped_when_it_cannot_be_cross_fitted():
+    """Too few test items to fold honestly leaves the row out, not a naive fit in."""
+    medias = _blob_dataset(n_per_cat=2)
+    rows, _ = _xfit_row(medias)
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Scope and validation
+# ---------------------------------------------------------------------------
+
+
+def test_patch_column_is_skipped_loudly():
+    """v1 is the whole-image column; a patch column's skyline is #3321's open item."""
+    medias, _ = _planted_dataset(n_per_cat=25, seed=0)
+    with pytest.warns(RuntimeWarning, match="skyline"):
+        rows = simulate_voting_iterations(
+            medias,
+            target_category="cat0",
+            seed=0,
+            dataset_name="planted",
+            inclusion=0,
+            region_voting=True,
+            safe_thresholds=False,
+            max_steps=10,
+            style="max_patch",
+            emit_calibration_metrics=True,
+            skyline_arms=[SKYLINE_TRAIN_FULL],
+        )
+    assert rows
+    assert all(r["gmm_variant"] not in SKYLINE_ARMS for r in rows)
+    assert all(np.isnan(r["skyline_oracle_cost"]) for r in rows)
+
+
+def test_unknown_arm_name_is_rejected():
+    with pytest.raises(ValueError, match="unknown skyline arm"):
+        _run(_blob_dataset(), arms=("skyline_train_ful",))
+
+
+def test_arm_requires_the_calibration_frame():
+    with pytest.raises(ValueError, match="emit_calibration_metrics"):
+        simulate_voting_iterations(
+            _blob_dataset(),
+            target_category="cat0",
+            seed=0,
+            style="whole_image",
+            emit_calibration_metrics=False,
+            skyline_arms=[SKYLINE_TRAIN_FULL],
+        )

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -131,6 +131,82 @@ PRODUCTION_HEAD: str = "linear_svm"
 #: region tree from ingest.
 PRODUCTION_PATCH_STYLE: str = "max_patch"
 
+#: The one detection style the #3322 skyline is defined for in v1 - spelled here
+#: rather than imported for the same reason :data:`_SAFE_GMM_VARIANTS` spells its
+#: rule names: this module is deliberately import-light at module scope.
+#: ``test_skyline_arm`` pins it against :class:`~vtscore.eval.patch_styles.WholeImageStyle`.
+_WHOLE_IMAGE_STYLE: str = "whole_image"
+
+
+#: The **supervised-skyline** arms (issue #3322), tagged in the ``gmm_variant``
+#: column exactly like every other variant family, and emitted **once per run**
+#: rather than once per step: a skyline is vote-independent, so its row is a
+#: constant of the ``(cell, seed)`` and repeating it 150 times would only invite
+#: a reader to average it against itself.
+#:
+#: * ``skyline_train_full`` - the **primary** arm and the one the decomposition
+#:   is defined against.  The same head, trained through the same trainer, on the
+#:   **entire simulation split with full ground-truth labels**, evaluated on the
+#:   untouched test split.  The standard supervised-skyline arm from the
+#:   active-learning literature: same hypothesis class, same features, full
+#:   supervision, disjoint eval, so its cost is "how learnable is this class in
+#:   this embedding with this head" and nothing else.
+#: * ``skyline_test_xfit`` - the optional **bracket** partner, cross-fitted over
+#:   the test split (train on K-1 folds, score the held-out one).  Never a naive
+#:   train-on-test fit: a ~769-parameter linear head on a test set of comparable
+#:   size can shatter near-arbitrary labelings, so a naive fit would report
+#:   ``d / n_test`` under the name "learnability" and hand back near-zero cost on
+#:   a class nothing can learn.  Cross-fitting is the SVM analogue of
+#:   :func:`~vtscore.eval.transfer_rules.honest_test_oracle`, which does the same
+#:   thing one level down for the *cut*.
+SKYLINE_TRAIN_FULL: str = "skyline_train_full"
+SKYLINE_TEST_XFIT: str = "skyline_test_xfit"
+SKYLINE_ARMS: tuple[str, ...] = (SKYLINE_TRAIN_FULL, SKYLINE_TEST_XFIT)
+
+#: ``threshold_provenance`` on a skyline row.  A skyline is a statement about a
+#: **ranking**, so it is deliberately *not* routed through a calibrated cut - that
+#: would re-mix in exactly the term ``regret`` already isolates.  Its threshold is
+#: the test oracle's, which makes ``cost == oracle_cost`` and ``regret == 0`` on
+#: the row **by construction**: read a skyline row's ``oracle_cost``, never its
+#: ``regret``.
+SKYLINE_PROVENANCE: str = "skyline_test_oracle"
+
+#: RNG salt for the cross-fitted arm's test-set partition.  Combined with the
+#: run's own ``seed`` so the folds are reproducible per cell, and kept off the
+#: trajectory's ``RandomState`` so turning the arm on cannot move a single vote.
+_SKYLINE_SEED: int = 3322
+
+#: The three-term decomposition the skyline unlocks (issue #3322), NaN on every
+#: row of a run that did not ask for :data:`SKYLINE_TRAIN_FULL`.
+#:
+#: ``cost = skyline_oracle_cost + training_regret + regret`` - the learnability
+#: floor, what the interactive loop left on the table, and what the cut rule gave
+#: away on the ranking it got.  ``oracle_cost`` alone conflates the first two:
+#: a cell can be expensive because no linear head in this embedding separates the
+#: class, or because 10-200 clicks did not find the head that does, and those two
+#: diagnoses buy different things (a better embedder vs. a better acquisition
+#: loop).  ``training_regret`` is defined on **rankings** -
+#: ``oracle_cost(mortal) - oracle_cost(skyline)`` - which is what makes the
+#: telescope exact.
+#:
+#: The honest columns re-base the same split off the cross-fitted reference, so
+#: ``cost = skyline_oracle_cost_honest + training_regret_honest + regret_honest``
+#: telescopes too.  **The terms share noise by construction** (they sum to a
+#: pinned total), so the sum-pinned caution `_operating_metrics` documents for
+#: ``rule_inefficiency`` / ``calibration_shift`` transfers verbatim: do not read
+#: one half moving as an effect when the knob also moves the yardstick.
+#:
+#: **Negative ``training_regret`` is legal and is information, not a bug.**
+#: Unlike the threshold oracle, the skyline is not a per-run optimum over the
+#: same object: region votes carry box information an image-labelled skyline
+#: lacks, and small samples get lucky.  Nothing clamps it.
+_SKYLINE_COLUMNS: tuple[str, ...] = (
+    "skyline_oracle_cost",
+    "skyline_oracle_cost_honest",
+    "training_regret",
+    "training_regret_honest",
+)
+
 
 def _resolve_hidden_dim(head: str, n_votes: int) -> int:
     """``hidden_dim`` sentinel for *head* at *n_votes* votes.
@@ -370,6 +446,7 @@ _CALIBRATION_COLUMNS: tuple[str, ...] = (
     "rule_inefficiency",
     "calibration_shift",
     "calibration_shift_honest",
+    *_SKYLINE_COLUMNS,
     "n_pool_rows",
     "fold_count",
     "fold_seconds",
@@ -1229,6 +1306,11 @@ def _operating_metrics(
         "rule_inefficiency": _r(rule_inefficiency),
         "calibration_shift": _r(calibration_shift),
         "calibration_shift_honest": _r(calibration_shift_honest),
+        # The #3322 decomposition (see `_SKYLINE_COLUMNS`).  Filled in one pass
+        # after the run, from the skyline arm's own row - a skyline is
+        # vote-independent, so there is nothing per-step to compute here, and
+        # NaN is the honest value on a run that asked for no skyline.
+        **dict.fromkeys(_SKYLINE_COLUMNS, nan),
         "n_pool_rows": _r(float(n_pool_rows)),
     }
 
@@ -3160,6 +3242,315 @@ def _svm_train_and_calibrate(
 
 
 # ------------------------------------------------------------------
+# Supervised skyline (issue #3322)
+# ------------------------------------------------------------------
+
+
+def _skyline_fit_and_score(
+    good_ids: list[int],
+    bad_ids: list[int],
+    score_ids: list[int],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    *,
+    trainer: str,
+    head: str,
+    style_obj: Any,
+    region_voting: bool,
+    input_dim: int,
+    inclusion: int,
+    calibrate_count: int,
+    calibration_fraction: float,
+) -> tuple[dict[int, float], _StepModel, dict[str, float], float]:
+    """Train one fully-supervised head and score *score_ids* with it.
+
+    The whole point of the skyline is that it differs from a mortal step in
+    **the labels and nothing else**, so this goes through
+    :func:`_train_and_calibrate` rather than fitting an estimator of its own:
+    same head, same inclusion class-weights, same pinned fit seed, same backend,
+    same bag-aware flooding.  A skyline that trained through a private
+    ``LinearSVC`` would report "fewer labels" and "different trainer" as one
+    number, and would need its own ``Mirror(...)`` entry in
+    ``scripts/check-eval-app-sync.py`` to stay honest; delegation needs neither.
+
+    The threshold the trainer calibrates is computed and **discarded** - the
+    caller takes the test oracle's cut instead (see :data:`SKYLINE_PROVENANCE`).
+    It is paid for rather than skipped because the alternative is a second entry
+    point into the trainer that only the skyline uses, which is exactly the kind
+    of near-copy this module keeps out.
+
+    Returns ``({media_id: score}, step, timings, test_score_seconds)``.
+    """
+    from vtscore.eval import calibration_metrics as cm  # noqa: PLC0415
+
+    step, _threshold, _n_labels, timings, _details = _train_and_calibrate(
+        trainer,
+        dict.fromkeys(good_ids),
+        dict.fromkeys(bad_ids),
+        clips_dict,
+        target_category,
+        region_voting=region_voting,
+        input_dim=input_dim,
+        inclusion=inclusion,
+        calibrate_count=calibrate_count,
+        calibration_fraction=calibration_fraction,
+        head=head,
+        style_obj=style_obj,
+        emit_calibration_metrics=False,
+    )
+    assert step.torch_model is not None  # v1 runs the styled torch path only
+    t_score = time.monotonic()
+    ids, flat, seg = style_obj.node_scores(step.torch_model, {cid: clips_dict[cid] for cid in score_ids})
+    pooled = cm.segment_max_pool(flat, seg)
+    score_seconds = time.monotonic() - t_score
+    return ({cid: float(v) for cid, v in zip(ids, pooled, strict=True)}, step, timings, score_seconds)
+
+
+def _skyline_arm_rows(
+    arms: list[str],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    sim_ids: list[int],
+    test_ids: list[int],
+    inclusion: int,
+    *,
+    trainer: str,
+    head: str,
+    style_obj: Any,
+    region_voting: bool,
+    input_dim: int,
+    calibrate_count: int,
+    calibration_fraction: float,
+    seed: int,
+) -> list[dict[str, Any]]:
+    """One metric row per requested skyline arm (issue #3322), or ``[]``.
+
+    Both arms are scored on the **untouched test split** - the same ``test_ids``
+    every mortal row is scored on, pooled through the same
+    ``style_obj.node_scores`` + segment max, so the two sides of
+    ``training_regret`` differ in the model and in nothing else.  The #3308
+    population convention is satisfied trivially rather than by re-applying
+    :func:`~vtscore.training.thresholds.apply_vote_exclusion`: that convention is
+    about the *haystack a threshold's population estimate is fitted on*, and a
+    skyline fits no such estimate - it takes the test oracle's cut - so there is
+    no haystack here to exclude votes from.
+
+    ``skyline_test_xfit`` pools **cross-fitted** scores: the test split is
+    partitioned into :data:`~vtscore.eval.transfer_rules.HONEST_ORACLE_FOLDS`
+    folds and each item is scored by a head that never saw it.  Two caveats ride
+    on that row and neither is a defect:
+
+    * The pooled scores come from K different heads, so they share a *ranking*
+      but not a calibrated scale.  That is fine for ``oracle_cost`` / ``auroc`` /
+      ``average_precision``, which is all this arm is read for.
+    * Its ``oracle_cost`` is still a sample minimum over those pooled scores, and
+      is optimistic for exactly the reason ``oracle_cost`` always is - which is
+      why ``oracle_cost_honest`` ships beside it, cross-fitting the *cut* on top
+      of the cross-fitted *model*.
+
+    Returns each row already carrying its ``gmm_variant`` tag and its own timing
+    / backend columns; the caller supplies the identifying columns.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.eval import calibration_metrics as cm  # noqa: PLC0415
+
+    nan = float("nan")
+    started = time.monotonic()
+    ordered_test = sorted(test_ids)
+    test_labels = np.array(
+        [1.0 if media_is_positive(clips_dict[cid], target_category) else 0.0 for cid in ordered_test],
+        dtype=np.float64,
+    )
+    wf, wn = cm.inclusion_weights(inclusion)
+
+    def _row(name: str, score_map: dict[int, float], step: _StepModel, timings: dict[str, float], secs: float):
+        scores = np.array([score_map[cid] for cid in ordered_test], dtype=np.float64)
+        o_thr, _o_cost, _o_fpr, _o_fnr = cm.oracle_cut(scores, test_labels, wf, wn)
+        if not np.isfinite(o_thr):
+            return None
+        row = _operating_metrics(
+            scores,
+            test_labels,
+            float(o_thr),
+            inclusion,
+            None,
+            None,
+            pool_variant="max",
+            provenance=SKYLINE_PROVENANCE,
+            n_pool_rows=1.0,
+        )
+        row["gmm_variant"] = name
+        row["schedule"] = ""
+        row.update(
+            {
+                "calibrate_count": calibrate_count,
+                "train_seconds": round(timings["train_seconds"], 6),
+                "final_score_seconds": nan,
+                "xcal_seconds": round(timings["xcal_seconds"], 6),
+                "pool_score_seconds": nan,
+                "test_score_seconds": round(secs, 6),
+                "backend": step.backend,
+                "device": step.device,
+                "elapsed_seconds": round(time.monotonic() - started, 3),
+            }
+        )
+        return row
+
+    rows: list[dict[str, Any]] = []
+
+    if SKYLINE_TRAIN_FULL in arms:
+        sim_pos = [cid for cid in sorted(sim_ids) if media_is_positive(clips_dict[cid], target_category)]
+        sim_neg = [cid for cid in sorted(sim_ids) if not media_is_positive(clips_dict[cid], target_category)]
+        if sim_pos and sim_neg:
+            score_map, step, timings, secs = _skyline_fit_and_score(
+                sim_pos,
+                sim_neg,
+                ordered_test,
+                clips_dict,
+                target_category,
+                trainer=trainer,
+                head=head,
+                style_obj=style_obj,
+                region_voting=region_voting,
+                input_dim=input_dim,
+                inclusion=inclusion,
+                calibrate_count=calibrate_count,
+                calibration_fraction=calibration_fraction,
+            )
+            row = _row(SKYLINE_TRAIN_FULL, score_map, step, timings, secs)
+            if row is not None:
+                rows.append(row)
+
+    if SKYLINE_TEST_XFIT in arms:
+        xfit = _skyline_xfit_scores(
+            ordered_test,
+            clips_dict,
+            target_category,
+            trainer=trainer,
+            head=head,
+            style_obj=style_obj,
+            region_voting=region_voting,
+            input_dim=input_dim,
+            inclusion=inclusion,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+            seed=seed,
+        )
+        if xfit is not None:
+            row = _row(SKYLINE_TEST_XFIT, *xfit)
+            if row is not None:
+                rows.append(row)
+
+    return rows
+
+
+def _skyline_xfit_scores(
+    ordered_test: list[int],
+    clips_dict: dict[int, dict[str, Any]],
+    target_category: str,
+    *,
+    trainer: str,
+    head: str,
+    style_obj: Any,
+    region_voting: bool,
+    input_dim: int,
+    inclusion: int,
+    calibrate_count: int,
+    calibration_fraction: float,
+    seed: int,
+) -> tuple[dict[int, float], _StepModel, dict[str, float], float] | None:
+    """Cross-fitted test-side skyline scores: every item scored by a head that never saw it.
+
+    Partitions *ordered_test* into :data:`~vtscore.eval.transfer_rules.HONEST_ORACLE_FOLDS`
+    folds, trains the fully-supervised head on the complement of each, and scores
+    the held-out fold with it.  ``None`` when the split cannot be made honestly -
+    fewer items than folds, or a fold whose complement carries only one class -
+    which leaves the bracket arm out of the frame rather than quietly falling back
+    to the train-on-test fit it exists to avoid.
+
+    Returns the same tuple shape as :func:`_skyline_fit_and_score`, with the
+    per-fold wall clocks summed and the *last* fold's step standing in for the
+    backend/device columns (every fold trains on the same backend).
+    """
+    import numpy as np  # noqa: PLC0415
+
+    from vtscore.eval.transfer_rules import HONEST_ORACLE_FOLDS  # noqa: PLC0415
+
+    if len(ordered_test) < HONEST_ORACLE_FOLDS:
+        return None
+    # Seeded off the run's own seed, never off the trajectory's RandomState:
+    # drawing from `rng` would move every subsequent vote, so turning the arm on
+    # would silently change the run it is meant to describe.
+    order = np.random.default_rng([_SKYLINE_SEED, seed]).permutation(len(ordered_test))
+    scores: dict[int, float] = {}
+    timings = {"train_seconds": 0.0, "xcal_seconds": 0.0}
+    total_secs = 0.0
+    step: _StepModel | None = None
+    for part in np.array_split(order, HONEST_ORACLE_FOLDS):
+        held = [ordered_test[i] for i in part]
+        if not held:
+            continue
+        held_set = set(held)
+        fit_pos: list[int] = []
+        fit_neg: list[int] = []
+        for cid in ordered_test:
+            if cid in held_set:
+                continue
+            (fit_pos if media_is_positive(clips_dict[cid], target_category) else fit_neg).append(cid)
+        if not fit_pos or not fit_neg:
+            return None
+        score_map, step, fold_timings, secs = _skyline_fit_and_score(
+            fit_pos,
+            fit_neg,
+            held,
+            clips_dict,
+            target_category,
+            trainer=trainer,
+            head=head,
+            style_obj=style_obj,
+            region_voting=region_voting,
+            input_dim=input_dim,
+            inclusion=inclusion,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+        )
+        scores.update({cid: score_map[cid] for cid in held})
+        timings["train_seconds"] += fold_timings["train_seconds"]
+        timings["xcal_seconds"] += fold_timings["xcal_seconds"]
+        total_secs += secs
+    if step is None or len(scores) != len(ordered_test):
+        return None
+    return scores, step, timings, total_secs
+
+
+def _apply_skyline_decomposition(rows: list[dict[str, Any]], skyline_rows: list[dict[str, Any]]) -> None:
+    """Fill the :data:`_SKYLINE_COLUMNS` on *rows* from the primary skyline arm.
+
+    ``training_regret = oracle_cost(row) - oracle_cost(skyline)`` on the naive
+    reference and the cross-fitted one alike, so both decompositions telescope
+    exactly against the ``regret`` / ``regret_honest`` the row already carries.
+    Applied to the skyline rows too, which makes ``skyline_train_full``'s own
+    ``training_regret`` exactly ``0`` and ``skyline_test_xfit``'s the bracket
+    between the two references - both of which are the right readings.
+
+    A no-op when :data:`SKYLINE_TRAIN_FULL` did not run: the columns stay NaN
+    rather than being re-based on the bracket partner, which measures capacity on
+    the test sample and not learnability.
+    """
+    ref = next((r for r in skyline_rows if r["gmm_variant"] == SKYLINE_TRAIN_FULL), None)
+    if ref is None:
+        return
+    floor = ref["oracle_cost"]
+    floor_honest = ref["oracle_cost_honest"]
+    for row in [*rows, *skyline_rows]:
+        row["skyline_oracle_cost"] = floor
+        row["skyline_oracle_cost_honest"] = floor_honest
+        row["training_regret"] = _r(row["oracle_cost"] - floor)
+        row["training_regret_honest"] = _r(row["oracle_cost_honest"] - floor_honest)
+
+
+# ------------------------------------------------------------------
 # Single (seed, dataset, category) evaluation
 # ------------------------------------------------------------------
 
@@ -3207,6 +3598,7 @@ def simulate_voting_iterations(  # noqa: C901
     startup_schedule: Optional[str] = None,
     pick_sink: Optional[list[dict[str, Any]]] = None,
     exclusion_min_remainder: Optional[float] = None,
+    skyline_arms: Optional[list[str]] = None,
 ) -> list[dict[str, Any]]:
     """Simulate voting on *clips_dict* and evaluate at every step.
 
@@ -3400,6 +3792,15 @@ def simulate_voting_iterations(  # noqa: C901
             ``K == calibrate_count`` reproduces this step's own conformal cut;
             see :func:`_fold_count_variant_rows`.  Costs ``Kmax - calibrate_count``
             extra fold fits per step and nothing else.
+        skyline_arms: **Supervised-skyline** arms to measure once per run
+            (issue #3322; see :data:`SKYLINE_ARMS`).  ``None``/``[]`` (default)
+            = off, and every other study runs exactly as before.  Requires
+            ``emit_calibration_metrics``, because the arm exists to split that
+            frame's ``oracle_cost`` into a learnability floor plus a
+            ``training_regret``; skipped with a warning on a patch column, whose
+            skyline needs a supervision decision this does not improvise (see
+            :data:`_SKYLINE_COLUMNS` and issue #3321).  Costs one extra fit per
+            arm per run - the skyline is vote-independent - not one per step.
         autopilot_fidelity: When ``True`` (default) the simulated user follows
             the app's own phase machine
             (:class:`vtscore.eval.autopilot_flow.AutopilotFlow`): no detector is
@@ -3454,6 +3855,18 @@ def simulate_voting_iterations(  # noqa: C901
         if not autopilot_fidelity or strategy != "autopilot":
             raise ValueError("startup_schedule requires autopilot_fidelity and the autopilot strategy")
         startup_state = StartupState(parse_startup_schedule(startup_schedule))
+
+    skyline_arms = list(skyline_arms or [])
+    if skyline_arms:
+        unknown = [a for a in skyline_arms if a not in SKYLINE_ARMS]
+        if unknown:
+            raise ValueError(f"unknown skyline arm(s) {unknown}; expected a subset of {list(SKYLINE_ARMS)}")
+        if not emit_calibration_metrics:
+            raise ValueError(
+                "skyline_arms requires emit_calibration_metrics: the decomposition is defined "
+                "against the calibration frame's oracle_cost/regret columns, which the plain "
+                "frame does not carry"
+            )
 
     if acq_rank_percentile is not None:
         if acq_inclusion_offset != 0:
@@ -3557,6 +3970,29 @@ def simulate_voting_iterations(  # noqa: C901
         from vtscore.eval.patch_styles import resolve_style  # noqa: PLC0415
 
         style_obj = resolve_style(style)
+
+    # **v1 is the whole-image columns.**  Full supervision hands out *image*
+    # labels, but the mortal max_patch flow trains on GT-box-pooled vectors (the
+    # sim user drags a box), so a patch column's skyline is a design decision -
+    # "oracle boxes + all images", or the multiple-instance problem of which
+    # patch of a positive image is the positive - and not something to improvise
+    # inside a metric row.  That decision is the named open item on #3321.  Skip
+    # rather than raise: a sweep over `styles=["whole_image", "max_patch"]` should
+    # get the decomposition on the column that has one instead of dying on the
+    # column that doesn't, and the skip is loud here and visible in the frame
+    # (no `skyline_*` rows, NaN decomposition columns) rather than silent.
+    if skyline_arms and (style_obj is None or style_obj.name != _WHOLE_IMAGE_STYLE):
+        import warnings  # noqa: PLC0415
+
+        warnings.warn(
+            f"skyline_arms={skyline_arms} skipped for style={style or 'none'!r}: the supervised "
+            f"skyline is scoped to the {_WHOLE_IMAGE_STYLE!r} column in v1, because a patch "
+            "column's skyline needs a supervision decision (GT boxes vs. multiple-instance) "
+            "that is still open - see issue #3321.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        skyline_arms = []
     # Mirror the app's per-mode schedule default (#2841): with no explicit arm, a
     # patch dataset blends under the region schedule and a single-vector one
     # under the binary schedule, exactly as `_blend_schedule_for_snap` decides in
@@ -4097,6 +4533,62 @@ def simulate_voting_iterations(  # noqa: C901
                     cut_inclusion_sink.append({**base_row, **cr})
         else:
             rows.append({**base_row, **metrics, **timing_cols})
+
+    # --- The supervised skyline (issue #3322), once per run. ---
+    #
+    # Deliberately **after** the loop rather than before it: every fit here draws
+    # from some RNG somewhere, and a skyline computed up front would have to be
+    # proved not to perturb the trajectory it is meant to describe.  Computed
+    # here it cannot, whatever the trainer does internally - the votes are
+    # already cast.  `test_skyline_does_not_perturb_the_trajectory` pins that.
+    if skyline_arms:
+        skyline_rows = _skyline_arm_rows(
+            skyline_arms,
+            clips_dict,
+            target_category,
+            sim_ids,
+            test_ids,
+            inclusion,
+            trainer=trainer,
+            head=head,
+            style_obj=style_obj,
+            region_voting=region_voting,
+            input_dim=input_dim,
+            calibrate_count=calibrate_count,
+            calibration_fraction=calibration_fraction,
+            seed=seed,
+        )
+        _apply_skyline_decomposition(rows, skyline_rows)
+        # `t=0` and `app_trained=0`: the skyline belongs to no step, so it is
+        # given a step index no trajectory can occupy (the first *trainable*
+        # step is t>=2) rather than being duplicated onto all of them.  The vote
+        # counts are the full supervision it was handed, and `n_remainder=0`
+        # says exactly what that means - nothing in the haystack was left
+        # unlabelled.
+        n_sky_good = sum(1 for cid in sim_ids if pool_labels[cid] == 1.0)
+        skyline_ident = {
+            "seed": seed,
+            "dataset": dataset_name,
+            "category": target_category,
+            "strategy": strategy,
+            "trainer": trainer,
+            "head": head if trainer == "mlp" else "",
+            "style": style or "",
+            "prevalence_arm": prevalence_arm,
+            "realized_prevalence": realized_prevalence,
+            "t": 0,
+            "n_good": n_sky_good,
+            "n_bad": len(sim_ids) - n_sky_good,
+            "n_haystack": len(sim_ids),
+            "n_remainder": 0,
+            "phase": "",
+            "app_trained": 0,
+            "startup_schedule": startup_schedule or "",
+            "acq_threshold": float("nan"),
+            "acq_pool_percentile": float("nan"),
+            "report_pool_percentile": float("nan"),
+        }
+        rows.extend({**skyline_ident, **sr} for sr in skyline_rows)
 
     return rows
 


### PR DESCRIPTION
Closes #3322.

`cost = oracle_cost + regret` splits a step's cost into "the ranking" and "the cut", but `oracle_cost` still conflates two causes that call for opposite fixes: **no linear head in this embedding can separate the class**, and **a head could, but 10–200 clicks did not find it**. This adds the missing third term, so a cell's cost can be routed to a better embedder or a better acquisition loop:

```
cost = skyline_oracle_cost   (learnability floor: embedding + head capacity)
     + training_regret       (headroom the interactive loop left on the table)
     + regret                (what the cut rule gave away on the ranking it got)
```

## What landed

**`skyline_arms` on `simulate_voting_iterations`** (opt-in; requires `emit_calibration_metrics`, since the decomposition is defined against that frame's `oracle_cost` / `regret`):

- **`skyline_train_full`** — the primary arm. The **same head, through the same trainer**, trained on the entire simulation split with **full ground-truth labels**, scored on the untouched test split. It delegates to `_train_and_calibrate` rather than fitting an estimator of its own, so the gap measures "fewer labels" and not "a different trainer" — and, being delegation, it needs no new `Mirror(...)` entry to stay drift-proof (`check-eval-app-sync.py` still reports 15 mirrors up to date).
- **`skyline_test_xfit`** — the optional bracket partner, **cross-fitted**: the test split is folded and each item is scored by a head that never saw it. Never a naive train-on-test fit — a ~769-parameter linear head on a test set of comparable size shatters near-arbitrary labelings, so a naive fit would report `d / n_test` under the name "learnability". It is the SVM analogue of `honest_test_oracle`, one level up.

**`training_regret` is defined on rankings**, `oracle_cost(mortal) − oracle_cost(skyline)`, which is what makes the telescope exact. The skyline is deliberately *not* routed through a calibrated cut — that would re-mix in the term `regret` already isolates — so its threshold is the test oracle's and `regret == 0` on a skyline row by construction. Four new columns (`skyline_oracle_cost{,_honest}`, `training_regret{,_honest}`) ride the calibration frame and telescope on both the naive and the cross-fitted reference; they are NaN on a run that asked for no skyline.

**One row per run, not per step.** A skyline is vote-independent, so each arm emits a single `t = 0` / `app_trained = 0` row tagged in `gmm_variant` like every other variant family. It is computed **after** the voting loop, so turning the arm on provably cannot move a vote (pinned by a test).

**Scope.** v1 is the whole-image column. Full supervision hands out *image* labels while the mortal `max_patch` flow trains on GT-box-pooled vectors, so a patch column's skyline is a design decision (oracle boxes vs. a multiple-instance problem) that stays open on #3321; the harness warns and skips on a patch style rather than improvising one, so a sweep over both columns still gets the decomposition on the column that has one.

Negative `training_regret` is legal and is not clamped — the skyline is not a per-run optimum over the same object.

## Also

- `CALIB_SKYLINE_ARMS` wired through `experiment_config.py` / `run_cells.py`, and `analyze_cut.py` classifies `skyline_*` as a non-candidate (a label-reading diagnostic, like the existing oracle variants) so it doesn't warn that a diagnostic "cannot ship".
- `docs/EVAL.md` and the calibration experiment README document the arm, the sum-pinned caution, and the bracket conventions.
- `tests_lib/detectors/test_skyline_arm.py` — 16 tests covering the exact telescope on both references, vote-independence (one row per run; mortal rows byte-identical with the arm on and off), the cross-fitting leak check (a naive in-sample fit shatters random labels at `oracle_cost < 0.1`; the shipped arm must be far from it), the patch-column skip, and the argument validation.

## Testing

Full `./run-tests.sh`: `RUN PASSED` — 9326 passed, 6 skipped, 2 xfailed; pyright, pip-audit, npm audit and the Vitest suite all green.

No app-side change; eval-only. The measurement rerun is #3321's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFkZQfNMre7XjgwtuXMo3e

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFkZQfNMre7XjgwtuXMo3e)_