### PR TITLE
docmarks report: size the whole-page caption over labelled marks, colour boxes by kind

### DIFF
--- a/scripts/experiments/docmarks/make_report.py
+++ b/scripts/experiments/docmarks/make_report.py
@@ -11,9 +11,11 @@ months later on a machine with no access to ``/expscratch``.
 Sections, in the order a reader needs them:
 
 1. **What is in it** — pages per source, marks per kind, class inventory.
-2. **Full pages** — marks boxed in situ, because the single most important
-   property of this task is how *small* the target is against the page, and no
-   crop conveys that.
+2. **Full pages** — marks boxed in situ and coloured by kind, because the single
+   most important property of this task is how *small* the target is against the
+   page, and no crop conveys that.  The one red box on each page is the largest
+   mark carrying a class identity — the same mark the caption measures, and the
+   same population the Scale section bands.
 3. **The Goods** — every roster/candidate class as a strip of its own instances,
    so within-class variation is visible at a glance.
 4. **The Bads** — distractor pages, and specifically the near-misses: other
@@ -41,7 +43,7 @@ from typing import Any, Optional, Sequence
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import docmarks_config as cfg  # noqa: E402
-from sources._common import Page, read_manifest  # noqa: E402
+from sources._common import Mark, Page, read_manifest  # noqa: E402
 
 #: Thumbnail long side, in px, per figure kind.  Kept small deliberately: the
 #: report is meant to be scrolled, and a 4000px scan inlined at full size makes
@@ -76,8 +78,50 @@ def _crop(page: Page, box: tuple[int, int, int, int], pad_frac: float = 0.12) ->
         )
 
 
-def _page_with_boxes(page: Page, *, highlight: Optional[str] = None) -> Any:
-    """The whole page with every mark outlined, so scale is visible in context."""
+#: Box colour per mark kind.  Kind is the single most useful thing the whole-page
+#: figure can convey — a box on a handwritten signature is a *deliberately*
+#: non-queryable mark, not a mislabelled logo — and one shade of blue for
+#: everything withholds exactly that.  This dict is the only source of truth:
+#: the drawing code and the HTML legend both read it, so a kind cannot appear in
+#: one and be missing from the other.
+_KIND_COLOURS: dict[str, tuple[int, int, int]] = {
+    "logo": (70, 130, 200),
+    "stamp": (35, 145, 115),
+    "signature": (230, 150, 20),
+    "text": (165, 165, 165),
+    "icon": (150, 95, 185),
+}
+_KIND_FALLBACK = (110, 110, 110)
+
+#: The largest *labelled* mark on the page — the one the caption measures.
+_HIGHLIGHT_COLOUR = (215, 25, 28)
+
+#: Kinds drawn thin and muted: recorded for context, never promoted to a query
+#: class, so they should not read as competing for the reader's attention.
+_MUTED_KINDS = frozenset({"text"})
+
+_KIND_MEANING = {
+    "logo": "queryable",
+    "stamp": "queryable",
+    "signature": "recorded, never queryable (a signature is a different mark every time it is made)",
+    "text": "the page body, drawn muted; never queryable",
+    "icon": "queryable",
+}
+
+
+def _rgb(colour: tuple[int, int, int]) -> str:
+    return "rgb({},{},{})".format(*colour)
+
+
+def _page_with_boxes(page: Page, *, highlight: Optional[Mark] = None) -> Any:
+    """The whole page with every mark outlined, so scale is visible in context.
+
+    Boxes are coloured by ``mark.kind``; *highlight*, when given, is the one
+    :class:`Mark` drawn in red.  It is matched by identity rather than by
+    ``class_id`` for two reasons: a class-id match reddens *every* instance of
+    that class on the page, and the marks worth highlighting are not always the
+    ones carrying a ``class_id`` at all.
+    """
     from PIL import Image, ImageDraw
 
     with Image.open(page.path) as src:
@@ -88,10 +132,35 @@ def _page_with_boxes(page: Page, *, highlight: Optional[str] = None) -> Any:
         if mark.area() <= 0:
             continue
         x, y, w, h = mark.box
-        hot = highlight is not None and mark.class_id == highlight
-        colour = (215, 25, 28) if hot else (70, 130, 200)
-        draw.rectangle([x, y, x + w, y + h], outline=colour, width=width * (2 if hot else 1))
+        if highlight is not None and mark is highlight:
+            colour, line = _HIGHLIGHT_COLOUR, width * 2
+        else:
+            colour = _KIND_COLOURS.get(mark.kind, _KIND_FALLBACK)
+            line = max(1, width // 2) if mark.kind in _MUTED_KINDS else width
+        draw.rectangle([x, y, x + w, y + h], outline=colour, width=line)
     return im
+
+
+def kinds_drawn(pages: Sequence[Page]) -> list[str]:
+    """The mark kinds that actually get a box in a figure built from *pages*."""
+    return sorted({m.kind for p in pages for m in p.marks if m.area() > 0})
+
+
+def _legend(pages: Sequence[Page], *, highlight_label: str = "") -> str:
+    """A swatch-per-kind legend, listing only what the figure actually draws."""
+    items = []
+    if highlight_label:
+        items.append(
+            f'<li><span class="sw" style="background:{_rgb(_HIGHLIGHT_COLOUR)}"></span>{_esc(highlight_label)}</li>'
+        )
+    for kind in kinds_drawn(pages):
+        colour = _KIND_COLOURS.get(kind, _KIND_FALLBACK)
+        meaning = _KIND_MEANING.get(kind, "")
+        gloss = f" — {_esc(meaning)}" if meaning else ""
+        items.append(
+            f'<li><span class="sw" style="background:{_rgb(colour)}"></span><code>{_esc(kind)}</code>{gloss}</li>'
+        )
+    return f'<ul class="legend">{"".join(items)}</ul>' if items else ""
 
 
 # --------------------------------------------------------------------------
@@ -128,6 +197,10 @@ code { font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; background:#f4
 .bar { height:9px; background:var(--cool); display:inline-block; vertical-align:middle; border-radius:1px; }
 .warn { background:#fff6f5; border-left:3px solid var(--hot); padding:10px 14px; margin:16px 0; font-size:14px; }
 .warn strong { color:var(--hot); }
+.legend { list-style:none; padding:0; margin:10px 0 2px; display:flex; flex-direction:column;
+  gap:4px; font-size:13px; color:var(--dim); max-width:74ch; }
+.legend li { display:flex; align-items:flex-start; gap:7px; }
+.legend .sw { width:13px; height:13px; border-radius:2px; margin-top:3px; flex:0 0 auto; }
 """
 
 
@@ -218,19 +291,30 @@ def section_full_pages(pages: Sequence[Page], n: int, seed: int) -> str:
 
     figs = []
     for page in picks:
-        biggest = max((m for m in page.marks if m.area() > 0), key=lambda m: m.area())
+        # Measured over the *labelled* marks only — the same population
+        # ``section_scale`` bands.  Sizing over every mark instead lets a
+        # signature, or a heading welded into one component by its underline,
+        # win the title and put a body-text number in a caption a reader quotes.
+        labelled = [m for m in page.marks if m.class_id and m.area() > 0]
+        if not labelled:
+            continue
+        biggest = max(labelled, key=lambda m: m.area())
         frac = biggest.area() / float(page.width * page.height)
         figs.append(
-            f'<figure><img src="{_b64(_page_with_boxes(page, highlight=biggest.class_id), long_side=THUMB_PAGE)}">'
-            f"<figcaption>{_esc(page.page_id)} — largest mark is "
+            f'<figure><img src="{_b64(_page_with_boxes(page, highlight=biggest), long_side=THUMB_PAGE)}">'
+            f"<figcaption>{_esc(page.page_id)} — largest labelled mark "
+            f"(<code>{_esc(biggest.kind)}</code>) is "
             f"{biggest.longest_side()}px, {frac:.2%} of the page</figcaption></figure>"
         )
     return (
         "<h2>Whole pages, marks boxed</h2>"
         "<p>The defining property of this task is the ratio between the target and the page. "
-        "Red is the largest labelled mark; blue is every other mark the source annotates. "
+        "Every mark the source annotates is boxed, coloured by kind. Exactly one box is red: the "
+        "largest mark that carries a class identity, which is the one the caption measures — so the "
+        "picture and its number always describe the same box. "
         "A crop gallery makes these look easy; this is what the matcher actually sees.</p>"
-        f'<div class="pages">{"".join(figs)}</div>'
+        + _legend(picks, highlight_label="the largest labelled mark on that page — the one the caption measures")
+        + f'<div class="pages">{"".join(figs)}</div>'
     )
 
 
@@ -302,8 +386,7 @@ def section_bads(pages: Sequence[Page], classes: dict[str, Any], n: int, seed: i
         f"<p><strong>{len(unlabelled):,}</strong> pages carry no labelled mark and serve as distractors: "
         + ", ".join(f"{v:,} from <code>{k}</code>" for k, v in sorted(by_source.items()))
         + ". These need no labels — only to be <em>safe to score against</em>, which the contamination "
-        "rules decide.</p>"
-        f'<div class="pages">{thumbs}</div>'
+        "rules decide.</p>" + _legend(picks) + f'<div class="pages">{thumbs}</div>'
         "<h3>Near misses — the negatives that actually matter</h3>"
         "<p>A blank page is a trivial negative. The hard one is a real mark on a real scan that simply "
         "is not the mark being searched for. Each of these is a positive for one class and a negative "

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -25,6 +25,7 @@ The scripts are loose modules, not package members, so the directory goes on
 
 import importlib
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -976,6 +977,171 @@ class TestReport:
         # cannot interpret, which defeats the point of tracking provenance.
         emitted = {"gt", "clustered", "clustered_band", "candidate", "synthetic"}
         assert emitted <= set(mods["report"]._PROVENANCE_MEANING)
+
+
+class TestReportWholePageFigure:
+    """The "whole pages, marks boxed" figure and the caption that measures it.
+
+    The caption's px/% is the number a reader quotes for "how small is the
+    target", so it has to describe a mark that is actually a *target*.  Sized
+    over every mark instead, an underlined heading welded into one component by
+    its own rule wins the title on a real SPODS page — and because such a mark
+    carries no ``class_id``, highlighting by class id then reddened nothing at
+    all, leaving the prose promising a colour the figure never drew.
+    """
+
+    @staticmethod
+    def _blank(tmp_path, size=(1000, 1400)):
+        from PIL import Image
+
+        path = tmp_path / "p.png"
+        Image.new("RGB", size, "white").save(path)
+        return str(path)
+
+    @staticmethod
+    def _text(html):
+        """*html* with the inlined image bytes removed.
+
+        A base64 payload is made of characters an assertion like ``"403px" not
+        in html`` can match by chance, so the captions are checked against the
+        markup only.
+        """
+        return re.sub(r'src="data:[^"]*"', "", html)
+
+    @staticmethod
+    def _colour_bbox(im, colour):
+        arr = np.asarray(im)
+        hit = np.all(arr == np.array(colour, dtype=arr.dtype), axis=-1)
+        ys, xs = np.nonzero(hit)
+        if not len(xs):
+            return None
+        return int(xs.min()), int(ys.min()), int(xs.max()), int(ys.max())
+
+    def test_caption_measures_a_labelled_mark_not_the_biggest_box(self, mods, tmp_path):
+        page = _page(
+            mods,
+            "spods/00622",
+            "spods",
+            [
+                ("logo", (50, 50, 120, 100), "spods/logo_a", "clustered"),
+                ("text", (60, 400, 403, 40), None, "gt"),  # an underlined heading
+            ],
+            path=self._blank(tmp_path),
+        )
+        html = self._text(mods["report"].section_full_pages([page], 4, 11))
+        assert "120px" in html
+        assert "403px" not in html
+        assert "<code>logo</code>" in html
+
+    def test_caption_population_matches_the_scale_section(self, mods, tmp_path):
+        # Both must band the same marks, or the histogram and the captions
+        # describe different corpora.
+        marks = [
+            ("logo", (50, 50, 120, 100), "spods/logo_a", "clustered"),
+            ("signature", (600, 1200, 300, 200), None, "gt"),
+        ]
+        page = _page(mods, "spods/00622", "spods", marks, path=self._blank(tmp_path))
+        html = self._text(mods["report"].section_full_pages([page], 4, 11))
+        sides = [m.longest_side() for m in page.marks if m.class_id and m.area() > 0]
+        assert f"{max(sides)}px" in html
+        assert "300px" not in html
+
+    def test_exactly_one_box_is_red_even_when_a_class_repeats_on_the_page(self, mods, tmp_path):
+        # Highlighting by class id reddens every instance of that class; the
+        # caption describes one of them.
+        page = _page(
+            mods,
+            "spods/00001",
+            "spods",
+            [
+                ("logo", (100, 100, 120, 90), "spods/logo_a", "clustered"),
+                ("logo", (400, 400, 300, 220), "spods/logo_a", "clustered"),
+            ],
+            path=self._blank(tmp_path),
+        )
+        biggest = max(page.marks, key=lambda m: m.area())
+        im = mods["report"]._page_with_boxes(page, highlight=biggest)
+        red = self._colour_bbox(im, mods["report"]._HIGHLIGHT_COLOUR)
+        assert red == (400, 400, 700, 620)
+        # ...and the other instance is still drawn, in its kind's colour.
+        assert self._colour_bbox(im, mods["report"]._KIND_COLOURS["logo"])[:2] == (100, 100)
+
+    def test_every_figure_carries_a_red_box(self, mods, tmp_path):
+        # The prose promises one; a page whose largest mark is unlabelled used
+        # to produce a figure with no red pixel in it at all.
+        page = _page(
+            mods,
+            "spods/00622",
+            "spods",
+            [
+                ("logo", (50, 50, 120, 100), "spods/logo_a", "clustered"),
+                ("text", (60, 400, 403, 40), None, "gt"),
+            ],
+            path=self._blank(tmp_path),
+        )
+        biggest = max((m for m in page.marks if m.class_id), key=lambda m: m.area())
+        im = mods["report"]._page_with_boxes(page, highlight=biggest)
+        assert self._colour_bbox(im, mods["report"]._HIGHLIGHT_COLOUR) is not None
+
+    def test_kinds_are_drawn_in_distinguishable_colours(self, mods, tmp_path):
+        # The single most useful thing this figure can say is that the box on a
+        # handwritten signature is a deliberately non-queryable mark rather than
+        # a mislabelled logo.  One shade of blue for everything withholds it.
+        page = _page(
+            mods,
+            "spods/00622",
+            "spods",
+            [
+                ("logo", (50, 50, 120, 100), None, "gt"),
+                ("stamp", (300, 300, 160, 160), None, "gt"),
+                ("signature", (600, 1200, 200, 90), None, "gt"),
+                ("text", (60, 400, 403, 40), None, "gt"),
+            ],
+            path=self._blank(tmp_path),
+        )
+        im = mods["report"]._page_with_boxes(page)
+        drawn = {c for _, c in im.getcolors(1 << 20)}
+        seen = [mods["report"]._KIND_COLOURS[k] for k in ("logo", "stamp", "signature", "text")]
+        assert all(c in drawn for c in seen)
+        assert len(set(seen)) == len(seen)
+
+    def test_legend_names_only_the_kinds_actually_drawn(self, mods, tmp_path):
+        # A legend that promises a colour the figure never draws is the same
+        # bug as prose that does, one line further down.
+        page = _page(
+            mods,
+            "spods/00622",
+            "spods",
+            [("logo", (50, 50, 120, 100), "spods/logo_a", "clustered")],
+            path=self._blank(tmp_path),
+        )
+        legend = mods["report"]._legend([page])
+        assert "<code>logo</code>" in legend
+        assert "signature" not in legend
+        assert mods["report"]._rgb(mods["report"]._KIND_COLOURS["logo"]) in legend
+
+    def test_zero_area_marks_are_neither_drawn_nor_advertised(self, mods, tmp_path):
+        page = _page(
+            mods,
+            "spods/00622",
+            "spods",
+            [
+                ("logo", (50, 50, 120, 100), "spods/logo_a", "clustered"),
+                ("stamp", (10, 10, 0, 0), None, "gt"),
+            ],
+            path=self._blank(tmp_path),
+        )
+        assert mods["report"].kinds_drawn([page]) == ["logo"]
+        im = mods["report"]._page_with_boxes(page)
+        assert self._colour_bbox(im, mods["report"]._KIND_COLOURS["stamp"]) is None
+
+    def test_every_kind_the_sources_emit_has_a_colour_and_a_gloss(self, mods):
+        # Same contract as the provenance glosses: a kind with no swatch falls
+        # back to grey and reads as "some other mark", which is the one thing
+        # this figure is supposed to stop doing.
+        emitted = set(mods["spods"].MARK_CATEGORIES) | set(mods["spods"].CONTEXT_CATEGORIES)
+        assert emitted <= set(mods["report"]._KIND_COLOURS)
+        assert emitted <= set(mods["report"]._KIND_MEANING)
 
 
 # ------------------------------------------------------------- embed cells

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -1064,7 +1064,8 @@ class TestReportWholePageFigure:
         red = self._colour_bbox(im, mods["report"]._HIGHLIGHT_COLOUR)
         assert red == (400, 400, 700, 620)
         # ...and the other instance is still drawn, in its kind's colour.
-        assert self._colour_bbox(im, mods["report"]._KIND_COLOURS["logo"])[:2] == (100, 100)
+        blue = self._colour_bbox(im, mods["report"]._KIND_COLOURS["logo"])
+        assert blue is not None and blue[:2] == (100, 100)
 
     def test_every_figure_carries_a_red_box(self, mods, tmp_path):
         # The prose promises one; a page whose largest mark is unlabelled used


### PR DESCRIPTION
The "Whole pages, marks boxed" figure could neither name what it was measuring nor show what it had drawn. Three fixes in `make_report.py`, plus tests.

**1. The caption measured the wrong population.** `max((m for m in page.marks if m.area() > 0), ...)` had no kind or class filter, so a `signature`, or a heading welded into one component by its own underline, competed with the logo the section exists to show. It now maxes over marks that carry a class identity — the same population `section_scale` bands — and names the winning mark's kind in the caption.

**2. Nothing was drawn red on those pages.** `highlight=biggest.class_id` matched `mark.class_id == highlight`; a `text` or `signature` winner carries `class_id=None`, so the highlight matched nothing while the prose promised "Red is the largest labelled mark". The highlight is now the `Mark` itself, matched by identity — which also fixes the converse: a class with two instances on one page used to redden both, so "the largest mark" was two boxes.

**3. Kind was invisible.** All four kinds shared one blue. Boxes are now coloured by `mark.kind` from `_KIND_COLOURS`, the single dict that both the drawing code and a new swatch legend read, so a kind cannot get a colour in one and not the other. `text` marks are drawn thin and muted rather than dropped — #3361 is the issue that decides what they are *for*, and this figure should not pre-empt it. The legend lists only the kinds a given figure actually draws, and appears under the distractor figure too. The prose above the figure was rewritten to describe what is drawn.

### What is still owed

**The re-render is not in this PR.** `docs/experiments/2026-08-31-docmarks-v0/report.html` still shows the old figure. The corpus lives on `/expscratch` and is not reachable from a Claude container; rebuilding it here is not a like-for-like substitute (SPODS is a 2.9 GB RAR and no RAR extractor is installed, the 432 UCSF distractors are re-sampled from a live API, and `classes.json` came from a specific clustering run), so a rebuild would change all 356 images and every count in the report for reasons unrelated to this fix.

That leaves the last acceptance item on #3362 open, and it is best paid once: #3361 changes the box geometry and its own acceptance already requires a fresh render, so the corpus rebuild that satisfies it satisfies this too.

### Verification

- New `TestReportWholePageFigure` class in `tests_lib/datasets/test_docmarks_corpus.py` (8 tests): the caption ignores an oversized unlabelled mark and agrees with `section_scale`'s population; exactly one box is red when a class repeats on a page; every figure carries a red box; the four kinds get distinguishable colours; the legend names only what is drawn; zero-area marks are neither drawn nor advertised; and every kind the SPODS adapter emits has both a colour and a gloss (the same contract the provenance glosses already have).
- Rendered the section in chromium against a synthetic corpus to check the legend's layout.
- Full `./run-tests.sh`: `RUN PASSED`.

Refs #3362


---
_Generated by [Claude Code](https://claude.ai/code/session_01JFEqYUVc58EPrSGNGDtaYz)_