### PR TITLE
#3329: refuse the domain-shift guard on patch embedders, delete the false null, and close the inventory

### DIFF
--- a/docs/ML.md
+++ b/docs/ML.md
@@ -2,7 +2,7 @@
 
 VTSearch learns a binary classifier from user votes ("good" vs "bad") using a **linear SVM head** — a single `Linear(input_dim, 1)` fitted to the maximum-margin boundary between the two vote classes (hinge loss + L2, class-balanced). The model operates on embeddings produced by pretrained feature extractors (LAION-CLAP for audio, SigLIP for images, X-CLIP for video, E5-base-v2 for text) and outputs a score in [0, 1] for each item in the dataset.
 
-Alongside the head, each dataset carries a **[Coverage Atlas](#coverage-atlas)** — a hierarchical partition of the embedding space that guides the autopilot's diversity sampling and provides calibrated typicality scores for domain-shift detection.
+Alongside the head, each dataset carries a **[Coverage Atlas](#coverage-atlas)** — a hierarchical partition of the embedding space that guides the autopilot's diversity sampling and provides typicality ranks for domain-shift detection.
 
 ## Architecture
 
@@ -321,13 +321,24 @@ How a query is scored:
 3. At every **calibrated** node along the path — at least 20 points *and* `rbar ≥ 0.1` — compute the alignment `t = mu . x` and read a p-value off the node's stored quantile grid.
 4. Average the p-values along the path.
 
-Three details make the p-values honest rather than merely monotone:
+Three details are meant to make the p-values honest rather than merely monotone. Each does real work, and together they still fall short of calibration — see [How good are these p-values?](#how-good-are-these-p-values) below:
 
 - **Leave-one-out calibration.** Each node's quantile grid is built from scores of its own points against the mean direction of the *other* points (closed form on the sphere: `(R.x - 1) / ||R - x||`). Scoring a point against a mean it helped shape is optimistic, and without the correction fresh in-domain queries systematically read as atypical.
 - **The `rbar` gate.** A node with no concentrated direction has a meaningless `mu` and pathological leave-one-out scores; the gate excludes it — notably the always-degenerate root. Sparse branches terminate shallow, which is the adaptive bandwidth: dense regions are judged at fine scale, sparse ones at coarse scale.
 - **Path averaging.** A hard partition has boundary artifacts (a fresh in-domain query near a k-means cell edge looks atypical at leaf scale); averaging across scales smooths them the way a tree ensemble would, at zero extra build cost.
 
-`domain_shift_report(atlas, matrix, alpha=0.05)` aggregates the p-values into a dataset-level verdict. Under no shift, about `alpha` of items fall below `alpha`; the report gives the observed fraction (`frac_atypical` — roughly the shifted proportion), a binomial z-score for the excess, the median p-value, and a headline `shifted` boolean (excess both statistically clear, z > 3, and practically large, ≥ 2×`alpha`).
+`domain_shift_report(atlas, matrix, alpha=0.05)` aggregates the p-values into a dataset-level verdict: the observed fraction below `alpha` (`frac_atypical` — roughly the shifted proportion), a binomial z-score for the excess against the *nominal* rate, the median p-value, and a headline `shifted` boolean (excess both statistically clear, z > 3, and practically large, ≥ 2×`alpha`).
+
+#### How good are these p-values?
+
+Not calibrated, and the gap was unmeasured for as long as the atlas existed. Measured on held-out in-domain data across five embedders ([the #3329 fit-quality study](experiments/2026-08-30-fit-quality-3329/REPORT.md), B1–B6):
+
+- The values are **under-dispersed** — sd 0.250 against the 0.289 a uniform would give — and sit **KS 0.103** from uniform. An in-domain query does not have an `alpha` chance of scoring below `alpha`, so `expected_atypical` is nominal, not measured.
+- **No combiner is calibrated.** Median 0.071, mean (shipped) 0.103, deepest-only 0.132, Fisher 0.186, min 0.329. Dropping the path averaging — the obvious suspect — makes it *worse*, not better.
+- **The shipped combiner looks right at exactly the number a spot check reads** (4.3 % flagged against a nominal 5 %) while being second-worst in overall shape. That is why this went unnoticed.
+- **Patch embedders are where it breaks.** Their spaces are the least concentrated (node `rbar` 0.61 against 0.66–0.70), and `dinov3_patch` puts 13.7 % of its own in-domain items below 0.05 — the verdict fires on 80 % of the atlas's own held-out data against 93 % cross-corpus, a separation of 0.13. The domain-shift route therefore **refuses patch embedders outright** rather than answering with noise. Refitting `alpha` per embedder was priced and does not rescue it; the fix, if it is ever wanted there, is the per-node vMF model.
+
+The **ranking** is unaffected, which is what the autopilot's diversity sampling actually uses (`next_sample` reads each node's score-sorted `ids` and gates on `rbar`, never a p-value). The defect is confined to the calibrated *value* and its one consumer, the domain-shift endpoint.
 
 ### Tutorial: how a diversity session works
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -770,12 +770,19 @@ trusting a detector trained on the reference against the active dataset.
 "frac_atypical": 0.31, "expected_atypical": 0.05, "z_score": 24.1,
 "median_pvalue": 0.18, "shifted": true}`
 
-`frac_atypical` is the fraction of active-dataset items whose calibrated
-typicality p-value falls below `alpha` — roughly the shifted proportion
-(it stays near `expected_atypical` when there is no shift). `shifted` is
-the headline verdict (statistically clear **and** practically large
-excess).
+`frac_atypical` is the fraction of active-dataset items whose typicality
+score falls below `alpha` — roughly the shifted proportion (it stays near
+`expected_atypical` when there is no shift). `shifted` is the headline
+verdict (statistically clear **and** practically large excess).
+
+**Not supported for patch embedders** (`dinov3_patch`, `dinov2_patch`,
+`eupe_patch`), which are refused with 400. In a patch space the guard does
+not separate in-domain from out-of-domain data: on `dinov3_patch` it fires
+on 80 % of the reference's own held-out data against 93 % for a different
+corpus. See [`docs/ML.md`](../ML.md#how-good-are-these-p-values) for what
+the scores are and are not.
 
 400 if either dataset isn't loaded, the reference has no coverage atlas,
-the two datasets use different embedders, or the active dataset equals the
-reference; 403 if access is denied; 404 if the reference doesn't exist.
+the two datasets use different embedders, the reference uses a patch
+embedder, or the active dataset equals the reference; 403 if access is
+denied; 404 if the reference doesn't exist.

--- a/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
+++ b/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
@@ -75,16 +75,19 @@ cosine magnitudes.
 ## Action items
 
 Ranked by value over effort. Nothing here is urgent; item 1 is a correctness bug
-in a user-facing diagnostic, the rest are hygiene.
+in a user-facing diagnostic, the rest are hygiene. Items 1 and 2 shipped with the
+close of #3329; the rest carry their own issues, which are the live home for each
+— this table is the record of what was recommended and why, not a task list to
+keep updated.
 
-| # | do | why | evidence | size |
-|---|---|---|---|---|
-| **1** | **Stop running `domain_shift_report` on patch embedders** — gate it at `registry.py:524` and return "not supported for this embedder" rather than a verdict | 0.13 separation between "my own data" and "a different corpus" is not carrying information; the endpoint currently answers a user's direct question with noise | [B4](#b4b5--the-guards-actual-operating-point), [B6](#b6--the-obvious-repair-priced-it-does-not-work) | one guard clause |
-| **2** | **Delete the false null from `typicality_pvalues`' docstring** and say what the p-values actually are: under-dispersed (sd 0.250 vs 0.289), path-averaged, uncalibrated | The docstring's claim is the reason nobody checked for two years. It is false for all five embedders, not just the broken one | [B1–B2](#b1b3--the-atlass-null-and-why-it-fails) | one docstring |
-| **3** | **Record one timing profile** with `VTSEARCH_RECORD_TIMING` on a real dataset load, and read the r² this PR started keeping | The r² is now persisted but has never been looked at; the fix is untested against real data | [Appendix A](#d--the-timing-statistic-that-was-computed-and-thrown-away) | one dataset load |
-| **4** | **Label coarse browse signs as approximate** in the UI, or stop showing signs below layer 2 | At layers 2–3, 45–48 % of regions have no ground-truth category holding even half their members — the sign names something no single label describes | [C4](#c4--are-the-browse-canvass-named-regions-coherent-inventory-item-10) | UX call, small |
-| **5** | **Audit other cosine-magnitude thresholds for patch embedders** — anywhere in the tree a constant is compared against a similarity | Four independent measurements say `dinov3_patch`'s absolute cosines live in a different range; `domain_shift_report` is the instance that was caught, not necessarily the only one | [§6 above](#the-short-version) | a grep and a think |
-| **6** | *If* the atlas guard is wanted on patch embedders: **fix the per-node vMF model**, not a threshold on top of it | r̄ = 0.61 says the mean-direction model describes this space poorly; every threshold repair was priced and failed | [B6](#b6--the-obvious-repair-priced-it-does-not-work) | real work, unbudgeted |
+| # | do | why | evidence | size | tracked |
+|---|---|---|---|---|---|
+| **1** | **Stop running `domain_shift_report` on patch embedders** — gate it at `registry.py:524` and return "not supported for this embedder" rather than a verdict | 0.13 separation between "my own data" and "a different corpus" is not carrying information; the endpoint currently answers a user's direct question with noise | [B4](#b4b5--the-guards-actual-operating-point), [B6](#b6--the-obvious-repair-priced-it-does-not-work) | one guard clause | **done** |
+| **2** | **Delete the false null from `typicality_pvalues`' docstring** and say what the p-values actually are: under-dispersed (sd 0.250 vs 0.289), path-averaged, uncalibrated | The docstring's claim is the reason nobody checked for two years. It is false for all five embedders, not just the broken one | [B1–B2](#b1b3--the-atlass-null-and-why-it-fails) | one docstring | **done** |
+| **3** | **Record one timing profile** with `VTSEARCH_RECORD_TIMING` on a real dataset load, and read the r² this PR started keeping | The r² is now persisted but has never been looked at; the fix is untested against real data | [Appendix A](#d--the-timing-statistic-that-was-computed-and-thrown-away) | one dataset load | #3345 |
+| **4** | **Label coarse browse signs as approximate** in the UI, or stop showing signs below layer 2 | At layers 2–3, 45–48 % of regions have no ground-truth category holding even half their members — the sign names something no single label describes | [C4](#c4--are-the-browse-canvass-named-regions-coherent-inventory-item-10) | UX call, small | #3346 |
+| **5** | **Audit other cosine-magnitude thresholds for patch embedders** — anywhere in the tree a constant is compared against a similarity | Four independent measurements say `dinov3_patch`'s absolute cosines live in a different range; `domain_shift_report` is the instance that was caught, not necessarily the only one | [§6 above](#the-short-version) | a grep and a think | #3347 |
+| **6** | *If* the atlas guard is wanted on patch embedders: **fix the per-node vMF model**, not a threshold on top of it | r̄ = 0.61 says the mean-direction model describes this space poorly; every threshold repair was priced and failed | [B6](#b6--the-obvious-repair-priced-it-does-not-work) | real work, unbudgeted | #3348 |
 
 ### Do *not* do these
 
@@ -842,7 +845,8 @@ Recorded so the next study does not over-read this one.
 ## E — what is still not measured
 
 Two inventory items are blocked on data rather than effort. They are left open
-rather than answered badly.
+rather than answered badly, and each carries an issue so the blocker survives:
+**#3349** (§11) and **#3350** (§10's naming half).
 
 - **§11 — SIFT/VLAD RANSAC reprojection error and the MatchStats verification
   MLP.** Structural search is *instance* matching, and every corpus in the pile

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -11116,7 +11116,7 @@
     },
     "/api/datasets/registry/{dataset_id}/domain-shift": {
       "get": {
-        "description": "*dataset_id* names the **reference** dataset \u2014 the one a detector was\ntrained on.  Its coverage atlas is queried with every embedding of the\n**active** dataset (the ``X-Dataset-Id`` header), yielding calibrated\ntypicality p-values.  The response summarises them: ``frac_atypical``\nis roughly the proportion of the active dataset that lies outside the\nreference domain, and ``shifted`` is the headline verdict.  Use it\nbefore trusting a detector trained on *dataset_id* against the active\ndataset without hands-on verification.",
+        "description": "*dataset_id* names the **reference** dataset \u2014 the one a detector was\ntrained on.  Its coverage atlas is queried with every embedding of the\n**active** dataset (the ``X-Dataset-Id`` header), yielding calibrated\ntypicality p-values.  The response summarises them: ``frac_atypical``\nis roughly the proportion of the active dataset that lies outside the\nreference domain, and ``shifted`` is the headline verdict.  Use it\nbefore trusting a detector trained on *dataset_id* against the active\ndataset without hands-on verification.\n\n**Refused for patch embedders** (400).  The guard's separation between\n\"my own data\" and \"a different corpus\" collapses to 0.13 on\n``dinov3_patch`` \u2014 close to a constant \u2014 because patch spaces are far\nless concentrated than single-vector ones, and every threshold repair\nwas priced and failed.  See\n``docs/experiments/2026-08-30-fit-quality-3329/REPORT.md`` (B4-B6).",
         "operationId": "dataset_domain_shift",
         "responses": {
           "200": {
@@ -11130,7 +11130,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "Reference dataset has no coverage atlas, embedders differ, or the active dataset has no embeddings."
+            "description": "Reference dataset has no coverage atlas, embedders differ, the reference uses a patch embedder (unsupported), or the active dataset has no embeddings."
           },
           "403": {
             "description": "Access denied for the current user."

--- a/tests/datasets/test_coverage_atlas_endpoint.py
+++ b/tests/datasets/test_coverage_atlas_endpoint.py
@@ -200,3 +200,44 @@ class TestDomainShiftEndpoint:
         )
         assert resp.status_code == 400
         assert "mismatch" in resp.get_json()["message"].lower()
+
+    def test_patch_embedder_returns_400(self, client):
+        """A patch-embedder reference is refused rather than answered with noise.
+
+        The typicality guard does not separate in-domain from out-of-domain
+        data in a patch space - on ``dinov3_patch`` it fires on 80% of the
+        reference's own held-out data against 93% cross-corpus, a separation
+        of 0.13.  See ``docs/experiments/2026-08-30-fit-quality-3329/`` (B4-B6).
+        """
+        from vtscore.state.coverage_atlas import CoverageAtlas
+
+        ref_entry, ref_ctx = _loaded_dataset(120, name="RefPatch", seed_offset=7000, embedder="dinov3_patch")
+        ref_ctx.coverage_atlas = CoverageAtlas({cid: m["embeddings"]["clap"] for cid, m in ref_ctx.medias.items()}, k=3)
+        target_entry, _ = _loaded_dataset(10, name="TargetPatch", seed_offset=8000, embedder="dinov3_patch")
+
+        resp = client.get(
+            f"/api/datasets/registry/{ref_entry['id']}/domain-shift",
+            headers={"X-Dataset-Id": target_entry["id"]},
+        )
+        assert resp.status_code == 400
+        assert "patch embedder" in resp.get_json()["message"].lower()
+
+    def test_single_vector_embedder_still_reports(self, client):
+        """The patch gate reads the capability, so single-vector siblings pass.
+
+        ``dinov3_single`` is the same model family as the refused
+        ``dinov3_patch`` and must not be caught by the gate: what fails is the
+        patch *space*, not the architecture.
+        """
+        from vtscore.state.coverage_atlas import CoverageAtlas
+
+        ref_entry, ref_ctx = _loaded_dataset(120, name="RefSingle", seed_offset=9000, embedder="dinov3_single")
+        ref_ctx.coverage_atlas = CoverageAtlas({cid: m["embeddings"]["clap"] for cid, m in ref_ctx.medias.items()}, k=3)
+        target_entry, _ = _loaded_dataset(10, name="TargetSingle", seed_offset=9500, embedder="dinov3_single")
+
+        resp = client.get(
+            f"/api/datasets/registry/{ref_entry['id']}/domain-shift",
+            headers={"X-Dataset-Id": target_entry["id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["n_items"] == 10

--- a/tests_lib/core/test_dataset_binding.py
+++ b/tests_lib/core/test_dataset_binding.py
@@ -367,3 +367,37 @@ class TestRealRegisteredEmbedder:
         ctx = _ctx_with_embedder(struct_emb.name)
         assert ctx.structural_embedder == struct_emb.name
         assert ctx.supports_geometric_verification is True
+
+
+class TestEmbedderSupportsPatchRegions:
+    """The public single-capability read used to gate patch-embedder callers.
+
+    Added for the #3329 fit-quality finding: the coverage atlas's typicality
+    guard is uninformative in a patch space, so the domain-shift route refuses
+    those references.  The gate reads the declared capability rather than a
+    hard-coded name list, so a newly registered patch embedder is covered the
+    day it lands.
+    """
+
+    def test_agrees_with_the_registry_for_every_embedder(self):
+        from vtscore.embedding.binding import embedder_supports_patch_regions
+        from vtscore.media import all_embedders
+
+        for emb in all_embedders():
+            assert embedder_supports_patch_regions(emb.name) is bool(emb.supports_patch_regions), emb.name
+
+    def test_finds_at_least_one_of_each(self):
+        """Guard against the agreement test passing vacuously on an empty side."""
+        from vtscore.embedding.binding import embedder_supports_patch_regions
+        from vtscore.media import all_embedders
+
+        names = [e.name for e in all_embedders()]
+        assert any(embedder_supports_patch_regions(n) for n in names)
+        assert any(not embedder_supports_patch_regions(n) for n in names)
+
+    def test_blank_and_unknown_names_are_false(self):
+        from vtscore.embedding.binding import embedder_supports_patch_regions
+
+        assert embedder_supports_patch_regions(None) is False
+        assert embedder_supports_patch_regions("") is False
+        assert embedder_supports_patch_regions("no_such_embedder") is False

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -81,6 +81,23 @@ def _capabilities(embedder_name: str) -> tuple[bool, bool, bool]:
     )
 
 
+def embedder_supports_patch_regions(embedder_name: str | None) -> bool:
+    """Whether *embedder_name* produces a patch grid.
+
+    The public single-capability read of the middle flag from
+    :func:`_capabilities`, for callers that need the patch bit on its own
+    rather than the full role-typed triple.  A blank or unregistered name is
+    ``False`` - "cannot do this", not an error - matching :func:`_capabilities`.
+
+    Distinct from asking whether a given *media* carries patch rows: this reads
+    the embedder's declared capability, so it answers the question before any
+    media is in hand (e.g. gating a route on the dataset's registry entry).
+    """
+    if not embedder_name:
+        return False
+    return _capabilities(embedder_name)[1]
+
+
 def expected_dim_for_embedder(embedder_name: str | None) -> int | None:
     """Return the declared output width of *embedder_name*, or ``None`` if unknown.
 

--- a/vtscore/state/coverage_atlas.py
+++ b/vtscore/state/coverage_atlas.py
@@ -1,4 +1,4 @@
-"""Coverage Atlas: hierarchical partition with evidence channels and calibrated typicality.
+"""Coverage Atlas: hierarchical partition with evidence channels and typicality ranks.
 
 The atlas recursively partitions a set of embeddings with k-means, like the
 Diversity Tree it replaces, but keeps what the tree threw away
@@ -17,10 +17,12 @@ Diversity Tree it replaces, but keeps what the tree threw away
   component — so the atlas read at any depth is a multiresolution mixture
   model.
 - **Calibration**: each node stores a quantile grid of its own points'
-  typicality ``t(x) = mu . x``, so a query returns a p-value ("what fraction of the
-  build data looks less typical than x?"), never a raw distance.  This is
+  typicality ``t(x) = mu . x``, so a query returns a rank ("what fraction of
+  the build data looks less typical than x?"), never a raw distance.  This is
   what powers domain-shift detection when a detector trained on dataset A
-  is pointed at dataset B.
+  is pointed at dataset B.  The scores are *ranks on a p-value-like scale*,
+  not calibrated p-values - see :meth:`CoverageAtlas.typicality_pvalues` for
+  the measured deviation and what it costs.
 
 The atlas supports:
 
@@ -34,7 +36,7 @@ The atlas supports:
   a concentrated direction, so the surprise is a representative
   counterexample rather than a lone oddball — with siblings visited
   largest-first so each click covers the biggest unexplored region.
-- Typicality: calibrated p-values for arbitrary query vectors, and a
+- Typicality: a typicality rank for arbitrary query vectors, and a
   dataset-level domain-shift report built on them.
 """
 
@@ -533,15 +535,38 @@ class CoverageAtlas:
     # ------------------------------------------------------------------
 
     def typicality_pvalues(self, matrix: np.ndarray) -> np.ndarray:
-        """Return one calibrated typicality p-value per row of *matrix*.
+        """Return one typicality score per row of *matrix*, on a p-value-like scale.
 
         Each query is centered into the atlas frame, routed down the tree
-        (cosine-nearest child), and scored at the deepest node with at least
-        ``_CALIBRATION_MIN_NODE`` build points — sparse regions terminate
-        shallow, which is the adaptive bandwidth.  The p-value is the
-        fraction of that node's own points whose typicality ``t = mu . x``
-        is below the query's, read off the stored quantiles: small p means
-        "almost nothing the atlas was built on looks this atypical here".
+        (cosine-nearest child), and scored at **every** calibrated node along
+        that path — not only the deepest — with the per-node values averaged.
+        A node qualifies on ``_CALIBRATION_MIN_NODE`` build points and
+        ``_CALIBRATION_MIN_RBAR`` concentration, so sparse regions drop out of
+        the average, which is the adaptive bandwidth.  A node's own value is
+        the fraction of its build points whose typicality ``t = mu . x`` is
+        below the query's, read off the stored quantiles: small means "almost
+        nothing the atlas was built on looks this atypical here".
+
+        **These are not calibrated p-values, despite the name.**  Measured on
+        held-out in-domain data across five embedders, the values are
+        **under-dispersed** (sd 0.250 against the 0.289 a uniform would give)
+        and sit KS 0.103 from uniform — an in-domain query does *not* have an
+        alpha chance of scoring below alpha.  The path averaging is the
+        mechanism: it smooths the hard partition's boundary artifacts, which
+        is why it is here, but a mean of correlated per-node values is
+        narrower than any one of them.  No combiner tried is calibrated
+        either (median 0.071, mean 0.103, deepest-only 0.132, Fisher 0.186,
+        min 0.329), and dropping the averaging makes it worse, not better.
+        The distortion is largest on **patch embedders**, whose spaces are the
+        least concentrated: ``dinov3_patch`` puts 13.7% of its own in-domain
+        items below 0.05.
+
+        So read the output as a *ranking* of typicality — which is all
+        :meth:`next_sample` uses it for, via ``node["ids"]`` — and not as a
+        probability.  Thresholding it against a nominal alpha is what
+        :func:`domain_shift_report` does; see there for what that costs.  Full
+        measurement: ``docs/experiments/2026-08-30-fit-quality-3329/REPORT.md``
+        (B1-B6).
 
         Returns an array of 1.0 (fully typical) for an empty atlas.
         """
@@ -592,7 +617,11 @@ class CoverageAtlas:
         return np.where(p_counts > 0, p_sums / np.maximum(p_counts, 1), 1.0).astype(np.float32)
 
     def typicality_pvalue(self, vector: np.ndarray) -> float:
-        """Return the calibrated typicality p-value of a single query vector."""
+        """Return the typicality score of a single query vector.
+
+        Row-of-one wrapper for :meth:`typicality_pvalues`; see there for why
+        the value is a ranking rather than a calibrated probability.
+        """
         return float(self.typicality_pvalues(np.asarray(vector)[None, :])[0])
 
     # ------------------------------------------------------------------
@@ -736,17 +765,34 @@ class CoverageAtlas:
 def domain_shift_report(atlas: CoverageAtlas, matrix: np.ndarray, alpha: float = 0.05) -> dict:
     """Compare a dataset's embeddings against an atlas and report domain shift.
 
-    Under the null "the queried items are drawn from the atlas's build
-    distribution", typicality p-values are roughly uniform, so about *alpha*
-    of them fall below *alpha*.  A large excess means the atlas's detector is
-    being pointed at data unlike what it was trained on and shouldn't be
-    trusted without hands-on verification.
+    A large excess of atypical items means the atlas's detector is being
+    pointed at data unlike what it was trained on and shouldn't be trusted
+    without hands-on verification.
+
+    **The null this is built on is false, and by how much depends on the
+    embedder.**  It reads as "typicality p-values are roughly uniform under
+    the atlas's own build distribution, so about *alpha* of them fall below
+    *alpha*" — but :meth:`CoverageAtlas.typicality_pvalues` returns
+    under-dispersed, uncalibrated scores (KS 0.103 from uniform on held-out
+    in-domain data, all five embedders measured), so ``expected_atypical`` is
+    nominal rather than measured and ``z_score`` is a binomial z against a
+    rate that does not hold.  On the four single-vector embedders the
+    verdict still separates usefully (``frac_atypical`` 0.00-0.20 on
+    in-domain data against 0.50-0.71 on a different corpus); on
+    ``dinov3_patch`` it fires on 80% of the atlas's *own* held-out data
+    against 93% cross-corpus, a separation of 0.13 — close to a constant.
+    Callers should therefore not run this on a patch embedder; the one
+    production caller (the domain-shift route) refuses those outright.
+    Refitting alpha per embedder was priced and does not rescue it; the fix,
+    if this is ever wanted on patch spaces, is the atlas's per-node vMF
+    model.  Measurements:
+    ``docs/experiments/2026-08-30-fit-quality-3329/REPORT.md`` (B4-B6).
 
     Returns a dict with ``n_items``, ``alpha``, ``frac_atypical`` (observed
-    fraction with p < alpha), ``expected_atypical`` (= alpha), ``z_score``
-    (binomial z of the excess), ``median_pvalue``, and ``shifted`` (True when
-    the excess is both statistically clear, z > 3, and practically large,
-    at least double the expected rate).
+    fraction scoring below alpha), ``expected_atypical`` (= alpha, the
+    nominal rate), ``z_score`` (binomial z of the excess), ``median_pvalue``,
+    and ``shifted`` (True when the excess is both statistically clear,
+    z > 3, and practically large, at least double the nominal rate).
     """
     pvals = atlas.typicality_pvalues(matrix)
     n = int(pvals.shape[0])

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -461,7 +461,10 @@ def build_dataset_coverage_atlas(dataset_id: str):
 @datasets_registry_bp.response(200, DatasetDomainShiftResponseSchema)
 @datasets_registry_bp.alt_response(
     400,
-    description="Reference dataset has no coverage atlas, embedders differ, or the active dataset has no embeddings.",
+    description=(
+        "Reference dataset has no coverage atlas, embedders differ, the reference uses a "
+        "patch embedder (unsupported), or the active dataset has no embeddings."
+    ),
 )
 @datasets_registry_bp.alt_response(403, description="Access denied for the current user.")
 @datasets_registry_bp.alt_response(404, description="Dataset not found.")
@@ -476,11 +479,19 @@ def dataset_domain_shift(dataset_id: str):
     reference domain, and ``shifted`` is the headline verdict.  Use it
     before trusting a detector trained on *dataset_id* against the active
     dataset without hands-on verification.
+
+    **Refused for patch embedders** (400).  The guard's separation between
+    "my own data" and "a different corpus" collapses to 0.13 on
+    ``dinov3_patch`` — close to a constant — because patch spaces are far
+    less concentrated than single-vector ones, and every threshold repair
+    was priced and failed.  See
+    ``docs/experiments/2026-08-30-fit-quality-3329/REPORT.md`` (B4-B6).
     """
     import numpy as np
 
     from vtsearch.auth import get_current_user
     from vtsearch.state import get_active_context, get_context
+    from vtscore.embedding.binding import embedder_supports_patch_regions
     from vtscore.embedding.media_vectors import media_embedding
     from vtscore.state.coverage_atlas import domain_shift_report
 
@@ -511,6 +522,23 @@ def dataset_domain_shift(dataset_id: str):
             message=(
                 f"Embedder mismatch: reference uses {ref_embedder or 'unknown'!r}, "
                 f"active dataset uses {active_embedder or 'unknown'!r}"
+            ),
+        )
+    # Patch spaces are too diffuse for the atlas's fixed-alpha guard to carry
+    # information — measured, not assumed: on ``dinov3_patch`` it fires on 80%
+    # of the reference dataset's *own* held-out data against 93% for a
+    # different corpus, a separation of 0.13, i.e. close to a constant.  Both
+    # obvious repairs (dropping the path averaging, refitting alpha per
+    # embedder) were priced and made it worse.  Refusing is the honest answer;
+    # returning a verdict here answers a direct question with noise.  See
+    # docs/experiments/2026-08-30-fit-quality-3329/REPORT.md (B4-B6).
+    if embedder_supports_patch_regions(ref_embedder):
+        abort(
+            400,
+            message=(
+                f"Domain-shift checks are not supported for patch embedders "
+                f"({ref_embedder!r}): the typicality guard does not separate "
+                f"in-domain from out-of-domain data in a patch space"
             ),
         )
 


### PR DESCRIPTION
Ties off [#3329](https://github.com/samggreenberg/VTSearch/issues/3329). The measurement was delivered by #3332 → #3333 → #3334 → #3337, all merged, but every one of them said `Refs` — so nothing carried a closing keyword and the `dev`→`main` sweep would never have closed the issue. This PR does the two action items that are one-clause fixes, homes the rest, and carries the keyword.

## What ships

**Action item 1 — stop answering a direct question with noise.** `GET /api/datasets/registry/<id>/domain-shift` now returns 400 for a patch-embedder reference instead of a verdict. On `dinov3_patch` the guard fires on **80 % of the reference's own held-out data** against 93 % for a different corpus — a separation of **0.13**, close to a constant. Both obvious repairs were priced in the part-2 grid and both fail: dropping the path averaging makes calibration worse (KS 0.103 → 0.132), and refitting α per embedder makes `dinov3_patch` worse still (separation 0.13 → 0.043).

The gate reads the declared `supports_patch_regions` capability, not a name list, so `dinov2_patch` and `eupe_patch` are covered too and a future patch embedder is covered the day it registers. `dinov3_single` — same model family, single-vector space — deliberately still works, and there is a test pinning that.

**Action item 2 — delete the false null.** `domain_shift_report`'s docstring asserted that "typicality p-values are roughly uniform, so about *alpha* of them fall below *alpha*". That claim is why nobody checked for two years, and it is false for all five embedders measured (KS 0.103 from uniform, sd 0.250 against a uniform's 0.289). Replaced — in the function docstring, in `typicality_pvalues` and its singular sibling, in the atlas module docstring, in `docs/ML.md` and in `docs/api/datasets.md` — with what the scores actually are: under-dispersed, path-averaged typicality **ranks**, with the per-combiner numbers and the patch-embedder failure spelled out.

`docs/ML.md` also loses "Three details make the p-values honest rather than merely monotone" and gains a **How good are these p-values?** section carrying the measurement. The section is explicit that the **ranking** is unaffected — which is all `next_sample` uses, via each node's score-sorted `ids` — so the defect is confined to the calibrated value and its one consumer.

## New public API

`vtscore.embedding.binding.embedder_supports_patch_regions(name)` — the public single-capability read of the middle flag from `_capabilities`, for callers that need the patch bit without the full role-typed triple. Additive; nothing changes for existing callers.

## The rest of the inventory, homed rather than dropped

The report's other four action items and its two blocked inventory items had no home on GitHub, which is how work like this quietly disappears. Each now has an issue, and the report's action table gains a `tracked` column pointing at them:

| | | model |
|---|---|---|
| #3345 | Record one timing profile and read the r² #3334 started keeping | Haiku 4.5 |
| #3346 | Coarse browse signs name something no single label describes | Sonnet 5 |
| #3347 | Audit cosine-magnitude thresholds for patch embedders | Opus 4.8 |
| #3348 | If the guard is wanted on patch spaces: fix the per-node vMF model | Fable 5 |
| #3349 | §11 SIFT/VLAD + MatchStats — needs an instance-level corpus | Opus 4.8 |
| #3350 | §10 Toponymy warning capture — needs real per-item texts | Sonnet 5 |

#3349 is worth a look sooner than it was: the DocMarks/SPODS corpus (#3262/#3338, full build tracked as #3343) is genuinely instance-level and model-free by construction, which is exactly what §11 was missing.

## Verification

Full `./run-tests.sh`: **9399 passed**, 6 skipped, 2 xfailed, all heavy gates green (pyright, pip-audit, npm audit, Vitest). OpenAPI snapshot regenerated for the changed 400 description and the route docstring.

Three new tests: the patch refusal, the single-vector sibling that must *not* be refused, and a library-tier check that `embedder_supports_patch_regions` agrees with the registry for every registered embedder (with a non-vacuity guard, so it cannot pass on an empty side).

## What this deliberately does not do

Everything in the report's "Do not do these", unchanged: no fit-replacement programme for the score mixture (H1 and H4 say the tail error at the operating point is a few per cent and goes with *lower* cost), no switch to the `median` combiner, no removal of the path averaging, no re-enabling of browse compaction, no Gumbel-family fit.

Closes #3329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTfEEx6DSLXWB35UjH2aQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTfEEx6DSLXWB35UjH2aQT)_