### PR TITLE
Make description enrichment per-embedder (option A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ not list every commit. Use `git log` for the full history.
 
 ### Changed
 
+- **"Enrich descriptions" is now a per-model choice, and can no longer make
+  your search worse.** The setting averages a typed query over several
+  phrasings ("the sound of a dog", "a recording of a dog", "a dog", ...)
+  instead of embedding it as typed. Measured across 22 evaluation collections
+  and 560 queries, that helps on some models and hurts on others: it is a gain
+  on CLAP General (audio) and X-CLIP (video), and a loss on SigLIP (images),
+  E5 and BGE (text) and the faster CLAP -- for text it ranked *worse on all 45
+  categories tested*. The phrasings are now attached to the models they
+  actually help, so turning the setting on is simply a no-op for the rest,
+  rather than a small silent cost. The default stays **off**. (Issue #3341,
+  following #3127.)
+
 - **The Settings -> Sorting "Enrich descriptions" tooltip described a
   different feature.** It read "Prepend item filenames to text-sort queries to
   improve matching for named items"; the setting has never touched filenames.

--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -45,7 +45,7 @@ python -m vtscore.eval [OPTIONS]
 | `--output FILE` | Write JSON results to FILE | none |
 | `--plot-dir DIR` | Save visualisation PNGs to DIR | none |
 | `--no-plot` | Disable plot generation | off |
-| `--enrich-descriptions` | Use enriched (wrapper-averaged) text embeddings for text-sort | off |
+| `--enrich-descriptions` | Use enriched (wrapper-averaged) text embeddings for text-sort. A no-op on embedders that declare no wrappers, which since #3341 is most of them — `siglip`, `clap`, `e5` and `bge` all measured worse enriched than plain | off |
 | `--calibrate-count K` | Number of random Train/Calibrate splits for threshold calibration | `2` |
 | `--calibration-fraction F` | Fraction of training data reserved for calibration | unset = the app's per-space default (0.3 single-vector / 0.5 patch) |
 | `--embedder NAME` | Build each demo dataset with this embedder (empty = media-type default) | `` |

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -561,7 +561,18 @@ loaded via `spec_from_file_location` so discovery still works.
 
 | Property               | Returns     | Description                                |
 |------------------------|-------------|--------------------------------------------|
-| `description_wrappers` | `list[str]` | Templates with `{text}` for enriched embedding (e.g. `["the sound of {text}"]`) |
+| `description_wrappers` | `list[str]` | Templates with `{text}` for enriched embedding (e.g. `["the sound of {text}"]`). Default `[]` — see below |
+
+Whether a prompt ensemble helps is a property of the **embedder**, not of the
+media type, and the default (`[]`) is a real answer rather than an unfilled
+slot: issue #3127 measured enrichment on/off over 22 eval datasets and 560
+paired queries and found it a clear loss on `e5`, `bge`, `siglip` and `clap`
+(text enrichment lost on 45 of 45 categories), and a gain only on
+`clap_general` and `xclip`.  Issue #3341 therefore emptied the list on the four
+losers, so the *Enrich descriptions* setting is a no-op there instead of a
+small, silent cost.  Leave `description_wrappers` empty unless you have
+measured a gain on **your** checkpoint; a sibling model's templates are not
+evidence.
 
 **Instance attributes:**
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -266,7 +266,7 @@ See [EXTENDING-media.md § Adding a Media Embedder](EXTENDING-media.md#adding-a-
 - [ ] Create `vtscore/media/<type>/embedder.py` (or `embedder_<variant>.py` for alternatives)
 - [ ] Subclass `MediaEmbedder`, implement `name`, `media_type_id`, `_load_models_impl()`, `embed_media()`
 - [ ] Optionally implement `embed_text()` for text-query sorting
-- [ ] Optionally set `description_wrappers` for enriched text embedding
+- [ ] Leave `description_wrappers` empty unless you have *measured* that a prompt ensemble beats the typed query on your checkpoint (see [EXTENDING-media.md](EXTENDING-media.md#adding-a-media-embedder))
 - [ ] Expose `EMBEDDER = YourEmbedder()` at module level (auto-discovery picks it up; no `__init__.py` edits needed; symlinked files are supported)
 - [ ] Test: load a dataset and verify embeddings are generated
 

--- a/docs/ML.md
+++ b/docs/ML.md
@@ -199,7 +199,7 @@ Embeddings are computed once when a dataset is loaded. The full-image vector lan
 
 ### Description enrichment
 
-The Settings toggle **Enrich descriptions** (`enrich_descriptions`, off by default) changes one thing: the *query* vector. With it on, `embed_text_query` replaces the embedding of what you typed with the L2-normalised mean over the embedder's `description_wrappers` applied to it — SigLIP's are `"a photo of {text}"`, `"a photograph of {text}"`, `"an image of {text}"`, `"{text}"`, `"a picture of {text}"` — via `MediaEmbedder.embed_text_enriched`. Media vectors are untouched, and the Text Sort box (`vtsearch/routes/sorting.py`) is its only consumer. It costs 5 text-encoder passes instead of 1 on the query alone (~20-30 ms), cached per `(embedder, media type, enrich, text)`.
+The Settings toggle **Enrich descriptions** (`enrich_descriptions`, off by default) changes one thing: the *query* vector. With it on, `embed_text_query` replaces the embedding of what you typed with the L2-normalised mean over the embedder's `description_wrappers` applied to it — `clap_general`'s are `"the sound of {text}"`, `"a recording of {text}"`, `"{text}"`, `"audio of {text}"`, `"the noise of {text}"` — via `MediaEmbedder.embed_text_enriched`. Media vectors are untouched, and the Text Sort box (`vtsearch/routes/sorting.py`) is its only consumer. It costs 5 text-encoder passes instead of 1 on the query alone (~20-30 ms), cached per `(embedder, media type, enrich, text)`.
 
 **It is not a general improvement, and the default stays off.** Measured across every media-type default on 22 eval datasets and 560 paired queries ([`docs/experiments/2026-08-31-enrich-descriptions-3127/`](experiments/2026-08-31-enrich-descriptions-3127/REPORT.md), issue #3127), paired difference in text-sort average precision:
 
@@ -214,8 +214,12 @@ The Settings toggle **Enrich descriptions** (`enrich_descriptions`, off by defau
 
 Two things worth knowing before changing any of this:
 
-- **The effect belongs to the embedder-and-corpus pair, not to enrichment.** The wrappers were written per media type, and only two templates in the tree have a positive point estimate on their own embedder: `"the sound of {text}"` on `clap_general` (+0.014, which is the whole of that media type's gain) and `"a media showing {text}"` on `xclip`. Every wrapper is negative on `siglip`, `e5`, `bge` and `clap`.
-- **`{text}` is itself one of the five templates**, so enrichment always averages the plain query back in. Where the other four hurt, that is the only reason the ensemble does not hurt as much as they do.
+- **The effect belongs to the embedder-and-corpus pair, not to enrichment.** The wrappers were written per media type, and only two templates in the tree have a positive point estimate on their own embedder: `"the sound of {text}"` on `clap_general` (+0.014, which is the whole of that media type's gain) and `"a media showing {text}"` on `xclip`. Every wrapper measured negative on `siglip`, `e5`, `bge` and `clap`.
+- **`{text}` is itself one of the five templates**, so where an embedder has wrappers, enrichment always averages the plain query back in. Where the other four hurt, that is the only reason the ensemble did not hurt as much as they did — it is why `siglip`'s four negative templates netted out to only −0.001.
+
+**Which is why the wrapper list is now per-embedder** (issue #3341). Because the sign belongs to the model rather than the media type, `siglip`, `e5`, `bge` and `clap` declare **no wrappers at all**: `embed_text_enriched` falls back to `embed_text`, and the toggle is a no-op for them instead of a small silent cost. `clap_general` and `xclip` — the only two with a positive point estimate on their own model — keep theirs. The global default still stays off: `clap_general`'s +0.014 does not clear its own 2 SE, ESC-50's 50 categories are already fully used, and resolving it needs a second audio corpus.
+
+Two general CLAP checkpoints disagree on the *identical* five templates, so **a sibling model's prompts are not evidence for yours**. A new embedder should leave `description_wrappers` empty unless it has measured otherwise — see [EXTENDING-media.md](EXTENDING-media.md#adding-a-media-embedder).
 
 `face` (no text tower) and `document` (no embedder of its own) cannot text-sort, so the setting is inert for them.
 

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.html
@@ -190,7 +190,7 @@
         <!-- Sorting & Calibration -->
         @if (activeSettingsTab() === 'sorting') {
           <h3>Sorting &amp; Tuning</h3>
-          <label class="checkbox-row" title="Average the text-sort query over the model's phrasing templates (e.g. &quot;a photo of …&quot;) instead of embedding it as typed. Helps CLAP audio search; measurably hurts text search (issue #3127)">
+          <label class="checkbox-row" title="Average the text-sort query over the model's phrasing templates (e.g. &quot;a photo of …&quot;, &quot;the sound of …&quot;) instead of embedding it as typed. Only the models measured to benefit carry templates (CLAP General audio, X-CLIP video); on every other model this has no effect (issues #3127, #3341)">
             <input type="checkbox" [ngModel]="settings().enrich_descriptions" (ngModelChange)="onToggle('enrich_descriptions', $event)" />
             Enrich descriptions
           </label>

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -185,6 +185,25 @@ EXPERIMENT_QUERIES: dict[str, dict[str, str]] = {
 }
 
 
+#: Whether the simulated user's opening query is embedded through the
+#: embedder's ``description_wrappers`` ensemble ("Enrich Sort Descriptions") or
+#: plainly.
+#:
+#: This must track the app's shipped default for ``enrich_descriptions``
+#: (``vtsearch/settings_models.py``), which is ``False``: the opening and the
+#: click-0 anchor are supposed to be the sort a real user sees, and a harness
+#: that quietly embeds plainly while the app enriches is measuring a different
+#: opening than the one it reports.  Every ``embed_text_query`` call in this
+#: harness passes it explicitly rather than leaning on the library default, so
+#: that if the app's default ever moves there is exactly one line to change and
+#: it is grep-able (#3341).
+#:
+#: Note that under #3341 enrichment is per-embedder: ``siglip`` -- this study's
+#: text half -- returns no wrappers at all, so flipping this to ``True`` is a
+#: no-op there rather than a silent re-ranking.
+SEED_ENRICH = os.environ.get("CALIB_SEED_ENRICH", "0") == "1"
+
+
 def seed_query_text(dataset: str, category: str) -> str:
     """The text a user would type to find *category* in *dataset*, or "".
 

--- a/scripts/experiments/calibration/probe_startup_cuts.py
+++ b/scripts/experiments/calibration/probe_startup_cuts.py
@@ -60,7 +60,7 @@ def probe_cell(ds: str, emb: str, cat: str, medias: dict) -> dict | None:
     text = cfg.seed_query_text(ds, cat)
     if not text:
         return None
-    qvec = embed_text_query(text, "image", embedder_name=emb)
+    qvec = embed_text_query(text, "image", enrich=cfg.SEED_ENRICH, embedder_name=emb)
     if qvec is None:
         return None
 

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -136,7 +136,7 @@ def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, f
     text = _seed_query_text(ds, cat)
     if not text:
         return None
-    qvec = embed_text_query(text, "image", embedder_name=text_emb)
+    qvec = embed_text_query(text, "image", enrich=cfg.SEED_ENRICH, embedder_name=text_emb)
     if qvec is None:
         return None
 

--- a/scripts/experiments/calibration/text_baseline.py
+++ b/scripts/experiments/calibration/text_baseline.py
@@ -96,7 +96,7 @@ def main() -> int:
                 continue
 
             # Probe the text tower once before loading a multi-GB pickle.
-            probe = embed_text_query("a photo", "image", embedder_name=text_emb)
+            probe = embed_text_query("a photo", "image", enrich=cfg.SEED_ENRICH, embedder_name=text_emb)
             if probe is None:
                 common.log(f"{ds} x {emb}: NO TEXT TOWER on {text_emb} (vision-only) - recorded as n/a")
                 for cat in cats:
@@ -118,7 +118,7 @@ def main() -> int:
                 # measured a *different sort* from the one every arm opened on,
                 # so the zero-click anchor was not the run's own seed sort.
                 query = cfg.seed_query_text(ds, cat) or cat
-                tvec = embed_text_query(query, "image", embedder_name=text_emb)
+                tvec = embed_text_query(query, "image", enrich=cfg.SEED_ENRICH, embedder_name=text_emb)
                 if tvec is None:
                     rows.append({"dataset": ds, "embedder": emb, "category": cat, "supports_text": 0})
                     continue

--- a/scripts/experiments/enrich/run_enrich.py
+++ b/scripts/experiments/enrich/run_enrich.py
@@ -4,8 +4,18 @@
 ``enrich_descriptions`` is a single **global** setting whose only production
 consumer is the Text Sort query embedding (``vtsearch/routes/sorting.py`` ->
 ``embed_text_query(..., enrich=...)``).  Enrichment replaces the query vector
-with the L2-normalised mean of the embedder's ``description_wrappers`` applied
-to the typed text; the *media* vectors are untouched.
+with the L2-normalised mean of a set of ``description_wrappers`` applied to the
+typed text; the *media* vectors are untouched.
+
+Since #3341 the wrapper set is **per-embedder and measured**: this study's own
+result is why ``siglip``, ``e5``, ``bge`` and ``clap`` now ship an empty list.
+So the harness cannot simply read ``embedder.description_wrappers`` any more -
+on those four it would find nothing, emit an ``enriched`` arm identical to
+``plain``, and report a flat zero while looking perfectly healthy.  It resolves
+through :data:`CANDIDATE_WRAPPERS` instead (the embedder's own list when it has
+one, else the pre-#3341 templates for its media type) and overrides the
+embedder for the cell, so a re-run reproduces this report and a new checkpoint
+can be measured against a wrapper set it does not yet ship.
 
 That is what makes this study cheap and exactly paired: one dataset load serves
 every arm, so the two arms differ in the query vector and in nothing else -
@@ -33,6 +43,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import contextlib
 import csv
 import json
 import os
@@ -82,11 +93,88 @@ def _git(repo: Path, *args: str) -> str:
     return out.stdout.strip()
 
 
-def _arms(embedder, want_wrappers: bool) -> list[tuple[str, str]]:
+#: Wrapper templates per media type, as they stood before #3341 emptied the
+#: list on ``siglip``, ``e5``, ``bge`` and ``clap``.
+#:
+#: Production reads the embedder; this study has to be able to measure a
+#: *candidate* set the model does not ship - both to reproduce its own report
+#: (whose whole point was that these templates lose) and to put a wrapper set
+#: in front of a new checkpoint before deciding whether to ship it.  Keeping
+#: the deleted templates only in git history would make the report
+#: unreproducible and quietly turn the ``w<i>`` arms - and with them the
+#: ``{text}`` planted answer - into an empty set.
+CANDIDATE_WRAPPERS: dict[str, list[str]] = {
+    "audio": [
+        "the sound of {text}",
+        "a recording of {text}",
+        "{text}",
+        "audio of {text}",
+        "the noise of {text}",
+    ],
+    "image": [
+        "a photo of {text}",
+        "a photograph of {text}",
+        "an image of {text}",
+        "{text}",
+        "a picture of {text}",
+    ],
+    "text": [
+        "a document about {text}",
+        "an article discussing {text}",
+        "{text}",
+        "a text passage about {text}",
+        "writing on the topic of {text}",
+    ],
+    "video": [
+        "a video of {text}",
+        "a media showing {text}",
+        "{text}",
+        "footage of {text}",
+        "a video media of {text}",
+    ],
+}
+
+
+def _wrappers_for(embedder) -> tuple[list[str], str]:
+    """The wrapper set this cell measures, and where it came from.
+
+    An embedder that ships wrappers is measured on its own (that is the
+    production path).  One that ships none - the four #3341 emptied - falls
+    back to the pre-#3341 templates for its media type, so the arms stay
+    comparable to the rows already in this study's tables.
+    """
+    own = list(embedder.description_wrappers)
+    if own:
+        return own, "embedder"
+    return list(CANDIDATE_WRAPPERS.get(embedder.media_type_id, [])), "candidate"
+
+
+@contextlib.contextmanager
+def _wrappers_override(embedder, wrappers: list[str]):
+    """Make *embedder* report *wrappers* for the duration of the block.
+
+    ``eval_text_sort(enrich=True)`` reaches ``embed_text_enriched``, which
+    reads the property off the class - so measuring a candidate set means
+    patching the class, not passing a list.  Scoped to one cell; a no-op when
+    the embedder already reports exactly this set.
+    """
+    cls = type(embedder)
+    if list(embedder.description_wrappers) == wrappers:
+        yield
+        return
+    original = cls.description_wrappers
+    cls.description_wrappers = property(lambda _self: list(wrappers))
+    try:
+        yield
+    finally:
+        cls.description_wrappers = original
+
+
+def _arms(wrappers: list[str], want_wrappers: bool) -> list[tuple[str, str]]:
     """(arm name, wrapper template) pairs.  Empty template = no rewrite."""
     arms: list[tuple[str, str]] = [("plain", ""), ("enriched", "")]
     if want_wrappers:
-        for i, wrapper in enumerate(embedder.description_wrappers):
+        for i, wrapper in enumerate(wrappers):
             arms.append((f"w{i}", wrapper))
     return arms
 
@@ -138,14 +226,25 @@ def run_cell(
         return "failed"
 
     embedder = get_embedder(loaded)
+    wrappers, source = _wrappers_for(embedder)
+    if not wrappers:
+        print(
+            f"[{ds_id}] FAILED: no wrappers for {loaded!r} (media type {embedder.media_type_id!r}); "
+            "add a CANDIDATE_WRAPPERS entry -- an enrichment study with nothing to "
+            "enrich reports a flat zero rather than an error",
+            file=sys.stderr,
+            flush=True,
+        )
+        return "failed"
     queries = cfg["queries"]
     print(
-        f"[{ds_id}] {len(medias)} medias, {len(queries)} queries, embedder={loaded}, load={load_s:.0f}s",
+        f"[{ds_id}] {len(medias)} medias, {len(queries)} queries, embedder={loaded}, "
+        f"wrappers={len(wrappers)} ({source}), load={load_s:.0f}s",
         flush=True,
     )
 
     rows: list[dict] = []
-    for arm, wrapper in _arms(embedder, want_wrappers):
+    for arm, wrapper in _arms(wrappers, want_wrappers):
         armed = [
             EvalQuery(
                 text=wrapper.format(text=q.text) if wrapper else q.text,
@@ -154,14 +253,15 @@ def run_cell(
             for q in queries
         ]
         t_arm = time.monotonic()
-        metrics = eval_text_sort(
-            medias,
-            armed,
-            media_type,
-            K_VALUES,
-            enrich=(arm == "enriched"),
-            embedder_name=loaded,
-        )
+        with _wrappers_override(embedder, wrappers):
+            metrics = eval_text_sort(
+                medias,
+                armed,
+                media_type,
+                K_VALUES,
+                enrich=(arm == "enriched"),
+                embedder_name=loaded,
+            )
         arm_s = time.monotonic() - t_arm
         m_ap = sum(m.average_precision for m in metrics) / len(metrics)
         print(f"    {arm:10s} mAP={m_ap:.4f}  ({arm_s:.1f}s)", flush=True)

--- a/scripts/experiments/max_patch/experiment_config.py
+++ b/scripts/experiments/max_patch/experiment_config.py
@@ -51,6 +51,15 @@ N_CATEGORIES = int(os.environ.get("MAXPATCH_N_CATEGORIES", "6"))
 SEEDS = list(range(int(os.environ.get("MAXPATCH_N_SEEDS", "4"))))
 MAX_STEPS = int(os.environ.get("MAXPATCH_MAX_STEPS", "150"))
 
+#: Whether the simulated user's opening query is embedded through the
+#: embedder's ``description_wrappers`` ensemble ("Enrich Sort Descriptions") or
+#: plainly.  Tracks the app's shipped default for ``enrich_descriptions``
+#: (``vtsearch/settings_models.py``), which is ``False``; passed explicitly at
+#: every ``embed_text_query`` call so the opening this harness measures is the
+#: one a real user sees rather than whatever the library happens to default to
+#: (#3341).  The sibling knob is ``calibration/experiment_config.SEED_ENRICH``.
+SEED_ENRICH = os.environ.get("MAXPATCH_SEED_ENRICH", "0") == "1"
+
 # --- Startup-sort exemplars ---
 # Per category, this many candidate exemplars are cropped + embedded at prepare
 # time; seed *s* uses candidate ``s % len(candidates)``, so every arm at a given

--- a/scripts/experiments/max_patch/run_cells.py
+++ b/scripts/experiments/max_patch/run_cells.py
@@ -92,7 +92,7 @@ def _text_seed_scores(ds: str, emb: str, cat: str, medias: dict) -> "dict[int, f
     text = _seed_query_text(ds, cat)
     if not text:
         return None
-    qvec = embed_text_query(text, "image", embedder_name=emb)
+    qvec = embed_text_query(text, "image", enrich=cfg.SEED_ENRICH, embedder_name=emb)
     if qvec is None:
         return None
 

--- a/tests/sorting/test_enrich_descriptions.py
+++ b/tests/sorting/test_enrich_descriptions.py
@@ -1,7 +1,7 @@
 """Tests for the Enrich Sort Descriptions feature.
 
 Covers:
-- description_wrappers property on each media type
+- description_wrappers: the per-embedder split measured by #3127/#3341
 - embed_text_enriched method (base class logic)
 - enrich_descriptions setting (get/set/persist)
 - embed_text_query with enrich=True
@@ -18,11 +18,7 @@ import pytest
 
 from vtscore.eval.config import EvalQuery
 from vtscore.eval.runner import eval_text_sort
-from vtscore.media.audio.embedder_clap import AudioClapEmbedder
 from vtscore.media.embedder import MediaEmbedder
-from vtscore.media.image.embedder_siglip import ImageSiglipEmbedder
-from vtscore.media.text.embedder_e5 import TextE5Embedder
-from vtscore.media.video.embedder_xclip import VideoXClipEmbedder
 from vtscore.embedding.helpers import embed_text_query
 
 
@@ -32,47 +28,99 @@ from vtscore.embedding.helpers import embed_text_query
 
 
 class TestDescriptionWrappers:
-    def test_audio_has_wrappers(self):
-        emb = AudioClapEmbedder()
-        wrappers = emb.description_wrappers
-        assert len(wrappers) >= 3
-        for w in wrappers:
-            assert "{text}" in w
+    """Which embedders enrich, and which embed the typed query plainly.
 
-    def test_image_has_wrappers(self):
-        emb = ImageSiglipEmbedder()
-        wrappers = emb.description_wrappers
-        assert len(wrappers) >= 3
-        for w in wrappers:
-            assert "{text}" in w
+    Enrichment is a property of the **embedder**, not of the media type.
+    #3127 measured the ensemble on/off across 22 eval datasets and 560 paired
+    queries (paired Delta in text-sort average precision, SEs clustered on
+    (corpus, category)) and the answer split by model:
 
-    def test_text_has_wrappers(self):
-        emb = TextE5Embedder()
-        wrappers = emb.description_wrappers
-        assert len(wrappers) >= 3
-        for w in wrappers:
-            assert "{text}" in w
+    ======================  ==================
+    embedder                Delta AP
+    ======================  ==================
+    ``clap_general``        +0.014 +/- 0.009
+    ``xclip``               +0.008 +/- 0.014
+    ``siglip``              -0.001 +/- 0.002
+    ``clap``                -0.010 +/- 0.008
+    ``e5``                  -0.057 +/- 0.009
+    ``bge``                 -0.059 +/- 0.009
+    ======================  ==================
 
-    def test_video_has_wrappers(self):
-        emb = VideoXClipEmbedder()
-        wrappers = emb.description_wrappers
-        assert len(wrappers) >= 3
-        for w in wrappers:
-            assert "{text}" in w
+    Every individual template was negative on the bottom four, so #3341 gave
+    them an empty wrapper list: ``embed_text_enriched`` degrades to
+    ``embed_text`` there and the Enrich Sort Descriptions setting can no longer
+    cost anything.  These tests pin that split so the templates are not
+    re-added by a later "every embedder should have wrappers" sweep.
+    """
 
-    def test_wrappers_include_bare_text(self):
-        """Each embedder should include a plain '{text}' wrapper."""
-        for emb_cls in (AudioClapEmbedder, ImageSiglipEmbedder, TextE5Embedder, VideoXClipEmbedder):
-            emb = emb_cls()
-            assert "{text}" in emb.description_wrappers, f"{emb_cls.__name__} missing bare '{{text}}' wrapper"
+    #: Measured worse than the typed query on every template (#3127).
+    PLAIN_QUERY_EMBEDDERS = ("siglip", "clap", "e5", "bge")
+
+    #: The only two embedders with a positive point estimate on their own model.
+    ENRICHING_EMBEDDERS = ("clap_general", "xclip")
+
+    def test_measured_negative_embedders_have_no_wrappers(self):
+        from vtscore.media import get_embedder
+
+        for name in self.PLAIN_QUERY_EMBEDDERS:
+            emb = get_embedder(name)
+            assert emb is not None, f"{name} is not registered"
+            assert emb.description_wrappers == [], (
+                f"{name} measured worse than the typed query on every wrapper (#3127); "
+                "an empty list here is the measured answer, not an unfilled slot"
+            )
+
+    def test_measured_positive_embedders_keep_their_wrappers(self):
+        from vtscore.media import get_embedder
+
+        for name in self.ENRICHING_EMBEDDERS:
+            emb = get_embedder(name)
+            assert emb is not None, f"{name} is not registered"
+            wrappers = emb.description_wrappers
+            assert len(wrappers) >= 3, f"{name} lost the wrappers #3127 measured a gain from"
+            for w in wrappers:
+                assert "{text}" in w
+
+    def test_enriching_embedders_include_bare_text(self):
+        """The ensemble must average the plain query back in."""
+        from vtscore.media import get_embedder
+
+        for name in self.ENRICHING_EMBEDDERS:
+            assert "{text}" in get_embedder(name).description_wrappers, f"{name} missing bare '{{text}}' wrapper"
 
     def test_wrappers_format_correctly(self):
-        """All wrappers should format without errors."""
-        for emb_cls in (AudioClapEmbedder, ImageSiglipEmbedder, TextE5Embedder, VideoXClipEmbedder):
-            emb = emb_cls()
+        """Every wrapper still in the tree must format without errors."""
+        from vtscore.media import all_embedders
+
+        for emb in all_embedders():
             for wrapper in emb.description_wrappers:
-                result = wrapper.format(text="test query")
-                assert "test query" in result
+                assert "test query" in wrapper.format(text="test query")
+
+    def test_no_wrappers_means_setting_is_a_no_op(self):
+        """With no wrappers, enrich=True and enrich=False are the same query."""
+
+        class PlainEmbedder(MediaEmbedder):
+            @property
+            def name(self):
+                return "plain"
+
+            @property
+            def media_type_id(self):
+                return "plain"
+
+            def _load_models_impl(self):
+                pass
+
+            def _embed_media_impl(self, media):
+                return None
+
+            def embed_text(self, text):
+                assert text == "boats", "the typed query must reach embed_text unwrapped"
+                return np.array([1.0, 0.0])
+
+        emb = PlainEmbedder()
+        assert emb.description_wrappers == []
+        np.testing.assert_array_equal(emb.embed_text_enriched("boats"), emb.embed_text("boats"))
 
 
 # =====================================================================

--- a/tests/sorting/test_enrich_descriptions.py
+++ b/tests/sorting/test_enrich_descriptions.py
@@ -302,7 +302,13 @@ class TestEnrichDescriptionsSetting:
         after #3077 moved the audio default to ``clap_general``: it is worth
         +0.014 +/- 0.009 AP there, inert on ``siglip``, and **-0.057 +/- 0.009
         on ``e5``** -- worse on 45 of 45 text categories, and on ``bge`` too.
-        Equal-weighted over the four defaults the setting is negative.  See
+
+        #3341 then removed the wrappers from the four embedders that measured
+        negative, so the setting is no longer net-negative -- but the default
+        still stays off, for a different reason: the only gain left standing,
+        ``clap_general``'s +0.014, does not clear its own 2 SE, and ESC-50's 50
+        categories are already fully used, so resolving it needs a second audio
+        corpus.  See
         ``docs/experiments/2026-08-31-enrich-descriptions-3127/REPORT.md``
         before flipping this.
         """
@@ -444,3 +450,77 @@ class TestEvalTextSortEnrich:
             eval_text_sort(medias, queries, "image", k_values=[5], enrich=False)
 
         assert all(kw["enrich"] is False for kw in call_kwargs)
+
+
+# =====================================================================
+# The #3127 study harness vs. the tree it measures
+# =====================================================================
+
+
+class TestEnrichStudyCandidateWrappers:
+    """`scripts/experiments/enrich/run_enrich.py` keeps its own wrapper table.
+
+    It has to: #3341 emptied the list on the four embedders this very study
+    measured negative, so a harness that read `description_wrappers` would
+    find nothing on them, emit an `enriched` arm identical to `plain`, and
+    report a flat zero while looking healthy. The table holds the pre-#3341
+    templates so the report stays reproducible and a new checkpoint can be
+    measured against a set it does not yet ship.
+
+    That copy can rot, which is what these tests are for: on every media type
+    where an embedder still ships wrappers, the table must be that same list.
+    """
+
+    @staticmethod
+    def _module():
+        import importlib.util
+        from pathlib import Path
+
+        path = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "enrich" / "run_enrich.py"
+        spec = importlib.util.spec_from_file_location("_enrich_run_enrich", path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @pytest.mark.parametrize(
+        ("media_type", "embedder_name"),
+        [("audio", "clap_general"), ("image", "siglip2"), ("video", "xclip")],
+    )
+    def test_table_matches_the_embedders_that_still_ship_wrappers(self, media_type, embedder_name):
+        from vtscore.media import get_embedder
+
+        table = self._module().CANDIDATE_WRAPPERS
+        assert table[media_type] == get_embedder(embedder_name).description_wrappers, (
+            f"the study's {media_type} templates have drifted from {embedder_name}'s; "
+            "the harness would measure a set nobody ships"
+        )
+
+    def test_every_media_type_has_a_candidate_set_with_the_identity(self):
+        """The bare `{text}` arm is the analyzer's planted answer."""
+        table = self._module().CANDIDATE_WRAPPERS
+        assert set(table) == {"audio", "image", "text", "video"}
+        for media_type, wrappers in table.items():
+            assert len(wrappers) >= 3, media_type
+            assert "{text}" in wrappers, f"{media_type} lost the identity arm"
+
+    def test_emptied_embedders_resolve_to_the_candidate_set(self):
+        """The four #3341 emptied are still measurable, and flagged as such."""
+        from vtscore.media import get_embedder
+
+        module = self._module()
+        for name, media_type in (("siglip", "image"), ("clap", "audio"), ("e5", "text"), ("bge", "text")):
+            wrappers, source = module._wrappers_for(get_embedder(name))
+            assert source == "candidate", name
+            assert wrappers == module.CANDIDATE_WRAPPERS[media_type], name
+
+    def test_override_restores_the_embedders_own_property(self):
+        """The class patch must not leak past the cell."""
+        from vtscore.media import get_embedder
+
+        module = self._module()
+        emb = get_embedder("siglip")
+        assert emb.description_wrappers == []
+        with module._wrappers_override(emb, ["a photo of {text}"]):
+            assert emb.description_wrappers == ["a photo of {text}"]
+        assert emb.description_wrappers == []

--- a/tests_lib/detectors/test_new_embedders.py
+++ b/tests_lib/detectors/test_new_embedders.py
@@ -25,13 +25,11 @@ class TestImageSiglipEmbedderProperties:
         emb = ImageSiglipEmbedder()
         assert emb.media_type_id == "image"
 
-    def test_description_wrappers_non_empty(self):
+    def test_no_description_wrappers(self):
+        """#3341: every wrapper measured below the typed query on SigLIP."""
         from vtscore.media.image.embedder_siglip import ImageSiglipEmbedder
 
-        emb = ImageSiglipEmbedder()
-        wrappers = emb.description_wrappers
-        assert len(wrappers) > 0
-        assert all("{text}" in w for w in wrappers)
+        assert ImageSiglipEmbedder().description_wrappers == []
 
     def test_registered_in_registry(self):
         from vtscore.media import get_embedder
@@ -729,13 +727,11 @@ class TestTextBGEEmbedderProperties:
         emb = TextBGEEmbedder()
         assert emb.media_type_id == "text"
 
-    def test_description_wrappers_non_empty(self):
+    def test_no_description_wrappers(self):
+        """#3341: enrichment lost on 45 of 45 text categories for bge."""
         from vtscore.media.text.embedder_bge import TextBGEEmbedder
 
-        emb = TextBGEEmbedder()
-        wrappers = emb.description_wrappers
-        assert len(wrappers) > 0
-        assert all("{text}" in w for w in wrappers)
+        assert TextBGEEmbedder().description_wrappers == []
 
     def test_registered_in_registry(self):
         from vtscore.media import get_embedder

--- a/tests_lib/detectors/test_paired_embedder_seeding.py
+++ b/tests_lib/detectors/test_paired_embedder_seeding.py
@@ -141,10 +141,10 @@ def text_tower(monkeypatch):
     """``embed_text_query`` answering only for SigLIP, as the real towers do."""
     import vtscore.embedding.helpers as helpers
 
-    calls: list[tuple[str, str | None]] = []
+    calls: list[tuple[str, str | None, bool]] = []
 
-    def _embed(text, media_type, embedder_name=None):  # noqa: ARG001
-        calls.append((text, embedder_name))
+    def _embed(text, media_type, enrich=False, embedder_name=None):  # noqa: ARG001
+        calls.append((text, embedder_name, enrich))
         if embedder_name != "siglip":
             return None  # DINOv3 has no text tower
         return np.asarray([1.0, 0.0], dtype=np.float32)
@@ -160,7 +160,7 @@ _SIGLIP = {1: [1.0, 0.0], 2: [0.0, 1.0]}
 _DINOV3 = {1: [0.0, 1.0], 2: [1.0, 0.0]}
 
 
-def test_pair_ranks_in_the_text_space_over_the_learn_ids(run_cells, queried, text_tower, monkeypatch, tmp_path):
+def test_pair_ranks_in_the_text_space_over_the_learn_ids(cfg, run_cells, queried, text_tower, monkeypatch, tmp_path):
     """SigLIP orders the opening; the ids are the DINOv3 cell's own."""
     learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
     text = {cid: _media({"siglip": v}, "siglip") for cid, v in _SIGLIP.items()}
@@ -175,7 +175,12 @@ def test_pair_ranks_in_the_text_space_over_the_learn_ids(run_cells, queried, tex
 
     assert set(scores) == set(learn)
     assert scores[1] > scores[2], "the opening must follow SigLIP, not DINOv3"
-    assert ("a boat on the water", "siglip") in text_tower
+    assert ("a boat on the water", "siglip", False) in text_tower
+    # #3341: the opening must be embedded the way the app embeds it, not
+    # however `embed_text_query` happens to default.  The harness passes
+    # cfg.SEED_ENRICH explicitly, which tracks the app's shipped
+    # `enrich_descriptions` default (off).
+    assert all(enrich is cfg.SEED_ENRICH for _text, _name, enrich in text_tower)
 
 
 def test_pair_prefers_vectors_already_on_the_media(run_cells, queried, text_tower, monkeypatch, tmp_path):

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -12,6 +12,27 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **`description_wrappers` is now a per-embedder, measured choice, and four
+  built-in embedders return `[]`** (issue #3341, following #3127). Issue
+  #3127 measured wrapper-averaged text embedding on/off across 22 eval
+  datasets and 560 paired queries (paired Δ in text-sort average precision,
+  SEs clustered on (corpus, category)). The result splits by *model*, not by
+  media type: `clap_general` +0.014 ± 0.009 and `xclip` +0.008 ± 0.014, but
+  `siglip` −0.001 ± 0.002, `clap` −0.010 ± 0.008, `e5` −0.057 ± 0.009 and
+  `bge` −0.059 ± 0.009 (the two text embedders lost on 45 of 45 categories,
+  and every individual template was negative on all four). Those four now
+  override `description_wrappers` to return `[]`, so `embed_text_enriched`
+  degrades to `embed_text` and the app's `enrich_descriptions` setting is a
+  no-op for them. `clap_general`, `xclip` and the unmeasured cross-modal
+  siblings are unchanged.
+
+  **For plugin authors:** the base-class default is still `[]` and nothing in
+  the ABC moved, so no out-of-tree embedder is affected. But the default is
+  now documented as a *measured answer* rather than an unfilled slot — do not
+  add wrappers to your own embedder without measuring that they beat the typed
+  query on your checkpoint, because a sibling model's templates are not
+  evidence (`clap` and `clap_general` disagree on the identical five).
+
 - **Voted media are excluded from the calibrated threshold's haystacks**
   (issue #3308). The fold-anchored threshold estimator drops the voted
   items from every population sample it touches - each calibration fold
@@ -120,6 +141,11 @@ instead, since every commit on `dev` is effectively a new app release.)
   flooding weights a Bad image's many region rows down to one image's worth.
 
 ### Added
+
+- `vtscore.eval.seed_scores.build_seed_scores` accepts an `enrich` keyword
+  (default `False`, matching the app's shipped `enrich_descriptions`
+  default), so a simulated-user study can open on the same sort a real user
+  sees instead of silently always embedding the query plainly (issue #3341).
 
 - **`vtscore.concurrency.notifications`** - `notify()`, `Notification` and
   `NotificationBroker`: a fan-out channel for one-off user-facing messages.

--- a/vtscore/docs/extending/embedders.md
+++ b/vtscore/docs/extending/embedders.md
@@ -45,7 +45,7 @@ Optional but commonly overridden:
 | `display_name` | `name` | Friendlier label for the picker UI |
 | `is_default` | `False` | Exactly one embedder per media type should return `True` - that one is what `embedders_for_type(t)[0]` returns |
 | `embed_text(text)` | `None` | Return `None` to disable text-query sort, or a vector in the same space as `_embed_media_impl` |
-| `description_wrappers` | `[]` | Templates with `{text}` for enriched text embedding (e.g. `["the sound of {text}"]`) |
+| `description_wrappers` | `[]` | Templates with `{text}` for enriched text embedding (e.g. `["the sound of {text}"]`). Keep the default unless you have measured that the ensemble beats the typed query on your checkpoint - it is a loss on most (#3127/#3341) |
 | `_embed_media_bulk_impl(medias)` | per-item loop | Native bulk hook for service embedders or batched GPU forward passes |
 | `_patch_forward_impl(media)` | `None` | For patch-capable image encoders; required when `supports_patch_regions = True` |
 

--- a/vtscore/docs/packages/embedding.md
+++ b/vtscore/docs/packages/embedding.md
@@ -103,7 +103,10 @@ against media embeddings. When `embedder_name` is set, that specific
 embedder is used; otherwise it falls back to the default for the
 given `media_type`. `enrich=True` runs `embed_text_enriched`, which
 averages the query across the embedder's `description_wrappers`
-(e.g. `"a photo of {text}"`, `"a video of {text}"`).
+(e.g. `"a photo of {text}"`, `"a video of {text}"`). Most embedders
+declare no wrappers - the ensemble was measured to *lose* to the typed
+query on `siglip`, `clap`, `e5` and `bge` (#3127/#3341) - so on those
+`enrich=True` is simply `embed_text`.
 
 Results are cached in a small process-wide LRU
 (`_query_cache` in `vtscore/embedding/helpers.py`):

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -125,7 +125,7 @@ embedders. Subclasses implement four things:
 | `_embed_media_impl(media)`                    | yes      | Forward pass for one item            |
 | `embed_text(text)`                            | optional | Embed a query into the same space    |
 | `_embed_media_bulk_impl(medias)`              | optional | Batched forward; default loops       |
-| `description_wrappers`                        | optional | Prompts used by `embed_text_enriched`|
+| `description_wrappers`                        | optional | Prompts used by `embed_text_enriched`; `[]` (the default, and the measured answer for most models) makes it plain `embed_text` |
 
 Threading and lock contract:
 

--- a/vtscore/eval/seed_scores.py
+++ b/vtscore/eval/seed_scores.py
@@ -42,6 +42,7 @@ def build_seed_scores(
     media_type: str = "image",
     embedder_name: str = "siglip",
     categories: Optional[dict[str, list[str]]] = None,
+    enrich: bool = False,
 ) -> dict[str, dict[str, dict[int, float]]]:
     """Build ``{dataset: {category: {media_id: cosine}}}`` text-sort rankings.
 
@@ -58,6 +59,13 @@ def build_seed_scores(
             the embedder the medias were embedded with (``"siglip"``).
         categories: Optional ``{dataset: [category, ...]}`` restriction; when a
             dataset is present only those categories' queries are embedded.
+        enrich: Whether to embed the query through the embedder's
+            ``description_wrappers`` ensemble rather than plainly.  Defaults to
+            ``False`` to match the app's shipped ``enrich_descriptions``
+            setting — the simulated user's opening must be the sort a real user
+            actually sees.  Pass the app's value explicitly if it ever stops
+            defaulting to off, or the seed ranking silently stops being the
+            one the run's arms were opened on (#3341).
 
     Returns:
         Nested mapping suitable for ``run_voting_iterations_eval(seed_scores=…)``.
@@ -85,7 +93,7 @@ def build_seed_scores(
             cat = query.target_category
             if wanted is not None and cat not in wanted:
                 continue
-            qvec = embed_text_query(query.text, media_type, embedder_name=embedder_name)
+            qvec = embed_text_query(query.text, media_type, enrich=enrich, embedder_name=embedder_name)
             if qvec is None:
                 continue
             cos = matrix @ _unit(np.asarray(qvec, dtype=np.float32))  # (N,)

--- a/vtscore/media/audio/embedder_clap.py
+++ b/vtscore/media/audio/embedder_clap.py
@@ -36,5 +36,17 @@ class AudioClapEmbedder(_ClapBase):
     def model_id(self) -> str:
         return CLAP_MODEL_ID
 
+    @property
+    def description_wrappers(self) -> list[str]:
+        """No wrappers: the sound-prompt ensemble helps ``clap_general``, not this.
+
+        #3127 ran the same five templates on both general-purpose CLAP
+        checkpoints and they split by model: +0.014 +/- 0.009 AP on
+        ``clap_general`` (which keeps them, inherited from
+        :class:`~vtscore.media.audio._clap_shared._ClapBase`) and
+        -0.010 +/- 0.008 on this one.  See #3341.
+        """
+        return []
+
 
 EMBEDDER = AudioClapEmbedder()

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -1451,7 +1451,18 @@ class MediaEmbedder(ABC):
         """Wrapper templates for enriching sort descriptions.
 
         Each template is a format string containing ``{text}``.  Override in
-        subclasses to provide media-specific wrappers that improve embedding quality.
+        subclasses to provide media-specific wrappers that improve embedding
+        quality.
+
+        Whether wrappers help is a property of the **embedder**, not of the
+        media type: #3127 measured enrichment on/off across 22 eval datasets
+        and 560 paired queries and found the ensemble a clear loss on ``e5``,
+        ``bge``, ``siglip`` and ``clap``, and a gain only on ``clap_general``
+        and ``xclip``.  So an empty list here is a real answer -- "no wrapper
+        beats the typed query on this model" -- and not merely an unfilled
+        slot.  Return ``[]`` (the default) unless you have measured otherwise;
+        :meth:`embed_text_enriched` then degrades to :meth:`embed_text` and the
+        Enrich Sort Descriptions setting is a no-op for that embedder.
         """
         return []
 

--- a/vtscore/media/image/embedder_siglip.py
+++ b/vtscore/media/image/embedder_siglip.py
@@ -51,6 +51,21 @@ class ImageSiglipEmbedder(_CrossModalHFEmbedder):
     def is_default(self) -> bool:
         return True
 
+    @property
+    def description_wrappers(self) -> list[str]:
+        """No wrappers: the CLIP-style prompt ensemble does not help SigLIP.
+
+        #3127 measured enrichment on/off over the image eval corpora and every
+        one of the four non-identity templates inherited from
+        :class:`~vtscore.media.image._cross_modal_shared._CrossModalHFEmbedder`
+        scored *below* the typed query here; the ensemble only netted out to
+        -0.001 +/- 0.002 AP because the bare ``"{text}"`` template averages the
+        plain query back in.  Dropping them makes the Enrich Sort Descriptions
+        setting a no-op on the default image embedder rather than a small,
+        silent loss.  See #3341.
+        """
+        return []
+
     def _load_models_impl(self) -> None:
         if self._model is not None:
             return

--- a/vtscore/media/text/embedder_bge.py
+++ b/vtscore/media/text/embedder_bge.py
@@ -128,13 +128,16 @@ class TextBGEEmbedder(MediaEmbedder):
 
     @property
     def description_wrappers(self) -> list[str]:
-        return [
-            "a document about {text}",
-            "an article discussing {text}",
-            "{text}",
-            "a text passage about {text}",
-            "writing on the topic of {text}",
-        ]
+        """No wrappers: every template measured worse than the typed query.
+
+        #3127 ran the five document-style templates over the text eval corpora
+        and enrichment lost on **45 of 45 categories** for both text
+        embedders (``bge``: -0.059 +/- 0.009 AP).  Retrieval-tuned sentence encoders
+        are trained on queries that already read like the user's typed one, so
+        padding them with "a document about ..." moves the query off the
+        manifold rather than onto it.  See #3341.
+        """
+        return []
 
     def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:

--- a/vtscore/media/text/embedder_e5.py
+++ b/vtscore/media/text/embedder_e5.py
@@ -132,13 +132,16 @@ class TextE5Embedder(MediaEmbedder):
 
     @property
     def description_wrappers(self) -> list[str]:
-        return [
-            "a document about {text}",
-            "an article discussing {text}",
-            "{text}",
-            "a text passage about {text}",
-            "writing on the topic of {text}",
-        ]
+        """No wrappers: every template measured worse than the typed query.
+
+        #3127 ran the five document-style templates over the text eval corpora
+        and enrichment lost on **45 of 45 categories** for both text
+        embedders (``e5``: -0.057 +/- 0.009 AP).  Retrieval-tuned sentence encoders
+        are trained on queries that already read like the user's typed one, so
+        padding them with "a document about ..." moves the query off the
+        manifold rather than onto it.  See #3341.
+        """
+        return []
 
     def _embed_media_impl(self, media: dict) -> Optional[np.ndarray]:
         if self._model is None:


### PR DESCRIPTION
Closes #3341.

Takes **option A** from the issue: drop the wrappers that only hurt, so the one global boolean survives but can no longer cost anything.

## What changed

`description_wrappers` now returns `[]` on the four embedders #3127 measured negative — `siglip`, `clap`, `e5`, `bge`. `embed_text_enriched` already falls back to `embed_text` when the list is empty, so *Enrich descriptions* becomes a no-op there: no new state, no new machinery, no UI question about what the toggle means on a given dataset. `clap_general` (+0.014) and `xclip` (+0.008) keep their templates, and the unmeasured cross-modal siblings are untouched.

Every individual template was negative on all four, so nothing positive is lost. The image ensemble only netted out near zero (−0.001) because the bare `"{text}"` template averages the plain query back in; on text, enrichment lost on **45 of 45** categories for both embedders.

Each override carries its own numbers in a docstring, and the base-class default is now documented as a *measured answer* rather than an unfilled slot — two general CLAP checkpoints disagree on the identical five templates, so a sibling model's prompts are not evidence.

## Keeping the #3127 study runnable

Rebasing onto #3340 surfaced a trap this change would otherwise have set. `scripts/experiments/enrich/run_enrich.py` reads `embedder.description_wrappers` for both its per-wrapper `w<i>` arms and (via `enrich=True`) its `enriched` arm — so emptying that list, which this very study is why we did, would leave a re-run with **no `w<i>` arms at all**, an `enriched` arm identical to `plain`, and a flat zero that looks perfectly healthy. The `{text}` identity that the analyzer checks as its planted answer would have had nothing to check.

The harness now carries a `CANDIDATE_WRAPPERS` table with the pre-#3341 templates, resolves through it when an embedder ships none, and overrides the embedder for the cell so `enrich=True` measures the resolved set. A cell with no resolvable wrappers fails loudly instead of reporting zero. Tests pin the table against the embedders that still ship wrappers, so the copy cannot drift, and check the class patch does not leak past the cell.

## The harness fidelity gap

`run_cells.py`, `text_baseline.py` and `probe_startup_cuts.py` called `embed_text_query` without `enrich`, so every calibration study's opening and click-0 anchor was a plain query no matter what the app was set to. Both simulated-user harnesses now pass an explicit `SEED_ENRICH` that tracks the app's shipped default, with one grep-able line to change if that default ever moves; `vtscore.eval.seed_scores.build_seed_scores` grows the same `enrich` keyword `eval_text_sort` already had. `tests_lib/detectors/test_paired_embedder_seeding.py` pins the value the harness passes, so the fix has a regression guard rather than just a comment.

## Also

- The tooltip #3340 landed said enrichment "measurably hurts text search". After this PR it can't — the text embedders have no wrappers to average. Reworded to say that only the models measured to benefit carry templates, and it is inert on the rest.
- #3340's `docs/ML.md` section describes the measurement; it now also records what #3341 did with it, and its worked example no longer quotes SigLIP's (now deleted) templates.
- `test_default_is_false`'s docstring said the default stays off because the setting is net-negative. It isn't any more — the reason is now that `clap_general`'s +0.014 doesn't clear its own 2 SE. Corrected, so the test documents a true rationale.

## Still owed (not this PR)

`clap_general`'s +0.014 ± 0.009 does not clear its own 2 SE, and ESC-50's 50 categories are already fully used, so more power needs a second audio corpus (UrbanSound8K and GTZAN are both cached on the GRID with eval-ready labels). Option A does not carry that arm because it only *removes* wrappers measured negative — the global default stays `False`, so nothing here rests on the unresolved positive. That measurement remains the open half of #3127, which stays open and keeps its `experiment` label.

## Testing

Full `./run-tests.sh` after the rebase onto current `dev`: **9399 passed, 6 skipped**; pyright, pip-audit, npm audit and the Vitest suite all green.