### PR TITLE
Draw the cost-vs-clicks coverage strip only when it says something

### DIFF
--- a/docs/experiments/2026-08-27-calibration-fraction-3287/REPORT.md
+++ b/docs/experiments/2026-08-27-calibration-fraction-3287/REPORT.md
@@ -368,8 +368,8 @@ One panel per arm; colour is the fraction; the band is the inter-quartile range 
 cells. **Click 0 is the free text sort** — 0.45 for `clip`, 0.47 for `clip_l` — so the
 drop from the left marker to the right end is what clicking bought, and the ordering
 of the five lines at the right end is this study's whole subject. Dashed where fewer
-than 95% of that arm's cells are measured; the coverage strip beneath reaches 100% by
-click 4 and stays there, so every level quoted above is on solid segments. Do **not**
+than 95% of that arm's cells are measured; coverage reaches 100% by click 4 and stays
+there, so every level quoted above is on solid segments. Do **not**
 read across the two panels: `clip` and `clip_l` have different absolute costs for
 reasons that have nothing to do with this knob.
 

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -391,11 +391,20 @@ panel. The far left is what typing was worth, the far right is what clicking was
 worth, and how many clicks it took to overtake the query is reported as a number
 in `REPORT_startup.md`'s crossover table rather than eyeballed off a crossing.
 
-The coverage strip under each panel is the denominator: a starved cell trains no
-detector and emits no metric row, so an arm that starves on a third of its grid
-would otherwise have its mean computed over the two thirds that worked and look
-*better* for it. The mean is dashed wherever it describes fewer than 95% of the
-arm's cells; only a solid segment is a level worth quoting.
+**Coverage is the denominator.** A starved cell trains no detector and emits no
+metric row, so an arm that starves on a third of its grid would otherwise have
+its mean computed over the two thirds that worked and look *better* for it. The
+mean is dashed wherever it describes fewer than 95% of the arm's cells; only a
+solid segment is a level worth quoting.
+
+A coverage strip under the panel draws that fraction outright, but only when the
+dashing does not already tell it: on a healthy grid every arm ramps to full
+inside the first handful of clicks and then holds a flat 100% line across the
+rest of the axis, so the strip is drawn only when a shortfall reaches past
+`CURVE_STRIP_SPAN` (default 25%) of the click axis, or when coverage falls back
+after reaching full. Suppressed, the panel title names the click from which
+every arm is fully measured. `coverage` is a column of the emitted CSV either
+way; set `CURVE_STRIP_SPAN=0` to get the strip unconditionally.
 
 ### The interactive viewer
 

--- a/scripts/experiments/calibration/curves.py
+++ b/scripts/experiments/calibration/curves.py
@@ -45,12 +45,20 @@ into a good-looking curve:
    the first *trainable* step — before one Good and one Bad vote coexist there
    is no model, no threshold and no row.  So a starved cell simply is not in
    the average, and an arm that starves on a third of its cells gets its mean
-   computed over the two thirds that worked.  Every mean here is drawn against
-   a **coverage strip** showing what fraction of that arm's cells are
-   measured at each click, and the mean is dashed wherever coverage is below
-   :data:`SOLID_COVERAGE`.  A dashed line means "this level describes a subset".
-   The stretch between ``t=0`` and the first trainable click is dashed by the
-   same rule and for the same reason: nothing was measured in there.
+   computed over the two thirds that worked.  Every mean is therefore dashed
+   wherever coverage — the fraction of that arm's cells measured at that click
+   — is below :data:`SOLID_COVERAGE`.  A dashed line means "this level
+   describes a subset".  The stretch between ``t=0`` and the first trainable
+   click is dashed by the same rule and for the same reason: nothing was
+   measured in there.
+
+   A **coverage strip** under the panel draws that fraction outright, but only
+   when it is not already told by the dashing (:func:`_strip_worth_drawing`):
+   on a healthy grid every arm ramps to full inside a handful of clicks and
+   then holds a flat 100% line across the rest of the axis, which spends a
+   quarter of the figure restating one number per arm.  Suppressed, the panel
+   title names the click from which everything is measured, and ``coverage``
+   is in the CSV either way.
 2. **Count a cell that never trained as absent.**  Pass ``denominator`` — one
    row per ``(arm, *keys)`` cell the run *attempted* — and coverage is measured
    against the cells that exist rather than against the cells that produced
@@ -94,6 +102,11 @@ import pandas as pd  # noqa: E402
 #: Below this fraction of an arm's cells carrying a detector, the mean is drawn
 #: dashed: it describes a subset of the grid, not the grid.
 SOLID_COVERAGE = float(os.environ.get("CURVE_SOLID_COVERAGE", "0.95"))
+
+#: How far into the click axis a shortfall in coverage has to reach before the
+#: coverage strip is drawn at all.  See :func:`_strip_worth_drawing`; set to 0
+#: to get the strip on every figure unconditionally.
+STRIP_SPAN = float(os.environ.get("CURVE_STRIP_SPAN", "0.25"))
 
 #: Default identity of a cell.  Filtered to the columns actually present, so a
 #: frame without an ``embedder`` column keys on the other three.
@@ -234,6 +247,69 @@ def _coverage(wide: pd.DataFrame, n_cells: int) -> np.ndarray:
     return wide.notna().sum(axis=1).to_numpy(dtype=float) / float(n_cells)
 
 
+def _strip_worth_drawing(covs: Sequence[np.ndarray], t_index: np.ndarray) -> bool:
+    """Does a coverage strip say anything the mean above it does not?
+
+    The mean is already drawn dashed below :data:`SOLID_COVERAGE` and solid
+    above it, so the *crossing* is on the figure twice: once as the strip's
+    ramp and once as the line thickening.  On a healthy grid that is the whole
+    content of the strip — every arm ramps to full inside the first handful of
+    clicks and then draws a flat 100% line across the rest of the axis, which
+    is a quarter of the figure spent restating one number per arm.
+
+    What the dashed/solid switch cannot show is **how far** below full the
+    denominator went and **whether it came back**, and that only matters where
+    a reader would otherwise trust the average:
+
+    * a shortfall reaching past :data:`STRIP_SPAN` of the click axis — an arm
+      starving over a meaningful part of the run, or never recovering; and
+    * coverage that goes *down* at any point after the first click — cells
+      dropping out of the average partway is a different failure from starting
+      late, and it is worth its depth being drawn however early it happens.
+
+    Either shape keeps the strip; neither present, the panel gets the height
+    and the click from which everything is measured is written in its title.
+    ``coverage`` stays in the CSV regardless, so suppressing the strip drops a
+    drawing, not a record.
+    """
+    if STRIP_SPAN <= 0:
+        return True
+    if len(t_index) == 0:
+        return False
+    late = float(t_index.max()) * STRIP_SPAN
+    # Click 0 is fully covered by construction (every cell has a text sort) and
+    # click 1 has no detectors yet, so that one step down is the axis, not a
+    # denominator shrinking.  Monotonicity is asked of the clicked stretch.
+    clicked = t_index >= 1
+    for cov in covs:
+        cov = np.asarray(cov, dtype=float)
+        short = cov < SOLID_COVERAGE
+        if short.any() and float(t_index[np.flatnonzero(short)].max()) > late:
+            return True
+        if bool((np.diff(cov[clicked]) < -1e-9).any()):
+            return True
+    return False
+
+
+def _fully_measured_from(covs: Sequence[np.ndarray], t_index: np.ndarray) -> int | None:
+    """The click from which **every** series here is measured on every cell.
+
+    ``None`` when some series never gets there, or when there was never a
+    shortfall to report — in the first case the strip is being drawn anyway,
+    and in the second there is nothing for a reader to discount.
+    """
+    firsts: list[int] = []
+    for cov in covs:
+        short = np.asarray(cov, dtype=float) < SOLID_COVERAGE
+        if not short.any():
+            continue
+        after = int(np.flatnonzero(short).max()) + 1
+        if after >= len(t_index):
+            return None
+        firsts.append(int(t_index[after]))
+    return max(firsts) if firsts else None
+
+
 def _cell_index(
     main: pd.DataFrame,
     keys: list[str],
@@ -283,10 +359,15 @@ def mean_figure(  # noqa: C901
     lower_is_better: bool = True,
     dpi: int = FIG_DPI,
 ) -> tuple[str | None, pd.DataFrame]:
-    """Per-dataset mean curves with an inter-quartile band and a coverage strip.
+    """Per-dataset mean curves with an inter-quartile band.
+
+    Carries a coverage strip under each panel when coverage says something the
+    dashed/solid switch does not — see :func:`_strip_worth_drawing`; otherwise
+    the panel takes the height and its title names the click from which every
+    arm is fully measured.
 
     Returns ``(filename, curves)``; ``curves`` is the plotted numbers, long
-    format, one row per ``(arm, dataset, t)``.
+    format, one row per ``(arm, dataset, t)``, and always carries ``coverage``.
     """
     import matplotlib
 
@@ -306,27 +387,63 @@ def mean_figure(  # noqa: C901
     index = _cell_index(main, kk, denominator)
     rows: list[dict] = []
 
-    fig = plt.figure(figsize=(6.6 * len(datasets), 5.4), layout="constrained")
-    gs = fig.add_gridspec(2, len(datasets), height_ratios=[3.1, 1.0], hspace=0.04)
-    palette = {a: f"C{i}" for i, a in enumerate(arms_present)}
-    top_axes = []
-    for di, ds in enumerate(datasets):
-        ax = fig.add_subplot(gs[0, di])
-        axc = fig.add_subplot(gs[1, di], sharex=ax)
-        top_axes.append(ax)
-        base_level = float("nan")
+    # Everything the figure plots, computed before a single axis exists: the
+    # coverage strip only gets a row of the gridspec when it has something to
+    # say (see _strip_worth_drawing), and that cannot be known until every
+    # arm's coverage has been measured.
+    series: dict[tuple[str, str], dict] = {}
+    for ds in datasets:
         for arm in arms_present:
             g = main[(main["arm"] == arm) & (main["dataset"] == ds)]
             if g.empty:
                 continue
             wide = _wide(g, metric, kk, t_index, base, index.get((arm, ds)))
-            n_cells = int(wide.shape[1])
-            cov = _coverage(wide, n_cells)
             centre = wide.mean(axis=1) if stat == "mean" else wide.median(axis=1)
-            lo, hi = wide.quantile(0.25, axis=1), wide.quantile(0.75, axis=1)
-            y = centre.to_numpy(dtype=float)
-            if base and 0 in wide.index:
-                base_level = float(centre.loc[0])
+            n_cells = int(wide.shape[1])
+            series[(ds, arm)] = {
+                "y": centre.to_numpy(dtype=float),
+                "cov": _coverage(wide, n_cells),
+                "lo": wide.quantile(0.25, axis=1).to_numpy(dtype=float),
+                "hi": wide.quantile(0.75, axis=1).to_numpy(dtype=float),
+                "n_cells": n_cells,
+                "base_level": float(centre.loc[0]) if (base and 0 in wide.index) else float("nan"),
+            }
+    if not series:
+        return None, pd.DataFrame()
+    for (ds, arm), sr in series.items():
+        for t, yy, c, l_, h_ in zip(t_index, sr["y"], sr["cov"], sr["lo"], sr["hi"], strict=False):
+            rows.append(
+                {
+                    "arm": arm,
+                    "dataset": ds,
+                    "t": int(t),
+                    stat: yy,
+                    "q25": float(l_),
+                    "q75": float(h_),
+                    "coverage": float(c),
+                    "n_cells": int(sr["n_cells"]),
+                    "baseline": sr["base_level"],
+                }
+            )
+
+    strip = _strip_worth_drawing([sr["cov"] for sr in series.values()], t_index)
+    fig = plt.figure(figsize=(6.6 * len(datasets), 5.4 if strip else 4.4), layout="constrained")
+    gs = (
+        fig.add_gridspec(2, len(datasets), height_ratios=[3.1, 1.0], hspace=0.04)
+        if strip
+        else fig.add_gridspec(1, len(datasets))
+    )
+    palette = {a: f"C{i}" for i, a in enumerate(arms_present)}
+    top_axes = []
+    for di, ds in enumerate(datasets):
+        ax = fig.add_subplot(gs[0, di])
+        axc = fig.add_subplot(gs[1, di], sharex=ax) if strip else None
+        top_axes.append(ax)
+        for arm in arms_present:
+            sr = series.get((ds, arm))
+            if sr is None:
+                continue
+            y, cov = sr["y"], sr["cov"]
             # The whole curve, thin and dashed: this is the level over whatever
             # subset of cells had a detector at that click.  Bridged across the
             # clicks with no measurement, which is what carries the line from
@@ -340,8 +457,8 @@ def mean_figure(  # noqa: C901
             band = np.where(cov >= SOLID_COVERAGE, 1.0, np.nan)
             ax.fill_between(
                 t_index,
-                lo.to_numpy(dtype=float) * band,
-                hi.to_numpy(dtype=float) * band,
+                sr["lo"] * band,
+                sr["hi"] * band,
                 color=palette[arm],
                 alpha=0.09,
                 lw=0,
@@ -357,31 +474,29 @@ def mean_figure(  # noqa: C901
             # implied a level that holds at every click when it holds at one.
             if base and np.isfinite(y[0]):
                 ax.plot(0, y[0], marker="o", ms=4.5, color=palette[arm], zorder=5)
-            axc.plot(t_index[clicked], 100.0 * cov[clicked], color=palette[arm], lw=1.2)
-            if not clicked.all():
-                axc.plot(0, 100.0 * cov[0], marker="o", ms=2.5, color=palette[arm])
-            for t, yy, c, l_, h_ in zip(t_index, y, cov, lo, hi, strict=False):
-                rows.append(
-                    {
-                        "arm": arm,
-                        "dataset": ds,
-                        "t": int(t),
-                        stat: yy,
-                        "q25": float(l_),
-                        "q75": float(h_),
-                        "coverage": float(c),
-                        "n_cells": int(n_cells),
-                        "baseline": base_level,
-                    }
-                )
-        ax.set_title(ds, fontsize=10)
-        ax.tick_params(labelbottom=False)
-        axc.set_ylim(0, 105)
-        axc.set_xlabel(f"clicks spent  (0 = {baseline_label})" if base else "clicks spent")
+            if axc is not None:
+                axc.plot(t_index[clicked], 100.0 * cov[clicked], color=palette[arm], lw=1.2)
+                if not clicked.all():
+                    axc.plot(0, 100.0 * cov[0], marker="o", ms=2.5, color=palette[arm])
+        title = ds
+        if axc is None:
+            # The one fact the suppressed strip was carrying: every arm in this
+            # panel is measured on every cell from here on, so the dashed
+            # stretch to its left is the only part a reader has to discount.
+            from_t = _fully_measured_from([sr["cov"] for (d, _a), sr in series.items() if d == ds], t_index)
+            if from_t:
+                title = f"{ds}\nall cells measured from click {from_t}"
+        ax.set_title(title, fontsize=10)
+        if axc is not None:
+            ax.tick_params(labelbottom=False)
+            axc.set_ylim(0, 105)
+            axc.axhline(100.0 * SOLID_COVERAGE, color="#888", lw=0.8, ls=":")
+        xlabel = f"clicks spent  (0 = {baseline_label})" if base else "clicks spent"
+        (axc or ax).set_xlabel(xlabel)
         if di == 0:
             ax.set_ylabel(f"{metric} ({stat} over cells)", fontsize=9)
-            axc.set_ylabel("% of cells\nmeasured", fontsize=8)
-        axc.axhline(100.0 * SOLID_COVERAGE, color="#888", lw=0.8, ls=":")
+            if axc is not None:
+                axc.set_ylabel("% of cells\nmeasured", fontsize=8)
     top_axes[0].legend(fontsize=7, ncol=2)
     better = "lower is better" if lower_is_better else "higher is better"
     fig.suptitle(

--- a/scripts/experiments/calibration/selftest_curves.py
+++ b/scripts/experiments/calibration/selftest_curves.py
@@ -15,6 +15,10 @@ subset and said nothing".  Every check here is one of those:
   so the far left of the figure is what typing got for free;
 * an arm that never beats that anchor must report **no crossover**, not the last
   click it happened to be measured at;
+* the coverage strip must be drawn only when coverage says something the
+  dashed rule above it does not — a healthy grid must not spend a quarter of
+  the figure restating the crossing the line thickness already marks — while a
+  starving, never-recovering, or falling-back denominator must keep it;
 * the per-run panel must **count** the runs that drew no line at all.
 
 Run: ``python selftest_curves.py``
@@ -191,6 +195,67 @@ def main() -> int:  # noqa: C901
             "the stretch between the anchor and the first trained click is not drawn solid",
             bool((gap["coverage"] < C.SOLID_COVERAGE).all()),
             str(gap["coverage"].unique()),
+        )
+
+        # --- the coverage strip: drawn only when it says something ----------
+        # The dashed/solid switch already marks the SOLID_COVERAGE crossing, so
+        # a grid where every arm ramps to full inside the first few clicks and
+        # holds there would spend a quarter of the figure redrawing it.
+        t_axis = np.arange(0, N_STEP + 1)
+        healthy = np.where(t_axis < FIRST_T, 0.0, 1.0)
+        healthy[0] = 1.0  # every cell has a text sort at click 0
+        ok &= _check(
+            "a grid where every arm ramps to full early does NOT get the strip",
+            not C._strip_worth_drawing([healthy, healthy], t_axis),
+        )
+        late = healthy.copy()
+        late[t_axis <= int(0.6 * N_STEP)] = 0.4
+        late[0] = 1.0
+        ok &= _check(
+            "a shortfall reaching past a quarter of the click axis DOES",
+            C._strip_worth_drawing([healthy, late], t_axis),
+        )
+        never = np.full_like(healthy, 0.4)
+        never[0] = 1.0
+        ok &= _check(
+            "an arm that never recovers DOES",
+            C._strip_worth_drawing([never], t_axis),
+        )
+        # Cells dropping back out of the average is a different failure from
+        # starting late, and it is worth drawing however early it happens.
+        dip = healthy.copy()
+        dip[FIRST_T + 2] = 0.5
+        ok &= _check(
+            "coverage falling back after reaching full DOES, even early",
+            C._strip_worth_drawing([dip], t_axis),
+            f"dip at t={FIRST_T + 2}, last shortfall well inside {C.STRIP_SPAN:.0%} of the axis",
+        )
+        ok &= _check(
+            "...and the click-0-to-click-1 step is not mistaken for such a fall",
+            not C._strip_worth_drawing([healthy], t_axis),
+        )
+        # The one fact the suppressed strip was carrying.
+        ok &= _check(
+            "the suppressed strip's fact is the click from which all arms are measured",
+            C._fully_measured_from([healthy, healthy], t_axis) == FIRST_T,
+            str(C._fully_measured_from([healthy, healthy], t_axis)),
+        )
+        ok &= _check(
+            "...taken over the slowest arm, not the fastest",
+            C._fully_measured_from([healthy, late], t_axis) == int(0.6 * N_STEP) + 1,
+            str(C._fully_measured_from([healthy, late], t_axis)),
+        )
+        ok &= _check(
+            "...and withheld when an arm never gets there",
+            C._fully_measured_from([never], t_axis) is None,
+        )
+        # The starving grid above is exactly the case the strip exists for.
+        ok &= _check(
+            "the planted starving grid keeps its strip",
+            C._strip_worth_drawing(
+                [curve[curve["arm"] == a].groupby("t")["coverage"].mean().to_numpy() for a in arms],
+                np.arange(0, N_STEP + 1),
+            ),
         )
 
         # --- the level itself ----------------------------------------------


### PR DESCRIPTION
The coverage strip under each `{metric}_vs_clicks.png` panel takes ~24% of the figure (`height_ratios=[3.1, 1.0]`) to restate a crossing the line thickness already marks.

## What it was drawing

Checked `coverage` in every committed `*_vs_clicks.csv` under `docs/experiments/`:

| study | coverage 0 until | at 100% by | flat 1.00 through |
|---|---|---|---|
| calibration-fraction-3287 (3 embedders × 5 arms) | t=3 | t≈3–4 | t=150 |
| fold-count-3310 (6 arms × 3 panels) | t=4 | t≈4 | t=150 |
| inclusion-knob-3196 | t=12 | t=12 | t=150 |

Every arm in every study: a step from 0 to 100 inside the first 12 clicks, then exactly 1.00 for the remaining ~138. That is one number per arm — and the top panel already encodes the same event by switching dashed→solid at the 95% crossing, so the strip's only unique content is the shape of the ramp *below* 95%, over the range where the curve above is already dashed and explicitly not quotable.

## What changed

`mean_figure` now computes every series before building any axes, and draws the strip only when coverage carries what the dashed/solid switch cannot — its **depth** and whether it **came back**:

- a shortfall reaching past `CURVE_STRIP_SPAN` (default 25%) of the click axis — an arm starving over a meaningful part of the run, or never recovering; or
- coverage going *down* at any point after the first click — cells dropping back out of the average, worth its depth being drawn however early.

Otherwise the second gridspec row is not created at all, the panel takes the height, and its title names the click from which every arm is fully measured (`all cells measured from click 12`) — the one fact the strip was carrying. `coverage` and `n_cells` stay columns of the emitted CSV either way, so this drops a drawing, not a record. `CURVE_STRIP_SPAN=0` restores the strip unconditionally.

All three committed studies fall on the suppressed side; the planted starving grid in `selftest_curves.py` keeps its strip.

There is precedent for the cheaper encoding: `per_run_figures` already states `"{never}/{n_cells} never trained"` in the panel title and draws no strip.

## Committed figures

Not regenerated, and they need not be: `docs/experiments/**/figures/*.png` were drawn from the per-cell result frames under `$CALIB_RESULTS` on the GRID, which are not in the repo (only the derived curve CSVs are). Per the [committed-figure lesson](scripts/experiments/lessons/2026-08-28-a-committed-figure-is-output-not-a-file.md), the caption that would rot on the next regeneration is fixed instead: #3287's report said "the coverage strip beneath reaches 100% by click 4", which is now "coverage reaches 100% by click 4" — the fact is on the figure under either rendering, the graphical element is not.

## Tests

- `selftest_curves.py` gains seven checks: a healthy grid gets no strip; a late shortfall, a never-recovering arm, and an early fall-back each keep it; the click-0→click-1 step is not mistaken for a fall-back; and `_fully_measured_from` reports the slowest arm's click and withholds when an arm never gets there. 30/30 pass.
- Full `./run-tests.sh`: `RUN PASSED`, 9372 passed / 6 skipped, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjeByLwvxxDZdTvnnMnPAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjeByLwvxxDZdTvnnMnPAz)_