### PR TITLE
#3329 item 5: audit cosine-magnitude thresholds for patch embedders

### DIFF
--- a/docs/experiments/2026-08-30-fit-quality-3329/AUDIT-cosine-thresholds.md
+++ b/docs/experiments/2026-08-30-fit-quality-3329/AUDIT-cosine-thresholds.md
@@ -1,0 +1,224 @@
+# Cosine-magnitude thresholds, audited for patch embedders (issue #3347)
+
+Action item 5 of the [#3329 fit-quality report](REPORT.md). That report found
+`dinov3_patch`'s embedding space to be far less concentrated than the four
+single-vector spaces, four independent ways, and closed with a standing warning:
+the coverage atlas's fixed-α typicality guard is *an* instance of a constant
+fitted on single-vector cosine magnitudes, **not necessarily the only one**.
+
+This is the inventory. Every place in `vtscore/` and `vtsearch/` where a
+constant meets a cosine similarity or a cosine distance, what it was fitted on,
+whether it runs on a patch embedder's vectors, and whether it still means there
+what it meant where it was fitted.
+
+**Headline: one live-path hit, and it holds.** `_CALIBRATION_MIN_RBAR` in the
+coverage atlas is the only fixed cosine-magnitude constant on the click loop,
+and #3329's own r̄ table clears it by ~4× at the worst measured decile of the
+worst embedder. Two other real hits are inert — one has no consumer, one is an
+experiment arm. Everything else in the loop draws its line from the data it is
+handed, which is why the sweep came back this quiet.
+
+---
+
+## Method, and what would have been missed
+
+The grep the issue asked for is `constant [<>] cosine`, and on its own it finds
+**nothing** — no line in the production tree compares a similarity to a literal.
+That result is misleading, and worth recording so the next pass does not stop
+there. The two real code hits are a **multiplication** (`sims * 4.0`) and a
+**convex blend** (`alpha * cos_d + …`); neither is a comparison. The sweep that
+found them looks for a numeric literal anywhere in a statement that also names a
+cosine-valued quantity, then reads each hit.
+
+Scope is production code: `vtscore/` and `vtsearch/`, plus `frontend/src/`.
+`scripts/experiments/` is deliberately out — those are per-study arms whose
+constants are the study's subject. `vtscore/eval/` is **in**, because the
+default arm is the shipped algorithm (see `CLAUDE.md`); its named arms are
+called out as such where they appear.
+
+A "hit" is a constant whose meaning changes with the absolute scale of the
+cosines it meets. A rank, a quantile, a ratio's indifference point, or a
+threshold refit on the observed distribution is scale-free and is **not** a hit,
+however many literals sit near it.
+
+---
+
+## The hits
+
+### 1. `_CALIBRATION_MIN_RBAR = 0.1` — the only one on the live path
+
+`vtscore/state/coverage_atlas.py`. A floor on each node's mean resultant length
+r̄ = ‖Σ unit vectors‖ / n, which is a cosine magnitude: the average cosine of a
+node's members to their own mean direction. Two consumers, and they are not
+equally exposed:
+
+| consumer | reachability |
+|---|---|
+| node calibration → `typicality_pvalues` → `domain_shift_report` | one on-demand HTTP endpoint, and #3351 now refuses it outright on patch embedders |
+| **`CoverageAtlas.next_sample`** | **the click loop** — autopilot's `new` phase and the diversity probe |
+
+The second is the exposure that matters, and #3329 traced it explicitly:
+`next_sample` "reads `node["ids"]`, which is sorted by raw `mu · x`, and gates
+on `node["rbar"]`". The gate decides whether to probe a node's **typical half**
+or the **whole node**. Below the floor the typicality ordering is treated as
+noise and the whole node is probed.
+
+Was the constant fitted? No — it is a degeneracy guard, aimed at the root, whose
+resultant vanishes by construction after centering. That provenance is what
+saves it: it is not asserting "this space is concentrated to degree 0.1", it is
+asserting "this node has *a* direction at all".
+
+Checked against measurement rather than assumed. #3329's part-2 grid reports
+node r̄ per embedder:
+
+| embedder | node r̄ (median) | r̄ 10th pct |
+|---|---|---|
+| `clip` | 0.70 | 0.53 |
+| `siglip` | 0.69 | 0.52 |
+| `siglip2_l` | 0.67 | 0.49 |
+| `clip_l` | 0.66 | 0.50 |
+| **`dinov3_patch`** | **0.61** | **0.38** |
+
+The worst decile of the least concentrated space sits at 3.8× the floor.
+**Verdict: correct on patch spaces, with real margin.** The residual is that the
+grid reports a median and a 10th percentile, not a full distribution, and
+`dinov3_patch`'s atlas splits to the `max_depth` cap of 10 — deeper nodes are
+smaller and less concentrated. Nothing below the 10th percentile was measured.
+The margin recorded above is now in the constant's comment, so the next reader
+inherits the check instead of redoing it.
+
+### 2. `torch.softmax(sims * 4.0)` — real, and inert
+
+`vtscore/media/patch_embed.py`, the CLS-cosine saliency proxy. An inverse
+temperature applied directly to per-patch cosines against the CLS vector. How
+peaked the resulting map is depends entirely on the spread of those cosines, so
+4.0 means something different in every embedding space.
+
+Provenance is the giveaway: the comment said it was "empirically tunable in the
+caltech101_s sweep alongside K and α" — K and α of the HAC region tree, which
+**#2886 deleted**. Nothing has read `patch_saliency` since:
+`_attach_patch_grid_to_media` in `vtscore/datasets/stages/embedding.py` says so
+in its docstring ("nothing downstream reads it now that leaf pooling is gone"),
+and a repo-wide search for the attribute finds only its own construction and
+three test assertions.
+
+**Verdict: a genuine cosine-magnitude constant with zero blast radius.** Left in
+place — re-tuning a number with no consumer is not an improvement — but the
+comment now records that it is inert, why it is embedder-dependent, and that
+anything reviving saliency-weighted pooling must re-derive it per embedder
+rather than inherit 4.0. This is the item most likely to bite later, precisely
+because it looks tuned and is sitting in live code.
+
+### 3. `alpha = 0.5` in the HAC merge affinity — experiment arm, not comparable across embedders
+
+`vtscore/eval/patch_styles.py`, `build_patch_hac_tree`:
+`blended = alpha * cos_d + (1 - alpha) * spatial`.
+
+Both terms are nominally in [0, 1]. Only one of them fills that range. The
+spatial term is a normalised grid distance and spans its range on every image by
+construction; `cos_d = (1 − cos)/2` spans only what the embedder's within-image
+patch cosines span. In a concentrated space `cos_d` stays in a narrow band near
+0 and the merge order comes out mostly **spatial**; in a less concentrated one
+the cosine term carries more of the decision at the same nominal α. The
+*effective* α is therefore per-embedder.
+
+This is an arm (`max_patch_hac`, `max_patch_pca_hac`), never the default — the
+shipped path has had no tree since #2886 — so it is out of scope for the
+"default arm is the app" rule. It matters anyway, because cross-embedder
+comparison is exactly what that arm exists to do: an α-sweep read across
+embedders is not reading the same knob twice.
+
+**Verdict: a caveat, not a bug.** Whitening `cos_d` per image would fix it and
+would also change the arm's definition, so this is recorded at the call site
+rather than edited. One honest limit: #3329 measured **media-level** cosines
+(atlas nodes, browse regions, Shepard distances), never within-image
+patch-to-patch cosines. The mechanism above is arithmetic; its magnitude on
+`dinov3_patch` specifically is a prediction, not a measurement.
+
+### 4. `return 0.5` in `calculate_gmm_threshold` — degenerate branch
+
+`vtscore/training/thresholds.py`. The function is the app's threshold for every
+cosine and text sort, and it is scale-adaptive by construction (a 2-component
+GMM refit on the scores it is handed). The single literal is the fewer-than-two-
+scores return: a sigmoid-scale sentinel handed back on a cosine scale.
+
+**Verdict: harmless, documented.** With at most one item ranked there is nothing
+for a threshold to separate. Noted in the docstring so it is not mistaken for a
+fitted cosine cutoff.
+
+---
+
+## Checked, and fine — with the reason
+
+The useful half of the answer. Each of these looks like a candidate to a grep
+and is immune for a stated reason, so a future pass can skip it or re-check the
+reason rather than re-derive it.
+
+**Scale-free by construction — the loop's whole defence.**
+
+| site | why the scale cannot reach it |
+|---|---|
+| `calculate_gmm_threshold`, the conformal rule, `fold_anchored_gmm_threshold` (`vtscore/training/thresholds.py`) | every threshold on the sort/vote path is **refit on the observed distribution**. This is why a patch embedder's compressed cosines produce a compressed threshold automatically, and it is the single biggest reason this audit is short |
+| `support_pvalues` (`vtscore/detectors/evidence_coverage.py`) | a rank-based inductive-conformal p-value — the query's k-NN distance against the class's own leave-one-out distances. Uniform under exchangeability **whatever the geometry**. Same *shape* as the atlas guard, none of its defect: no path averaging, no vMF model, no α fitted on a magnitude |
+| `trust_scores` … `TS < 1.0` (same file) | 1.0 is the exact indifference point of a **ratio** of distances (other class ÷ predicted class), not a fitted magnitude. It survives any monotone rescaling of the distances |
+| `@q0.05` startup cuts (`vtscore/eval/startup_schedule.py`) | an explicit rank quantile of the live sort's own scores |
+| centroid and query rankings (`vtscore/eval/al_strategies.py`) | cosines feed `min`/`max` only; the cut is the sort's own GMM line |
+| vocabulary tagging (`vtscore/projection/signpost_texts.py`) | top-*k* by dot product. No magnitude floor for a term to qualify |
+
+**Not embedder cosines at all** — the category a naive grep flags hardest.
+
+| site | what the constant actually meets |
+|---|---|
+| `_THRESHOLDS = {"image": 4, "text": 4}` (`vtscore/state/near_dupes.py`) | Hamming distance out of 64 bits, over pHash/SimHash of **pixels and text**. The module docstring draws this line itself: a perceptual hash answers "these *are* the same thing", an embedding answers "these *mean* the same thing" |
+| `_LOWE_RATIO = 0.75` (`vtscore/media/structural.py`) | ratio of two SIFT descriptor **L2** distances — and a ratio at that |
+| `_LG_FILTER_THRESHOLD = 0.1` (`vtscore/media/structural_splg.py`) | LightGlue match confidence |
+| `_RANSAC_REPROJ_THRESHOLD = 0.02`, `_MIN_SANE_SCALE`/`_MAX_SANE_SCALE` (`vtscore/media/structural_geometry.py`) | normalised pixel reprojection error and a scale sanity band |
+| `STRUCTURAL_DECISION_THRESHOLD = 0.5` (`vtscore/training/structural_similarity.py`) | a calibrated match **probability**; also the structural slot, a different embedder from the patch slot |
+| scene-cut threshold (`vtscore/media/video/clipper.py`) | Pearson correlation of hue×saturation **histograms** |
+| VAD threshold, `top_db` (`vtscore/media/audio/clipper.py`) | Silero speech probability; amplitude in dB |
+| detection threshold (`vtscore/media/image/clipper.py`) | object-detector confidence |
+| `PROJECTION_MIN_DIST = 0.1` (`vtscore/config.py`) | a UMAP **output-space** parameter. The metric is cosine; the constant is not |
+| compaction radius (`vtscore/projection/compaction.py`) | a 90th percentile of 2-D layout coordinates — data-driven, and off by default |
+| `_LOGISTIC_K = 8.0` (`vtscore/training/blend_schedules.py`) | warps a vote-count ramp in [0, 1] |
+| `SMART_FLAT_THRESHOLD`, `STABLE_*` (`vtscore/eval/autopilot_flow.py`) | a relative cost slope and a class-flip rate. Both dimensionless |
+| `NO_GOOD_THRESHOLD = 2.0` (`vtscore/training/thresholds.py`) | a sentinel chosen to exceed **any** score; still above the cosine maximum of 1 |
+
+**No cosine constant to find.** The production MaxPatch path —
+`pool_box_from_media`, `bad_negative_vecs`, `media_score_rows` — selects rows
+spatially and floods all of them; there is no similarity threshold anywhere in
+it. `frontend/src/` contains no similarity constant at all: the SPA reads
+`score`/`similarity` for display and takes its cutoff from the server.
+
+---
+
+## Prior art: where the codebase already got this right
+
+Two patterns worth copying rather than reinventing, both already in the tree:
+
+- **Key on the capability, not the space's numbers.**
+  `PRODUCTION_SPLIT_BY_SPACE` (`vtscore/training/thresholds.py`) is a dict on
+  `single_vector` vs `patch`, because #3287 measured the two wanting opposite
+  train/calibrate splits. It carries the measurement in its comment.
+- **Refuse rather than answer.** #3351 gates the domain-shift endpoint on the
+  declared `supports_patch_regions` capability — not a name list — so every
+  present and future patch embedder is covered the day it registers.
+
+The failure mode this audit was looking for is the inverse of both: a plausible
+number, no runtime check that the data resembles what it was fitted on, and a
+wrong answer that arrives as confident output rather than an error. Item 1 has
+the shape and survives on measurement; item 2 has the shape and has no reader;
+item 3 has the shape inside an arm. Nothing else in the tree has the shape.
+
+---
+
+## What this does not cover
+
+- **Within-image patch-to-patch cosine spread is unmeasured.** #3329 read
+  media-level vectors throughout. Item 3's magnitude, and any future
+  saliency-weighted pooling, both turn on that distribution.
+- **`typicality_pvalues` remains callable on a patch atlas** as library API.
+  #3351 gates the *endpoint*; a direct library caller still gets the
+  miscalibrated values. Fixing the model rather than the caller is #3348.
+- **Learned constants are out of scope by construction.** MLP weights, GMM
+  parameters, and conformal quantiles are refit per detector per session; they
+  are not tuned numbers and cannot go stale against a new embedder.

--- a/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
+++ b/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md
@@ -68,7 +68,11 @@ Atlas node r̄ 0.61 vs 0.66–0.70, a displaced Shepard distance range, and both
 the within- and between-cluster region cosines. Its space is far less
 concentrated than the four single-vector spaces, which is why a fixed α fails on
 it — and a standing warning about any other threshold in the tree tuned on
-cosine magnitudes.
+cosine magnitudes. That warning has since been discharged: the
+[inventory](AUDIT-cosine-thresholds.md) found one such constant on the live
+click loop (the atlas's own `_CALIBRATION_MIN_RBAR`, which the r̄ table below
+clears by ~4× at `dinov3_patch`'s worst measured decile), one inert, and one
+confined to an experiment arm.
 
 ---
 
@@ -86,7 +90,7 @@ keep updated.
 | **2** | **Delete the false null from `typicality_pvalues`' docstring** and say what the p-values actually are: under-dispersed (sd 0.250 vs 0.289), path-averaged, uncalibrated | The docstring's claim is the reason nobody checked for two years. It is false for all five embedders, not just the broken one | [B1–B2](#b1b3--the-atlass-null-and-why-it-fails) | one docstring | **done** |
 | **3** | **Record one timing profile** with `VTSEARCH_RECORD_TIMING` on a real dataset load, and read the r² this PR started keeping | The r² is now persisted but has never been looked at; the fix is untested against real data | [Appendix A](#d--the-timing-statistic-that-was-computed-and-thrown-away) | one dataset load | #3345 |
 | **4** | **Label coarse browse signs as approximate** in the UI, or stop showing signs below layer 2 | At layers 2–3, 45–48 % of regions have no ground-truth category holding even half their members — the sign names something no single label describes | [C4](#c4--are-the-browse-canvass-named-regions-coherent-inventory-item-10) | UX call, small | #3346 |
-| **5** | **Audit other cosine-magnitude thresholds for patch embedders** — anywhere in the tree a constant is compared against a similarity | Four independent measurements say `dinov3_patch`'s absolute cosines live in a different range; `domain_shift_report` is the instance that was caught, not necessarily the only one | [§6 above](#the-short-version) | a grep and a think | #3347 |
+| **5** | **Audit other cosine-magnitude thresholds for patch embedders** — anywhere in the tree a constant is compared against a similarity | Four independent measurements say `dinov3_patch`'s absolute cosines live in a different range; `domain_shift_report` is the instance that was caught, not necessarily the only one | [§6 above](#the-short-version) | a grep and a think | #3347, [inventory](AUDIT-cosine-thresholds.md) |
 | **6** | *If* the atlas guard is wanted on patch embedders: **fix the per-node vMF model**, not a threshold on top of it | r̄ = 0.61 says the mean-direction model describes this space poorly; every threshold repair was priced and failed | [B6](#b6--the-obvious-repair-priced-it-does-not-work) | real work, unbudgeted | #3348 |
 
 ### Do *not* do these

--- a/vtscore/eval/patch_styles.py
+++ b/vtscore/eval/patch_styles.py
@@ -479,6 +479,18 @@ def build_patch_hac_tree(
         cos_d = np.clip((1.0 - sim @ sim.T) * 0.5, 0.0, 1.0)
         centers = np.stack([(cols + 0.5) / width, (rows + 0.5) / height], axis=1).astype(np.float32)
         spatial = np.sqrt(((centers[:, None, :] - centers[None, :, :]) ** 2).sum(-1)) / np.sqrt(2.0)
+        # *alpha* mixes two terms that share a nominal [0, 1] range but not a
+        # realised one: *spatial* fills its range on every image by
+        # construction, while *cos_d* only spans whatever the embedder's
+        # patch-to-patch cosines happen to span.  A concentrated space keeps
+        # cos_d in a narrow band near 0 and the merge order comes out mostly
+        # spatial; a less concentrated one gives the cosine term more say at
+        # the same *alpha*.  So the **effective** alpha is per-embedder, and
+        # `max_patch_hac` results are not alpha-comparable across embedders
+        # (#3347; the within-image patch cosine spread was not itself measured
+        # by #3329, which read media-level vectors).  Whitening cos_d per image
+        # would fix it, and would change the arm's definition — so it is a
+        # caveat here rather than an edit.
         blended = alpha * cos_d + (1.0 - alpha) * spatial
         np.fill_diagonal(blended, 0.0)
         linkage_matrix = linkage(squareform(blended, checks=False), method="average")

--- a/vtscore/media/patch_embed.py
+++ b/vtscore/media/patch_embed.py
@@ -176,8 +176,20 @@ def eupe_features_to_patch_output(
     patches_n = patches / torch.clamp(patches.norm(dim=-1, keepdim=True), min=1e-8)
     sims = patches_n @ cls_n  # (N,) cosine similarity per patch to CLS
     # Softmax with a moderate temperature so a few cells dominate without
-    # collapsing to a one-hot. Empirically tunable in the caltech101_s
-    # sweep alongside K and α.
+    # collapsing to a one-hot.
+    #
+    # The 4.0 is an inverse temperature applied directly to **cosine
+    # magnitudes**, so how peaked this map comes out depends on the spread of
+    # patch-to-CLS cosines in the embedder's space, which differs per embedder
+    # (#3329 part 2 measured dinov3_patch as the least concentrated space in
+    # its grid).  It was tuned in the caltech101_s sweep alongside the K and α
+    # of the HAC region tree — the tree #2886 deleted — and nothing has read
+    # ``patch_saliency`` since: ingest drops it (see
+    # ``vtscore.datasets.stages.embedding._attach_patch_grid_to_media``) and no
+    # other caller exists.  So the #3347 audit found the constant real but
+    # inert, and left it rather than re-tuning a number with no consumer.
+    # Anything that revives saliency-weighted pooling must re-derive this
+    # per embedder rather than inherit 4.0.
     saliency = torch.softmax(sims * 4.0, dim=-1).reshape(side, side)
 
     return PatchEmbedOutput(

--- a/vtscore/state/coverage_atlas.py
+++ b/vtscore/state/coverage_atlas.py
@@ -86,6 +86,18 @@ _CALIBRATION_MIN_NODE = 20
 # one point from a near-zero resultant flips it), which reads every query as
 # "more typical than everything".  K-means cells are cohesive and land well
 # above this floor.
+#
+# This is a **cosine-magnitude** constant, and the one such constant on the live
+# click loop: :meth:`CoverageAtlas.next_sample` gates on it too, to decide
+# whether to probe a node's typical half or the whole node.  Absolute cosines
+# live in different ranges per embedder, so the #3347 audit checked the margin
+# against the #3329 part-2 grid rather than assuming it.  Node r̄ by embedder
+# (median / 10th percentile): clip 0.70/0.53, siglip 0.69/0.52, siglip2_l
+# 0.67/0.49, clip_l 0.66/0.50, and the least concentrated space in the grid,
+# dinov3_patch, 0.61/0.38.  The worst decile of the worst embedder clears this
+# floor by ~4x, and the floor exists to catch the *degenerate* r̄ ~ 0 case (the
+# root), not to assert concentration — so it holds on patch spaces.  The tail
+# below the 10th percentile was not measured; that is the residual.
 _CALIBRATION_MIN_RBAR = 0.1
 
 # Quantile grid stored per node for typicality calibration.  21 points

--- a/vtscore/training/thresholds.py
+++ b/vtscore/training/thresholds.py
@@ -1477,6 +1477,14 @@ def calculate_gmm_threshold(scores: list[float]) -> float:
         A float threshold. Scores at or above this value are classified as Good.
         Returns ``0.5`` when fewer than 2 scores are provided; falls back to
         the median of scores if GMM fitting fails.
+
+    The two-Gaussian fit is refit on whatever distribution it is handed, so this
+    is scale-adaptive: it is the reason every cosine sort draws an embedder-
+    appropriate line without a per-embedder constant (#3347).  The ``0.5``
+    literal is the sole exception — a sigmoid-scale sentinel returned on a
+    haystack of 0 or 1 items, where there is no distribution to fit.  On a
+    cosine sort it is a cosine-scale number that was never fitted on cosines;
+    with at most one item ranked it changes nothing, which is why it stands.
     """
     if len(scores) < 2:
         return 0.5


### PR DESCRIPTION
Action item 5 of the [#3329 fit-quality report](https://github.com/samggreenberg/VTSearch/blob/dev/docs/experiments/2026-08-30-fit-quality-3329/REPORT.md): the report's §6 closed with a standing warning that `domain_shift_report` was the fixed-α-on-cosine-magnitudes instance that got *caught*, not necessarily the only one. This discharges it.

The inventory ships as [`docs/experiments/2026-08-30-fit-quality-3329/AUDIT-cosine-thresholds.md`](https://github.com/samggreenberg/VTSearch/blob/claude/issue-3347-z0646a/docs/experiments/2026-08-30-fit-quality-3329/AUDIT-cosine-thresholds.md), linked from the report's action table and from §6.

## The finding

**One fixed cosine-magnitude constant is on the live click loop, and it holds.** Three real hits total; none needs a fix.

| | constant | reachability | verdict |
|---|---|---|---|
| 1 | `_CALIBRATION_MIN_RBAR = 0.1` (`coverage_atlas.py`) | **the click loop** — `next_sample` gates on it | correct, with ~4× margin |
| 2 | `torch.softmax(sims * 4.0)` (`patch_embed.py`) | none — no consumer since #2886 | real constant, zero blast radius |
| 3 | `alpha = 0.5` in the HAC merge blend (`patch_styles.py`) | `max_patch_hac` arms only | caveat: not α-comparable across embedders |

**Item 1 is the one worth reading.** `_CALIBRATION_MIN_RBAR` has two consumers, and only one of them is the diagnostic endpoint #3351 just gated: the other is `CoverageAtlas.next_sample`, which #3329 itself traced as gating on `node["rbar"]` to decide whether to probe a node's typical half or the whole node. So it sits in autopilot's `new` phase and the diversity probe. Checked against #3329's own r̄ table rather than assumed — `dinov3_patch`'s **10th percentile** node r̄ is **0.38** against the 0.1 floor, and the floor guards the degenerate r̄ ≈ 0 case (the root, whose resultant vanishes after centering) rather than asserting concentration. It holds on patch spaces. The margin now lives in the constant's comment, so the next reader inherits the check instead of redoing it. Residual: the grid reports a median and a 10th percentile, not a tail.

**Item 2 is the one most likely to bite later**, precisely because it looks tuned and sits in live code. The comment claimed it was "empirically tunable in the caltech101_s sweep alongside K and α" — K and α of the HAC region tree that **#2886 deleted**. Nothing has read `patch_saliency` since; ingest drops it (`_attach_patch_grid_to_media` says so) and a repo-wide search finds only its own construction and three test assertions. Left in place — re-tuning a number with no consumer is not an improvement — but the comment now records that it is inert and that anything reviving saliency-weighted pooling must re-derive it per embedder.

**Item 3** mixes a cosine term whose realised range is per-embedder with a spatial term that fills [0, 1] on every image, so the *effective* α differs per embedder. An arm, never the default — but cross-embedder comparison is what that arm is for, so an α-sweep read across embedders is not reading the same knob twice.

## Why the grep the issue asked for finds nothing

Worth recording so the next pass doesn't stop there: **no line in the production tree compares a similarity to a literal.** Both real code hits are a multiplication and a convex blend, not a comparison. The sweep that found them looks for a numeric literal anywhere in a statement that also names a cosine-valued quantity.

## The checked-and-fine half

The issue asked for it explicitly, and it is most of the document — each entry with the reason, so a future pass re-checks a claim rather than re-deriving it. Two clusters:

- **Scale-free by construction.** Every threshold on the sort/vote path is refit on the observed distribution (`calculate_gmm_threshold`, the conformal rule, `fold_anchored_gmm_threshold`) — which is the single biggest reason this audit is short. `evidence_coverage`'s `D` is a rank-based inductive-conformal p-value, uniform under exchangeability whatever the geometry; its `TS < 1.0` is a *ratio*'s indifference point, not a fitted magnitude. Same shape as the atlas guard, none of its defect. Plus `@q0.05` rank quantiles, `al_strategies` rankings, and top-*k* vocabulary tagging.
- **Never meets an embedder cosine at all** — the category a naive grep flags hardest: near-dupes (pHash/SimHash Hamming over pixels and text), Lowe's ratio (SIFT L2), LightGlue confidence, RANSAC reprojection, VAD/dB, scene-cut histogram correlation, detector confidence, UMAP `min_dist` (output space), the compaction percentile, `_LOGISTIC_K` (a vote ramp), and autopilot's dimensionless rates. The production MaxPatch path has no similarity threshold anywhere in it, and `frontend/src/` has no similarity constant at all.

It also names the two patterns the codebase already got right and worth copying: `PRODUCTION_SPLIT_BY_SPACE` keying on `single_vector` vs `patch` with the measurement in its comment, and #3351 gating on the declared `supports_patch_regions` capability rather than a name list.

## What this deliberately does not do

- **No re-tuning of item 2.** A constant with no reader does not have a right value to find.
- **No whitening of item 3's `cos_d`.** It would fix the comparability and would also change the arm's definition — that is a study decision, not an audit's.
- **No measurement of within-image patch-to-patch cosine spread.** #3329 read media-level vectors throughout. Item 3's mechanism is arithmetic; its magnitude on `dinov3_patch` specifically is stated as a prediction, not a measurement. The document says so.
- **`typicality_pvalues` stays callable on a patch atlas** as library API — #3351 gates the endpoint, and fixing the model rather than the caller is #3348.

## Changes

Docs plus four comment/docstring edits. **No behaviour change**, and no digest moves in `check-eval-app-sync.py` (it ignores comments).

- new `AUDIT-cosine-thresholds.md`; `REPORT.md` action table + §6 point at it
- `coverage_atlas.py` — the measured r̄ margin, and that `next_sample` is the exposed consumer
- `patch_embed.py` — the 4.0 is inert, why, and what a reviver owes
- `patch_styles.py` — the effective-α caveat at the call site
- `thresholds.py` — the `<2`-score `0.5` is the one sigmoid-scale literal on a cosine path

## Verification

Full `./run-tests.sh`: **9404 passed**, 6 skipped, 2 xpassed. All heavy gates green (pyright, pip-audit, npm audit, Vitest).

Closes #3347

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFcFvocjvDyK9xmbHxW838)_