### PR TITLE
Skylines and baselines: notches, an oracle line and an overlay mode in the report viewer

### DIFF
--- a/docs/experiments/README.md
+++ b/docs/experiments/README.md
@@ -24,11 +24,24 @@ do not write it again.
 **…and it owes an interactive `viewer.html`, linked from the report.** The PNGs
 answer the questions the analyzer asked; the viewer is what lets a reader ask
 their own — any dataset (one / all / each), any category (one / all / each), any
-subset of arms, any subset of embedders (one panel each, never averaged), seeds
-averaged or every seed, and any metric the run emitted (cost, precision, recall,
-F1, FPR, FNR, average precision, AUROC). Built by
-[`scripts/experiments/calibration/viewer.py`](../../scripts/experiments/calibration/viewer.py)
+subset of arms, any subset of embedders, seeds averaged or every seed, and any
+metric the run emitted (cost, precision, recall, F1, FPR, FNR, average
+precision, AUROC). Two draw toggles decide the shape: **overlay** puts every
+varying dimension on one chart in distinct hues (off, each gets its own chart
+with the ±1 SD shadow, which is the only place that shadow is readable), and
+**oracle threshold** adds the cut the test labels say the model should have
+used, dotted beside the solid line it achieved. Two more reference marks are
+notched into the margins: the free text sort at the left and, for a run
+launched with `CALIB_SKYLINE_ARMS`, the supervised skyline at the right. Built
+by [`scripts/experiments/calibration/viewer.py`](../../scripts/experiments/calibration/viewer.py)
 from the same CSVs as everything else, self-contained, no network.
+
+**A page can be re-skinned without its results.** The template carries all of
+the viewer's behaviour and the payload only the study's numbers, so
+`python viewer.py --reskin docs/experiments/*/viewer.html` pushes a template
+improvement onto every committed report — even one whose results directory is
+long gone. It cannot add data the payload never carried: a study that measured
+no oracle cut and no skyline still shows neither.
 
 **The other archives.** [`docs/reports/`](../reports/) holds standalone HTML study
 pages (narrative write-ups with inlined charts — see [its

--- a/docs/experiments/calibration-fold-count-3310/viewer.html
+++ b/docs/experiments/calibration-fold-count-3310/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -180,6 +212,13 @@
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
     </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
+    </div>
     <div class="ctl">
       <label class="h">Seeds</label>
       <div class="radios" id="seedMode">
@@ -248,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -262,11 +305,37 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
 
   // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
   // three target sizes - and the band is that study's headline axis, so it gets
@@ -294,8 +363,12 @@
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -384,6 +457,31 @@
     each.closest("label").style.opacity = ".45";
   }
 
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
+  }
+
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
   // An empty one has no honest rendering: the page would either go blank or
   // quietly fall back to "all", and a reader who did not notice would take a
@@ -433,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -490,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -507,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -532,73 +670,92 @@
   const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -644,38 +801,49 @@
       showCov = covMin < COV_FLAT;
     }
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, showCov));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length, showCov);
-    tableView(spec, panels);
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
     const nCats = categoriesInPlay().length;
     const pooled = state.band === ALL
       ? `all ${nCats} categories pooled`
       : `all ${nCats} ${state.band}-band categories pooled`;
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
+    bits.push(splits("category")
       ? (state.band === ALL ? null : `${state.band} band`)
       : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi, showCov) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -684,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -698,32 +868,55 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
       if (showCov) {
         parts.push(
           `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
@@ -746,32 +939,53 @@
 
     el.insertAdjacentHTML("beforeend",
       `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y, showCov);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -781,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -796,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -833,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y, showCov) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -858,12 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
         (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
         `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)}${showCov ? " · % = cells measured" : ""}</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -873,48 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted, showCov) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
       `segment is a level worth quoting.` +
-      (showCov
+      (opt.showCov
         ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
         : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
-          ` as a flat 100% line: nothing in this slice dropped out, and the dashed run-up already says when each` +
-          ` series' detector started.`));
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/calibration-fraction-3287/clip/viewer.html
+++ b/docs/experiments/calibration-fraction-3287/clip/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -164,6 +196,10 @@
       <label class="h" for="ds">Dataset</label>
       <select id="ds"></select>
     </div>
+    <div class="ctl" id="bandWrap">
+      <label class="h" for="band">Target size</label>
+      <select id="band"></select>
+    </div>
     <div class="ctl">
       <label class="h" for="cat">Category</label>
       <select id="cat"></select>
@@ -175,6 +211,13 @@
     <div class="ctl" id="embWrap">
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
+    </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
     </div>
     <div class="ctl">
       <label class="h">Seeds</label>
@@ -244,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -258,19 +305,70 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
+
+  // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
+  // three target sizes - and the band is that study's headline axis, so it gets
+  // its own control. Parsed out of the category names rather than added to the
+  // payload: every other study's categories are bare names, and a viewer that
+  // needs a schema change per study is a viewer nobody reuses. The control
+  // appears only when EVERY category carries a suffix and there is more than one
+  // band to choose between, for the same reason the embedder chips hide
+  // themselves at one embedder - a control with one option is furniture.
+  const BAND_ORDER = ["small", "medium", "large"];
+  const bandOf = (c) => { const i = String(c).lastIndexOf("@"); return i < 0 ? null : String(c).slice(i + 1); };
+  const BANDS = (() => {
+    const bs = P.categories.map(bandOf);
+    if (!bs.length || bs.some((b) => !b)) return [];
+    const u = [...new Set(bs)];
+    if (u.length < 2) return [];
+    const rank = (b) => { const i = BAND_ORDER.indexOf(b); return i < 0 ? BAND_ORDER.length : i; };
+    return u.sort((x, y) => rank(x) - rank(y) || x.localeCompare(y));
+  })();
+  const inBand = (c) => state.band === ALL || bandOf(c) === state.band;
 
   const state = {
     dataset: P.datasets.length > 1 ? ALL : P.datasets[0],
+    band: ALL,
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -284,7 +382,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const all = [...s].sort();
+    const all = [...s].sort().filter(inBand);
     return state.category === ALL || state.category === EACH ? all : all.filter((c) => c === state.category);
   }
 
@@ -308,7 +406,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const cats = [...s].sort();
+    const cats = [...s].sort().filter(inBand);
     catSel.innerHTML =
       `<option value="${ALL}">All categories — averaged together</option>` +
       `<option value="${EACH}">Each category — one line each</option>` +
@@ -317,6 +415,20 @@
     catSel.value = state.category;
   }
   catSel.onchange = () => { state.category = catSel.value; render(); };
+
+  const bandSel = $("band");
+  if (!BANDS.length) {
+    $("bandWrap").style.display = "none";
+  } else {
+    bandSel.innerHTML =
+      `<option value="${ALL}">All sizes</option>` +
+      BANDS.map((b) => `<option value="${esc(b)}">${esc(b)}</option>`).join("");
+    bandSel.value = state.band;
+    // Narrowing the band can strip the category currently selected, so refill
+    // rather than leaving a selection that names no group: `fillCats` falls back
+    // to "all categories" when the current one is no longer on offer.
+    bandSel.onchange = () => { state.band = bandSel.value; fillCats(); render(); };
+  }
   fillCats();
 
   const mSel = $("metric");
@@ -343,6 +455,31 @@
     each.disabled = true;
     each.closest("label").title = P.runs_note || "no per-seed data in this payload";
     each.closest("label").style.opacity = ".45";
+  }
+
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
   }
 
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
@@ -394,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -451,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -468,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -487,75 +664,98 @@
 
   // ---- render -------------------------------------------------------------
   const SOLID = P.solid_coverage;
+  // "Fully measured", for deciding whether the coverage strip has anything to
+  // show. Not 1.0: coverage is a ratio of integers and a pooled slice can land a
+  // hair under it, which would keep a flat strip on screen forever.
+  const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -568,34 +768,82 @@
     const pad = (hi - lo) * 0.06 || 0.02;
     lo = Math.max(spec.lo, lo - pad); hi = Math.min(spec.hi, hi + pad);
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length);
-    tableView(spec, panels);
+    // Does the coverage strip earn its space in THIS selection?
+    //
+    // It exists to expose survivorship: a mean at click 140 pooled from a third
+    // of the cells is a different quantity from one pooled from all of them, and
+    // nothing else on the page says which you are looking at. But in a study
+    // where every cell runs to the horizon it is a flat 100% line under every
+    // panel -- a fifth of each panel's height, in every panel, carrying one bit
+    // that never changes. Same rule as the embedder chips at one embedder: an
+    // axis with one value is furniture.
+    //
+    // The run-up does NOT count as variation. Coverage climbs from nothing to
+    // full over the first clicks because detectors only start once a run has
+    // both classes, and the main chart already says so by DASHING the mean
+    // there. So the strip's only unique information is a dip AFTER every series
+    // has come up, and that is exactly what this tests.
+    //
+    // Decided across all panels rather than per panel: panels of two different
+    // heights are two charts, which is why the y-scale is shared already.
+    let covStart = -1;
+    for (let t = 1; t < nT && covStart < 0; t++) {
+      let all = true;
+      for (const p of panels) for (const q of p.per) if (!(q.agg.cov[t] >= COV_FLAT)) all = false;
+      if (all) covStart = t;
+    }
+    let showCov = true;
+    if (covStart >= 0) {
+      let covMin = 1;
+      for (const p of panels) for (const q of p.per) {
+        for (let t = covStart; t < nT; t++) if (Number.isFinite(q.agg.cov[t])) covMin = Math.min(covMin, q.agg.cov[t]);
+      }
+      showCov = covMin < COV_FLAT;
+    }
+
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
-      ? null
-      : (state.category === ALL ? "all categories pooled" : state.category));
+    const nCats = categoriesInPlay().length;
+    const pooled = state.band === ALL
+      ? `all ${nCats} categories pooled`
+      : `all ${nCats} ${state.band}-band categories pooled`;
+    bits.push(splits("category")
+      ? (state.band === ALL ? null : `${state.band} band`)
+      : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -604,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -618,75 +868,124 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`,
-        `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
-      // Click 0 is a point, not the start of the line: every cell is measured
-      // there (it has a text sort) and none has a detector at click 1, so a
-      // joined line renders two different facts as a spike.
-      if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      if (showCov) {
+        parts.push(
+          `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
+        // Click 0 is a point, not the start of the line: every cell is measured
+        // there (it has a text sort) and none has a detector at click 1, so a
+        // joined line renders two different facts as a spike.
+        if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
+          `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+      }
     }
-    parts.push(
+    if (showCov) parts.push(
       `<line x1="${M.l}" x2="${W - M.r}" y1="${yc(SOLID).toFixed(1)}" y2="${yc(SOLID).toFixed(1)}" stroke="var(--muted)" stroke-width="1" stroke-dasharray="1 3"/>`,
       `<text x="${M.l - 8}" y="${(yc(1) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">100%</text>`,
       `<text x="${M.l - 8}" y="${(yc(0) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">0%</text>`,
-      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`,
-      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${H + CH + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
+      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`);
+    const foot = showCov ? H + CH : H;
+    parts.push(
+      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${foot + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
       `<text transform="translate(13,${(M.t + (H - M.b) / 2).toFixed(0)}) rotate(-90)" text-anchor="middle" font-size="11" fill="var(--muted)">${esc(spec.label)}</text>`);
 
     el.insertAdjacentHTML("beforeend",
-      `<svg viewBox="0 0 ${W} ${H + CH + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y);
+      `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -696,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -711,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -748,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -773,11 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
-        `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td></tr>`).join("");
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
+        (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
+        `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · % = cells measured</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -787,43 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
-      `segment is a level worth quoting. The strip underneath is that fraction.`);
+      `segment is a level worth quoting.` +
+      (opt.showCov
+        ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
+        : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/calibration-fraction-3287/clip_l/viewer.html
+++ b/docs/experiments/calibration-fraction-3287/clip_l/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -164,6 +196,10 @@
       <label class="h" for="ds">Dataset</label>
       <select id="ds"></select>
     </div>
+    <div class="ctl" id="bandWrap">
+      <label class="h" for="band">Target size</label>
+      <select id="band"></select>
+    </div>
     <div class="ctl">
       <label class="h" for="cat">Category</label>
       <select id="cat"></select>
@@ -175,6 +211,13 @@
     <div class="ctl" id="embWrap">
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
+    </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
     </div>
     <div class="ctl">
       <label class="h">Seeds</label>
@@ -244,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -258,19 +305,70 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
+
+  // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
+  // three target sizes - and the band is that study's headline axis, so it gets
+  // its own control. Parsed out of the category names rather than added to the
+  // payload: every other study's categories are bare names, and a viewer that
+  // needs a schema change per study is a viewer nobody reuses. The control
+  // appears only when EVERY category carries a suffix and there is more than one
+  // band to choose between, for the same reason the embedder chips hide
+  // themselves at one embedder - a control with one option is furniture.
+  const BAND_ORDER = ["small", "medium", "large"];
+  const bandOf = (c) => { const i = String(c).lastIndexOf("@"); return i < 0 ? null : String(c).slice(i + 1); };
+  const BANDS = (() => {
+    const bs = P.categories.map(bandOf);
+    if (!bs.length || bs.some((b) => !b)) return [];
+    const u = [...new Set(bs)];
+    if (u.length < 2) return [];
+    const rank = (b) => { const i = BAND_ORDER.indexOf(b); return i < 0 ? BAND_ORDER.length : i; };
+    return u.sort((x, y) => rank(x) - rank(y) || x.localeCompare(y));
+  })();
+  const inBand = (c) => state.band === ALL || bandOf(c) === state.band;
 
   const state = {
     dataset: P.datasets.length > 1 ? ALL : P.datasets[0],
+    band: ALL,
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -284,7 +382,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const all = [...s].sort();
+    const all = [...s].sort().filter(inBand);
     return state.category === ALL || state.category === EACH ? all : all.filter((c) => c === state.category);
   }
 
@@ -308,7 +406,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const cats = [...s].sort();
+    const cats = [...s].sort().filter(inBand);
     catSel.innerHTML =
       `<option value="${ALL}">All categories — averaged together</option>` +
       `<option value="${EACH}">Each category — one line each</option>` +
@@ -317,6 +415,20 @@
     catSel.value = state.category;
   }
   catSel.onchange = () => { state.category = catSel.value; render(); };
+
+  const bandSel = $("band");
+  if (!BANDS.length) {
+    $("bandWrap").style.display = "none";
+  } else {
+    bandSel.innerHTML =
+      `<option value="${ALL}">All sizes</option>` +
+      BANDS.map((b) => `<option value="${esc(b)}">${esc(b)}</option>`).join("");
+    bandSel.value = state.band;
+    // Narrowing the band can strip the category currently selected, so refill
+    // rather than leaving a selection that names no group: `fillCats` falls back
+    // to "all categories" when the current one is no longer on offer.
+    bandSel.onchange = () => { state.band = bandSel.value; fillCats(); render(); };
+  }
   fillCats();
 
   const mSel = $("metric");
@@ -343,6 +455,31 @@
     each.disabled = true;
     each.closest("label").title = P.runs_note || "no per-seed data in this payload";
     each.closest("label").style.opacity = ".45";
+  }
+
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
   }
 
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
@@ -394,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -451,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -468,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -487,75 +664,98 @@
 
   // ---- render -------------------------------------------------------------
   const SOLID = P.solid_coverage;
+  // "Fully measured", for deciding whether the coverage strip has anything to
+  // show. Not 1.0: coverage is a ratio of integers and a pooled slice can land a
+  // hair under it, which would keep a flat strip on screen forever.
+  const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -568,34 +768,82 @@
     const pad = (hi - lo) * 0.06 || 0.02;
     lo = Math.max(spec.lo, lo - pad); hi = Math.min(spec.hi, hi + pad);
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length);
-    tableView(spec, panels);
+    // Does the coverage strip earn its space in THIS selection?
+    //
+    // It exists to expose survivorship: a mean at click 140 pooled from a third
+    // of the cells is a different quantity from one pooled from all of them, and
+    // nothing else on the page says which you are looking at. But in a study
+    // where every cell runs to the horizon it is a flat 100% line under every
+    // panel -- a fifth of each panel's height, in every panel, carrying one bit
+    // that never changes. Same rule as the embedder chips at one embedder: an
+    // axis with one value is furniture.
+    //
+    // The run-up does NOT count as variation. Coverage climbs from nothing to
+    // full over the first clicks because detectors only start once a run has
+    // both classes, and the main chart already says so by DASHING the mean
+    // there. So the strip's only unique information is a dip AFTER every series
+    // has come up, and that is exactly what this tests.
+    //
+    // Decided across all panels rather than per panel: panels of two different
+    // heights are two charts, which is why the y-scale is shared already.
+    let covStart = -1;
+    for (let t = 1; t < nT && covStart < 0; t++) {
+      let all = true;
+      for (const p of panels) for (const q of p.per) if (!(q.agg.cov[t] >= COV_FLAT)) all = false;
+      if (all) covStart = t;
+    }
+    let showCov = true;
+    if (covStart >= 0) {
+      let covMin = 1;
+      for (const p of panels) for (const q of p.per) {
+        for (let t = covStart; t < nT; t++) if (Number.isFinite(q.agg.cov[t])) covMin = Math.min(covMin, q.agg.cov[t]);
+      }
+      showCov = covMin < COV_FLAT;
+    }
+
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
-      ? null
-      : (state.category === ALL ? "all categories pooled" : state.category));
+    const nCats = categoriesInPlay().length;
+    const pooled = state.band === ALL
+      ? `all ${nCats} categories pooled`
+      : `all ${nCats} ${state.band}-band categories pooled`;
+    bits.push(splits("category")
+      ? (state.band === ALL ? null : `${state.band} band`)
+      : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -604,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -618,75 +868,124 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`,
-        `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
-      // Click 0 is a point, not the start of the line: every cell is measured
-      // there (it has a text sort) and none has a detector at click 1, so a
-      // joined line renders two different facts as a spike.
-      if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      if (showCov) {
+        parts.push(
+          `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
+        // Click 0 is a point, not the start of the line: every cell is measured
+        // there (it has a text sort) and none has a detector at click 1, so a
+        // joined line renders two different facts as a spike.
+        if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
+          `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+      }
     }
-    parts.push(
+    if (showCov) parts.push(
       `<line x1="${M.l}" x2="${W - M.r}" y1="${yc(SOLID).toFixed(1)}" y2="${yc(SOLID).toFixed(1)}" stroke="var(--muted)" stroke-width="1" stroke-dasharray="1 3"/>`,
       `<text x="${M.l - 8}" y="${(yc(1) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">100%</text>`,
       `<text x="${M.l - 8}" y="${(yc(0) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">0%</text>`,
-      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`,
-      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${H + CH + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
+      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`);
+    const foot = showCov ? H + CH : H;
+    parts.push(
+      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${foot + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
       `<text transform="translate(13,${(M.t + (H - M.b) / 2).toFixed(0)}) rotate(-90)" text-anchor="middle" font-size="11" fill="var(--muted)">${esc(spec.label)}</text>`);
 
     el.insertAdjacentHTML("beforeend",
-      `<svg viewBox="0 0 ${W} ${H + CH + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y);
+      `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -696,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -711,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -748,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -773,11 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
-        `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td></tr>`).join("");
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
+        (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
+        `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · % = cells measured</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -787,43 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
-      `segment is a level worth quoting. The strip underneath is that fraction.`);
+      `segment is a level worth quoting.` +
+      (opt.showCov
+        ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
+        : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/calibration-fraction-3287/siglip2l/viewer.html
+++ b/docs/experiments/calibration-fraction-3287/siglip2l/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -164,6 +196,10 @@
       <label class="h" for="ds">Dataset</label>
       <select id="ds"></select>
     </div>
+    <div class="ctl" id="bandWrap">
+      <label class="h" for="band">Target size</label>
+      <select id="band"></select>
+    </div>
     <div class="ctl">
       <label class="h" for="cat">Category</label>
       <select id="cat"></select>
@@ -175,6 +211,13 @@
     <div class="ctl" id="embWrap">
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
+    </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
     </div>
     <div class="ctl">
       <label class="h">Seeds</label>
@@ -244,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -258,19 +305,70 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
+
+  // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
+  // three target sizes - and the band is that study's headline axis, so it gets
+  // its own control. Parsed out of the category names rather than added to the
+  // payload: every other study's categories are bare names, and a viewer that
+  // needs a schema change per study is a viewer nobody reuses. The control
+  // appears only when EVERY category carries a suffix and there is more than one
+  // band to choose between, for the same reason the embedder chips hide
+  // themselves at one embedder - a control with one option is furniture.
+  const BAND_ORDER = ["small", "medium", "large"];
+  const bandOf = (c) => { const i = String(c).lastIndexOf("@"); return i < 0 ? null : String(c).slice(i + 1); };
+  const BANDS = (() => {
+    const bs = P.categories.map(bandOf);
+    if (!bs.length || bs.some((b) => !b)) return [];
+    const u = [...new Set(bs)];
+    if (u.length < 2) return [];
+    const rank = (b) => { const i = BAND_ORDER.indexOf(b); return i < 0 ? BAND_ORDER.length : i; };
+    return u.sort((x, y) => rank(x) - rank(y) || x.localeCompare(y));
+  })();
+  const inBand = (c) => state.band === ALL || bandOf(c) === state.band;
 
   const state = {
     dataset: P.datasets.length > 1 ? ALL : P.datasets[0],
+    band: ALL,
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -284,7 +382,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const all = [...s].sort();
+    const all = [...s].sort().filter(inBand);
     return state.category === ALL || state.category === EACH ? all : all.filter((c) => c === state.category);
   }
 
@@ -308,7 +406,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const cats = [...s].sort();
+    const cats = [...s].sort().filter(inBand);
     catSel.innerHTML =
       `<option value="${ALL}">All categories — averaged together</option>` +
       `<option value="${EACH}">Each category — one line each</option>` +
@@ -317,6 +415,20 @@
     catSel.value = state.category;
   }
   catSel.onchange = () => { state.category = catSel.value; render(); };
+
+  const bandSel = $("band");
+  if (!BANDS.length) {
+    $("bandWrap").style.display = "none";
+  } else {
+    bandSel.innerHTML =
+      `<option value="${ALL}">All sizes</option>` +
+      BANDS.map((b) => `<option value="${esc(b)}">${esc(b)}</option>`).join("");
+    bandSel.value = state.band;
+    // Narrowing the band can strip the category currently selected, so refill
+    // rather than leaving a selection that names no group: `fillCats` falls back
+    // to "all categories" when the current one is no longer on offer.
+    bandSel.onchange = () => { state.band = bandSel.value; fillCats(); render(); };
+  }
   fillCats();
 
   const mSel = $("metric");
@@ -343,6 +455,31 @@
     each.disabled = true;
     each.closest("label").title = P.runs_note || "no per-seed data in this payload";
     each.closest("label").style.opacity = ".45";
+  }
+
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
   }
 
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
@@ -394,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -451,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -468,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -487,75 +664,98 @@
 
   // ---- render -------------------------------------------------------------
   const SOLID = P.solid_coverage;
+  // "Fully measured", for deciding whether the coverage strip has anything to
+  // show. Not 1.0: coverage is a ratio of integers and a pooled slice can land a
+  // hair under it, which would keep a flat strip on screen forever.
+  const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -568,34 +768,82 @@
     const pad = (hi - lo) * 0.06 || 0.02;
     lo = Math.max(spec.lo, lo - pad); hi = Math.min(spec.hi, hi + pad);
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length);
-    tableView(spec, panels);
+    // Does the coverage strip earn its space in THIS selection?
+    //
+    // It exists to expose survivorship: a mean at click 140 pooled from a third
+    // of the cells is a different quantity from one pooled from all of them, and
+    // nothing else on the page says which you are looking at. But in a study
+    // where every cell runs to the horizon it is a flat 100% line under every
+    // panel -- a fifth of each panel's height, in every panel, carrying one bit
+    // that never changes. Same rule as the embedder chips at one embedder: an
+    // axis with one value is furniture.
+    //
+    // The run-up does NOT count as variation. Coverage climbs from nothing to
+    // full over the first clicks because detectors only start once a run has
+    // both classes, and the main chart already says so by DASHING the mean
+    // there. So the strip's only unique information is a dip AFTER every series
+    // has come up, and that is exactly what this tests.
+    //
+    // Decided across all panels rather than per panel: panels of two different
+    // heights are two charts, which is why the y-scale is shared already.
+    let covStart = -1;
+    for (let t = 1; t < nT && covStart < 0; t++) {
+      let all = true;
+      for (const p of panels) for (const q of p.per) if (!(q.agg.cov[t] >= COV_FLAT)) all = false;
+      if (all) covStart = t;
+    }
+    let showCov = true;
+    if (covStart >= 0) {
+      let covMin = 1;
+      for (const p of panels) for (const q of p.per) {
+        for (let t = covStart; t < nT; t++) if (Number.isFinite(q.agg.cov[t])) covMin = Math.min(covMin, q.agg.cov[t]);
+      }
+      showCov = covMin < COV_FLAT;
+    }
+
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
-      ? null
-      : (state.category === ALL ? "all categories pooled" : state.category));
+    const nCats = categoriesInPlay().length;
+    const pooled = state.band === ALL
+      ? `all ${nCats} categories pooled`
+      : `all ${nCats} ${state.band}-band categories pooled`;
+    bits.push(splits("category")
+      ? (state.band === ALL ? null : `${state.band} band`)
+      : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -604,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -618,75 +868,124 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`,
-        `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
-      // Click 0 is a point, not the start of the line: every cell is measured
-      // there (it has a text sort) and none has a detector at click 1, so a
-      // joined line renders two different facts as a spike.
-      if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      if (showCov) {
+        parts.push(
+          `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
+        // Click 0 is a point, not the start of the line: every cell is measured
+        // there (it has a text sort) and none has a detector at click 1, so a
+        // joined line renders two different facts as a spike.
+        if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
+          `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+      }
     }
-    parts.push(
+    if (showCov) parts.push(
       `<line x1="${M.l}" x2="${W - M.r}" y1="${yc(SOLID).toFixed(1)}" y2="${yc(SOLID).toFixed(1)}" stroke="var(--muted)" stroke-width="1" stroke-dasharray="1 3"/>`,
       `<text x="${M.l - 8}" y="${(yc(1) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">100%</text>`,
       `<text x="${M.l - 8}" y="${(yc(0) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">0%</text>`,
-      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`,
-      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${H + CH + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
+      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`);
+    const foot = showCov ? H + CH : H;
+    parts.push(
+      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${foot + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
       `<text transform="translate(13,${(M.t + (H - M.b) / 2).toFixed(0)}) rotate(-90)" text-anchor="middle" font-size="11" fill="var(--muted)">${esc(spec.label)}</text>`);
 
     el.insertAdjacentHTML("beforeend",
-      `<svg viewBox="0 0 ${W} ${H + CH + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y);
+      `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -696,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -711,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -748,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -773,11 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
-        `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td></tr>`).join("");
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
+        (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
+        `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · % = cells measured</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -787,43 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
-      `segment is a level worth quoting. The strip underneath is that fraction.`);
+      `segment is a level worth quoting.` +
+      (opt.showCov
+        ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
+        : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/calibration-fraction-3287/viewer.html
+++ b/docs/experiments/calibration-fraction-3287/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -164,6 +196,10 @@
       <label class="h" for="ds">Dataset</label>
       <select id="ds"></select>
     </div>
+    <div class="ctl" id="bandWrap">
+      <label class="h" for="band">Target size</label>
+      <select id="band"></select>
+    </div>
     <div class="ctl">
       <label class="h" for="cat">Category</label>
       <select id="cat"></select>
@@ -175,6 +211,13 @@
     <div class="ctl" id="embWrap">
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
+    </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
     </div>
     <div class="ctl">
       <label class="h">Seeds</label>
@@ -244,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -258,19 +305,70 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
+
+  // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
+  // three target sizes - and the band is that study's headline axis, so it gets
+  // its own control. Parsed out of the category names rather than added to the
+  // payload: every other study's categories are bare names, and a viewer that
+  // needs a schema change per study is a viewer nobody reuses. The control
+  // appears only when EVERY category carries a suffix and there is more than one
+  // band to choose between, for the same reason the embedder chips hide
+  // themselves at one embedder - a control with one option is furniture.
+  const BAND_ORDER = ["small", "medium", "large"];
+  const bandOf = (c) => { const i = String(c).lastIndexOf("@"); return i < 0 ? null : String(c).slice(i + 1); };
+  const BANDS = (() => {
+    const bs = P.categories.map(bandOf);
+    if (!bs.length || bs.some((b) => !b)) return [];
+    const u = [...new Set(bs)];
+    if (u.length < 2) return [];
+    const rank = (b) => { const i = BAND_ORDER.indexOf(b); return i < 0 ? BAND_ORDER.length : i; };
+    return u.sort((x, y) => rank(x) - rank(y) || x.localeCompare(y));
+  })();
+  const inBand = (c) => state.band === ALL || bandOf(c) === state.band;
 
   const state = {
     dataset: P.datasets.length > 1 ? ALL : P.datasets[0],
+    band: ALL,
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -284,7 +382,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const all = [...s].sort();
+    const all = [...s].sort().filter(inBand);
     return state.category === ALL || state.category === EACH ? all : all.filter((c) => c === state.category);
   }
 
@@ -308,7 +406,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const cats = [...s].sort();
+    const cats = [...s].sort().filter(inBand);
     catSel.innerHTML =
       `<option value="${ALL}">All categories — averaged together</option>` +
       `<option value="${EACH}">Each category — one line each</option>` +
@@ -317,6 +415,20 @@
     catSel.value = state.category;
   }
   catSel.onchange = () => { state.category = catSel.value; render(); };
+
+  const bandSel = $("band");
+  if (!BANDS.length) {
+    $("bandWrap").style.display = "none";
+  } else {
+    bandSel.innerHTML =
+      `<option value="${ALL}">All sizes</option>` +
+      BANDS.map((b) => `<option value="${esc(b)}">${esc(b)}</option>`).join("");
+    bandSel.value = state.band;
+    // Narrowing the band can strip the category currently selected, so refill
+    // rather than leaving a selection that names no group: `fillCats` falls back
+    // to "all categories" when the current one is no longer on offer.
+    bandSel.onchange = () => { state.band = bandSel.value; fillCats(); render(); };
+  }
   fillCats();
 
   const mSel = $("metric");
@@ -343,6 +455,31 @@
     each.disabled = true;
     each.closest("label").title = P.runs_note || "no per-seed data in this payload";
     each.closest("label").style.opacity = ".45";
+  }
+
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
   }
 
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
@@ -394,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -451,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -468,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -487,75 +664,98 @@
 
   // ---- render -------------------------------------------------------------
   const SOLID = P.solid_coverage;
+  // "Fully measured", for deciding whether the coverage strip has anything to
+  // show. Not 1.0: coverage is a ratio of integers and a pooled slice can land a
+  // hair under it, which would keep a flat strip on screen forever.
+  const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -568,34 +768,82 @@
     const pad = (hi - lo) * 0.06 || 0.02;
     lo = Math.max(spec.lo, lo - pad); hi = Math.min(spec.hi, hi + pad);
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length);
-    tableView(spec, panels);
+    // Does the coverage strip earn its space in THIS selection?
+    //
+    // It exists to expose survivorship: a mean at click 140 pooled from a third
+    // of the cells is a different quantity from one pooled from all of them, and
+    // nothing else on the page says which you are looking at. But in a study
+    // where every cell runs to the horizon it is a flat 100% line under every
+    // panel -- a fifth of each panel's height, in every panel, carrying one bit
+    // that never changes. Same rule as the embedder chips at one embedder: an
+    // axis with one value is furniture.
+    //
+    // The run-up does NOT count as variation. Coverage climbs from nothing to
+    // full over the first clicks because detectors only start once a run has
+    // both classes, and the main chart already says so by DASHING the mean
+    // there. So the strip's only unique information is a dip AFTER every series
+    // has come up, and that is exactly what this tests.
+    //
+    // Decided across all panels rather than per panel: panels of two different
+    // heights are two charts, which is why the y-scale is shared already.
+    let covStart = -1;
+    for (let t = 1; t < nT && covStart < 0; t++) {
+      let all = true;
+      for (const p of panels) for (const q of p.per) if (!(q.agg.cov[t] >= COV_FLAT)) all = false;
+      if (all) covStart = t;
+    }
+    let showCov = true;
+    if (covStart >= 0) {
+      let covMin = 1;
+      for (const p of panels) for (const q of p.per) {
+        for (let t = covStart; t < nT; t++) if (Number.isFinite(q.agg.cov[t])) covMin = Math.min(covMin, q.agg.cov[t]);
+      }
+      showCov = covMin < COV_FLAT;
+    }
+
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
-      ? null
-      : (state.category === ALL ? "all categories pooled" : state.category));
+    const nCats = categoriesInPlay().length;
+    const pooled = state.band === ALL
+      ? `all ${nCats} categories pooled`
+      : `all ${nCats} ${state.band}-band categories pooled`;
+    bits.push(splits("category")
+      ? (state.band === ALL ? null : `${state.band} band`)
+      : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -604,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -618,75 +868,124 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`,
-        `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
-      // Click 0 is a point, not the start of the line: every cell is measured
-      // there (it has a text sort) and none has a detector at click 1, so a
-      // joined line renders two different facts as a spike.
-      if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      if (showCov) {
+        parts.push(
+          `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
+        // Click 0 is a point, not the start of the line: every cell is measured
+        // there (it has a text sort) and none has a detector at click 1, so a
+        // joined line renders two different facts as a spike.
+        if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
+          `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+      }
     }
-    parts.push(
+    if (showCov) parts.push(
       `<line x1="${M.l}" x2="${W - M.r}" y1="${yc(SOLID).toFixed(1)}" y2="${yc(SOLID).toFixed(1)}" stroke="var(--muted)" stroke-width="1" stroke-dasharray="1 3"/>`,
       `<text x="${M.l - 8}" y="${(yc(1) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">100%</text>`,
       `<text x="${M.l - 8}" y="${(yc(0) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">0%</text>`,
-      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`,
-      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${H + CH + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
+      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`);
+    const foot = showCov ? H + CH : H;
+    parts.push(
+      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${foot + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
       `<text transform="translate(13,${(M.t + (H - M.b) / 2).toFixed(0)}) rotate(-90)" text-anchor="middle" font-size="11" fill="var(--muted)">${esc(spec.label)}</text>`);
 
     el.insertAdjacentHTML("beforeend",
-      `<svg viewBox="0 0 ${W} ${H + CH + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y);
+      `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -696,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -711,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -748,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -773,11 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
-        `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td></tr>`).join("");
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
+        (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
+        `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · % = cells measured</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -787,43 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
-      `segment is a level worth quoting. The strip underneath is that fraction.`);
+      `segment is a level worth quoting.` +
+      (opt.showCov
+        ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
+        : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/good-mining-3267/viewer.html
+++ b/docs/experiments/good-mining-3267/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -164,6 +196,10 @@
       <label class="h" for="ds">Dataset</label>
       <select id="ds"></select>
     </div>
+    <div class="ctl" id="bandWrap">
+      <label class="h" for="band">Target size</label>
+      <select id="band"></select>
+    </div>
     <div class="ctl">
       <label class="h" for="cat">Category</label>
       <select id="cat"></select>
@@ -175,6 +211,13 @@
     <div class="ctl" id="embWrap">
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
+    </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
     </div>
     <div class="ctl">
       <label class="h">Seeds</label>
@@ -244,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -258,19 +305,70 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
+
+  // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
+  // three target sizes - and the band is that study's headline axis, so it gets
+  // its own control. Parsed out of the category names rather than added to the
+  // payload: every other study's categories are bare names, and a viewer that
+  // needs a schema change per study is a viewer nobody reuses. The control
+  // appears only when EVERY category carries a suffix and there is more than one
+  // band to choose between, for the same reason the embedder chips hide
+  // themselves at one embedder - a control with one option is furniture.
+  const BAND_ORDER = ["small", "medium", "large"];
+  const bandOf = (c) => { const i = String(c).lastIndexOf("@"); return i < 0 ? null : String(c).slice(i + 1); };
+  const BANDS = (() => {
+    const bs = P.categories.map(bandOf);
+    if (!bs.length || bs.some((b) => !b)) return [];
+    const u = [...new Set(bs)];
+    if (u.length < 2) return [];
+    const rank = (b) => { const i = BAND_ORDER.indexOf(b); return i < 0 ? BAND_ORDER.length : i; };
+    return u.sort((x, y) => rank(x) - rank(y) || x.localeCompare(y));
+  })();
+  const inBand = (c) => state.band === ALL || bandOf(c) === state.band;
 
   const state = {
     dataset: P.datasets.length > 1 ? ALL : P.datasets[0],
+    band: ALL,
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -284,7 +382,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const all = [...s].sort();
+    const all = [...s].sort().filter(inBand);
     return state.category === ALL || state.category === EACH ? all : all.filter((c) => c === state.category);
   }
 
@@ -308,7 +406,7 @@
     const ds = new Set(datasetsInPlay());
     const s = new Set();
     P.groups.forEach((g, i) => { if (ds.has(gDataset(i))) s.add(gCat(i)); });
-    const cats = [...s].sort();
+    const cats = [...s].sort().filter(inBand);
     catSel.innerHTML =
       `<option value="${ALL}">All categories — averaged together</option>` +
       `<option value="${EACH}">Each category — one line each</option>` +
@@ -317,6 +415,20 @@
     catSel.value = state.category;
   }
   catSel.onchange = () => { state.category = catSel.value; render(); };
+
+  const bandSel = $("band");
+  if (!BANDS.length) {
+    $("bandWrap").style.display = "none";
+  } else {
+    bandSel.innerHTML =
+      `<option value="${ALL}">All sizes</option>` +
+      BANDS.map((b) => `<option value="${esc(b)}">${esc(b)}</option>`).join("");
+    bandSel.value = state.band;
+    // Narrowing the band can strip the category currently selected, so refill
+    // rather than leaving a selection that names no group: `fillCats` falls back
+    // to "all categories" when the current one is no longer on offer.
+    bandSel.onchange = () => { state.band = bandSel.value; fillCats(); render(); };
+  }
   fillCats();
 
   const mSel = $("metric");
@@ -343,6 +455,31 @@
     each.disabled = true;
     each.closest("label").title = P.runs_note || "no per-seed data in this payload";
     each.closest("label").style.opacity = ".45";
+  }
+
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
   }
 
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
@@ -394,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -451,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -468,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -487,75 +664,98 @@
 
   // ---- render -------------------------------------------------------------
   const SOLID = P.solid_coverage;
+  // "Fully measured", for deciding whether the coverage strip has anything to
+  // show. Not 1.0: coverage is a ratio of integers and a pooled slice can land a
+  // hair under it, which would keep a flat strip on screen forever.
+  const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -568,34 +768,82 @@
     const pad = (hi - lo) * 0.06 || 0.02;
     lo = Math.max(spec.lo, lo - pad); hi = Math.min(spec.hi, hi + pad);
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length);
-    tableView(spec, panels);
+    // Does the coverage strip earn its space in THIS selection?
+    //
+    // It exists to expose survivorship: a mean at click 140 pooled from a third
+    // of the cells is a different quantity from one pooled from all of them, and
+    // nothing else on the page says which you are looking at. But in a study
+    // where every cell runs to the horizon it is a flat 100% line under every
+    // panel -- a fifth of each panel's height, in every panel, carrying one bit
+    // that never changes. Same rule as the embedder chips at one embedder: an
+    // axis with one value is furniture.
+    //
+    // The run-up does NOT count as variation. Coverage climbs from nothing to
+    // full over the first clicks because detectors only start once a run has
+    // both classes, and the main chart already says so by DASHING the mean
+    // there. So the strip's only unique information is a dip AFTER every series
+    // has come up, and that is exactly what this tests.
+    //
+    // Decided across all panels rather than per panel: panels of two different
+    // heights are two charts, which is why the y-scale is shared already.
+    let covStart = -1;
+    for (let t = 1; t < nT && covStart < 0; t++) {
+      let all = true;
+      for (const p of panels) for (const q of p.per) if (!(q.agg.cov[t] >= COV_FLAT)) all = false;
+      if (all) covStart = t;
+    }
+    let showCov = true;
+    if (covStart >= 0) {
+      let covMin = 1;
+      for (const p of panels) for (const q of p.per) {
+        for (let t = covStart; t < nT; t++) if (Number.isFinite(q.agg.cov[t])) covMin = Math.min(covMin, q.agg.cov[t]);
+      }
+      showCov = covMin < COV_FLAT;
+    }
+
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
-      ? null
-      : (state.category === ALL ? "all categories pooled" : state.category));
+    const nCats = categoriesInPlay().length;
+    const pooled = state.band === ALL
+      ? `all ${nCats} categories pooled`
+      : `all ${nCats} ${state.band}-band categories pooled`;
+    bits.push(splits("category")
+      ? (state.band === ALL ? null : `${state.band} band`)
+      : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -604,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -618,75 +868,124 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`,
-        `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
-      // Click 0 is a point, not the start of the line: every cell is measured
-      // there (it has a text sort) and none has a detector at click 1, so a
-      // joined line renders two different facts as a spike.
-      if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      if (showCov) {
+        parts.push(
+          `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
+        // Click 0 is a point, not the start of the line: every cell is measured
+        // there (it has a text sort) and none has a detector at click 1, so a
+        // joined line renders two different facts as a spike.
+        if (P.anchor.has && Number.isFinite(q.agg.cov[0])) parts.push(
+          `<circle cx="${x(0).toFixed(1)}" cy="${yc(q.agg.cov[0]).toFixed(1)}" r="2" fill="${q.color}"/>`);
+      }
     }
-    parts.push(
+    if (showCov) parts.push(
       `<line x1="${M.l}" x2="${W - M.r}" y1="${yc(SOLID).toFixed(1)}" y2="${yc(SOLID).toFixed(1)}" stroke="var(--muted)" stroke-width="1" stroke-dasharray="1 3"/>`,
       `<text x="${M.l - 8}" y="${(yc(1) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">100%</text>`,
       `<text x="${M.l - 8}" y="${(yc(0) + 4).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">0%</text>`,
-      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`,
-      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${H + CH + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
+      `<text x="${W - M.r}" y="${(yc(0) + 14).toFixed(1)}" text-anchor="end" font-size="10" fill="var(--muted)">cells measured</text>`);
+    const foot = showCov ? H + CH : H;
+    parts.push(
+      `<text x="${(M.l + (W - M.l) / 2).toFixed(0)}" y="${foot + 12}" text-anchor="middle" font-size="11" fill="var(--muted)">clicks spent${P.anchor.has ? "  (0 = the free text sort)" : ""}</text>`,
       `<text transform="translate(13,${(M.t + (H - M.b) / 2).toFixed(0)}) rotate(-90)" text-anchor="middle" font-size="11" fill="var(--muted)">${esc(spec.label)}</text>`);
 
     el.insertAdjacentHTML("beforeend",
-      `<svg viewBox="0 0 ${W} ${H + CH + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y);
+      `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -696,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -711,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -748,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -773,11 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
-        `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td></tr>`).join("");
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
+        (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
+        `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · % = cells measured</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -787,43 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
-      `segment is a level worth quoting. The strip underneath is that fraction.`);
+      `segment is a level worth quoting.` +
+      (opt.showCov
+        ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
+        : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/inclusion-knob-3196/viewer.html
+++ b/docs/experiments/inclusion-knob-3196/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -180,6 +212,13 @@
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
     </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
+    </div>
     <div class="ctl">
       <label class="h">Seeds</label>
       <div class="radios" id="seedMode">
@@ -248,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -262,11 +305,37 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
 
   // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
   // three target sizes - and the band is that study's headline axis, so it gets
@@ -294,8 +363,12 @@
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -384,6 +457,31 @@
     each.closest("label").style.opacity = ".45";
   }
 
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
+  }
+
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
   // An empty one has no honest rendering: the page would either go blank or
   // quietly fall back to "all", and a reader who did not notice would take a
@@ -433,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -490,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -507,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -532,73 +670,92 @@
   const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -644,38 +801,49 @@
       showCov = covMin < COV_FLAT;
     }
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, showCov));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length, showCov);
-    tableView(spec, panels);
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
     const nCats = categoriesInPlay().length;
     const pooled = state.band === ALL
       ? `all ${nCats} categories pooled`
       : `all ${nCats} ${state.band}-band categories pooled`;
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
+    bits.push(splits("category")
       ? (state.band === ALL ? null : `${state.band} band`)
       : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi, showCov) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -684,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -698,32 +868,55 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
       if (showCov) {
         parts.push(
           `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
@@ -746,32 +939,53 @@
 
     el.insertAdjacentHTML("beforeend",
       `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y, showCov);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -781,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -796,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -833,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y, showCov) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -858,12 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
         (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
         `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)}${showCov ? " · % = cells measured" : ""}</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -873,48 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted, showCov) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
       `segment is a level worth quoting.` +
-      (showCov
+      (opt.showCov
         ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
         : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
-          ` as a flat 100% line: nothing in this slice dropped out, and the dashed run-up already says when each` +
-          ` series' detector started.`));
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/docs/experiments/vg-scale/REPORT.md
+++ b/docs/experiments/vg-scale/REPORT.md
@@ -40,7 +40,19 @@ the `calibration_fraction` column.
 subset of columns, seeds averaged or one line each. Everything below is one
 slice of it, chosen in advance; the viewer is where you ask your own question
 instead of asking for a re-run. Its **Target size** control is the axis this
-study is about, and click 0 on every chart is the free text sort.
+study is about, and the notch in each chart's left margin is the free text sort.
+
+Tick **overlay on one chart** to put all five columns on one pair of axes in
+distinct hues — that is the five-way comparison this report keeps making in
+tables, drawn. Off (the default) each column gets its own chart with the ±1 SD
+spread of the population shaded under its line, which is the only arrangement
+where that shadow is readable.
+
+Two of the page's controls stay empty here, and both need a re-run rather than a
+re-draw: this study measured no **oracle threshold** (so the dotted
+cheating-cut line is unavailable and the checkbox says why) and no **supervised
+skyline** (#3322 postdates the run, so there is no learnability-floor notch at
+the right margin). See #3326.
 
 ## What a session actually looks like
 

--- a/docs/experiments/vg-scale/viewer.html
+++ b/docs/experiments/vg-scale/viewer.html
@@ -106,10 +106,42 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -180,6 +212,13 @@
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
     </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
+    </div>
     <div class="ctl">
       <label class="h">Seeds</label>
       <div class="radios" id="seedMode">
@@ -248,6 +287,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -262,11 +305,37 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
 
   // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
   // three target sizes - and the band is that study's headline axis, so it gets
@@ -294,8 +363,12 @@
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -384,6 +457,31 @@
     each.closest("label").style.opacity = ".45";
   }
 
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
+  }
+
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
   // An empty one has no honest rendering: the page would either go blank or
   // quietly fall back to "all", and a reader who did not notice would take a
@@ -433,44 +531,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -490,12 +603,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -507,9 +630,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -532,73 +670,92 @@
   const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -644,38 +801,49 @@
       showCov = covMin < COV_FLAT;
     }
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, showCov));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length, showCov);
-    tableView(spec, panels);
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
     const nCats = categoriesInPlay().length;
     const pooled = state.band === ALL
       ? `all ${nCats} categories pooled`
       : `all ${nCats} ${state.band}-band categories pooled`;
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
+    bits.push(splits("category")
       ? (state.band === ALL ? null : `${state.band} band`)
       : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi, showCov) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -684,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -698,32 +868,55 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 12;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
       if (showCov) {
         parts.push(
           `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
@@ -746,32 +939,53 @@
 
     el.insertAdjacentHTML("beforeend",
       `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y, showCov);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "", warn = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      warn + `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -781,9 +995,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -796,17 +1015,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -833,7 +1052,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y, showCov) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -858,12 +1078,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
         (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
         `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)}${showCov ? " · % = cells measured" : ""}</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -873,48 +1097,70 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted, showCov) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
       `segment is a level worth quoting.` +
-      (showCov
+      (opt.showCov
         ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
         : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
-          ` as a flat 100% line: nothing in this slice dropped out, and the dashed run-up already says when each` +
-          ` series' detector started.`));
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -412,12 +412,36 @@ their own without a re-run.
 | arms | any **non-empty** subset |
 | seeds | averaged, or every seed its own line |
 | metric | cost, precision, recall, F1, FPR, FNR, average precision, AUROC |
+| draw › oracle threshold | off (default), or the cheating-threshold line dotted beside the solid performance line |
+| draw › overlay on one chart | off (default), one chart per varying dimension with its ±1 SD shadow; on, all of them on one chart in distinct hues, shadows off |
 
-Hue is assigned to whichever dimension is actually being compared — the first
-varying one among arm → category → dataset that has at most 8 values — and every
-other varying dimension becomes a panel. The legend states which, in words. A
-dimension with more values than the palette's 8 validated slots folds into small
-multiples rather than getting invented hues.
+**Overlay is the shadow/comparison trade, made explicit.** Off, every varying
+dimension becomes its own chart holding exactly one bold line, so the shaded
+spread underneath it is readable and colour carries no meaning. On, they all
+land on one chart in distinct hues with the shadows dropped — because two
+translucent bands over one another are a third shape nobody can read the overlap
+of. Embedders overlay like anything else: the ban that keeps them out of one
+*number* is a ban on pooling, and two lines pool nothing. Past the palette's 8
+contrast-checked slots hues are generated on the golden angle, and the page says
+when that happened.
+
+**Four reference quantities, drawn as what each one is.** Two lines — the
+performance the loop achieved (solid) and the same model at the **oracle
+threshold** (dotted, same hue, behind the checkbox; the gap between them is the
+calibration regret) — and two points, notched into the margins: the free **text
+sort** at the left and the supervised **skyline** (issue #3322) at the right.
+Nothing joins the text-sort notch to the curve: no detector exists in between, so
+the gap is the honest drawing. The notches are marks in the margin rather than
+rules across the panel because each is a level that holds at one x, and a rule
+would claim it holds at every x — which for the skyline would read as "the
+learnability floor was reachable at click 3".
+
+The oracle is offered on every metric that is a statement about **one cut**.
+The harness emits only the oracle cut's cost and its FPR/FNR, so precision,
+recall and F1 there are reconstructed from those rates and the split's class
+counts — the same confusion matrix in a different unit. `average_precision` and
+`auroc` integrate over every threshold, so re-cutting cannot move them; the box
+disables itself and says so rather than drawing one line twice.
 
 Both chip controls are non-empty by construction — the last remaining chip is
 locked, with a tooltip, rather than snapping silently back — because an empty
@@ -435,6 +459,14 @@ python viewer.py --results "$CALIB_EXP/results" \
   --baseline "$OUT/text_baseline.csv" --out "$OUT/viewer.html"
 python selftest_viewer.py     # planted-answer check on the codec and the pooling
 ```
+
+The skyline notch needs skyline rows, so it appears only for a run launched with
+`CALIB_SKYLINE_ARMS` (see [Supervised skyline / training regret](#supervised-skyline--training-regret-issue-3322)
+above). `viewer.py` reads them straight out of the cell CSVs, because
+`analyze_spikes.load_arm` — which every analyzer goes through — filters
+`gmm_variant`-tagged rows out by design, and a skyline reads ground-truth labels
+the app can never see. A run without them still builds; the page just has no
+floor, and the builder says so. `--no-skyline` skips the pass.
 
 To redraw the PNGs without re-running the analysis:
 

--- a/scripts/experiments/calibration/analyze_calfrac.py
+++ b/scripts/experiments/calibration/analyze_calfrac.py
@@ -531,7 +531,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             arms=arms,
             baseline=baseline,
             title="calibration_fraction (#3287)",
-            subtitle="Colour = calibration_fraction · one panel per geometry × category",
+            subtitle="One chart per calibration_fraction × geometry × category; tick 'overlay on one chart' to compare them directly.",
         )
 
     write_report(out, frame, by_band, paired, vd, vg, spread, trap, counts, prov, figs)

--- a/scripts/experiments/calibration/analyze_exclusion.py
+++ b/scripts/experiments/calibration/analyze_exclusion.py
@@ -555,7 +555,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             arms=sorted(set(d["arm"])),
             baseline=baseline,
             title="voted-media exclusion floor (#3312)",
-            subtitle="Colour = exclusion arm · one panel per stage × geometry × category",
+            subtitle="One chart per exclusion arm × stage × geometry × category; tick 'overlay on one chart' to compare them directly.",
         )
 
     write_report(out, frame, by_band, paired, vd, regime, trap, counts, prov, figs, stages)

--- a/scripts/experiments/calibration/analyze_folds_3314.py
+++ b/scripts/experiments/calibration/analyze_folds_3314.py
@@ -979,7 +979,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             arms=["K=" + str(k) for k in sorted(set(ship_v["k"]))],
             baseline=baseline,
             title="calibration fold count (#3314)",
-            subtitle="Colour = fold count K · one panel per geometry × category",
+            subtitle="One chart per fold count K × geometry × category; tick 'overlay on one chart' to compare them directly.",
         )
 
     summary = {

--- a/scripts/experiments/calibration/selftest_viewer.py
+++ b/scripts/experiments/calibration/selftest_viewer.py
@@ -399,6 +399,20 @@ def main() -> int:  # noqa: C901
         ok &= _check("the payload token was substituted exactly once", V.TOKEN not in html)
         ok &= _check("the page reports its own payload budget", bool(P.get("payload_kb")))
 
+        # --- reskin ----------------------------------------------------------
+        # A template improvement has to be pushable onto a committed report
+        # whose results directory is long gone, and it must move the SHELL
+        # without touching a byte of the numbers.
+        V.reskin(out)
+        again = out.read_text(encoding="utf-8")
+        ok &= _check(
+            "reskin rewrites the page and leaves the payload byte-identical",
+            _payload(out) == P
+            and re.search(r'type="application/json">(.*?)</script>', again, re.S).group(1)
+            == re.search(r'type="application/json">(.*?)</script>', html, re.S).group(1),
+        )
+        ok &= _check("...and the reskinned page is still whole", again == html)
+
         print("\n" + ("SELFTEST PASSED" if ok else "SELFTEST FAILED"))
         return 0 if ok else 1
     finally:

--- a/scripts/experiments/calibration/selftest_viewer.py
+++ b/scripts/experiments/calibration/selftest_viewer.py
@@ -51,15 +51,50 @@ N_SEED, T_MAX = 8, 40
 TEXT_COST = 0.30
 LEVEL = {"ctl": 0.20, "alt": 0.10}
 
+#: The planted oracle cut.  Only the two rates and the split's class counts are
+#: emitted, exactly as the harness emits them - precision / recall / F1 at that
+#: cut have to be *reconstructed* by the builder, which is the point of the
+#: check: a wrong reconstruction is invisible on screen (it draws a plausible
+#: dotted line) and would misprice the calibration regret in every report.
+ORACLE_COST, ORACLE_FPR, ORACLE_FNR = 0.05, 0.02, 0.10
+N_TEST_POS, N_TEST_NEG = 100.0, 900.0
+_TP = N_TEST_POS * (1.0 - ORACLE_FNR)
+_FP = N_TEST_NEG * ORACLE_FPR
+_FN = N_TEST_POS * ORACLE_FNR
+ORACLE_PRECISION = _TP / (_TP + _FP)
+ORACLE_F1 = 2.0 * _TP / (2.0 * _TP + _FP + _FN)
 
-def _frames() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    rows, cells, base = [], [], []
+#: The planted supervised skyline (#3322), one row per cell, differing between
+#: the two categories so a wrong pool shows up as a level rather than as noise.
+SKY_COST = {"rich": 0.06, "lean": 0.16}
+
+
+def _frames() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    rows, cells, base, sky = [], [], [], []
     for arm in ARMS:
         for ds in DSS:
             for emb in EMBS:
                 for cat, trained in CATS.items():
                     for seed in range(N_SEED):
                         cells.append({"arm": arm, "dataset": ds, "embedder": emb, "category": cat, "seed": seed})
+                        # The skyline is vote-independent, so every attempted
+                        # cell has one whether or not the loop ever trained.
+                        sky.append(
+                            {
+                                "arm": arm,
+                                "dataset": ds,
+                                "embedder": emb,
+                                "category": cat,
+                                "seed": seed,
+                                "t": 0,
+                                "gmm_variant": "skyline_train_full",
+                                "cost": SKY_COST[cat],
+                                "precision": 0.9,
+                                "recall": 0.85,
+                                "f1": 0.87,
+                                "average_precision": 0.95,
+                            }
+                        )
                         if seed >= trained:
                             continue  # never trained: no metric row at all
                         for t in range(1, T_MAX + 1):
@@ -78,6 +113,14 @@ def _frames() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
                                     "recall": 0.6,
                                     "f1": 0.65,
                                     "average_precision": 0.8,
+                                    # The oracle cut, as the harness emits it:
+                                    # the cost and the two rates, never the
+                                    # confusion-matrix metrics at that cut.
+                                    "oracle_cost": ORACLE_COST,
+                                    "oracle_fpr": ORACLE_FPR,
+                                    "oracle_fnr": ORACLE_FNR,
+                                    "n_test_pos": N_TEST_POS,
+                                    "n_test_neg": N_TEST_NEG,
                                 }
                             )
     for ds in DSS:
@@ -98,7 +141,7 @@ def _frames() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
                             "text_AP": 0.5,
                         }
                     )
-    return pd.DataFrame(rows), pd.DataFrame(cells), pd.DataFrame(base)
+    return pd.DataFrame(rows), pd.DataFrame(cells), pd.DataFrame(base), pd.DataFrame(sky)
 
 
 def _payload(path: Path) -> dict:
@@ -131,9 +174,15 @@ def _check(label: str, ok: bool, detail: str = "") -> bool:
 def main() -> int:  # noqa: C901
     tmp = Path(tempfile.mkdtemp(prefix="viewer-selftest-"))
     try:
-        main_df, cells, base = _frames()
+        main_df, cells, base, sky = _frames()
         out = V.build_viewer(
-            main_df, tmp / "viewer.html", arms=ARMS, denominator=cells, baseline=base, runs_budget_mb=0.25
+            main_df,
+            tmp / "viewer.html",
+            arms=ARMS,
+            denominator=cells,
+            baseline=base,
+            skyline=sky,
+            runs_budget_mb=0.25,
         )
         P = _payload(out)
 
@@ -223,6 +272,87 @@ def main() -> int:  # noqa: C901
         cov = n_lean / cellsA[g_lean, ai["ctl"], 0]
         ok &= _check(
             "...so a starving category reports coverage well below 1", abs(cov - 1.0 / N_SEED) < 1e-6, f"{cov:.3f}"
+        )
+
+        # --- the oracle companion -------------------------------------------
+        # Reconstructed, not emitted: the harness ships an (FPR, FNR) pair and
+        # the split's class counts, and the builder turns that back into a full
+        # confusion matrix.  Checked against numbers computed the long way here,
+        # because a wrong reconstruction draws a perfectly plausible line.
+        oracle_on = {m["key"]: m["oracle"] for m in P["metrics"]}
+        ok &= _check(
+            "every cut metric gets an oracle, and the ranking metric does not",
+            all(oracle_on[k] for k in ("cost", "precision", "recall", "f1")) and not oracle_on["average_precision"],
+            str(oracle_on),
+        )
+        ok &= _check(
+            "...and the page is told which metrics those are",
+            set(P["oracle_metrics"]) >= {"cost", "precision", "recall", "f1"}
+            and "average_precision" not in P["oracle_metrics"],
+            str(P["oracle_metrics"]),
+        )
+        omean = _decode(P["agg"]["omean"])
+        on = _decode(P["agg"]["on"])
+        g0, a0 = gi[("dsA", "embA", "rich")], ai["ctl"]
+        step = 1.0 / P["agg"]["omean"]["scale"]
+        want = {
+            "cost": ORACLE_COST,
+            "recall": 1.0 - ORACLE_FNR,
+            "precision": ORACLE_PRECISION,
+            "f1": ORACLE_F1,
+        }
+        for key, expect in want.items():
+            got_o = omean[g0, a0, keys.index(key), ti]
+            ok &= _check(
+                f"oracle {key} is reconstructed exactly ({expect:.4f})",
+                abs(got_o - expect) <= 2 * step,
+                f"{got_o} vs {expect}",
+            )
+        ok &= _check(
+            "the oracle carries its own n, so a pooled oracle is weighted too",
+            abs(on[g0, a0, keys.index("cost"), ti] - CATS["rich"]) < 0.5,
+            str(on[g0, a0, keys.index("cost"), ti]),
+        )
+        ok &= _check(
+            "no oracle value is invented for the ranking metric",
+            not np.isfinite(omean[g0, a0, keys.index("average_precision"), ti]),
+        )
+        ok &= _check(
+            "the oracle line does not reach back to click 0 (there is no model there)",
+            not np.isfinite(omean[g0, a0, keys.index("cost"), P["t"].index(0)]),
+        )
+
+        # --- the supervised skyline -----------------------------------------
+        ok &= _check(
+            "the skyline reaches the page, named by arm",
+            P["skyline"] is not None and P["skyline"]["arm"] == "skyline_train_full",
+            str(P["skyline"] and P["skyline"]["arm"]),
+        )
+        sky_v = _decode(P["skyline"]["mean"])
+        sky_n = _decode(P["skyline"]["n"])
+        mi_cost = keys.index("cost")
+        got_s = sky_v[g0, a0, mi_cost, 0]
+        ok &= _check(
+            "a skyline value round-trips",
+            abs(got_s - SKY_COST["rich"]) <= 2.0 / P["skyline"]["mean"]["scale"],
+            f"{got_s} vs {SKY_COST['rich']}",
+        )
+        # Vote-independent: EVERY attempted cell has one, including the seven
+        # `lean` seeds that never trained a detector - which is exactly why the
+        # skyline can be a floor for a run that produced no curve at all.
+        ok &= _check(
+            "the skyline counts every attempted cell, trained or not",
+            abs(sky_n[gi[("dsA", "embA", "lean")], a0, mi_cost, 0] - N_SEED) < 0.5,
+            str(sky_n[gi[("dsA", "embA", "lean")], a0, mi_cost, 0]),
+        )
+        pooled_sky = (
+            sky_n[g0, a0, mi_cost, 0] * sky_v[g0, a0, mi_cost, 0]
+            + sky_n[gi[("dsA", "embA", "lean")], a0, mi_cost, 0] * sky_v[gi[("dsA", "embA", "lean")], a0, mi_cost, 0]
+        ) / (sky_n[g0, a0, mi_cost, 0] + sky_n[gi[("dsA", "embA", "lean")], a0, mi_cost, 0])
+        ok &= _check(
+            "a pooled skyline is the cell-weighted mean of the two categories",
+            abs(pooled_sky - (SKY_COST["rich"] + SKY_COST["lean"]) / 2) < 3e-3,
+            f"{pooled_sky:.5f}",
         )
 
         # --- the per-seed payload -------------------------------------------

--- a/scripts/experiments/calibration/viewer.py
+++ b/scripts/experiments/calibration/viewer.py
@@ -25,11 +25,50 @@ What the page lets a reader pick:
 * **seeds** — averaged, or every seed as its own line;
 * **metric** — cost, precision, recall, F1, FPR, FNR, average precision, AUROC:
   whatever the run emitted, from one shared definition
-  (:data:`vtscore.eval.calibration_metrics.DETECTION_METRICS`).
+  (:data:`vtscore.eval.calibration_metrics.DETECTION_METRICS`);
+* **overlay** — off (the default), every varying dimension is its own chart
+  carrying one bold line and the ±1 SD shadow of the population under it; on,
+  they all land on one chart in distinct hues and the shadows come off.  The
+  shadow only has an honest home in the first: two translucent bands over one
+  another are a third shape nobody can read the overlap of.  Overlaying two
+  embedders is **not** averaging them — the ban that keeps them out of one
+  number is a ban on pooling, and two lines pool nothing;
+* **oracle** — off (the default), or the same model's score at the cut the test
+  labels say it should have used, drawn dotted beside the solid performance
+  line.  The gap between them is the calibration regret.
 
-Click 0 is the **zero-click text sort**, exactly as in :mod:`curves`: the far
-left is what typing the query got for free, so a reader can see at a glance
-whether the clicking ever earned its keep and after how many clicks.
+Four reference quantities, and each is drawn as what it is
+------------------------------------------------------------
+
+The chart carries two **lines** and two **points**, and the whole redesign is
+about not letting a point be read as a line:
+
+``performance`` (a line)
+    What the loop actually achieved: the momentary model at its own computed
+    threshold, at every click.  Solid where it describes the whole grid, dashed
+    where it describes a subset.
+``oracle`` (a line, behind a checkbox)
+    The same momentary model with a **cheating threshold** — the cut a reader
+    would have picked knowing the test labels.  Same hue, dotted.  It is not a
+    rival system; it is the ceiling this system's *threshold rule* left on the
+    table, so it shares the colour and differs only in style.
+``text sort`` (a point, notched in the **left** margin)
+    What typing the query got for free, at zero clicks.
+``skyline`` (a point, notched in the **right** margin)
+    The same head, through the same trainer, with every training label handed
+    to it (issue #3322) — the learnability floor of this embedding space.
+    Vote-independent, so it does not move as the reader clicks.
+
+**Nothing joins the text-sort notch to the curve.**  The dotted bridge that used
+to run from click 0 to the first trained click was the most prominent mark on
+the chart and it stood for a measurement nobody made: between the two there is
+no detector, so there is no level to draw.  A gap says exactly that.
+
+The two notches sit in the margins rather than as rules across the panel for the
+same reason: each is a level that holds at *one* x, and a horizontal rule across
+the chart asserts it holds at every x.  The skyline is the sharper case — drawn
+as a rule it would read as "the floor was reachable at click 3", which is the
+one reading the number exists to prevent.
 
 Payload
 -------
@@ -44,6 +83,26 @@ is derivable from the other at an acceptable size:
     makes "all categories" and "all datasets" *exact* rather than a mean of
     means — the page pools them properly, weighted by the cells that actually
     contributed.
+``agg.omean`` / ``agg.on``
+    The oracle companion, on the same axes.  The harness emits the oracle
+    **cut** and the two rates it pays there, never the confusion-matrix metrics
+    at that cut — so precision / recall / F1 at the oracle threshold are
+    *reconstructed* here from ``(oracle_fpr, oracle_fnr, n_test_pos,
+    n_test_neg)``, which is a full confusion matrix.  That is why the oracle is
+    offered on every metric that is a statement about one cut, rather than on
+    cost alone: "the cut cost us 0.1" and "the cut cost us 11 points of recall"
+    are the same fact in the two units a reader thinks in.  It carries its own
+    ``n``, because an oracle that declines to flag anything has no precision at
+    a click where the trained cut's precision is perfectly well defined.
+    ``average_precision`` and ``auroc`` get none: they integrate over every
+    threshold, so re-cutting cannot move them and the "oracle" would be the
+    performance line drawn twice.
+``skyline``
+    Per ``(group, arm, metric)``: one number, not a series.  Read straight out
+    of the cell CSVs (:func:`load_skyline`) rather than out of the main frame,
+    because ``analyze_spikes.load_arm`` filters skyline rows out by design — a
+    skyline reads ground-truth labels the app can never see, so it must never
+    land in a mean of what the app achieved.
 ``runs``
     Per ``(group, arm, seed, metric, click)``: the raw series behind the
     per-seed lines, on a **thinned** click grid chosen to fit
@@ -122,6 +181,26 @@ TEMPLATE = Path(__file__).with_name("viewer_template.html")
 #: The one placeholder the template carries; see the note in its header comment.
 TOKEN = "__VIEWER" + "_PAYLOAD__"
 
+#: The **supervised-skyline** arms (issue #3322), in preference order.  These
+#: rows are tagged in ``gmm_variant``, so ``analyze_spikes.load_arm`` filters
+#: them out of the main frame by construction and the viewer re-reads the cell
+#: CSVs for them (:func:`load_skyline`).
+#:
+#: ``skyline_train_full`` is the primary: the same head, through the same
+#: trainer, on the entire sim split with full ground-truth labels.
+#: ``skyline_test_xfit`` is its cross-fitted test-side bracket partner and is
+#: used only when the primary was not run.
+SKYLINE_ARMS: tuple[str, ...] = ("skyline_train_full", "skyline_test_xfit")
+
+#: What each skyline arm is called on the page.  Spelled out rather than shown
+#: as its arm name, because "skyline_test_xfit" tells a reader nothing about the
+#: one thing they need to know: whether the number in front of them was fitted
+#: on the training split or cross-fitted on the test split.
+SKYLINE_LABELS: dict[str, str] = {
+    "skyline_train_full": "skyline — fully-supervised head",
+    "skyline_test_xfit": "skyline — cross-fitted on the test split",
+}
+
 
 def _b64gz(buf: bytes) -> str:
     return base64.b64encode(gzip.compress(buf, 9)).decode("ascii")
@@ -161,7 +240,74 @@ def _payload_bytes(enc: dict) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _metric_list(main: pd.DataFrame) -> list[dict]:
+#: Prefix of the derived per-row oracle columns :func:`add_oracle_columns` writes.
+OCOL = "__oracle__"
+
+#: Metrics the **oracle cut cannot move**, and therefore has no separate value
+#: for.  ``average_precision`` and ``auroc`` are properties of the *ranking*:
+#: they integrate over every threshold, so re-cutting the same scores at the
+#: cost-minimising point leaves them exactly where they were.  Drawing an
+#: "oracle AP" would be drawing the performance line twice, in two styles, and
+#: inviting a reader to read a gap that is zero by construction.
+#:
+#: Every other metric in :data:`~vtscore.eval.calibration_metrics.DETECTION_METRICS`
+#: *is* a statement about one cut, so each one has an oracle value and gets one.
+RANKING_METRICS: frozenset[str] = frozenset({"average_precision", "auroc"})
+
+
+def add_oracle_columns(main: pd.DataFrame) -> list[str]:
+    """Fill ``__oracle__<metric>`` in place; return the metrics that got one.
+
+    The harness emits the oracle **cut** and the two rates it pays there
+    (``oracle_threshold`` / ``oracle_cost`` / ``oracle_fpr`` / ``oracle_fnr``)
+    but not the confusion-matrix metrics at that cut.  It does not need to: an
+    ``(FPR, FNR)`` pair plus the split's own class counts — ``n_test_pos`` and
+    ``n_test_neg``, on every row — is a full confusion matrix, so precision,
+    recall and F1 at the oracle cut are *reconstructed exactly* here rather than
+    left off the page.  Deriving them beats re-running the grid to emit four
+    more columns, and it beats offering the oracle on cost alone: "the cut cost
+    us 0.1" and "the cut cost us 11 points of recall" are the same fact in the
+    two units a reader actually thinks in.
+
+    The conventions are :func:`~vtscore.eval.calibration_metrics.detection_metrics`'s,
+    because a derived precision that treated "flagged nothing" as 0 rather than
+    NaN would read as a catastrophically bad oracle where the truth is that the
+    oracle declined to flag anything — which on a rare class is often the
+    cost-minimising move.
+
+    Returns the metric keys that ended up with an oracle column, so
+    :func:`_metric_list` can flag them and the page can hide the control where
+    there is nothing to show.
+    """
+    have = set(main.columns)
+    got: list[str] = []
+    if "oracle_cost" in have:
+        main[OCOL + "cost"] = pd.to_numeric(main["oracle_cost"], errors="coerce")
+        got.append("cost")
+    if not {"oracle_fpr", "oracle_fnr"} <= have:
+        return got
+    fpr = pd.to_numeric(main["oracle_fpr"], errors="coerce")
+    fnr = pd.to_numeric(main["oracle_fnr"], errors="coerce")
+    main[OCOL + "fpr"] = fpr
+    main[OCOL + "fnr"] = fnr
+    main[OCOL + "recall"] = 1.0 - fnr
+    got += ["fpr", "fnr", "recall"]
+    if not {"n_test_pos", "n_test_neg"} <= have:
+        return got
+    n_pos = pd.to_numeric(main["n_test_pos"], errors="coerce")
+    n_neg = pd.to_numeric(main["n_test_neg"], errors="coerce")
+    tp = n_pos * (1.0 - fnr)
+    fn = n_pos * fnr
+    fp = n_neg * fpr
+    flagged = tp + fp
+    f1_denom = 2.0 * tp + fp + fn
+    main[OCOL + "precision"] = (tp / flagged).where(flagged > 0)
+    main[OCOL + "f1"] = (2.0 * tp / f1_denom).where(f1_denom > 0)
+    got += ["precision", "f1"]
+    return [k for k in got if main[OCOL + k].notna().any()]
+
+
+def _metric_list(main: pd.DataFrame, oracle_keys: Sequence[str] = ()) -> list[dict]:
     """Every metric the run emitted, in the shared canonical order.
 
     Read from :data:`vtscore.eval.calibration_metrics.DETECTION_METRICS` so a
@@ -171,10 +317,21 @@ def _metric_list(main: pd.DataFrame) -> list[dict]:
     """
     from vtscore.eval.calibration_metrics import DETECTION_METRICS
 
+    oracle = {k for k in oracle_keys if k not in RANKING_METRICS}
     out = []
     for key, (label, lower, domain) in DETECTION_METRICS.items():
         if key in main.columns and main[key].notna().any():
-            out.append({"key": key, "label": label, "lower": bool(lower), "lo": domain[0], "hi": domain[1]})
+            out.append(
+                {
+                    "key": key,
+                    "label": label,
+                    "lower": bool(lower),
+                    "lo": domain[0],
+                    "hi": domain[1],
+                    "oracle": key in oracle,
+                    "ranking": key in RANKING_METRICS,
+                }
+            )
     return out
 
 
@@ -195,9 +352,15 @@ def _thin(t_full: np.ndarray, keep: int) -> np.ndarray:
 class _Shape:
     """The index a payload is built against: groups, arms, seeds, metrics."""
 
-    def __init__(self, main: pd.DataFrame, arms: Sequence[str], denominator: pd.DataFrame | None):
+    def __init__(
+        self,
+        main: pd.DataFrame,
+        arms: Sequence[str],
+        denominator: pd.DataFrame | None,
+        oracle_keys: Sequence[str] = (),
+    ):
         self.arms = [a for a in arms if (main["arm"] == a).any()]
-        self.metrics = _metric_list(main)
+        self.metrics = _metric_list(main, oracle_keys)
         self.datasets = sorted(str(d) for d in main["dataset"].dropna().unique())
         self.embedders = (
             sorted(str(e) for e in main["embedder"].dropna().unique()) if "embedder" in main.columns else [""]
@@ -238,19 +401,29 @@ def _agg_arrays(  # noqa: C901
     t_full: np.ndarray,
     base: dict[str, dict[tuple, float]],
     cells: dict[tuple[str, str], int],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """``(mean, sd, n, cells)`` over ``(group, arm, metric, click)``.
+) -> dict[str, np.ndarray]:
+    """``mean`` / ``sd`` / ``n`` / ``cells`` over ``(group, arm, metric, click)``.
 
     ``n`` is stored beside the moments on purpose: it is what makes an "all
     categories" or "all datasets" selection *exact* in the page.  Pooling means
     of means would weight a category that trained on 3 cells the same as one
     that trained on 42, which is precisely the survivorship the coverage strip
     exists to expose.
+
+    ``omean`` / ``on`` are the same thing for the **oracle cut** — the value the
+    very same model would have scored had its threshold been chosen with the
+    test labels in hand.  It carries its own ``n`` rather than borrowing the
+    metric's, because the two genuinely differ: an oracle that declines to flag
+    anything has an undefined precision at a click where the trained cut's
+    precision is perfectly well defined, and pooling that cell in at weight 1
+    with a NaN would poison the whole average.
     """
     nG, nA, nM, nT = len(shape.groups), len(shape.arms), len(shape.metrics), len(t_full)
     mean = np.full((nG, nA, nM, nT), np.nan)
     sd = np.full((nG, nA, nM, nT), np.nan)
     n = np.zeros((nG, nA, nM, nT))
+    omean = np.full((nG, nA, nM, nT), np.nan)
+    on = np.zeros((nG, nA, nM, nT))
     ncells = np.zeros((nG, nA))
     t_pos = {int(t): i for i, t in enumerate(t_full)}
 
@@ -277,6 +450,19 @@ def _agg_arrays(  # noqa: C901
             mean[gi, ai, mi] = mu
             sd[gi, ai, mi] = np.sqrt(np.clip(var, 0.0, None))
             n[gi, ai, mi] = cnt
+        for mi, spec in enumerate(shape.metrics):
+            ocol = OCOL + spec["key"]
+            if not spec.get("oracle") or ocol not in g.columns:
+                continue
+            ovals = g.loc[ok, ocol].to_numpy(dtype=float)
+            ogood = np.isfinite(ovals)
+            if not ogood.any():
+                continue
+            ocnt = np.bincount(cols[ogood], minlength=nT).astype(float)
+            os1 = np.bincount(cols[ogood], weights=ovals[ogood], minlength=nT)
+            with np.errstate(invalid="ignore", divide="ignore"):
+                omean[gi, ai, mi] = np.where(ocnt > 0, os1 / np.maximum(ocnt, 1), np.nan)
+            on[gi, ai, mi] = ocnt
 
     for (ds, emb, cat), gi in shape.gi.items():
         for arm, ai in shape.ai.items():
@@ -302,7 +488,7 @@ def _agg_arrays(  # noqa: C901
                     mean[gi, ai, mi, z] = float(arr.mean())
                     sd[gi, ai, mi, z] = float(arr.std())
                     n[gi, ai, mi, z] = float(ncells[gi, ai])
-    return mean, sd, n, ncells
+    return {"mean": mean, "sd": sd, "n": n, "cells": ncells, "omean": omean, "on": on}
 
 
 def _runs_arrays(
@@ -359,6 +545,89 @@ def _runs_arrays(
     return (np.stack(blocks) if blocks else np.zeros((0, nM, nT))), index
 
 
+def load_skyline(results: Path, dirs: Sequence[str], arms: Sequence[str]) -> pd.DataFrame:
+    """The **supervised-skyline** rows (issue #3322) under *results*, if any.
+
+    These have to be read separately because
+    :func:`analyze_spikes.load_arm` — which every analyzer and
+    :func:`curves._load` go through — keeps only *base* rows, and a skyline row
+    is tagged in ``gmm_variant`` precisely so it cannot be mistaken for one.
+    That filter is right: a skyline reads ground-truth labels the app can never
+    see, so it must never land in a mean of what the app achieved.  It is also
+    why the skyline needs its own door into the page.
+
+    One row per ``(cell, skyline arm)``, at ``t = 0`` and vote-independent, so
+    the frame is tiny next to the main one.  ``arm`` is set to the *results*
+    arm's label, matching the main frame; the skyline arm's own name lands in
+    ``gmm_variant``.
+    """
+    import _cells_io
+    import analyze_spikes as sp  # noqa: F401  (kept beside _cells_io: same reader family)
+
+    want = set(SKYLINE_ARMS)
+    parts = []
+    for d, label in zip(dirs, arms, strict=True):
+        for f in _cells_io.main_frame_files(Path(results) / d / "cells"):
+            if f.stat().st_size == 0:
+                continue
+            try:
+                fr = pd.read_csv(f)
+            except Exception:  # noqa: BLE001, S112
+                continue
+            if fr.empty or "gmm_variant" not in fr.columns:
+                continue
+            fr = fr[fr["gmm_variant"].astype(str).str.strip().isin(want)]
+            if fr.empty:
+                continue
+            fr = fr.copy()
+            fr["arm"] = label
+            parts.append(fr)
+    return pd.concat(parts, ignore_index=True) if parts else pd.DataFrame()
+
+
+def _skyline_arrays(skyline: pd.DataFrame | None, shape: _Shape) -> tuple[np.ndarray, np.ndarray, str]:
+    """``(mean, n, arm_name)`` over ``(group, arm, metric)`` — one number, not a line.
+
+    The skyline is **vote-independent**: it is what the same head reaches on the
+    same cell with every training label handed to it, so it does not move as the
+    reader clicks and it is drawn as a notch at the horizon rather than as a
+    line across the chart.  A line would assert that the floor was reachable at
+    click 3, which is exactly the reading the point exists to prevent.
+
+    Only one skyline arm reaches the page — :data:`SKYLINE_ARMS` in preference
+    order — because the two are a *bracket* on the same quantity rather than two
+    findings, and two notches a hair apart at the same x read as a comparison
+    that was never run.
+    """
+    nG, nA, nM = len(shape.groups), len(shape.arms), len(shape.metrics)
+    mean = np.full((nG, nA, nM), np.nan)
+    n = np.zeros((nG, nA, nM))
+    if skyline is None or skyline.empty:
+        return mean, n, ""
+    tags = skyline["gmm_variant"].astype(str).str.strip()
+    pick = next((a for a in SKYLINE_ARMS if (tags == a).any()), "")
+    if not pick:
+        return mean, n, ""
+    df = skyline[tags == pick].copy()
+    if "embedder" not in df.columns:
+        df["embedder"] = ""
+    df["__group"] = _group_key(df)
+    for (gk, arm), g in df.groupby(["__group", "arm"], dropna=False):
+        gi, ai = shape.gi.get(tuple(str(gk).split(GSEP))), shape.ai.get(arm)
+        if gi is None or ai is None:
+            continue
+        for mi, spec in enumerate(shape.metrics):
+            if spec["key"] not in g.columns:
+                continue
+            vals = pd.to_numeric(g[spec["key"]], errors="coerce").to_numpy(dtype=float)
+            vals = vals[np.isfinite(vals)]
+            if not vals.size:
+                continue
+            mean[gi, ai, mi] = float(vals.mean())
+            n[gi, ai, mi] = float(vals.size)
+    return mean, n, pick
+
+
 def _baselines(baseline: pd.DataFrame | None, shape: _Shape) -> dict[str, dict[tuple, float]]:
     """``metric -> {(dataset, embedder, category, seed): value}``.
 
@@ -400,6 +669,7 @@ def build_viewer(  # noqa: C901
     arms: Sequence[str],
     denominator: pd.DataFrame | None = None,
     baseline: pd.DataFrame | None = None,
+    skyline: pd.DataFrame | None = None,
     title: str = "Quality over clicks",
     subtitle: str = "",
     runs_budget_mb: float = RUNS_BUDGET_MB,
@@ -413,8 +683,9 @@ def build_viewer(  # noqa: C901
     if "embedder" not in main.columns:
         main["embedder"] = ""
     main["__group"] = _group_key(main)
+    oracle_keys = add_oracle_columns(main)
 
-    shape = _Shape(main, arms, denominator)
+    shape = _Shape(main, arms, denominator, oracle_keys)
     if not shape.metrics:
         raise SystemExit("viewer: the frame carries none of the known metric columns")
 
@@ -432,13 +703,29 @@ def build_viewer(  # noqa: C901
     has_anchor = bool(base)
     t_full = np.arange(0 if has_anchor else 1, int(main["t"].max()) + 1)
 
-    mean, sd, n, ncells = _agg_arrays(main, shape, t_full, base, cells)
+    ag = _agg_arrays(main, shape, t_full, base, cells)
     agg = {
-        "mean": _encode(mean),
-        "sd": _encode(sd),
-        "n": _encode(n, scale=1),
-        "cells": _encode(ncells.reshape(len(shape.groups), len(shape.arms), 1), scale=1),
+        "mean": _encode(ag["mean"]),
+        "sd": _encode(ag["sd"]),
+        "n": _encode(ag["n"], scale=1),
+        "cells": _encode(ag["cells"].reshape(len(shape.groups), len(shape.arms), 1), scale=1),
+        "omean": _encode(ag["omean"]),
+        "on": _encode(ag["on"], scale=1),
     }
+
+    sky_mean, sky_n, sky_arm = _skyline_arrays(skyline, shape)
+    sky = (
+        {
+            "arm": sky_arm,
+            "label": SKYLINE_LABELS.get(sky_arm, sky_arm),
+            # Trailing axis of length 1: the encoder delta-codes along the last
+            # axis, and a scalar per (group, arm, metric) is a one-click series.
+            "mean": _encode(sky_mean[:, :, :, None]),
+            "n": _encode(sky_n[:, :, :, None], scale=1),
+        }
+        if sky_arm
+        else None
+    )
 
     # Per-seed payload: thin the click axis until it fits, and say which grid it
     # landed on.  Never drop runs, never drop metrics - a reader comparing two
@@ -484,6 +771,7 @@ def build_viewer(  # noqa: C901
         "title": title,
         "subtitle": subtitle,
         "anchor": {"has": has_anchor, "label": anchor_label},
+        "skyline": sky,
         "solid_coverage": curves.SOLID_COVERAGE,
         "datasets": shape.datasets,
         "embedders": shape.embedders,
@@ -497,6 +785,7 @@ def build_viewer(  # noqa: C901
         "runs": runs,
         "runs_note": runs_note,
         "n_cells": int(sum(cells.values())),
+        "oracle_metrics": [k for k in oracle_keys if k not in RANKING_METRICS],
         "payload_kb": {k: round(v / 1024) for k, v in sizes.items()},
     }
 
@@ -526,6 +815,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     ap.add_argument("--title", default="Quality over clicks")
     ap.add_argument("--subtitle", default="")
     ap.add_argument("--runs-budget-mb", type=float, default=RUNS_BUDGET_MB)
+    ap.add_argument(
+        "--no-skyline",
+        action="store_true",
+        help="skip the supervised-skyline pass over the cell CSVs (issue #3322)",
+    )
     args = ap.parse_args(list(argv) if argv is not None else None)
 
     # `dir=label` exists for the single-arm studies. A study that sweeps a knob
@@ -545,11 +839,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arms != dirs:
         frame["arm"] = frame["arm"].map(dict(zip(dirs, arms, strict=True)))
     baseline = curves.text_sort_baseline(args.baseline) if args.baseline else None
+    skyline = None if args.no_skyline else load_skyline(Path(args.results), dirs, arms)
     out = build_viewer(
         frame,
         Path(args.out),
         arms=arms,
         baseline=baseline,
+        skyline=skyline,
         title=args.title,
         subtitle=args.subtitle,
         runs_budget_mb=args.runs_budget_mb,
@@ -557,6 +853,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(f"wrote {out}  ({out.stat().st_size / 1e6:.2f} MB)")
     if not args.baseline:
         print("NOTE: no --baseline, so the page has no click-0 anchor and nothing to compare the far right against.")
+    if skyline is None or skyline.empty:
+        print(
+            "NOTE: no supervised-skyline rows under --results, so the page has no learnability floor. "
+            "Re-run with CALIB_SKYLINE_ARMS=skyline_train_full to get one (issue #3322)."
+        )
     return 0
 
 

--- a/scripts/experiments/calibration/viewer.py
+++ b/scripts/experiments/calibration/viewer.py
@@ -140,6 +140,7 @@ import base64
 import gzip
 import json
 import os
+import re
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -562,7 +563,6 @@ def load_skyline(results: Path, dirs: Sequence[str], arms: Sequence[str]) -> pd.
     ``gmm_variant``.
     """
     import _cells_io
-    import analyze_spikes as sp  # noqa: F401  (kept beside _cells_io: same reader family)
 
     want = set(SKYLINE_ARMS)
     parts = []
@@ -572,7 +572,10 @@ def load_skyline(results: Path, dirs: Sequence[str], arms: Sequence[str]) -> pd.
                 continue
             try:
                 fr = pd.read_csv(f)
-            except Exception:  # noqa: BLE001, S112
+            except Exception:  # noqa: BLE001
+                # A cell whose CSV is truncated costs its skyline, never the
+                # page: the main frame's own loader reports unreadable cells,
+                # and this pass must not be the thing that fails the build.
                 continue
             if fr.empty or "gmm_variant" not in fr.columns:
                 continue
@@ -767,7 +770,12 @@ def build_viewer(  # noqa: C901
         runs_note = "No per-seed rows were found, so per-seed lines are unavailable."
 
     payload = {
-        "schema": 1,
+        # 2 adds `agg.omean` / `agg.on` (the oracle companion) and `skyline`.
+        # Nothing branches on it - the page treats both as optional, which is
+        # what lets `--reskin` push a template improvement onto a schema-1 page
+        # built before either existed.  It is here so a reader can tell which
+        # reports still predate them.
+        "schema": 2,
         "title": title,
         "subtitle": subtitle,
         "anchor": {"has": has_anchor, "label": anchor_label},
@@ -802,15 +810,48 @@ def build_viewer(  # noqa: C901
     return out_path
 
 
+def reskin(page: Path, template: Path = TEMPLATE) -> Path:
+    """Re-substitute *page*'s own payload into the current template, in place.
+
+    The template is the whole of the viewer's behaviour — every control, every
+    drawing rule, every word of the reading note — and the payload is just the
+    study's numbers.  So a change to how the page *reads* can be pushed onto a
+    committed report without the results directory it was built from, which for
+    a finished study lives on the GRID and may be gone.
+
+    It cannot add data the payload never carried: a page rebuilt this way keeps
+    whatever ``schema`` it had, so a study that measured no oracle cut and no
+    skyline still shows neither, and the page disables those controls rather
+    than drawing an empty one.  Re-running the analyzer is the only way to get
+    them.
+    """
+    page = Path(page)
+    html = page.read_text(encoding="utf-8")
+    m = re.search(r'<script id="payload" type="application/json">(.*?)</script>', html, re.S)
+    if not m:
+        raise SystemExit(f"{page}: no payload script tag - not a viewer page")
+    blob = m.group(1)
+    fresh = template.read_text(encoding="utf-8")
+    if fresh.count(TOKEN) != 1:
+        raise SystemExit(f"{template}: expected exactly 1 {TOKEN}, found {fresh.count(TOKEN)}")
+    page.write_text(fresh.replace(TOKEN, blob), encoding="utf-8")
+    return page
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--reskin",
+        nargs="+",
+        metavar="PAGE",
+        help="re-substitute each built viewer.html's own payload into the current template, in place",
+    )
     ap.add_argument("--results", default=str(common.RESULTS), help="results root holding one dir per arm")
     ap.add_argument(
         "--arms",
-        required=True,
         help="comma-separated arm directories, in report order; `dir=label` renames one on the page",
     )
-    ap.add_argument("--out", required=True, help="path to write the HTML to")
+    ap.add_argument("--out", help="path to write the HTML to")
     ap.add_argument("--baseline", default=None, help="text_baseline.py CSV: the click-0 anchor")
     ap.add_argument("--title", default="Quality over clicks")
     ap.add_argument("--subtitle", default="")
@@ -821,6 +862,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="skip the supervised-skyline pass over the cell CSVs (issue #3322)",
     )
     args = ap.parse_args(list(argv) if argv is not None else None)
+
+    if args.reskin:
+        for page in args.reskin:
+            out = reskin(Path(page))
+            print(f"reskinned {out}  ({out.stat().st_size / 1e6:.2f} MB)")
+        return 0
+    if not args.arms or not args.out:
+        ap.error("--arms and --out are required unless --reskin is given")
 
     # `dir=label` exists for the single-arm studies. A study that sweeps a knob
     # has one results directory per arm and the directory name IS the arm name,

--- a/scripts/experiments/calibration/viewer_template.html
+++ b/scripts/experiments/calibration/viewer_template.html
@@ -122,11 +122,26 @@
   .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
   .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
   .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+  /* Sits ABOVE the swatches, not below them: at sixty series the swatch list is
+     taller than the viewport, so a warning under it is a warning nobody reads. */
+  .legend-warn {
+    font-size: 12.5px; color: var(--ink); margin-bottom: 7px;
+    border-left: 3px solid var(--s2); padding: 3px 0 3px 9px;
+  }
+  .legend-warn b { font-weight: 600; }
+  /* Cap the swatch list so a hairball's legend cannot push the chart itself
+     off the screen; it scrolls in place instead. */
+  .legend { max-height: 148px; overflow-y: auto; }
 
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
   .panels { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 14px; }
+  /* A lone panel - the overlay view, or a study with one series - must not
+     stretch to the full page. The SVG scales its 660-wide viewBox to whatever
+     width it gets, so a full-bleed panel renders 11px axis labels as
+     billboards and pushes the rotated y-axis title off its own left edge. */
+  .panels.one { grid-template-columns: minmax(0, 940px); justify-content: center; }
   .panel {
     background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
     padding: 10px 12px 6px; position: relative; min-width: 0;
@@ -670,6 +685,7 @@
   function render() {
     const host = $("panels");
     host.innerHTML = "";
+    host.classList.remove("one");
     const pl = plan();
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
@@ -787,6 +803,7 @@
 
     const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
     const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    host.classList.toggle("one", panels.length === 1);
     for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
     legend(pl, panels, opt);
     reading(spec, pl, hidden, facetKeys.length, opt);
@@ -835,8 +852,10 @@
     const yc = (c) => H + 16 + (1 - c) * (CH - 22);
 
     const nCells = pnl.per.reduce((a, q) => a + q.agg.cells, 0);
+    // In overlay the panel IS the page, so its heading would be the <h1> again.
+    const head = useOverlay ? "" : panelTitle(pnl.fk, pl);
     el.innerHTML =
-      `<h2>${esc(panelTitle(pnl.fk, pl))}</h2>` +
+      (head ? `<h2>${esc(head)}</h2>` : "") +
       `<p class="pn">${esc(panelSub(pl))} · ${nCells} cell${nCells === 1 ? "" : "s"}</p>`;
 
     const parts = [];
@@ -857,7 +876,7 @@
     // the first trained click and the two reference marks sit in the margins.
     const t0 = P.anchor.has ? 1 : 0;
     const ts = P.t.slice(t0);
-    const NOTCH = 9;
+    const NOTCH = 12;
     const clamp = (v) => Math.min(hi, Math.max(lo, v));
     const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
 
@@ -938,12 +957,21 @@
       : (panels.length > 1
         ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
         : `One series`);
-    let rows = "";
+    let rows = "", warn = "";
     if (opt.useOverlay) {
       const seen = new Map();
       for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
       rows = `<div class="legend">` + [...seen].map(([name, col]) =>
         `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+      // The palette has 8 contrast-checked slots; past them hues are generated
+      // on the golden angle so a twelve-class overlay is drawable at all. That
+      // is a real trade and the reader is told where it starts, at the top,
+      // where the swatch list has not already pushed it off screen.
+      if (seen.size > SERIES.length) warn =
+        `<div class="legend-warn"><b>${seen.size} series on one chart</b> — past the palette's ` +
+        `${SERIES.length} contrast-checked slots, so the rest are generated on the golden angle: ` +
+        `distinguishable, but not validated${seen.size > 20 ? ", and at this count the chart is a hairball" : ""}. ` +
+        `Narrow the selection, or untick <b>overlay</b> for one chart each.</div>`;
     }
     const key = [];
     const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
@@ -956,7 +984,7 @@
       `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
     if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}</div>` + rows +
+      warn + `<div class="legend-head">${heading}</div>` + rows +
       `<div class="legend-key">${key.join("")}</div>`;
   }
 
@@ -1106,12 +1134,6 @@
     if (opt.useOverlay && state.embedders.size > 1) bits.push(
       `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
       `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
-    if (opt.useOverlay) {
-      const n = opt.nSeries;
-      if (n > 8) bits.push(
-        `<b>${n} series share this chart</b>, past the palette's 8 contrast-checked slots; the rest are generated on ` +
-        `the golden angle and are distinguishable but not validated. Narrow the selection if two hues read alike.`);
-    }
     if (hidden) bits.push(
       `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
       `or tick <b>overlay on one chart</b> to put them all on one.`);

--- a/scripts/experiments/calibration/viewer_template.html
+++ b/scripts/experiments/calibration/viewer_template.html
@@ -106,6 +106,23 @@
   .radios label[data-on="1"] { color: var(--ink); font-weight: 500; border-color: var(--ink-2); }
   .radios label:focus-within { outline: 2px solid var(--s1); outline-offset: 2px; }
 
+  /* Draw-what toggles.  Square boxes rather than chips: a chip group is a
+     subset of one dimension and these are two independent switches, so they
+     must not read as "pick some of these". */
+  .checks { display: flex; flex-direction: column; gap: 5px; }
+  .checks label {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    font-size: 13px; color: var(--ink-2); user-select: none;
+  }
+  .checks label[data-on="1"] { color: var(--ink); font-weight: 500; }
+  .checks label[data-off="1"] { opacity: .4; cursor: not-allowed; }
+  .checks input { accent-color: var(--s1); margin: 0; }
+  .checks .why { font-size: 11px; color: var(--muted); margin: -2px 0 0 24px; max-width: 34ch; }
+
+  .legend-key { display: flex; flex-wrap: wrap; gap: 4px 16px; font-size: 12.5px; margin-top: 6px; }
+  .legend-key span { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); }
+  .legend-key svg { display: inline-block; width: 22px; height: 10px; overflow: visible; }
+
   /* Grid, not flex: a flex row lets the last panel of an uneven row stretch to
      the full width, so the same series is drawn at two different sizes on one
      screen and the small multiples stop being comparable. */
@@ -180,6 +197,13 @@
       <label class="h">Embedder <span style="text-transform:none;letter-spacing:0">— one or more; one panel each, never averaged</span></label>
       <div class="chips" id="emb"></div>
     </div>
+    <div class="ctl" id="drawWrap">
+      <label class="h">Draw</label>
+      <div class="checks" id="draw">
+        <label id="oracleLab"><input type="checkbox" id="oracleBox">oracle threshold, dotted</label>
+        <label id="overlayLab"><input type="checkbox" id="overlayBox">overlay on one chart</label>
+      </div>
+    </div>
     <div class="ctl">
       <label class="h">Seeds</label>
       <div class="radios" id="seedMode">
@@ -248,6 +272,10 @@
       sd: await decode(P.agg.sd),
       n: await decode(P.agg.n),
       cells: await decode(P.agg.cells),
+      omean: P.agg.omean ? await decode(P.agg.omean) : null,
+      on: P.agg.on ? await decode(P.agg.on) : null,
+      sky: P.skyline ? await decode(P.skyline.mean) : null,
+      skyN: P.skyline ? await decode(P.skyline.n) : null,
       runs: P.runs ? await decode(P.runs.values) : null,
     };
   } catch (err) {
@@ -262,11 +290,37 @@
   const cellsAt = (g, a) => A.cells[g * nA + a];
   const rT = P.runs ? P.runs.t.length : 0;
   const runAt = (i, m) => A.runs.subarray((i * nM + m) * rT, (i * nM + m + 1) * rT);
+  // The skyline is one number per (group, arm, metric), encoded with a trailing
+  // axis of length 1 so it goes through the same delta codec as everything else.
+  const skyAt = (g, a, m) => (A.sky ? A.sky[(g * nA + a) * nM + m] : NaNv);
+  const skyNAt = (g, a, m) => (A.skyN ? A.skyN[(g * nA + a) * nM + m] : 0);
 
   // ---- state --------------------------------------------------------------
+  // The eight VALIDATED categorical slots, contrast-checked in both themes.
   const SERIES = ["--s1","--s2","--s3","--s4","--s5","--s6","--s7","--s8"];
-  const MAX_HUES = SERIES.length;
   const ALL = "__all__", EACH = "__each__";
+
+  // Past the validated eight, hues are GENERATED on the golden angle so a
+  // twelve-class overlay is drawable at all.  Two things keep that honest:
+  // the generated hues start only where the validated ones run out (so the
+  // common small overlay is still the checked palette), and lightness is
+  // picked for the live theme rather than left to a var() nested inside an SVG
+  // presentation attribute.  A theme flip re-renders; see the listener below.
+  let DARK = false;
+  function readTheme() {
+    const t = document.documentElement.dataset.theme;
+    DARK = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches);
+  }
+  readTheme();
+  function paletteColor(i) {
+    if (i < SERIES.length) return `var(${SERIES[i]})`;
+    const h = Math.round((20 + (i - SERIES.length + 1) * 137.508) % 360);
+    return `hsl(${h}, 62%, ${DARK ? 66 : 40}%)`;
+  }
+  //: The one hue used when colour carries no information - split mode, where
+  //: every panel holds exactly one bold line and a second colour would be
+  //: inviting a comparison the layout does not make.
+  const SOLO = "var(--s1)";
 
   // Categories in the #3156 map are `<class>@<band>` - the same twelve classes at
   // three target sizes - and the band is that study's headline axis, so it gets
@@ -294,8 +348,12 @@
     category: ALL,
     metric: P.metrics[0].key,
     embedders: new Set(P.embedders),
-    arms: new Set(P.arms.slice(0, MAX_HUES)),
+    arms: new Set(P.arms),
     seedMode: "avg",
+    // Both off on open: the plain shipped-performance read is the least
+    // cluttered one, and each of these answers a follow-up question.
+    oracle: false,
+    overlay: false,
   };
 
   const gDataset = (g) => P.groups[g][0];
@@ -384,6 +442,31 @@
     each.closest("label").style.opacity = ".45";
   }
 
+  // The two draw toggles.  `oracle` is per-metric: the oracle is a CUT, so it
+  // moves every metric that is a statement about one cut and none of the two
+  // that integrate over all of them.  Rather than offer a switch that does
+  // nothing on AUROC, the box disables itself and says why - the same rule the
+  // embedder chips follow when a study ran one embedder.
+  const oracleBox = $("oracleBox"), overlayBox = $("overlayBox");
+  oracleBox.checked = state.oracle;
+  overlayBox.checked = state.overlay;
+  oracleBox.onchange = () => { state.oracle = oracleBox.checked; render(); };
+  overlayBox.onchange = () => { state.overlay = overlayBox.checked; render(); };
+  function syncDraw(spec) {
+    const can = !!spec.oracle;
+    oracleBox.disabled = !can;
+    $("oracleLab").dataset.off = can ? "0" : "1";
+    $("oracleLab").dataset.on = can && state.oracle ? "1" : "0";
+    $("oracleLab").title = can
+      ? "Draw what the same model would have scored had its threshold been chosen with the test labels in hand."
+      : (spec.ranking
+        ? `${spec.label} integrates over every threshold, so the oracle CUT cannot move it — the two lines would be identical.`
+        : `This run emitted no oracle cut for ${spec.label}.`);
+    $("overlayLab").dataset.on = state.overlay ? "1" : "0";
+    // Never leave a checked-but-inert box on screen.
+    oracleBox.checked = can && state.oracle;
+  }
+
   // Every chip group is a NON-EMPTY subset - arms exactly as much as embedders.
   // An empty one has no honest rendering: the page would either go blank or
   // quietly fall back to "all", and a reader who did not notice would take a
@@ -433,44 +516,59 @@
 
   // ---- the series model ---------------------------------------------------
   //
-  // Hue must mean whatever the reader is actually comparing, so it is assigned
-  // from the selection rather than nailed to one dimension.  Three dimensions
-  // can vary - arm, category, dataset - and the rule is:
+  // Two modes, chosen by the reader rather than inferred:
   //
-  //   * the FIRST varying dimension, in the order arm -> category -> dataset,
-  //     that has at most 8 values takes HUE (the palette has 8 validated
-  //     categorical slots and a 9th is never invented);
-  //   * every other varying dimension, plus embedder, becomes a PANEL.
+  //   SPLIT (default) - every dimension that varies becomes a PANEL, so each
+  //     panel carries exactly one bold line plus the +/-1 SD shadow of the
+  //     population under it.  The line is drawn in one colour, because with a
+  //     single series per panel hue would be decoration and a reader is
+  //     entitled to assume any colour difference means something.  This is the
+  //     shadow's honest home: two shaded bands over one another are two clouds
+  //     nobody can read the overlap of.
   //
-  // So one arm across each category is coloured by category; eight arms across
-  // each category is coloured by arm and split into a panel per category; and
-  // twelve categories with a single arm - too many for the palette - fold into
-  // twelve panels rather than twelve made-up hues.  Colour follows the VALUE,
-  // not its position in the current selection, so deselecting a series never
-  // repaints the survivors.
-  const DIMS = ["arm", "category", "dataset"];
+  //   OVERLAY - every dimension that varies becomes a HUE and everything lands
+  //     on one chart, with the shadows dropped.  This is the comparison view:
+  //     bikes vs birds, SigLIP vs CLIP, arm vs arm, all against one y-scale.
+  //
+  // Overlaying two embedders is not averaging them - the ban that keeps
+  // embedders in separate panels is a ban on pooling two representations of the
+  // haystack into one number, and drawing two lines pools nothing.
+  const DIMS = ["embedder", "arm", "category", "dataset"];
 
   function plan() {
     const values = {
+      embedder: P.embedders.filter((e) => state.embedders.has(e)),
       arm: P.arms.filter((a) => state.arms.has(a)),
       // `null` means "pooled over everything in play" rather than a single value.
       category: state.category === EACH ? categoriesInPlay() : [state.category === ALL ? null : state.category],
       dataset: state.dataset === EACH ? datasetsInPlay() : [state.dataset === ALL ? null : state.dataset],
     };
     const varying = DIMS.filter((d) => values[d].length > 1);
-    const hueDim = varying.find((d) => values[d].length <= MAX_HUES) || null;
-    const facetDims = varying.filter((d) => d !== hueDim);
-    return { values, varying, hueDim, facetDims };
+    return { values, varying, overlay: state.overlay, hueDims: state.overlay ? varying : [], facetDims: state.overlay ? [] : varying };
   }
 
-  // Colour index is the value's position in the STUDY's own list, never in the
-  // current selection.
+  // Colour follows the VALUE, not its position in the current selection, so
+  // deselecting one series never repaints the survivors.  With several
+  // dimensions varying at once the index is mixed-radix over the STUDY's own
+  // lists - each digit is that value's position in the study, so removing a
+  // category leaves every other series' colour exactly where it was.
   const ORDER = {
+    embedder: (v) => P.embedders.indexOf(v),
     arm: (v) => P.arms.indexOf(v),
     category: (v) => P.categories.indexOf(v),
     dataset: (v) => P.datasets.indexOf(v),
   };
-  const hueOf = (dim, v) => `var(${SERIES[((dim && ORDER[dim](v)) + SERIES.length) % SERIES.length]})`;
+  const SIZE = {
+    embedder: () => Math.max(1, P.embedders.length),
+    arm: () => Math.max(1, P.arms.length),
+    category: () => Math.max(1, P.categories.length),
+    dataset: () => Math.max(1, P.datasets.length),
+  };
+  function hueIndex(hueDims, sel) {
+    let i = 0;
+    for (const d of hueDims) i = i * SIZE[d]() + Math.max(0, ORDER[d](sel[d]));
+    return i;
+  }
 
   function groupsFor(sel) {
     const cats = new Set(sel.category === null ? categoriesInPlay() : [sel.category]);
@@ -490,12 +588,22 @@
     const mean = new Float64Array(nT).fill(NaNv);
     const sd = new Float64Array(nT).fill(NaNv);
     const cov = new Float64Array(nT);
+    // The oracle carries its own weights: an oracle that declines to flag
+    // anything has no precision at a click where the trained cut's precision
+    // is perfectly well defined, so the two are not measured on the same cells.
+    const omean = new Float64Array(nT).fill(NaNv);
+    const ocov = new Float64Array(nT);
     let cells = 0;
     for (const g of groups) cells += cellsAt(g, ai);
     for (let t = 0; t < nT; t++) {
-      let n = 0, s1 = 0, s2 = 0;
+      let n = 0, s1 = 0, s2 = 0, on = 0, os1 = 0;
       for (const g of groups) {
         const c = aggAt(A.n, g, ai, mi)[t];
+        if (A.omean) {
+          const oc = aggAt(A.on, g, ai, mi)[t];
+          const omu = aggAt(A.omean, g, ai, mi)[t];
+          if (oc > 0 && Number.isFinite(omu)) { on += oc; os1 += oc * omu; }
+        }
         if (!(c > 0)) continue;
         const mu = aggAt(A.mean, g, ai, mi)[t];
         const s = aggAt(A.sd, g, ai, mi)[t];
@@ -507,9 +615,24 @@
         mean[t] = mu;
         sd[t] = Math.sqrt(Math.max(0, s2 / n - mu * mu));
       }
+      if (on > 0) omean[t] = os1 / on;
       cov[t] = cells > 0 ? n / cells : 0;
+      ocov[t] = cells > 0 ? on / cells : 0;
     }
-    return { mean, sd, cov, cells };
+    return { mean, sd, cov, omean, ocov, cells };
+  }
+
+  // The supervised skyline, pooled the same way and for the same reason: it is
+  // a per-cell number, so "all categories" must weight it by the cells that
+  // produced one.  Returns NaN when this run measured no skyline.
+  function skyline(groups, ai, mi) {
+    if (!A.sky) return NaNv;
+    let n = 0, s1 = 0;
+    for (const g of groups) {
+      const c = skyNAt(g, ai, mi), v = skyAt(g, ai, mi);
+      if (c > 0 && Number.isFinite(v)) { n += c; s1 += c * v; }
+    }
+    return n > 0 ? s1 / n : NaNv;
   }
 
   function runLines(groups, ai, mi) {
@@ -532,7 +655,17 @@
   const COV_FLAT = 0.995;
   const MAX_PANELS = 16;
   const fmt = (v, d = 3) => (Number.isFinite(v) ? v.toFixed(d) : "—");
-  const shortLabel = (dim, v) => (v === null ? (dim === "category" ? "all categories" : "all datasets") : String(v));
+  const shortLabel = (dim, v) =>
+    v === null ? (dim === "category" ? "all categories" : "all datasets")
+    : dim === "embedder" ? (String(v) || "(unnamed embedder)")
+    : String(v);
+  // In overlay the name has to name the COMBINATION, because that is what the
+  // hue stands for; in split the panel title already carries every varying
+  // dimension, so the series is named by its arm and nothing is said twice.
+  function seriesName(pl, sel, useOverlay) {
+    const dims = useOverlay ? pl.hueDims : [];
+    return dims.length ? dims.map((d) => shortLabel(d, sel[d])).join(" · ") : String(sel.arm);
+  }
 
   function render() {
     const host = $("panels");
@@ -541,64 +674,72 @@
     const mi = P.metrics.findIndex((m) => m.key === state.metric);
     const spec = P.metrics[mi];
 
-    // Chip swatches only carry colour when that dimension IS the hue.
-    // The legend's fallback branch colours by arm too, so the chips must carry
-    // swatches there as well - a legend reading "Colour = arm" beside swatchless
-    // chips is two answers to one question.
-    $("arms")._colorOf = pl.hueDim === "arm" || pl.hueDim === null ? (v) => hueOf("arm", v) : null;
+    syncDraw(spec);
+    // Chip swatches carry colour only where hue means something: overlay mode
+    // with arm among the varying dimensions.  A swatch beside a chip in split
+    // mode would promise a colour the chart never uses.
+    $("arms")._colorOf = pl.hueDims.includes("arm")
+      ? (v) => paletteColor(hueIndex(pl.hueDims, { embedder: pl.values.embedder[0], arm: v, category: pl.values.category[0], dataset: pl.values.dataset[0] }))
+      : null;
     $("arms")._sync();
     $("emb")._sync();
 
-    // Panels: embedder x every varying dimension that did not get the hue.
-    let facetKeys = [{ embedder: null }];
-    const embs = P.embedders.filter((e) => state.embedders.has(e));
-    facetKeys = embs.map((e) => ({ embedder: e }));
-    for (const dim of pl.facetDims) {
+    // Every combination the selection names, as one flat list.  In overlay mode
+    // they all land on one panel and are told apart by hue; in split mode each
+    // one IS a panel and holds a single line.
+    let combos = [{}];
+    for (const dim of DIMS) {
       const next = [];
-      for (const fk of facetKeys) for (const v of pl.values[dim]) next.push({ ...fk, [dim]: v });
-      facetKeys = next;
+      for (const c of combos) for (const v of pl.values[dim]) next.push({ ...c, [dim]: v });
+      combos = next;
     }
+    const useOverlay = pl.overlay;
+    let facetKeys = useOverlay ? [{}] : combos;
     let hidden = 0;
     if (facetKeys.length > MAX_PANELS) { hidden = facetKeys.length - MAX_PANELS; facetKeys = facetKeys.slice(0, MAX_PANELS); }
 
-    const hueValues = pl.hueDim ? pl.values[pl.hueDim] : [null];
+    const seriesFor = (fk) => (useOverlay ? combos : [fk]);
     const panels = facetKeys.map((fk) => {
       const per = [];
-      for (const hv of hueValues) {
-        for (const arm of (pl.hueDim === "arm" ? [hv] : pl.values.arm)) {
-          const sel = {
-            embedder: fk.embedder,
-            arm,
-            category: pl.hueDim === "category" ? hv : ("category" in fk ? fk.category : pl.values.category[0]),
-            dataset: pl.hueDim === "dataset" ? hv : ("dataset" in fk ? fk.dataset : pl.values.dataset[0]),
-          };
-          const ai = P.arms.indexOf(arm);
-          if (ai < 0) continue;
-          const groups = groupsFor(sel);
-          if (!groups.length) continue;
-          per.push({
-            sel, ai,
-            color: pl.hueDim ? hueOf(pl.hueDim, hv) : hueOf("arm", arm),
-            name: pl.hueDim ? shortLabel(pl.hueDim, hv) : String(arm),
-            agg: pooled(groups, ai, mi),
-            runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
-          });
-        }
+      for (const sel of seriesFor(fk)) {
+        const ai = P.arms.indexOf(sel.arm);
+        if (ai < 0) continue;
+        const groups = groupsFor(sel);
+        if (!groups.length) continue;
+        per.push({
+          sel, ai,
+          color: useOverlay ? paletteColor(hueIndex(pl.hueDims, sel)) : SOLO,
+          name: seriesName(pl, sel, useOverlay),
+          agg: pooled(groups, ai, mi),
+          sky: skyline(groups, ai, mi),
+          runs: state.seedMode === "each" ? runLines(groups, ai, mi) : [],
+        });
       }
       return { fk, per };
     }).filter((p) => p.per.length);
 
     // One y-scale across every panel: two panels on two scales is a dual-axis
     // chart wearing a disguise.
+    const showOracle = state.oracle && !!spec.oracle;
+    const showSky = panels.some((p) => p.per.some((q) => Number.isFinite(q.sky)));
     let lo = Infinity, hi = -Infinity;
     for (const p of panels) for (const q of p.per) {
       for (let t = 0; t < nT; t++) {
         const m = q.agg.mean[t], sd = q.agg.sd[t];
         if (!Number.isFinite(m)) continue;
-        const wide = state.seedMode === "avg" && Number.isFinite(sd);
+        // The shadow is drawn only where it is honest - one line per panel -
+        // so it only widens the scale there.
+        const wide = !useOverlay && state.seedMode === "avg" && Number.isFinite(sd);
         lo = Math.min(lo, wide ? m - sd : m);
         hi = Math.max(hi, wide ? m + sd : m);
       }
+      if (showOracle) for (let t = 0; t < nT; t++) {
+        const o = q.agg.omean[t];
+        if (Number.isFinite(o)) { lo = Math.min(lo, o); hi = Math.max(hi, o); }
+      }
+      // The notches are the whole point of the left and right margins: a
+      // skyline clipped off the bottom is a floor the reader cannot see.
+      if (Number.isFinite(q.sky)) { lo = Math.min(lo, q.sky); hi = Math.max(hi, q.sky); }
       for (const v of q.runs) for (let t = 0; t < rT; t++) {
         if (Number.isFinite(v[t])) { lo = Math.min(lo, v[t]); hi = Math.max(hi, v[t]); }
       }
@@ -644,38 +785,48 @@
       showCov = covMin < COV_FLAT;
     }
 
-    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, showCov));
-    legend(pl, panels);
-    reading(spec, pl, hidden, facetKeys.length, showCov);
-    tableView(spec, panels);
+    const nSeries = new Set(panels.flatMap((p) => p.per.map((q) => q.name))).size;
+    const opt = { showCov, showOracle, showSky, useOverlay, nSeries };
+    for (const p of panels) host.appendChild(panel(p, pl, spec, lo, hi, opt));
+    legend(pl, panels, opt);
+    reading(spec, pl, hidden, facetKeys.length, opt);
+    tableView(spec, panels, opt);
   }
+
+  // A theme flip changes the lightness the generated hues are picked at, and
+  // those are baked into the SVG rather than left to a CSS variable, so the
+  // page has to redraw.  Cheap: everything is already in memory.
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => { readTheme(); render(); });
 
   const W = 660, H = 300, CH = 54, M = { l: 56, r: 14, t: 10, b: 26 };
 
   function panelTitle(fk, pl) {
     const bits = [];
-    if (P.embedders.length > 1) bits.push(fk.embedder || "(unnamed embedder)");
-    for (const dim of pl.facetDims) bits.push(shortLabel(dim, fk[dim]));
-    return bits.length ? bits.join(" · ") : (P.embedders[0] || P.title);
+    if (P.embedders.length > 1 && "embedder" in fk) bits.push(shortLabel("embedder", fk.embedder));
+    for (const dim of pl.facetDims) if (dim !== "embedder" && dim in fk) bits.push(shortLabel(dim, fk[dim]));
+    if (bits.length) return bits.join(" · ");
+    return (P.embedders.length === 1 ? P.embedders[0] : "") || P.title;
   }
 
   function panelSub(pl) {
     const bits = [];
-    bits.push(pl.hueDim === "dataset" || pl.facetDims.includes("dataset")
+    const splits = (d) => pl.hueDims.includes(d) || pl.facetDims.includes(d);
+    bits.push(splits("dataset")
       ? null
       : (state.dataset === ALL ? `all ${P.datasets.length} datasets pooled` : state.dataset));
     const nCats = categoriesInPlay().length;
     const pooled = state.band === ALL
       ? `all ${nCats} categories pooled`
       : `all ${nCats} ${state.band}-band categories pooled`;
-    bits.push(pl.hueDim === "category" || pl.facetDims.includes("category")
+    bits.push(splits("category")
       ? (state.band === ALL ? null : `${state.band} band`)
       : (state.category === ALL ? pooled : state.category));
     bits.push(state.seedMode === "each" ? "every seed" : "seeds averaged");
     return bits.filter(Boolean).join(" · ");
   }
 
-  function panel(pnl, pl, spec, lo, hi, showCov) {
+  function panel(pnl, pl, spec, lo, hi, opt) {
+    const { showCov, showOracle, useOverlay } = opt;
     const el = document.createElement("div");
     el.className = "panel";
     const tmax = P.t[nT - 1];
@@ -698,32 +849,55 @@
       `<text x="${x(t).toFixed(1)}" y="${H - 6}" text-anchor="middle" font-size="11" fill="var(--muted)">${Math.round(t)}</text>`);
     parts.push(`<line x1="${M.l}" x2="${W - M.r}" y1="${H - M.b}" y2="${H - M.b}" stroke="var(--axis)"/>`);
 
+    // The click-0 anchor is a NOTCH, not the first point of the curve, and
+    // nothing joins it to the curve.  The dotted bridge that used to run from
+    // the text sort to the first trained click was drawing across a stretch
+    // where nothing was measured, in the one place a reader's eye goes first;
+    // a gap says the same thing and asserts nothing.  So the curves start at
+    // the first trained click and the two reference marks sit in the margins.
+    const t0 = P.anchor.has ? 1 : 0;
+    const ts = P.t.slice(t0);
+    const NOTCH = 9;
+    const clamp = (v) => Math.min(hi, Math.max(lo, v));
+    const inRange = (v) => Number.isFinite(v) && v >= lo && v <= hi;
+
     for (const q of pnl.per) {
       if (state.seedMode === "each") {
         for (const v of q.runs) {
+          const from = P.anchor.has && P.runs.t[0] === 0 ? 1 : 0;
           parts.push(
-            `<path d="${path(P.runs.t, v, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
-          // A run that never trained has ONLY its click-0 point, and a
-          // single-point path draws nothing - so mark it, or total starvation
-          // renders as an absent line.
-          if (P.anchor.has && Number.isFinite(v[0])) parts.push(
-            `<circle cx="${x(0).toFixed(1)}" cy="${y(Math.min(hi, Math.max(lo, v[0]))).toFixed(1)}" r="1.5" fill="${q.color}" opacity="0.3"/>`);
+            `<path d="${path(P.runs.t.slice(from), v.subarray(from), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1" opacity="0.16"/>`);
+          // A run that never trained has ONLY its click-0 value, and a
+          // single-point path draws nothing - so it gets its own faint notch,
+          // or total starvation renders as an absent line.
+          if (P.anchor.has && inRange(v[0])) parts.push(
+            `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH * 0.6).toFixed(1)}" y1="${y(v[0]).toFixed(1)}" y2="${y(v[0]).toFixed(1)}" stroke="${q.color}" stroke-width="1" opacity="0.3"/>`);
         }
-      } else {
-        parts.push(`<path d="${band(q.agg, x, y, lo, hi)}" fill="${q.color}" opacity="0.10"/>`);
+      } else if (!useOverlay) {
+        // The shadow lives only in split mode.  Two translucent clouds over one
+        // another are a third shape nobody can read, which is exactly why the
+        // overlay drops them rather than stacking them.
+        parts.push(`<path d="${band(q.agg, x, y, lo, hi, t0)}" fill="${q.color}" opacity="0.10"/>`);
       }
-      // Click 0 IS the text sort, drawn as this series' own first point rather
-      // than as a rule across the panel.  A horizontal reference line dominated
-      // the figure to make a point the leftmost marker already makes, and it
-      // implied a level that holds at every click when it holds at one.
-      if (P.anchor.has && Number.isFinite(q.agg.mean[0]) && q.agg.mean[0] >= lo && q.agg.mean[0] <= hi) parts.push(
-        `<circle cx="${x(0).toFixed(1)}" cy="${y(q.agg.mean[0]).toFixed(1)}" r="2.5" fill="${q.color}"/>`);
       // The mean, dashed wherever it describes fewer than SOLID of that
-      // series' cells - including the stretch from click 0 to the first
-      // trained click, where nothing was measured at all.
+      // series' cells: there it is a level for a subset, not for the grid.
       parts.push(
-        `<path d="${path(P.t, q.agg.mean, x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
-        `<path d="${path(P.t, mask(q.agg.mean, q.agg.cov), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+        `<path d="${path(ts, q.agg.mean.subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.1" stroke-dasharray="3 3" opacity="0.85"/>`,
+        `<path d="${path(ts, mask(q.agg.mean, q.agg.cov).subarray(t0), x, y, lo, hi)}" fill="none" stroke="${q.color}" stroke-width="2"/>`);
+      // The oracle: the same model, cut with the test labels in hand.  Dotted
+      // against the solid performance line, in the SAME hue, because it is not
+      // another system - it is the ceiling this one's threshold left on the
+      // table, and the gap between the two IS the calibration regret.
+      if (showOracle) parts.push(
+        `<path d="${path(ts, mask(q.agg.omean, q.agg.ocov).subarray(t0), x, y, lo, hi, true)}" fill="none" stroke="${q.color}" stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round" opacity="0.95"/>`);
+      // Baseline notch, hard left: what typing the query got for free.
+      if (P.anchor.has && inRange(q.agg.mean[0])) parts.push(
+        `<line x1="${M.l.toFixed(1)}" x2="${(M.l + NOTCH).toFixed(1)}" y1="${y(q.agg.mean[0]).toFixed(1)}" y2="${y(q.agg.mean[0]).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
+      // Skyline notch, hard right: the same head trained on every label there
+      // is.  A notch and not a rule across the panel, because it is a floor the
+      // loop is walking toward, not a level it reached at click 3.
+      if (inRange(q.sky)) parts.push(
+        `<line x1="${(W - M.r - NOTCH).toFixed(1)}" x2="${(W - M.r).toFixed(1)}" y1="${y(q.sky).toFixed(1)}" y2="${y(q.sky).toFixed(1)}" stroke="${q.color}" stroke-width="3"/>`);
       if (showCov) {
         parts.push(
           `<path d="${path(P.t.slice(1), q.agg.cov.slice(1), x, yc, 0, 1)}" fill="none" stroke="${q.color}" stroke-width="1.2"/>`);
@@ -746,32 +920,44 @@
 
     el.insertAdjacentHTML("beforeend",
       `<svg viewBox="0 0 ${W} ${foot + 20}" role="img" aria-label="${esc(spec.label)} against clicks">${parts.join("")}</svg>`);
-    hover(el, pnl, spec, x, y, showCov);
+    hover(el, pnl, spec, x, y, opt);
     return el;
   }
 
   // ---- legend -------------------------------------------------------------
-  // Always present, and it says what hue MEANS in this configuration - which
-  // changes with the selection, so a legend that only listed values would leave
-  // a reader guessing which dimension they are looking at.
-  function legend(pl, panels) {
+  // Two jobs, and the second one is why it is always on screen: it says what
+  // hue MEANS in this configuration - which the reader chose, and which
+  // therefore changes - and it decodes the line styles, which carry as much of
+  // the chart's meaning as the colours do.
+  function legend(pl, panels, opt) {
     const host = $("legend");
-    const seen = new Map();
-    for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
-    const what = pl.hueDim
-      ? { arm: "arm", category: "category", dataset: "dataset" }[pl.hueDim]
-      : null;
-    const rows = [...seen].map(([name, col]) =>
-      `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("");
-    const heading = what
-      ? `Colour = <b>${esc(what)}</b>`
-      : (panels.length > 1 ? `Colour = <b>arm</b> (one panel per split below)` : `Colour = <b>arm</b>`);
-    const facet = [];
-    if (P.embedders.length > 1) facet.push("embedder");
-    facet.push(...pl.facetDims);
+    const heading = opt.useOverlay
+      ? (pl.hueDims.length
+        ? `Colour = <b>${pl.hueDims.map(esc).join(" × ")}</b>, all on one chart`
+        : `One series`)
+      : (panels.length > 1
+        ? `<b>One chart per ${pl.facetDims.map(esc).join(" × ")}</b> — one line each, so the shaded spread underneath it is readable. Colour carries no meaning here; tick <b>overlay on one chart</b> to compare them directly.`
+        : `One series`);
+    let rows = "";
+    if (opt.useOverlay) {
+      const seen = new Map();
+      for (const p of panels) for (const q of p.per) if (!seen.has(q.name)) seen.set(q.name, q.color);
+      rows = `<div class="legend">` + [...seen].map(([name, col]) =>
+        `<span><i style="background:${col}"></i>${esc(name)}</span>`).join("") + `</div>`;
+    }
+    const key = [];
+    const stroke = (extra) => `<svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="22" y2="5" stroke="var(--ink-2)" ${extra}/></svg>`;
+    key.push(`<span>${stroke('stroke-width="2"')}measured level</span>`);
+    key.push(`<span>${stroke('stroke-width="1.1" stroke-dasharray="3 3"')}a subset of the cells</span>`);
+    if (opt.showOracle) key.push(`<span>${stroke('stroke-width="1.4" stroke-dasharray="1 3" stroke-linecap="round"')}oracle threshold</span>`);
+    if (P.anchor.has) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="0" y1="5" x2="9" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.anchor.label)}</span>`);
+    if (opt.showSky) key.push(
+      `<span><svg viewBox="0 0 22 10" aria-hidden="true"><line x1="13" y1="5" x2="22" y2="5" stroke="var(--ink-2)" stroke-width="3"/></svg>${esc(P.skyline.label)}</span>`);
+    if (!opt.useOverlay) key.push(`<span><i style="width:16px;height:9px;border-radius:2px;background:${SOLO};opacity:.22;display:inline-block"></i>±1 SD across cells</span>`);
     host.innerHTML =
-      `<div class="legend-head">${heading}${facet.length ? ` · one panel per <b>${facet.map(esc).join(" × ")}</b>` : ""}</div>` +
-      `<div class="legend">${rows}</div>`;
+      `<div class="legend-head">${heading}</div>` + rows +
+      `<div class="legend-key">${key.join("")}</div>`;
   }
 
   function mask(vals, cov) {
@@ -781,9 +967,14 @@
   }
   // `bridge` draws straight through the clicks with no measurement instead of
   // lifting the pen.  Used for the thin dashed line only, and that is the whole
-  // reason it is dashed: it is what carries a series from its click-0 text-sort
-  // point to its first trained click, across a stretch where nothing was
-  // measured.  The solid line never bridges - a solid segment must be a level.
+  // reason it is dashed: it is what carries a series across a stretch of low or
+  // absent coverage without claiming a level there.  The solid line never
+  // bridges - a solid segment must be a level.
+  //
+  // It does NOT bridge the click-0 anchor to the first trained click any more.
+  // That stretch is now a plain gap with a notch in the left margin: a dotted
+  // line across it was the most prominent mark on the chart and it stood for a
+  // measurement nobody made.
   function path(ts, vals, x, y, lo, hi, bridge) {
     let d = "", pen = false;
     for (let i = 0; i < ts.length; i++) {
@@ -796,17 +987,17 @@
     return d;
   }
   // Segmented on purpose.  Skipping the un-measured clicks and joining what is
-  // left would draw one polygon straight from the click-0 anchor to the first
-  // trained click - a wedge across the region where nothing was measured, which
-  // is the exact opposite of what the dashed-mean rule says there.
-  function band(agg, x, y, lo, hi) {
+  // left would draw one polygon straight across a stretch where nothing was
+  // measured, which is the exact opposite of what the dashed-mean rule says
+  // there.  Starts at *from* so the click-0 notch is never a corner of it.
+  function band(agg, x, y, lo, hi, from) {
     const segs = [];
     let up = [], dn = [];
     const flush = () => {
       if (up.length > 1) segs.push("M" + up.join(" L") + " L" + dn.reverse().join(" L") + " Z");
       up = []; dn = [];
     };
-    for (let i = 0; i < nT; i++) {
+    for (let i = from || 0; i < nT; i++) {
       const m = agg.mean[i], s = agg.sd[i];
       if (!Number.isFinite(m) || !Number.isFinite(s) || agg.cov[i] < SOLID) { flush(); continue; }
       up.push(`${x(P.t[i]).toFixed(1)} ${y(Math.min(hi, m + s)).toFixed(1)}`);
@@ -833,7 +1024,8 @@
   };
 
   // ---- hover: crosshair + tooltip ----------------------------------------
-  function hover(el, pnl, spec, x, y, showCov) {
+  function hover(el, pnl, spec, x, y, opt) {
+    const showCov = opt.showCov;
     const svg = el.querySelector("svg");
     const tip = document.createElement("div");
     tip.className = "tip";
@@ -858,12 +1050,16 @@
       const rows = pnl.per.map((q) =>
         `<tr><td class="k"><span class="sw" style="background:${q.color}"></span>${esc(q.name)}</td>` +
         `<td class="v">${fmt(q.agg.mean[i])}</td>` +
+        (opt.showOracle ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.agg.omean[i])}</td>` : "") +
+        (opt.showSky ? `<td class="v" style="color:var(--ink-2);padding-left:10px">${fmt(q.sky)}</td>` : "") +
         (showCov ? `<td class="v" style="color:var(--muted);padding-left:10px">${(q.agg.cov[i] * 100).toFixed(0)}%</td>` : "") +
         `</tr>`).join("");
+      const cols = ["value"]
+        .concat(opt.showOracle ? ["oracle"] : [], opt.showSky ? ["skyline"] : [], showCov ? ["% measured"] : []);
       tip.innerHTML =
         `<div class="hd">${P.t[i]} click${P.t[i] === 1 ? "" : "s"}${P.t[i] === 0 && P.anchor.has ? " — " + esc(P.anchor.label) : ""}</div>` +
         `<table>${rows}</table>` +
-        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)}${showCov ? " · % = cells measured" : ""}</div>`;
+        `<div style="color:var(--muted);margin-top:4px">${esc(spec.label)} · ${cols.join(" · ")}</div>`;
       tip.style.opacity = "1";
       tip.style.left = Math.min(ev.clientX - r.left + 14, r.width - tip.offsetWidth - 8) + "px";
       tip.style.top = Math.max(4, ev.clientY - r.top - 10) + "px";
@@ -873,48 +1069,76 @@
   }
 
   // ---- prose + table ------------------------------------------------------
-  function reading(spec, pl, hidden, wanted, showCov) {
+  function reading(spec, pl, hidden, wanted, opt) {
     const bits = [];
     bits.push(
       `<b>Reading it.</b> Each line is the ${state.seedMode === "each" ? "individual run" : "mean over the cells it pools"}; ` +
-      `the shaded band is ±1 SD. A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
+      (opt.useOverlay
+        ? `the shaded spread is dropped in this view — several translucent bands over one another are a shape nobody can read, so overlay trades the spread for the comparison. Untick it to get one chart per series with its band back.`
+        : `the shaded band is ±1 SD.`) +
+      ` A line is <b>dashed</b> wherever fewer than ${(SOLID * 100).toFixed(0)}% of that ` +
       `series' cells are measured at that click — there it describes a subset, not the grid, so only a solid ` +
       `segment is a level worth quoting.` +
-      (showCov
+      (opt.showCov
         ? ` The strip underneath is that fraction, and it drops below full somewhere in this slice.`
         : ` <b>Every cell is measured at every click here</b>, so the coverage strip is omitted rather than drawn` +
-          ` as a flat 100% line: nothing in this slice dropped out, and the dashed run-up already says when each` +
-          ` series' detector started.`));
+          ` as a flat 100% line: nothing in this slice dropped out.`));
     if (P.anchor.has) bits.push(
-      `<b>Click 0 is the ${esc(P.anchor.label)}</b> — what typing the query got for free. It is each series' own ` +
-      `leftmost point, so a curve is worth its clicks only once it has moved past where it started. ` +
-      `Nothing is measured between click 0 and a series' first trained click, which is why that stretch is dashed.`);
+      `<b>The notch in the left margin is the ${esc(P.anchor.label)}</b> — what typing the query got for free. ` +
+      `Nothing joins it to the curve on purpose: no detector exists between it and the first trained click, so the ` +
+      `gap is the honest drawing. A curve is worth its clicks once it has crossed that notch.`);
+    if (opt.showSky) bits.push(
+      `<b>The notch in the right margin is the ${esc(P.skyline.label)}</b> — the same head, through the same ` +
+      `trainer, with every training label handed to it (issue #3322). It is vote-independent, which is why it is a ` +
+      `mark at the horizon and not a rule across the chart: it is the floor this loop is walking toward, not a level ` +
+      `it reached early. The distance still left to it is what better <b>acquisition</b> could buy; the floor itself ` +
+      `is what only a better <b>embedder</b> can move.`);
+    if (opt.showOracle) bits.push(
+      `<b>The dotted line is the oracle threshold</b> — the same model's scores, cut where the test labels say the ` +
+      `cut should have gone. The gap between it and the solid line is the <b>calibration regret</b>: quality the ` +
+      `ranking already had and the threshold rule gave away.` +
+      (spec.key === "cost" ? "" : ` For ${esc(spec.label)} it is reconstructed exactly from the oracle cut's own ` +
+        `FPR/FNR and the split's class counts — the same confusion matrix, read in a different unit.`));
+    else if (spec.ranking) bits.push(
+      `<b>${esc(spec.label)} has no oracle line.</b> It integrates over every threshold, so moving the cut cannot ` +
+      `move it — the oracle and the performance line would be the same line drawn twice.`);
     if (state.seedMode === "each" && P.runs_note) bits.push(esc(P.runs_note));
-    if (state.embedders.size > 1) bits.push(
-      `<b>Embedders are never averaged</b> — each gets its own panel. Two embedders are two different ` +
-      `representations of the haystack and their mean describes no system anyone could run.`);
-    if (pl.varying.length && !pl.hueDim) bits.push(
-      `<b>${esc(pl.varying[0])}</b> has more than ${MAX_HUES} values, which is more than the palette's validated ` +
-      `slots, so it is split into panels rather than given invented hues.`);
+    if (opt.useOverlay && state.embedders.size > 1) bits.push(
+      `<b>Overlaying embedders is not averaging them.</b> Two embedders are two representations of the haystack and ` +
+      `their mean describes no system anyone could run — but two lines pool nothing, so the comparison is fair.`);
+    if (opt.useOverlay) {
+      const n = opt.nSeries;
+      if (n > 8) bits.push(
+        `<b>${n} series share this chart</b>, past the palette's 8 contrast-checked slots; the rest are generated on ` +
+        `the golden angle and are distinguishable but not validated. Narrow the selection if two hues read alike.`);
+    }
     if (hidden) bits.push(
-      `<b>${hidden} of ${wanted} panels are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection ` +
-      `to see them.`);
+      `<b>${hidden} of ${wanted} charts are not drawn</b> (the page caps at ${MAX_PANELS}). Narrow the selection, ` +
+      `or tick <b>overlay on one chart</b> to put them all on one.`);
     $("reading").innerHTML = bits.join(" ");
   }
 
-  function tableView(spec, panels) {
+  function tableView(spec, panels, opt) {
     const marks = [0, 10, 20, 50, 100, P.t[nT - 1]].filter((t, i, a) => P.t.includes(t) && a.indexOf(t) === i);
+    const pl = plan();
     let html = "";
     for (const p of panels) {
-      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, plan()))}</caption>` +
-        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t}</th>`).join("") + `</tr></thead><tbody>`;
+      html += `<table class="data"><caption style="text-align:left;color:var(--muted);padding:8px 0 2px">${esc(panelTitle(p.fk, pl))}</caption>` +
+        `<thead><tr><th>series</th>` + marks.map((t) => `<th>${t === 0 && P.anchor.has ? "text" : t}</th>`).join("") +
+        (opt.showSky ? `<th>skyline</th>` : "") + `</tr></thead><tbody>`;
       for (const q of p.per) {
         html += `<tr><td><span class="sw" style="display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:6px;background:${q.color}"></span>${esc(q.name)}${q.sel.arm && q.name !== q.sel.arm ? " · " + esc(q.sel.arm) : ""}</td>` +
-          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") + `</tr>`;
+          marks.map((t) => `<td>${fmt(q.agg.mean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>${fmt(q.sky)}</td>` : "") + `</tr>`;
+        if (opt.showOracle) html +=
+          `<tr style="color:var(--muted)"><td style="padding-left:21px">↳ oracle threshold</td>` +
+          marks.map((t) => `<td>${t === 0 && P.anchor.has ? "—" : fmt(q.agg.omean[P.t.indexOf(t)])}</td>`).join("") +
+          (opt.showSky ? `<td>—</td>` : "") + `</tr>`;
       }
       html += `</tbody></table>`;
     }
-    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.</p>`;
+    $("table").innerHTML = html + `<p class="note">${esc(spec.label)} at the click marks above, for the current selection.` +
+      (P.anchor.has ? ` The <b>text</b> column is click 0, the free text sort.` : "") + `</p>`;
   }
 
   render();


### PR DESCRIPTION
Closes #3325.

Reworks `scripts/experiments/calibration/viewer.py` + `viewer_template.html` so the four reference quantities a report actually compares are each drawn as *what they are* — two lines and two points — and so several bold lines can share one chart.

## Four quantities, drawn as what each one is

| | what it is | how it draws |
|---|---|---|
| **performance** | the momentary model at its own computed threshold | solid line; dashed where it describes a subset of the cells |
| **oracle** | the same model cut where the test labels say it should have been | dotted line, **same hue**, behind a checkbox |
| **text sort** | what typing the query got for free, at zero clicks | **notch in the left margin** |
| **skyline** | the same head with every training label handed to it (#3322) | **notch in the right margin** |

**The dotted bridge from click 0 to the first trained click is gone**, replaced by a plain gap. It was the most prominent mark on the chart and it stood for a measurement nobody made: between the text sort and the first trained click there is no detector, so there is no level to draw.

The notches sit in the margins rather than as rules across the panel because each is a level that holds at *one* x. The skyline is the sharper case — as a rule it would read as "the learnability floor was reachable at click 3", which is the one reading the number exists to prevent.

## Overlay: the shadow/comparison trade, made explicit

The ±1 SD shadow only works under one bold line — two translucent bands over one another are a third shape nobody can read the overlap of. So that trade is now a checkbox instead of an inference:

- **off (default)** — every varying dimension becomes its own chart holding exactly one line, with its shadow. Colour carries no meaning and is therefore one colour. This retires the old auto-hue planner (*"the first varying dimension with ≤8 values takes hue"*), which could put several shadowed lines in one panel.
- **on** — they all land on one chart in distinct hues, shadows dropped, with a legend. Bikes vs birds, SigLIP vs CLIP, arm vs arm.

Embedders overlay like anything else: the ban that keeps them out of one *number* is a ban on pooling, and two lines pool nothing. Past the palette's 8 contrast-checked slots hues are generated on the golden angle, and a warning at the **top** of the legend says so (above the swatch list, which at sixty series is taller than the viewport).

## The oracle is offered on every metric that is a statement about one cut

The harness emits only the oracle cut's cost and its FPR/FNR — but an (FPR, FNR) pair plus `n_test_pos`/`n_test_neg`, on every row, *is* a full confusion matrix, so precision, recall and F1 at that cut are reconstructed exactly rather than left off the page. "The cut cost us 0.1" and "the cut cost us 11 points of recall" are the same fact in the two units a reader thinks in.

`average_precision` and `auroc` get none: they integrate over every threshold, so re-cutting cannot move them and the "oracle" would be the performance line drawn twice. The checkbox disables itself there and the tooltip says why.

## `--reskin`, and the committed reports

The template is the whole of the viewer's behaviour; the payload is only the study's numbers. `python viewer.py --reskin docs/experiments/*/viewer.html` re-substitutes a page's own payload into the current template, so a layout improvement reaches a finished study whose results directory lives on the GRID. All eight committed `viewer.html` pages are re-skinned here and each was driven in Chromium across every metric and both toggles with no console errors.

It cannot add data the payload never carried, and **no committed study measured an oracle cut or a skyline** — so on those pages the oracle box disables itself and no skyline notch appears. Recovering them needs the cell CSVs: filed as **#3326** (a re-analysis for the oracle, one cheap re-run for the skyline), and `vg-scale/REPORT.md` says so and points there.

## Checks

- `selftest_viewer.py` grows nine planted-answer checks: the oracle reconstruction verified against precision/F1 computed the long way, the oracle's own `n` (an oracle that flags nothing has no precision at a click where the trained cut does), no oracle invented for the ranking metric or at click 0, the skyline pooled cell-weighted across a category that trained 8 cells and one that trained 1, and `--reskin` leaving the payload byte-identical. All pass.
- Full `./run-tests.sh`: **9326 passed, 6 skipped, 2 xpassed**; pyright, pip-audit, npm audit and the Vitest suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gnujpHNi5zcCxaJwMYwXg

---
_Generated by [Claude Code](https://claude.ai/code/session_017gnujpHNi5zcCxaJwMYwXg)_