### PR TITLE
docs: drop the stale .html suffix from the #3329 report's UMAP-tuning link label

### DIFF
--- a/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
+++ b/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
@@ -737,7 +737,7 @@ is the one fit in this whole inventory that does exactly what it says.
 
 **But compaction is off in production.** `PROJECTION_COMPACT_DEFAULT` is `False`
 and has been since the July UMAP-tuning sweep
-([`2026-07-22-vtsbrowse-umap-tuning.html`](../2026-07-22-vtsbrowse-umap-tuning/report.html)),
+([`2026-07-22-vtsbrowse-umap-tuning`](../2026-07-22-vtsbrowse-umap-tuning/report.html)),
 which found `compact_layout` costs ~2 % taxonomy separability and ~5–6 %
 neighbourhood structure on *every* dataset and embedder. `compact` is not a
 user-facing setting: `resolve_projection_params` hard-wires it to that constant


### PR DESCRIPTION
Finishes what #3342 set out to do. Supersedes that PR, which is now redundant and conflicted.

## What #3342 reported, and what is left of it

#3342 reported that the docs restructure (#3337) moved `docs/reports/2026-07-22-vtsbrowse-umap-tuning.html` to `docs/experiments/2026-07-22-vtsbrowse-umap-tuning/report.html` but missed the reference in the #3329 report, leaving a dangling link that failed `check-docs.py` — a `run-tests.sh` gate *and* `tests_lib/core/test_docs_gate.py::TestRepoIsClean::test_no_drift`, so `dev` was red for everyone.

**That half already landed.** Commit `9e678514` (the #3127 PR) repointed the href independently, and `dev` has been green since: `python scripts/check-docs.py` → `check-docs OK: 283 markdown files, 7 invariants, no drift.`

What `9e678514` did *not* do is update the link's **label**, which #3342's diff also changed. So the line currently names a file that no longer exists while pointing at one that does:

```markdown
([`2026-07-22-vtsbrowse-umap-tuning.html`](../2026-07-22-vtsbrowse-umap-tuning/report.html))
```

## The change

```diff
-([`2026-07-22-vtsbrowse-umap-tuning.html`](../2026-07-22-vtsbrowse-umap-tuning/report.html)),
+([`2026-07-22-vtsbrowse-umap-tuning`](../2026-07-22-vtsbrowse-umap-tuning/report.html)),
```

One line in `docs/experiments/2026-08-30-fit-quality-3329/REPORT.md`. The label now names the experiment directory, matching how the other three references to that sweep already read — `docs/experiments/README.md`, `docs/plans/vtsbrowse.md`, `docs/plans/vtsbrowse-empirical-tuning.md`.

## Why not just rebase #3342

Its branch (`claude/fix-3329-report-link`) forked from `be546eed3` and now reports `mergeable_state: dirty` — its single commit touches the exact line `9e678514` rewrote, so the two conflict. Rebasing would leave only the label hunk, which is what this PR is.

## Verification

Full `./run-tests.sh` on this branch: **`RUN PASSED`** — 9399 passed, 6 skipped, 2 xpassed; every stage-1 gate green (including `check-docs.py`), plus pyright, pip-audit, npm audit, and the Vitest suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjdXhCGENV4mNPFXMm8a5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjdXhCGENV4mNPFXMm8a5X)_