### PR TITLE
docs: repoint the #3329 report's UMAP-tuning link at its moved target

### DIFF
--- a/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
+++ b/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
@@ -695,7 +695,7 @@ and that statistic means what it says.
 
 **Compaction is off in production and this measurement does not change that.**
 `PROJECTION_COMPACT_DEFAULT` is `False` and has been since the July UMAP-tuning
-sweep ([`2026-07-22-vtsbrowse-umap-tuning.html`](../../reports/2026-07-22-vtsbrowse-umap-tuning.html)),
+sweep ([`2026-07-22-vtsbrowse-umap-tuning`](../2026-07-22-vtsbrowse-umap-tuning/report.html)),
 which found `compact_layout` costs ~2 % taxonomy separability and ~5–6 %
 neighbourhood structure on *every* dataset and embedder. `compact` is not a
 user-facing setting: `resolve_projection_params` hard-wires it to that constant


### PR DESCRIPTION
One-line docs fix. `dev` is currently red for everyone; this makes it green.

## What

The docs restructure (#3337) moved `docs/reports/2026-07-22-vtsbrowse-umap-tuning.html` to `docs/experiments/2026-07-22-vtsbrowse-umap-tuning/report.html` and updated every other reference to it — `docs/experiments/README.md`, `docs/plans/vtsbrowse-empirical-tuning.md`, `docs/plans/vtsbrowse.md` — but missed the one in the #3329 report. `docs/reports/` no longer exists at all.

```diff
-sweep ([`2026-07-22-vtsbrowse-umap-tuning.html`](../../reports/2026-07-22-vtsbrowse-umap-tuning.html)),
+sweep ([`2026-07-22-vtsbrowse-umap-tuning`](../2026-07-22-vtsbrowse-umap-tuning/report.html)),
```

## Why it matters

Not a cosmetic nit. `check-docs.py` fails on the dangling link, and it is enforced twice:

- `run-tests.sh` runs it as a gate **before pytest**, so the full suite aborts having validated nothing (`TESTS BLOCKED: documentation check found drift`).
- `tests_lib/core/test_docs_gate.py::TestRepoIsClean::test_no_drift` asserts the same thing, so it is also a hard test failure.

## How I found it

Running the full suite for #3062. That branch came back `1 failed, 9376 passed`, and the one failure was this. I reproduced it on a clean detached worktree at `origin/dev` (`be546eed3` — the exact commit #3062 forked from) to confirm the branch had not introduced it:

```
FAILED tests_lib/core/test_docs_gate.py::TestRepoIsClean::test_no_drift
  - [LINK] docs/experiments/2026-08-30-fit-quality-3329/REPORT.md:698:
    '../../reports/2026-07-22-vtsbrowse-umap-tuning.html' does not exist
1 failed, 55 passed
```

## Verification

After the fix, on this branch:

- `python scripts/check-docs.py` → `check-docs OK: 279 markdown files, 7 invariants, no drift.`
- `tests_lib/core/test_docs_gate.py` → **56 passed**

Kept separate from #3339 (the #3062 calibration) so that PR stays reviewable on its own terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxV5UUxW5cXKV6YfGhVL1o
