### PR TITLE
Present the weak coarse browse signposts as approximate

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -844,6 +844,16 @@ region when you're zoomed out, finer names inside it as you zoom in. They
 turn "there's a dense blob at the top-left" into "that blob is dogs
 barking."
 
+Some names come with a visible hedge: `~ Foraging birds`, in italics and
+without the slight shadow the other names carry. That marks the broadest
+couple of zoom bands, where a region covers so much ground that no single
+name really describes it - measured across 2832 regions, roughly half the
+regions at those bands have no majority category at all. The name is still
+the best short answer to "what is over here", and it is still worth
+steering by; the `~` is there so you read it as a direction rather than a
+label. Names at the finer bands, and names lettered from a dataset's own
+category paths, never carry it.
+
 The signpost toggle sits in the bottom-left control cluster next to Region
 select, and is greyed out on a map that has no names to show. Naming
 happens when the map is built, so a freshly built map may letter itself a

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1582,6 +1582,11 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
    * text and paints what the layout kept. The view level is *continuous* (the
    * unrounded form of the LOD picker's level), so signs grow/fade smoothly
    * through a zoom rather than stepping at level boundaries.
+   *
+   * Signs the layout marked `approximate` — the coarse bands whose ground-truth
+   * purity is measurably weak (issue #3346) — letter in italic with a `~`
+   * prefix, at slightly lower opacity and with no drop shadow, so they read as
+   * "roughly this way" rather than as a name.
    */
   private drawSigns(ctx: CanvasRenderingContext2D): void {
     const meta = this.meta();
@@ -1597,8 +1602,8 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
         height: this.height,
         viewLevel: viewLevelForZoom(meta.base_radius, this.effZoom, this.targetRadius),
       },
-      (text, fontPx) => {
-        ctx.font = this.signFont(fontPx);
+      (text, fontPx, approximate) => {
+        ctx.font = this.signFont(fontPx, approximate);
         return ctx.measureText(text).width;
       },
     );
@@ -1613,7 +1618,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
       // more-offset shadow — see `signShadow`. Shadow blurs are among the most
       // expensive canvas ops under software rasterization, and the signs repaint
       // on every pan frame — low-effects mode paints them flat (issue #2695).
-      const shadow = this.lowFx ? null : signShadow(sign.scale, sign.fontPx);
+      const shadow = this.lowFx ? null : signShadow(sign.scale, sign.fontPx, sign.approximate);
       ctx.globalAlpha = sign.alpha * 0.6;
       ctx.fillStyle = pillBg;
       if (shadow) {
@@ -1631,16 +1636,20 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
       ctx.shadowOffsetY = 0;
       ctx.globalAlpha = sign.alpha;
       ctx.fillStyle = textColor;
-      ctx.font = this.signFont(sign.fontPx);
-      ctx.fillText(sign.label.text, sign.sx, sign.sy);
+      ctx.font = this.signFont(sign.fontPx, sign.approximate);
+      ctx.fillText(sign.text, sign.sx, sign.sy);
     }
     ctx.restore();
   }
 
   /** Canvas font spec for a sign at `fontPx`. Semibold so the lettering holds
-   *  up over busy density fills without needing an outline. */
-  private signFont(fontPx: number): string {
-    return `600 ${fontPx}px ${SIGN_FONT_FAMILY}`;
+   *  up over busy density fills without needing an outline; italic when the sign
+   *  names one of the weak coarse bands, which is the hedge's quietest half (the
+   *  `~` prefix and the missing shadow carry it at small sizes). Both the
+   *  measure pass and the paint pass go through here so a pill is never sized in
+   *  a face it isn't drawn in. */
+  private signFont(fontPx: number, approximate = false): string {
+    return `${approximate ? 'italic ' : ''}600 ${fontPx}px ${SIGN_FONT_FAMILY}`;
   }
 
   /** Translucent fill + dashed accent border for the in-progress marquee. */

--- a/frontend/src/app/components/browse-canvas/sign-layout.spec.ts
+++ b/frontend/src/app/components/browse-canvas/sign-layout.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  approximateLevelKeys,
+  GROUND_TRUTH_SIGN_SOURCE,
   layoutSigns,
   SIGN_APPEAR_DELTA,
+  SIGN_APPROXIMATE_ALPHA,
+  SIGN_APPROXIMATE_PREFIX,
   SIGN_BASE_FONT_PX,
   SIGN_EXPIRE_DELTA,
   SIGN_FADE_IN_SPAN,
@@ -187,6 +191,13 @@ describe('signShadow', () => {
     expect(big.offsetY).toBeCloseTo(small.offsetY * 2, 10);
     expect(big.alpha).toBeCloseTo(small.alpha, 10);
   });
+
+  it('never lifts an approximate sign off the map, at any scale', () => {
+    // The lift reads as a sign asserting itself; a hedged name should not.
+    expect(signShadow(1.2, SIGN_BASE_FONT_PX)).not.toBeNull();
+    expect(signShadow(1.2, SIGN_BASE_FONT_PX, true)).toBeNull();
+    expect(signShadow(SIGN_SHADOW_MAX_SCALE, 20, true)).toBeNull();
+  });
 });
 
 describe('layoutSigns', () => {
@@ -273,5 +284,153 @@ describe('layoutSigns', () => {
     // ...but a root (no coarser parent naming the area) stays on the map.
     const placed = layoutSigns([label({ level: 3, has_coarser: false })], centeredView(0), measure);
     expect(placed).toHaveLength(1);
+  });
+});
+
+/** The server's zoom-band step between adjacent Toponymy layers
+ *  (`signpost_build._LEVEL_STEP`); a four-layer tree lands on 5.4/3.6/1.8/0. */
+const STEP = 1.8;
+
+/** A four-layer clustered tree, finest (rank 0, `level` 5.4) to coarsest
+ *  (rank 3, `level` 0) — the shape the C4 table measured. Anchors are spread
+ *  across the 800 px viewport so nothing de-clutters or falls off screen. */
+const fourLayers = (): RegionLabelPayload[] =>
+  [0, 1, 2, 3].map((rank) =>
+    label({
+      level: (3 - rank) * STEP,
+      x: -300 + rank * 200,
+      text: `layer-${rank}`,
+      source: 'keyphrase',
+    }),
+  );
+
+/** A view level showing exactly one crisp band (rank 1) and one hedged band
+ *  (rank 2): with bands 1.8 apart and a 4-level-wide visibility window, those
+ *  are the only two of the four in view. */
+const CRISP_AND_HEDGED_VIEW = 3.0;
+
+describe('approximateLevelKeys', () => {
+  it('marks the two coarsest bands of a four-layer tree', () => {
+    const keys = approximateLevelKeys(fourLayers());
+    // Ranks 0 and 1 (levels 5.4, 3.6) are crisp; ranks 2 and 3 (1.8, 0) hedge.
+    expect(keys.has(Math.round(3 * STEP * 1000))).toBe(false);
+    expect(keys.has(Math.round(2 * STEP * 1000))).toBe(false);
+    expect(keys.has(Math.round(STEP * 1000))).toBe(true);
+    expect(keys.has(0)).toBe(true);
+  });
+
+  it('ranks from the finest band present, so a three-layer tree hedges only its coarsest', () => {
+    // A three-layer tree emits 3.6 / 1.8 / 0 — the same absolute levels as a
+    // four-layer tree's ranks 1–3, but only one of them is the C4 table's layer
+    // 2. Ranking, not a level threshold, is what gets this right.
+    const keys = approximateLevelKeys([
+      label({ level: 2 * STEP, text: 'fine' }),
+      label({ level: STEP, x: 200, text: 'mid' }),
+      label({ level: 0, x: 400, text: 'coarse' }),
+    ]);
+    expect(keys.has(Math.round(2 * STEP * 1000))).toBe(false);
+    expect(keys.has(Math.round(STEP * 1000))).toBe(false);
+    expect(keys.has(0)).toBe(true);
+  });
+
+  it('hedges nothing when the tree has two bands or fewer', () => {
+    expect(approximateLevelKeys([label({ level: 0 })]).size).toBe(0);
+    expect(
+      approximateLevelKeys([label({ level: STEP }), label({ level: 0, x: 200 })]).size,
+    ).toBe(0);
+  });
+
+  it('never hedges ground-truth signs, however deep the taxonomy', () => {
+    const gt = fourLayers().map((l) => ({ ...l, source: GROUND_TRUTH_SIGN_SOURCE }));
+    expect(approximateLevelKeys(gt).size).toBe(0);
+  });
+
+  it('buckets levels that differ by a float hair into one band', () => {
+    // Bands are derived from a float product server-side (`(n_layers - 1 - i) *
+    // 1.8`). Two signs of one band splitting into two would shift every rank
+    // below them and hedge a layer the measurement found fine, so the bucketing
+    // has to be tolerant rather than exact.
+    const drifted = 3 * STEP + Number.EPSILON * 4;
+    expect(drifted).not.toBe(3 * STEP);
+    const keys = approximateLevelKeys([
+      label({ level: drifted, text: 'a' }),
+      label({ level: 3 * STEP, x: 200, text: 'b' }),
+      label({ level: STEP, x: 400, text: 'c' }),
+      label({ level: 0, x: 600, text: 'd' }),
+    ]);
+    // Three bands, not four → only the coarsest hedges.
+    expect(keys.size).toBe(1);
+    expect(keys.has(0)).toBe(true);
+  });
+
+  it('ignores empty-text labels when ranking bands', () => {
+    // An unnamed band never reaches the map, so it must not push real bands
+    // one rank coarser.
+    const keys = approximateLevelKeys([
+      label({ level: 3 * STEP, text: '' }),
+      label({ level: 2 * STEP, x: 200, text: 'fine' }),
+      label({ level: STEP, x: 400, text: 'mid' }),
+      label({ level: 0, x: 600, text: 'coarse' }),
+    ]);
+    expect(keys.size).toBe(1);
+    expect(keys.has(0)).toBe(true);
+  });
+});
+
+describe('layoutSigns — approximate coarse bands', () => {
+  it('hedges a coarse band and leaves the fine one alone', () => {
+    const placed = layoutSigns(fourLayers(), centeredView(CRISP_AND_HEDGED_VIEW), measure);
+    expect(placed.map((p) => p.label.text).sort()).toEqual(['layer-1', 'layer-2']);
+
+    const crisp = placed.find((p) => p.label.text === 'layer-1')!;
+    expect(crisp.approximate).toBe(false);
+    expect(crisp.text).toBe('layer-1');
+
+    const hedged = placed.find((p) => p.label.text === 'layer-2')!;
+    expect(hedged.approximate).toBe(true);
+    expect(hedged.text).toBe(`${SIGN_APPROXIMATE_PREFIX}layer-2`);
+    // `label.text` stays the raw name — only the painted text carries the hedge.
+    expect(hedged.label.text).toBe('layer-2');
+  });
+
+  it('dims an approximate sign by SIGN_APPROXIMATE_ALPHA', () => {
+    const placed = layoutSigns(fourLayers(), centeredView(CRISP_AND_HEDGED_VIEW), measure);
+    // Both bands sit inside the opaque plateau, so the only alpha difference is
+    // the hedge.
+    expect(placed.find((p) => p.label.text === 'layer-1')!.alpha).toBe(1);
+    expect(placed.find((p) => p.label.text === 'layer-2')!.alpha).toBeCloseTo(
+      SIGN_APPROXIMATE_ALPHA,
+      6,
+    );
+  });
+
+  it('measures the prefixed text, and tells the measurer which face to use', () => {
+    const seen: [string, boolean][] = [];
+    const spy = (text: string, fontPx: number, approximate: boolean) => {
+      seen.push([text, approximate]);
+      return measure(text, fontPx);
+    };
+    layoutSigns(fourLayers(), centeredView(CRISP_AND_HEDGED_VIEW), spy);
+    expect(seen).toContainEqual(['layer-1', false]);
+    expect(seen).toContainEqual([`${SIGN_APPROXIMATE_PREFIX}layer-2`, true]);
+  });
+
+  it('changes only presentation — the same bands appear either way', () => {
+    const clustered = layoutSigns(fourLayers(), centeredView(CRISP_AND_HEDGED_VIEW), measure);
+    const groundTruth = layoutSigns(
+      fourLayers().map((l) => ({ ...l, source: GROUND_TRUTH_SIGN_SOURCE })),
+      centeredView(CRISP_AND_HEDGED_VIEW),
+      measure,
+    );
+    expect(clustered.map((p) => p.label.text).sort()).toEqual(
+      groundTruth.map((p) => p.label.text).sort(),
+    );
+    expect(groundTruth.every((p) => !p.approximate)).toBe(true);
+  });
+
+  it('leaves a single-band label set entirely un-hedged', () => {
+    const placed = layoutSigns([label({ level: 0 })], centeredView(0), measure);
+    expect(placed[0].approximate).toBe(false);
+    expect(placed[0].text).toBe('Birdsong');
   });
 });

--- a/frontend/src/app/components/browse-canvas/sign-layout.ts
+++ b/frontend/src/app/components/browse-canvas/sign-layout.ts
@@ -32,6 +32,19 @@
 // edge fade and stays visible when zoomed in. The size curve is unchanged —
 // `interpolateScale` clamps outside the band — so a terminal sign simply holds
 // its smallest/largest size at full opacity past the edge instead of vanishing.
+//
+// **Approximate signs.** The coarse end of the stack is measured, and it is
+// weak: across 2832 regions in 25 environments, the two coarsest clustered
+// layers have no ground-truth category holding even half a region's members
+// 45–48 % of the time, against 19 % at the finest layer (issue #3346; the C4
+// section of `docs/experiments/2026-08-30-fit-quality-3329/REPORT.md`). The
+// regions themselves are fine — every one of the 2832 is more self-similar
+// than it is similar to everything else — so the fix is not to re-cluster them
+// nor to stop naming them, but to stop the *sign* claiming more than the
+// region supports. Those bands render hedged rather than confident: a `~`
+// prefix, italic lettering, slightly lower opacity, and no drop shadow (they
+// lie flat on the map instead of floating toward the viewer). See
+// {@link approximateLevelKeys} for which bands qualify.
 
 import type { RegionLabelPayload, ViewTransform } from '../../models/projection.models';
 import { projToScreen } from './view-transform';
@@ -48,6 +61,14 @@ export interface SignAppearance {
 /** A sign that survived visibility + de-cluttering, ready to paint. */
 export interface PlacedSign {
   label: RegionLabelPayload;
+  /** The lettering to paint — `label.text`, prefixed with
+   *  {@link SIGN_APPROXIMATE_PREFIX} when {@link approximate}. Always use this
+   *  rather than `label.text`, so the painted glyphs match the measured pill. */
+  text: string;
+  /** Whether this sign names one of the weak coarse bands and is therefore
+   *  presented as a hedge rather than a name: italic, `~`-prefixed, dimmed, and
+   *  shadowless. See the module comment and {@link approximateLevelKeys}. */
+  approximate: boolean;
   /** Screen (canvas CSS px) centre of the sign. */
   sx: number;
   sy: number;
@@ -77,6 +98,27 @@ export interface SignViewContext {
 export const SIGN_BASE_FONT_PX = 13;
 /** Font the signs render/measure with. Weight rides separately (600). */
 export const SIGN_FONT_FAMILY = 'system-ui, sans-serif';
+
+/** ``source`` of a sign lettered straight from a dataset's ground-truth
+ *  taxonomy (`vtscore/projection/demo_signposts.py`) rather than from
+ *  clustering. Its regions *are* the categories the C4 purity was measured
+ *  against, so they are exact by construction at every depth and are never
+ *  hedged. Any other source is a clustered namer and is hedged at the coarse
+ *  bands — the conservative direction for a namer added later. */
+export const GROUND_TRUTH_SIGN_SOURCE = 'ground-truth';
+
+/** How many bands coarser than the finest a clustered sign must sit before it
+ *  is presented as approximate. Two: the C4 table's layers 2 and 3, counted
+ *  from the finest layer exactly as the measurement counted them. */
+export const SIGN_APPROXIMATE_RANK = 2;
+
+/** Prepended to an approximate sign's lettering, so the hedge survives at sizes
+ *  where the italic alone is easy to miss. */
+export const SIGN_APPROXIMATE_PREFIX = '~ ';
+
+/** Opacity multiplier applied to an approximate sign, so it sits back from the
+ *  crisp names around it. */
+export const SIGN_APPROXIMATE_ALPHA = 0.85;
 
 /** `delta` below which a sign is invisible: it lives that many levels finer
  *  than the view ("far below the user's zoom"). */
@@ -138,8 +180,17 @@ export interface SignShadow {
  * `fontPx`, so the shadow stays proportional to the sign at every size (a bigger
  * sign both is larger and throws a larger shadow, compounding the "coming toward
  * you" read). Pure and total — the canvas painter just applies the result.
+ *
+ * An `approximate` sign never casts one, at any scale: the lift is the cue that
+ * a sign is asserting itself over the map, which is exactly what a hedged name
+ * should not do. It stays flat on the map instead.
  */
-export function signShadow(scale: number, fontPx: number): SignShadow | null {
+export function signShadow(
+  scale: number,
+  fontPx: number,
+  approximate = false,
+): SignShadow | null {
+  if (approximate) return null;
   const span = SIGN_SHADOW_MAX_SCALE - SIGN_SHADOW_MIN_SCALE;
   const lift = span > 0 ? (scale - SIGN_SHADOW_MIN_SCALE) / span : 0;
   if (!(lift > 0)) return null;
@@ -219,11 +270,51 @@ function interpolateScale(delta: number): number {
   return stops[stops.length - 1][1];
 }
 
+/** Quantise a `level` into a bucket key, so the float arithmetic that produced
+ *  it (`(n_layers - 1 - i) * 1.8` server-side) doesn't split one band in two. */
+function levelKey(level: number): number {
+  return Math.round(level * 1000);
+}
+
+/**
+ * The quantised `level`s (see {@link levelKey}) whose signs render as
+ * approximate: the {@link SIGN_APPROXIMATE_RANK} rank and coarser, counting
+ * bands from the **finest** one present.
+ *
+ * Ranking the bands actually in the payload — rather than testing `level`
+ * against a constant — is what makes this match the measurement on every
+ * dataset. Server-side a Toponymy layer `i` (0 = finest) becomes
+ * `level = (n_layers - 1 - i) * 1.8`, so the absolute level of "layer 2"
+ * depends on how many layers that corpus's tree grew; its rank from the finest
+ * band does not, and rank *is* the C4 table's layer index. A tree with three
+ * layers therefore hedges only its coarsest, a four-layer tree its coarsest
+ * two — in both cases exactly the rows the measurement found weak.
+ *
+ * {@link GROUND_TRUTH_SIGN_SOURCE} signs are excluded from both the ranking and
+ * the result: they are not clustered, so the finding does not apply to them.
+ */
+export function approximateLevelKeys(
+  labels: readonly RegionLabelPayload[],
+): ReadonlySet<number> {
+  const bands = new Set<number>();
+  for (const label of labels) {
+    if (!label.text || label.source === GROUND_TRUTH_SIGN_SOURCE) continue;
+    if (Number.isFinite(label.level)) bands.add(levelKey(label.level));
+  }
+  // Descending level == finest band first, so index in this array is the C4
+  // layer index.
+  const finestFirst = [...bands].sort((a, b) => b - a);
+  return new Set(finestFirst.slice(SIGN_APPROXIMATE_RANK));
+}
+
 /**
  * Resolve which signs are visible at the current view and where, de-cluttered
  * so no two pills overlap. `measure` returns the rendered width of `text` at
  * `fontPx` (the canvas passes `ctx.measureText`; tests pass a stub), keeping
- * this module free of any canvas dependency.
+ * this module free of any canvas dependency. It is handed the *painted*
+ * text — `~`-prefixed for an approximate sign — plus that sign's `approximate`
+ * flag, because the hedged bands letter in italic and the pill has to be
+ * measured in the face it is drawn in.
  *
  * De-cluttering is greedy by priority: larger (coarser-relative) signs first,
  * score as the tiebreak, so when a country name and a state name compete for
@@ -234,9 +325,10 @@ function interpolateScale(delta: number): number {
 export function layoutSigns(
   labels: readonly RegionLabelPayload[],
   view: SignViewContext,
-  measure: (text: string, fontPx: number) => number,
+  measure: (text: string, fontPx: number, approximate: boolean) => number,
   baseFontPx: number = SIGN_BASE_FONT_PX,
 ): PlacedSign[] {
+  const approximateBands = approximateLevelKeys(labels);
   const candidates: PlacedSign[] = [];
   for (const label of labels) {
     if (!label.text) continue;
@@ -247,15 +339,29 @@ export function layoutSigns(
     );
     if (!appearance || appearance.alpha <= 0.02) continue;
 
+    const approximate = approximateBands.has(levelKey(label.level));
+    const text = approximate ? SIGN_APPROXIMATE_PREFIX + label.text : label.text;
+    const alpha = approximate ? appearance.alpha * SIGN_APPROXIMATE_ALPHA : appearance.alpha;
     const [sx, sy] = projToScreen(label.x, label.y, view.transform, view.width, view.height);
     const fontPx = baseFontPx * appearance.scale;
-    const w = measure(label.text, fontPx) + 2 * SIGN_PAD_X_EM * fontPx;
+    const w = measure(text, fontPx, approximate) + 2 * SIGN_PAD_X_EM * fontPx;
     const h = SIGN_HEIGHT_EM * fontPx;
     // Cull signs entirely off screen (their pill can't reach the viewport).
     if (sx + w / 2 < 0 || sx - w / 2 > view.width) continue;
     if (sy + h / 2 < 0 || sy - h / 2 > view.height) continue;
 
-    candidates.push({ label, sx, sy, fontPx, scale: appearance.scale, alpha: appearance.alpha, w, h });
+    candidates.push({
+      label,
+      text,
+      approximate,
+      sx,
+      sy,
+      fontPx,
+      scale: appearance.scale,
+      alpha,
+      w,
+      h,
+    });
   }
 
   // Priority: bigger signs first (they're the ones nearest their own zoom


### PR DESCRIPTION
The C4 measurement in the [#3329 fit-quality report](``https://github.com/samggreenberg/VTSearch/blob/dev/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md#c4--are-the-browse-canvass-named-regions-coherent-inventory-item-10)`` put a number on where the browse canvas's region names stop meaning much: at the two coarsest clustered layers, **45–48 % of regions have no ground-truth category holding even half their members**, against 19 % at the finest layer. The regions are fine — all 2832 measured are more self-similar than they are similar to everything else — but the sign over them was a confident single name for a group no single name describes.

Issue #3346 offered two ways out; this takes the first (keep the wayfinding, drop the false precision) rather than culling the coarse signs.

## What changed

Those bands now render as a hedge rather than a name — a leading `~`, italic lettering, opacity ×0.85, and no drop shadow, so they lie flat on the map instead of floating toward the viewer:

| crisp (fine band) | approximate (coarse band) |
|---|---|
| **Rainfall** | *~ Rainfall* |

Culling the coarse signs instead would not have been the simpler option it looks: those layers *are* the low-zoom signs, so the zoomed-out map would go essentially unlettered, and the backend's `has_coarser` / `has_finer` terminal flags — which exist precisely so a region is never left nameless — would then be wrong for every survivor.

## Which bands qualify

Derived from the label payload rather than tested against a level constant, so it matches the measurement on every dataset. Server-side a Toponymy layer `i` (0 = finest) becomes `level = (n_layers - 1 - i) * 1.8`, so the absolute level of "layer 2" depends on how many layers that corpus's tree grew — while its **rank from the finest band present** does not, and that rank *is* the C4 table's layer index. A three-layer tree therefore hedges only its coarsest band, a four-layer tree its coarsest two.

Ground-truth signposts (`demo_signposts.py`, `source: "ground-truth"`) are exempt at every depth: their regions are the categories the purity was measured *against*, so they are exact by construction. Any other namer is clustered and gets hedged — the conservative direction for a source added later.

Deriving it client-side also means the change applies to projections already on disk, with no rebuild and no payload change.

## Files

- `frontend/src/app/components/browse-canvas/sign-layout.ts` — new `approximateLevelKeys()` (band ranking + float-tolerant bucketing), `PlacedSign.text` / `.approximate`, the alpha multiplier, and `signShadow(…, approximate)` returning `null`. The `measure` callback now takes the painted text plus the flag, so a pill is never sized in a face it isn't drawn in.
- `frontend/src/app/components/browse-canvas/browse-canvas.component.ts` — `signFont()` gains the italic face; measure and paint both route through it.
- `docs/user/USER_GUIDE.md` — one paragraph in the Signposts section saying what the mark means.

## Testing

- `./run-tests.sh` full: **RUN PASSED**, 9399 passed / 6 skipped, all gates green (pyright, pip-audit, npm audit, Vitest).
- 12 new specs in `sign-layout.spec.ts` covering the ranking (four-layer, three-layer, ≤2-band, ground-truth, float-hair bucketing, empty-text bands), the hedged text/alpha/measure-face, that the hedge changes presentation only and not which signs appear, and that `signShadow` never lifts an approximate sign.
- Verified in real chromium, not just jsdom: `ctx.font` reads back `italic 600 13px system-ui, sans-serif`, so the canvas font shorthand actually parses (a silently-ignored font string is exactly the failure jsdom would have waved through), and the two treatments are legibly distinct over a busy density fill.

No screenshot reshoot is owed: the `browse-view` shot uses `syn-imgs`, whose signposts are ground-truth and therefore unhedged.

Closes #3346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LexoWisLwL6zJTWjbMtDR

---
_Generated by [Claude Code](https://claude.ai/code/session_018LexoWisLwL6zJTWjbMtDR)_