### PR TITLE
Serve dynamic_options for results exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,19 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A results exporter's `dynamic_options` select is now filled in, in both
+  places an exporter is configured.** A `"select"` field declared with
+  `dynamic_options=True` is supposed to have its options computed at runtime by
+  the plugin's `get_field_options()`, which is how an exporter whose
+  destinations are only knowable then (mailboxes, buckets, remote queues) offers
+  real choices. Exporters never had the route the importer families have, so the
+  dropdown rendered the (usually empty) list frozen into the plugin definition —
+  the only way to get options was to hard-code them at definition time. Both the
+  Export modal and Settings › Auto-Find's **Results Exporter** tab now fetch the
+  live list (`POST /api/exporters/field-options/<name>`), re-fetch a field when
+  something it declares in `depends_on` changes, show fetch failures inline, and
+  honour `allow_free_text` by rendering a combobox. (Issue #3360.)
+
 - **One file a host won't serve no longer sinks a whole multi-file demo
   download.** The Apollo 11 Mission Audio demo pulls its tracks as separate
   files from the Internet Archive, which serves each one from a data node that

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -869,8 +869,13 @@ The frontend wiring is fully automatic:
    dropdown the user has already navigated away from, and it can never
    auto-select a value for an importer that is no longer on screen.
 
-API contract: `POST /api/dataset/import/<name>/options` with body
-`{"field_key": "...", "values": {...}}` returns
+API contract: every plugin family that renders a field form has an options
+route of the same shape — `POST /api/dataset/import/<name>/options`
+(dataset importers), `POST /api/label-importers/field-options/<name>`,
+`POST /api/datasource-import/<name>/options`,
+`POST /api/seed-import/<name>/options`, and
+`POST /api/exporters/field-options/<name>` (results exporters). With body
+`{"field_key": "...", "values": {...}}` each returns
 `{"options": [{"value": "...", "label": "..."}, ...]}` — both the plain-
 string and `(value, label)` shapes are coerced to `{value, label}` before
 serialisation. Any exception your `get_field_options()` raises is returned
@@ -1611,10 +1616,23 @@ The library-side guide has the full worked example and the encoding/truncation
 pitfalls: [`vtscore/docs/extending/results-exporters.md` § Opening a URL in the
 browser](../vtscore/docs/extending/results-exporters.md#opening-a-url-in-the-browser).
 
+### Dynamic select options
+
+Dynamic select options work exactly as for dataset importers: declare a
+field with `dynamic_options=True` and implement
+`get_field_options(field_key, current_values)`
+(see [Dynamic field options](#dynamic-field-options)). Both surfaces that
+render an exporter's fields honour them — the Export modal and the
+Settings › Auto-Find **Results Exporter** tab — so a destination list that
+is only knowable at runtime (mailboxes, buckets, remote queues) fills in
+the same way in each.
+
 ### How it gets invoked
 
 1. `GET /api/exporters` returns available exporters.
 2. `POST /api/exporters/export` with `exporter_name` and `field_values`.
+3. `POST /api/exporters/field-options/<name>` serves dynamic field
+   options.
 
 ### CLI usage
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -52,6 +52,27 @@ arrival. That path runs the same `validate_browser_url` check, but drops an
 unusable URL and notes it in `message` rather than failing the request: the
 export already happened and the scored results must survive it.
 
+### Dynamic field options
+
+```
+POST /api/exporters/field-options/{exporter_name}
+```
+
+**Body:** `{"field_key": "...", "values": {...}}` (`values` is a snapshot of
+the form's current field values)
+
+Returns the dropdown options for a `dynamic_options` field on a results
+exporter, for an exporter whose destinations are only knowable at runtime.
+Both surfaces that render exporter fields use it: the Export modal and the
+Settings › Auto-Find results exporter.
+
+→ `{"options": [{"value": "...", "label": "..."}, ...]}` (same shape as the
+label-importer route below).
+
+Errors: 400 (unknown/non-dynamic field key), 404 (unknown exporter),
+501 (exporter does not implement `get_field_options`),
+502 (remote service backing dynamic options failed).
+
 **Streaming support** (CLI `--autodetect --stream-results` for sources larger
 than RAM): `server_json_file` (NDJSON), `server_csv_file`, and `gui` write hits
 incrementally; `webhook` and `email_smtp` deliver in `batch_size`-sized batches
@@ -78,7 +99,8 @@ GET /api/label-importers
 POST /api/label-importers/field-options/{importer_name}
 ```
 
-**Body:** `{"field_key": "...", "field_values": {...}}`
+**Body:** `{"field_key": "...", "values": {...}}` (`values` is a snapshot of
+the form's current field values)
 
 Returns the dropdown options for a dynamic-options field on a label importer
 (used to populate dependent selects in the importer form).

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -13565,6 +13565,70 @@
         ]
       }
     },
+    "/api/exporters/field-options/{exporter_name}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "exporter_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Same contract as ``POST /api/dataset/import/<name>/options``: the\nexporter's ``get_field_options(field_key, current_values)`` is called\nwith the supplied snapshot of current form values, and plugin errors\n(network failure, auth error, etc.) surface as a 502 with the\noriginal message so the frontend can display them inline.",
+        "operationId": "exporter_field_options",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImporterFieldOptionsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImporterFieldOptionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Unknown or non-dynamic field key."
+          },
+          "404": {
+            "description": "Unknown exporter name."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "500": {
+            "description": "get_field_options did not return a list."
+          },
+          "501": {
+            "description": "Exporter does not implement get_field_options."
+          },
+          "502": {
+            "description": "Remote service backing dynamic options raised an error."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return dropdown options for a dynamic-options field on an exporter.",
+        "tags": [
+          "exporters"
+        ]
+      }
+    },
     "/api/extract": {
       "post": {
         "operationId": "run_extract",

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.html
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.html
@@ -228,16 +228,45 @@
                     [attr.max]="field.max || null"
                     [attr.step]="field.step || null"
                   />
+                } @else if (field.field_type === 'select' && field.allow_free_text) {
+                  <input
+                    [id]="'field-' + field.key"
+                    type="text"
+                    class="form-input"
+                    [attr.list]="'field-' + field.key + '-list'"
+                    [(ngModel)]="formValues[field.key]"
+                    [disabled]="!!fieldOptions.loading()[field.key]"
+                    [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                    (ngModelChange)="onFieldChanged(field.key)"
+                  />
+                  <datalist [id]="'field-' + field.key + '-list'">
+                    @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                      <option [value]="opt.value">{{ opt.label }}</option>
+                    }
+                  </datalist>
+                  @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                    <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+                  }
                 } @else if (field.field_type === 'select') {
                   <select
                     [id]="'field-' + field.key"
                     class="form-select"
                     [(ngModel)]="formValues[field.key]"
+                    (ngModelChange)="onFieldChanged(field.key)"
+                    [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
                   >
-                    @for (opt of field.options || []; track opt) {
-                      <option [value]="opt">{{ opt }}</option>
+                    @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
+                      <option value="">Loading…</option>
+                    } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
+                      <option value="">No options available</option>
+                    }
+                    @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                      <option [value]="opt.value">{{ opt.label }}</option>
                     }
                   </select>
+                  @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                    <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+                  }
                 } @else {
                   <input
                     [id]="'field-' + field.key"

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -696,4 +696,127 @@ describe('ExportModalComponent', () => {
       table.remove();
     });
   });
+
+  // An exporter whose destination list is only knowable at runtime. Before
+  // issue #3360 the select rendered `field.options` verbatim, so a
+  // `dynamic_options` field was permanently empty here.
+  describe('dynamic_options exporter fields', () => {
+    const dynamicExporter = {
+      name: 'remote_queue',
+      display_name: 'Remote Queue',
+      supported_payloads: ['find_results', 'labelset'],
+      fields: [
+        {
+          key: 'account',
+          field_type: 'select',
+          label: 'Account',
+          options: ['personal', 'team'],
+          default: 'personal',
+        },
+        {
+          key: 'queue',
+          field_type: 'select',
+          label: 'Queue',
+          required: true,
+          dynamic_options: true,
+          depends_on: ['account'],
+        },
+      ],
+    };
+
+    /** Flush one options POST, asserting the exporter and body it carried. */
+    function flushOptions(
+      values: Record<string, string>,
+      options: { value: string; label: string }[],
+    ): void {
+      const req = httpMock.expectOne(
+        '/api/exporters/field-options/remote_queue',
+      );
+      expect(req.request.body).toEqual({ field_key: 'queue', values });
+      req.flush({ options });
+    }
+
+    it('fetches the option list when the exporter tab is selected', async () => {
+      await flushInit([...mockExporters, dynamicExporter]);
+      component.selectExporterTab(dynamicExporter as never);
+
+      flushOptions({ account: 'personal', queue: '' }, [
+        { value: 'p-1', label: 'Personal 1' },
+        { value: 'p-2', label: 'Personal 2' },
+      ]);
+      await settleResource();
+
+      const field = component.activeTabExporterFields[1];
+      expect(component.fieldOptions.optionsFor(field)).toEqual([
+        { value: 'p-1', label: 'Personal 1' },
+        { value: 'p-2', label: 'Personal 2' },
+      ]);
+      // Required with no default: the first fetched option is selected, so the
+      // export body carries a real value rather than a blank.
+      expect(component.formValues['queue']).toBe('p-1');
+    });
+
+    it('renders the fetched options in the select', async () => {
+      await flushInit([...mockExporters, dynamicExporter]);
+      component.selectExporterTab(dynamicExporter as never);
+      flushOptions({ account: 'personal', queue: '' }, [
+        { value: 'p-1', label: 'Personal 1' },
+      ]);
+      await settleResource();
+
+      const labels = Array.from(
+        (fixture.nativeElement as HTMLElement).querySelectorAll(
+          '.tab-field select option',
+        ),
+      ).map((o) => o.textContent?.trim());
+      expect(labels).toContain('Personal 1');
+    });
+
+    it('re-fetches a dependent field when its dependency changes', async () => {
+      await flushInit([...mockExporters, dynamicExporter]);
+      component.selectExporterTab(dynamicExporter as never);
+      flushOptions({ account: 'personal', queue: '' }, [
+        { value: 'p-1', label: 'Personal 1' },
+      ]);
+      await settleResource();
+
+      component.formValues['account'] = 'team';
+      component.onFieldChanged('account');
+      flushOptions({ account: 'team', queue: '' }, [
+        { value: 't-1', label: 'Team 1' },
+      ]);
+      await settleResource();
+
+      // The stale personal-account selection is gone, replaced by one the new
+      // list offers.
+      expect(component.formValues['queue']).toBe('t-1');
+    });
+
+    it('surfaces a fetch failure inline instead of silently emptying the dropdown', async () => {
+      await flushInit([...mockExporters, dynamicExporter]);
+      component.selectExporterTab(dynamicExporter as never);
+      httpMock
+        .expectOne('/api/exporters/field-options/remote_queue')
+        .flush(
+          { message: 'queue service down' },
+          { status: 502, statusText: 'Bad Gateway' },
+        );
+      await settleResource();
+
+      expect(component.fieldOptions.error()['queue']).toBe(
+        'queue service down',
+      );
+      expect((fixture.nativeElement as HTMLElement).textContent).toContain(
+        'queue service down',
+      );
+    });
+
+    it('does not fetch anything for an exporter with only static fields', async () => {
+      await flushInit([...mockExporters, dynamicExporter]);
+      component.selectExporterTab(mockExporters[0] as never);
+      // `httpMock.verify()` in `afterEach` fails the test if a request was made.
+      expect(component.fieldOptions.options()).toEqual({});
+    });
+  });
+
 });

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -29,6 +29,7 @@ import { SortingApiService } from '../../../services/sorting-api.service';
 import type { LabelFilter } from '../../../services/sorting-api.service';
 import { ToastService } from '../../../services/toast.service';
 import { ImporterField } from '../../../models/api.models';
+import { DynamicFieldOptions } from '../../../utils/dynamic-field-options';
 import {
   openBlankTab,
   openExternalUrl,
@@ -173,6 +174,19 @@ export class ExportModalComponent implements OnInit {
   selectedExporter: ExporterEntry | null = null;
   formValues: Record<string, string> = {};
   readonly submitting = signal(false);
+
+  /** Option lists for the active exporter's ``dynamic_options`` fields. An
+   *  exporter whose destinations are only knowable at runtime (mailboxes,
+   *  buckets, remote queues) fills its select from
+   *  ``POST /api/exporters/field-options/<name>`` rather than from a list
+   *  frozen at plugin-definition time (issue #3360). */
+  readonly fieldOptions = new DynamicFieldOptions((key, values) =>
+    this.exportersApi.getFieldOptions(this.activeExporterName, key, values),
+  );
+
+  /** Exporter the in-flight option fetches belong to. Read by the fetcher
+   *  above at subscribe time, so it must be set before any refresh. */
+  private activeExporterName = '';
 
   /** Dataset display name for default filenames. */
   private readonly datasetName = computed(
@@ -552,6 +566,23 @@ export class ExportModalComponent implements OnInit {
       this.formValues[f.key] = value;
       this.lastAutoValues[f.key] = value;
     }
+    // Drop the previous exporter's lists (and invalidate anything still in
+    // flight for it) before fetching this one's.
+    this.fieldOptions.reset();
+    this.activeExporterName = exporter.name;
+    this.fieldOptions.refreshAll(this.exporterFieldsOf(exporter), this.formValues);
+  }
+
+  /** Re-fetch the option lists of every field that depends on the one the
+   *  user just edited. */
+  onFieldChanged(changedKey: string): void {
+    const exporter = this.activeTabExporter ?? this.selectedExporter;
+    if (!exporter) return;
+    this.fieldOptions.refreshDependentsOf(
+      changedKey,
+      this.exporterFieldsOf(exporter),
+      this.formValues,
+    );
   }
 
   /** Re-resolve templated defaults once a variable they need arrives.

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.html
@@ -51,16 +51,43 @@
       @for (field of activeFields; track field.key) {
         <div class="form-group">
           <label class="form-label">{{ field.label || field.key }}{{ field.required ? ' *' : '' }}</label>
-          @if (field.field_type === 'select') {
+          @if (field.field_type === 'select' && field.allow_free_text) {
+            <input
+              type="text"
+              class="form-input"
+              [attr.list]="'autofind-' + field.key + '-list'"
+              [ngModel]="fieldValue(field.key)"
+              (ngModelChange)="setFieldValue(field.key, $event)"
+              [disabled]="!!fieldOptions.loading()[field.key]"
+              [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || '')"
+              [attr.aria-label]="field.label || field.key" />
+            <datalist [id]="'autofind-' + field.key + '-list'">
+              @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                <option [value]="opt.value">{{ opt.label }}</option>
+              }
+            </datalist>
+            @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+              <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+            }
+          } @else if (field.field_type === 'select') {
             <select
               class="form-select"
               [ngModel]="fieldValue(field.key)"
               (ngModelChange)="setFieldValue(field.key, $event)"
+              [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
               [attr.aria-label]="field.label || field.key">
-              @for (opt of field.options || []; track opt) {
-                <option [value]="opt">{{ opt }}</option>
+              @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
+                <option value="">Loading…</option>
+              } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
+                <option value="">No options available</option>
+              }
+              @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                <option [value]="opt.value">{{ opt.label }}</option>
               }
             </select>
+            @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+              <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+            }
           } @else if (field.field_type === 'number') {
             <input
               type="number"

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.spec.ts
@@ -59,13 +59,55 @@ describe('AutoFindSettingsComponent', () => {
     },
   ] as unknown as ExporterEntry[];
 
+  /** An exporter whose destination list is only knowable at runtime: the
+   *  shape issue #3360 reported as broken on this panel. */
+  const dynamicExporter = {
+    name: 'remote_queue',
+    display_name: 'Remote Queue',
+    description: 'Post results to a queue',
+    icon: '',
+    hidden_from_picker: false,
+    supported_payloads: ['find_results'],
+    ui_mode: 'form',
+    fields: [
+      { key: 'account', field_type: 'select', label: 'Account', options: ['personal', 'team'], default: 'personal' },
+      {
+        key: 'queue',
+        field_type: 'select',
+        label: 'Queue',
+        required: true,
+        dynamic_options: true,
+        depends_on: ['account'],
+      },
+    ] as ImporterField[],
+  } as unknown as ExporterEntry;
+
   let exportersResponse: () => Observable<unknown>;
+  /** Every `(field, values)` pair the panel asked options for, in order. */
+  let optionsCalls: { exporter: string; field: string; values: Record<string, string> }[];
+  let optionsResponse: (
+    exporter: string,
+    field: string,
+    values: Record<string, string>,
+  ) => Observable<{ options: { value: string; label: string }[] }>;
 
   beforeEach(() => {
     exportersResponse = () => of(exporters);
+    optionsCalls = [];
+    optionsResponse = (_exporter, _field, values) =>
+      of({
+        options: [
+          { value: `${values['account']}-a`, label: `${values['account']} A` },
+          { value: `${values['account']}-b`, label: `${values['account']} B` },
+        ],
+      });
 
     const exportersStub: Partial<ExportersApiService> = {
       getExporters: () => exportersResponse() as Observable<never>,
+      getFieldOptions: (exporter: string, field: string, values: Record<string, string>) => {
+        optionsCalls.push({ exporter, field, values });
+        return optionsResponse(exporter, field, values) as Observable<never>;
+      },
     };
 
     TestBed.configureTestingModule({
@@ -217,6 +259,83 @@ describe('AutoFindSettingsComponent', () => {
     expect(component.inputType({ field_type: 'anything-else' } as unknown as ImporterField)).toBe(
       'text',
     );
+  });
+
+  describe('dynamic_options fields (issue #3360)', () => {
+    beforeEach(() => {
+      exportersResponse = () => of([...exporters, dynamicExporter]);
+    });
+
+    it('fetches the option list for the exporter restored from settings', async () => {
+      await create({ exporter: 'remote_queue', fieldValues: { remote_queue: { account: 'team' } } });
+
+      expect(optionsCalls).toEqual([
+        { exporter: 'remote_queue', field: 'queue', values: { account: 'team' } },
+      ]);
+      expect(component.fieldOptions.optionsFor(component.activeFields[1])).toEqual([
+        { value: 'team-a', label: 'team A' },
+        { value: 'team-b', label: 'team B' },
+      ]);
+    });
+
+    it('renders the fetched options rather than the (empty) declared ones', async () => {
+      await create({ exporter: 'remote_queue', fieldValues: { remote_queue: { account: 'team' } } });
+
+      const options = Array.from(
+        (fixture.nativeElement as HTMLElement).querySelectorAll('select.form-select option'),
+      ).map((o) => o.textContent?.trim());
+      expect(options).toContain('team A');
+      expect(options).toContain('team B');
+    });
+
+    it('persists the auto-selected option so the parent saves a real value', async () => {
+      await create({ exporter: 'remote_queue', fieldValues: { remote_queue: { account: 'team' } } });
+      // `queue` is required with no default: the helper picks the first option,
+      // which is only useful if the panel emits it onward.
+      expect(component.fieldValue('queue')).toBe('team-a');
+      expect(component.fieldValues['remote_queue']).toEqual({ account: 'team', queue: 'team-a' });
+    });
+
+    it('fetches options when the exporter tab is selected', async () => {
+      await create();
+      component.selectExporter('remote_queue');
+      expect(optionsCalls).toEqual([
+        { exporter: 'remote_queue', field: 'queue', values: { account: 'personal' } },
+      ]);
+    });
+
+    it('re-fetches a dependent field when the field it depends on changes', async () => {
+      await create({ exporter: 'remote_queue', fieldValues: { remote_queue: { account: 'personal' } } });
+      optionsCalls = [];
+
+      component.setFieldValue('account', 'team');
+
+      expect(optionsCalls).toEqual([
+        { exporter: 'remote_queue', field: 'queue', values: { account: 'team', queue: '' } },
+      ]);
+      // The stale selection is replaced by one the new list actually offers.
+      expect(component.fieldValue('queue')).toBe('team-a');
+    });
+
+    it('shows the fetch failure inline instead of an empty dropdown', async () => {
+      // The 502 the options route returns when the plugin's remote service
+      // fails, in the `flask_smorest.abort` envelope the app emits.
+      optionsResponse = () =>
+        throwError(() => ({ status: 502, error: { message: 'queue service down' } }));
+      await create({ exporter: 'remote_queue' });
+
+      expect(component.fieldOptions.error()['queue']).toContain('queue service down');
+      const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+      expect(text).toContain('queue service down');
+    });
+
+    it('drops the previous tab\'s options when switching exporters', async () => {
+      await create({ exporter: 'remote_queue' });
+      expect(component.fieldOptions.options()['queue']).toBeTruthy();
+
+      component.selectExporter('server_json_file');
+      expect(component.fieldOptions.options()['queue']).toBeUndefined();
+    });
   });
 
   it('emits a cloned field-value map so the parent cannot mutate the working copy', async () => {

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -7,6 +7,7 @@ import { takeUntil } from 'rxjs/operators';
 import { IconComponent } from '../../../icon/icon.component';
 import { ImporterField } from '../../../../models/api.models';
 import { ExportersApiService } from '../../../../services/exporters-api.service';
+import { DynamicFieldOptions } from '../../../../utils/dynamic-field-options';
 import type { ExporterEntry } from '../../../../generated/api-client/models/exporter-entry';
 
 /** The selected exporter + its per-exporter field-value map, emitted to the
@@ -51,6 +52,10 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
     effect(() => {
       this.activeExporter = this.autofindExporter() || '';
       this.fieldValues = this.cloneFieldValues(this.autofindExporterFieldValues());
+      // Reads `loadingExporters`, so this also re-runs when the exporter list
+      // lands - the first moment the restored exporter's fields are known and
+      // its dynamic selects can be filled.
+      this.syncFieldOptions();
     });
   }
 
@@ -76,6 +81,25 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
   /** Working copy of the per-exporter field values (cloned from the input so
    *  edits don't mutate the parent's object before it persists them). */
   fieldValues: Record<string, Record<string, string>> = {};
+
+  /** Option lists for the active exporter's ``dynamic_options`` fields.
+   *  Without this the select rendered only the options frozen into the
+   *  plugin definition, so an exporter that computes its destinations at
+   *  runtime had an empty dropdown here (issue #3360).
+   *
+   *  ``onApplied`` persists the auto-selected value: the helper writes its
+   *  pick straight into the values object, which alone would leave the
+   *  parent (and the saved settings) holding a blank. */
+  readonly fieldOptions = new DynamicFieldOptions(
+    (key, values) => this.exportersApi.getFieldOptions(this.activeExporter, key, values),
+    () => this.commitWorkingValues(),
+  );
+
+  /** The active exporter's field values as one stable, mutable object — what
+   *  :class:`DynamicFieldOptions` reads its ``depends_on`` snapshot from and
+   *  writes its auto-selected value into. ``fieldValues`` (which the template
+   *  and the parent read) is re-derived from it on every commit. */
+  private workingValues: Record<string, string> = {};
 
   private destroy$ = new Subject<void>();
 
@@ -115,6 +139,7 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
     if (name && !this.fieldValues[name]) {
       this.fieldValues[name] = this.defaultFieldValues(name);
     }
+    this.syncFieldOptions();
     this.emitChange();
   }
 
@@ -130,13 +155,14 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
     return this.fieldValues[this.activeExporter]?.[key] ?? '';
   }
 
-  /** Write a field value for the active exporter and emit the change. */
+  /** Write a field value for the active exporter and emit the change. Any
+   *  ``dynamic_options`` field declaring *key* in its ``depends_on`` gets its
+   *  option list re-fetched against the new value. */
   setFieldValue(key: string, value: string): void {
     if (!this.activeExporter) return;
-    const current = { ...(this.fieldValues[this.activeExporter] || {}) };
-    current[key] = value;
-    this.fieldValues = { ...this.fieldValues, [this.activeExporter]: current };
-    this.emitChange();
+    this.workingValues[key] = value;
+    this.fieldOptions.refreshDependentsOf(key, this.activeFields, this.workingValues);
+    this.commitWorkingValues();
   }
 
   /** Concrete `<input type>` for a plugin field, mirroring the auto-detect
@@ -146,6 +172,39 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
     if (field.field_type === 'email') return 'email';
     if (field.field_type === 'url') return 'url';
     return 'text';
+  }
+
+  /** Exporter whose dynamic option lists have already been fetched.
+   *  ``null`` until the exporter list has loaded, because the fields (and so
+   *  which of them are dynamic) aren't known before then. */
+  private optionsLoadedFor: string | null = null;
+
+  /** Fetch the active exporter's dynamic option lists, once per exporter.
+   *
+   *  The guard is what keeps this safe to call from the seeding effect: the
+   *  parent re-pushes both inputs on every emit, so an unguarded fetch here
+   *  would answer its own auto-selection with another fetch, forever. */
+  private syncFieldOptions(): void {
+    if (this.loadingExporters()) return;
+    if (this.optionsLoadedFor === this.activeExporter) return;
+    this.optionsLoadedFor = this.activeExporter;
+
+    // Drop the tab we just left: ``reset`` invalidates its in-flight requests
+    // too, so a late response can't populate this exporter's dropdown.
+    this.fieldOptions.reset();
+    this.workingValues = this.activeExporter
+      ? { ...(this.fieldValues[this.activeExporter] || {}) }
+      : {};
+    if (!this.activeExporter) return;
+    this.fieldOptions.refreshAll(this.activeFields, this.workingValues);
+  }
+
+  /** Publish :attr:`workingValues` onto ``fieldValues`` and emit, so an
+   *  auto-selected dynamic option is persisted like a typed one. */
+  private commitWorkingValues(): void {
+    if (!this.activeExporter) return;
+    this.fieldValues = { ...this.fieldValues, [this.activeExporter]: { ...this.workingValues } };
+    this.emitChange();
   }
 
   private defaultFieldValues(name: string): Record<string, string> {

--- a/frontend/src/app/services/exporters-api.service.ts
+++ b/frontend/src/app/services/exporters-api.service.ts
@@ -5,8 +5,10 @@ import { map } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { ExporterEntry } from '../generated/api-client/models/exporter-entry';
+import type { FieldOptions } from '../generated/api-client/models/field-options';
 import type { RunExportRequest } from '../generated/api-client/models/run-export-request';
 import type { RunExportResponse } from '../generated/api-client/models/run-export-response';
+import { exporterFieldOptions } from '../generated/api-client/fn/exporters/exporter-field-options';
 import { getExporters } from '../generated/api-client/fn/exporters/get-exporters';
 import { runExport } from '../generated/api-client/fn/exporters/run-export';
 
@@ -17,6 +19,19 @@ export class ExportersApiService {
 
   getExporters(): Observable<ExporterEntry[]> {
     return getExporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  /** Current option list for one of *exporterName*'s ``dynamic_options``
+   *  select fields, given a snapshot of the form's current values. */
+  getFieldOptions(
+    exporterName: string,
+    fieldKey: string,
+    values: Record<string, string>,
+  ): Observable<{ options: FieldOptions[] }> {
+    return exporterFieldOptions(this.http, this.config.rootUrl, {
+      exporter_name: exporterName,
+      body: { field_key: fieldKey, values },
+    }).pipe(map((r) => ({ options: r.body.options ?? [] })));
   }
 
   runExport(body: RunExportRequest): Observable<RunExportResponse> {

--- a/tests/io/test_dynamic_field_options.py
+++ b/tests/io/test_dynamic_field_options.py
@@ -11,15 +11,21 @@ Covers:
   surfaces other plugin exceptions as 502 with the message body.
 - The ReCaller scaffold declares its ``query_id`` field as dynamic and
   routes ``get_field_options`` through ``_rc_list_queries``.
+- The ``POST /api/exporters/field-options/<name>`` route does the same for
+  results exporters, whose dynamic selects had no route at all (issue
+  #3360), and the export route accepts a value the declared options don't
+  list.
 """
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import cast
 
 import pytest
 
 from vtscore.datasets.importers.base import DatasetImporter
+from vtscore.exporters.base import ResultsExporter
 from vtscore.plugins import PluginField
 
 
@@ -385,3 +391,135 @@ class TestReCallerDynamicQueryId:
         rc = get_importer("recaller")
         with pytest.raises(NotImplementedError):
             rc.get_field_options("not_a_field", {})
+
+
+# ---------------------------------------------------------------------------
+# /api/exporters/field-options/<name> route
+# ---------------------------------------------------------------------------
+
+
+class _StubExporter(ResultsExporter):
+    """Results exporter whose destination list is computed at runtime.
+
+    The shape issue #3360 reported: a ``dynamic_options`` select is useless
+    unless the exporter families have an options route of their own.
+    """
+
+    name = "_stub_dynamic_exporter"
+    display_name = "Stub Dynamic Exporter"
+    description = "Test exporter with a dynamic-options field."
+    fields = [
+        PluginField("account", "Account", "select", options=["personal", "team"], default="personal"),
+        PluginField(
+            "mailbox",
+            "Mailbox",
+            "select",
+            dynamic_options=True,
+            depends_on=["account"],
+        ),
+    ]
+
+    def __init__(self, fail_with: Exception | None = None) -> None:
+        super().__init__()
+        self._fail_with = fail_with
+
+    def get_field_options(self, field_key, current_values):
+        if self._fail_with is not None:
+            raise self._fail_with
+        if field_key == "mailbox":
+            account = current_values.get("account", "personal")
+            return [(f"{account}-inbox", f"{account.title()} Inbox"), f"{account}-archive"]
+        return super().get_field_options(field_key, current_values)
+
+    def export_find_results(self, results, field_values):  # pragma: no cover; unused here
+        return {"message": "ok"}
+
+
+@contextmanager
+def _registered_exporter(exporter):
+    from vtscore.exporters import get_exporter
+
+    registry = get_exporter.__self__
+    registry._ensure_discovered()
+    registry._items[exporter.name] = exporter
+    try:
+        yield exporter
+    finally:
+        registry._items.pop(exporter.name, None)
+
+
+class TestExporterFieldOptionsRoute:
+    URL_TEMPLATE = "/api/exporters/field-options/{name}"
+
+    def test_returns_options_from_exporter(self, client):
+        with _registered_exporter(_StubExporter()) as stub:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "mailbox", "values": {"account": "team"}},
+            )
+        assert resp.status_code == 200
+        assert resp.get_json() == {
+            "options": [
+                {"value": "team-inbox", "label": "Team Inbox"},
+                {"value": "team-archive", "label": "team-archive"},
+            ]
+        }
+
+    def test_unknown_exporter_returns_404(self, client):
+        resp = client.post(
+            self.URL_TEMPLATE.format(name="does_not_exist"),
+            json={"field_key": "mailbox", "values": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_unknown_field_returns_400(self, client):
+        with _registered_exporter(_StubExporter()) as stub:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "no_such_field", "values": {}},
+            )
+        assert resp.status_code == 400
+        assert "Unknown field" in resp.get_json()["message"]
+
+    def test_static_field_returns_400(self, client):
+        with _registered_exporter(_StubExporter()) as stub:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "account", "values": {}},
+            )
+        assert resp.status_code == 400
+        assert "not dynamic" in resp.get_json()["message"]
+
+    def test_not_implemented_returns_501(self, client):
+        with _registered_exporter(_StubExporter(fail_with=NotImplementedError("nope"))) as stub:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "mailbox", "values": {}},
+            )
+        assert resp.status_code == 501
+        assert resp.get_json()["message"] == "nope"
+
+    def test_plugin_exception_returns_502(self, client):
+        with _registered_exporter(_StubExporter(fail_with=RuntimeError("remote service down"))) as stub:
+            resp = client.post(
+                self.URL_TEMPLATE.format(name=stub.name),
+                json={"field_key": "mailbox", "values": {}},
+            )
+        assert resp.status_code == 502
+        assert resp.get_json()["message"] == "remote service down"
+
+    def test_export_accepts_a_value_absent_from_the_declared_options(self, client):
+        """A dynamic select's value is whatever the plugin resolved, so the
+        export route must not validate it against the declared list."""
+        with _registered_exporter(_StubExporter()) as stub:
+            resp = client.post(
+                "/api/exporters/export",
+                json={
+                    "exporter_name": stub.name,
+                    "payload_kind": "find_results",
+                    "results": {"detectors": {}},
+                    "field_values": {"account": "team", "mailbox": "team-inbox"},
+                },
+            )
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["success"] is True

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -142,6 +142,17 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`PluginBase.get_field_options(field_key, current_values)`** — the
+  dynamic-select hook now lives on the shared plugin base instead of on the
+  importer families alone, so every plugin family inherits it and a results
+  exporter can compute its options at runtime (issue #3360). The default
+  raises `NotImplementedError` naming the field, matching what the importer
+  bases already did; existing overrides are unaffected. A dynamic select's
+  declared `options` are also no longer used as the `choices` of its
+  auto-generated CLI flag — they are a seed for the first render, not the
+  allowed set, so pinning argparse to them rejected every value the plugin
+  resolved at runtime.
+
 - `vtscore.eval.seed_scores.build_seed_scores` accepts an `enrich` keyword
   (default `False`, matching the app's shipped `enrich_descriptions`
   default), so a simulated-user study can open on the same sort a real user

--- a/vtscore/docs/packages/exporters.md
+++ b/vtscore/docs/packages/exporters.md
@@ -215,6 +215,13 @@ Field semantics - `field_type` literals, `dynamic_options`,
 `depends_on`, number-field type inference - are documented in detail in
 [`plugins.md#pluginfield`](plugins.md#pluginfield).
 
+A `dynamic_options` select is served by
+`POST /api/exporters/field-options/<name>`, which calls the exporter's
+`get_field_options(field_key, current_values)`. Both surfaces that render
+an exporter's fields use it - the app's Export modal and its Auto-Find
+results-exporter settings - so an exporter whose destinations are only
+knowable at runtime fills its dropdown in either place.
+
 ## Built-in exporters
 
 | Name | Target | Notes |

--- a/vtscore/docs/packages/plugins.md
+++ b/vtscore/docs/packages/plugins.md
@@ -128,9 +128,23 @@ a decimal - e.g. `step="0.1"` or `default="1.0"`.
 
 A `"select"` field marked `dynamic_options=True` has its options
 computed at runtime by the plugin's `get_field_options(field_key,
-current_values) -> list[str]` method. List dependencies in
-`depends_on=[...]` so the frontend re-fetches whenever any depended-on
-field changes.
+current_values) -> list[FieldOption]` method, which `PluginBase`
+declares (the default raises `NotImplementedError`, naming the field).
+List dependencies in `depends_on=[...]` so the frontend re-fetches
+whenever any depended-on field changes.
+
+Every family that renders a field form serves the options over a route
+of the same shape, so the hook works the same wherever the plugin lives:
+dataset importers (`POST /api/dataset/import/<name>/options`), label
+importers (`POST /api/label-importers/field-options/<name>`), datasource
+importers (`POST /api/datasource-import/<name>/options`), seed importers
+(`POST /api/seed-import/<name>/options`), and results exporters
+(`POST /api/exporters/field-options/<name>`).
+
+A dynamic select's declared `options` are only a seed for the first
+render, so the CLI does *not* pin the generated flag's `choices` to them
+and the request schema does not validate against them - the value a
+plugin resolves at runtime is by definition not in the declared list.
 
 `PluginField.to_dict()` returns the JSON shape served by every plugin
 listing endpoint; the keys mirror the dataclass attributes 1-to-1 (with

--- a/vtscore/plugins/__init__.py
+++ b/vtscore/plugins/__init__.py
@@ -118,9 +118,11 @@ class PluginField:
     be computed at runtime (e.g. by querying a remote service).  The plugin
     must implement ``get_field_options(field_key, current_values)`` to return
     the list.  The frontend re-fetches options every time any field listed
-    in :attr:`depends_on` changes value.  Currently honoured by dataset
-    importers (``POST /api/dataset/import/<name>/options``); other plugin
-    families may opt in similarly.
+    in :attr:`depends_on` changes value.  Honoured by dataset importers
+    (``POST /api/dataset/import/<name>/options``), label importers
+    (``POST /api/label-importers/field-options/<name>``), seed importers,
+    datasource importers, and results exporters
+    (``POST /api/exporters/field-options/<name>``).
     """
 
     key: str
@@ -495,6 +497,37 @@ class PluginBase:
         """
         return self.display_name
 
+    # -- Dynamic field options ----------------------------------------------
+
+    def get_field_options(self, field_key: str, current_values: dict[str, Any]) -> list[FieldOption]:
+        """Return the dropdown options for a ``dynamic_options`` field.
+
+        Override this on any plugin declaring a :class:`PluginField` with
+        ``dynamic_options=True``.  The frontend calls it through that
+        family's options route (e.g.
+        ``POST /api/exporters/field-options/<name>``) when the form is
+        first built and again whenever a field listed in this field's
+        :attr:`~PluginField.depends_on` changes.
+
+        Args:
+            field_key: :attr:`PluginField.key` of the field whose options
+                are being requested.
+            current_values: Snapshot of every form field's current value,
+                keyed by :attr:`PluginField.key`.  Values are plain
+                strings (empty for unfilled fields).
+
+        Returns:
+            The allowed options.  Each is either a plain string (shown
+            verbatim) or a ``(value, label)`` tuple (the option submits
+            the opaque ``value`` while displaying ``label``).
+
+        Raises:
+            NotImplementedError: When the plugin declares no dynamic
+                fields, or does not handle *field_key*.  Subclasses should
+                delegate to ``super()`` for keys they do not recognise.
+        """
+        raise NotImplementedError(f"{type(self).__name__}.get_field_options({field_key!r}) is not implemented")
+
     # -- User notifications -------------------------------------------------
 
     def notify(
@@ -559,7 +592,10 @@ class PluginBase:
                 continue
             if f.default:
                 kwargs["default"] = f.default
-            if f.field_type == "select" and f.options and not f.allow_free_text:
+            if f.field_type == "select" and f.options and not f.allow_free_text and not f.dynamic_options:
+                # A dynamic-options select computes its list at runtime, so its
+                # declared ``options`` are only a seed - pinning argparse to them
+                # would reject every value the plugin resolves later.
                 kwargs["choices"] = f.options
             if f.field_type == "number":
                 kwargs["type"] = int if f.is_integer_number() else float

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -399,6 +399,48 @@ def _normalise_option(option: Any) -> dict[str, str]:
     return {"value": text, "label": text}
 
 
+def plugin_field_options(plugin: PluginBase, body: dict) -> dict:
+    """Resolve one ``dynamic_options`` field's option list for *plugin*.
+
+    The body of every plugin family's options route (dataset importers,
+    label importers, seed importers, datasource importers, results
+    exporters): validate that the named field exists and is dynamic, call
+    the plugin's ``get_field_options(field_key, current_values)`` with the
+    supplied snapshot of form values, and coerce the result into the
+    ``{"options": [{"value", "label"}, ...]}`` response shape.
+
+    Args:
+        plugin: The already-resolved plugin instance.
+        body: The parsed ``ImporterFieldOptionsRequestSchema`` body
+            (``field_key`` plus a ``values`` snapshot).
+
+    Aborts:
+        400 for an unknown or non-dynamic ``field_key``; 501 when the
+        plugin does not implement the hook; 502 for any other plugin
+        error (network failure, auth error) so the frontend can show the
+        message inline; 500 when the hook returns a non-list.
+    """
+    field_key = body["field_key"].strip()
+    values = body.get("values") or {}
+
+    field = next((f for f in plugin.fields if f.key == field_key), None)
+    if field is None:
+        abort(400, message=f"Unknown field: {field_key!r}")
+    if not getattr(field, "dynamic_options", False):
+        abort(400, message=f"Field {field_key!r} is not dynamic")
+
+    try:
+        options = plugin.get_field_options(field_key, values)
+    except NotImplementedError as exc:
+        abort(501, message=str(exc) or "Importer does not implement get_field_options")
+    except Exception as exc:  # noqa: BLE001 (surface remote-service errors verbatim)
+        abort(502, message=str(exc) or type(exc).__name__)
+
+    if not isinstance(options, list):
+        abort(500, message="get_field_options must return a list")
+    return {"options": [_normalise_option(o) for o in options]}
+
+
 def get_json_or_400():
     """Parse the request body as JSON, returning a 400 response on failure.
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -47,9 +47,9 @@ from vtscore.datasets.registry import (
 )
 from vtsearch.auth import get_current_user
 from vtsearch.routes._shared import (
-    _normalise_option,
     abort_if_semantic_only_embedders,
     get_plugin_or_404,
+    plugin_field_options,
     register_plugin_typed_routes,
     validate_plugin_args,
 )
@@ -621,25 +621,7 @@ def importer_field_options(body: dict, importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_key = body["field_key"].strip()
-    values = body.get("values") or {}
-
-    field = next((f for f in importer.fields if f.key == field_key), None)
-    if field is None:
-        abort(400, message=f"Unknown field: {field_key!r}")
-    if not getattr(field, "dynamic_options", False):
-        abort(400, message=f"Field {field_key!r} is not dynamic")
-
-    try:
-        options = importer.get_field_options(field_key, values)
-    except NotImplementedError as exc:
-        abort(501, message=str(exc) or "Importer does not implement get_field_options")
-    except Exception as exc:  # noqa: BLE001 (surface remote-service errors verbatim)
-        abort(502, message=str(exc) or type(exc).__name__)
-
-    if not isinstance(options, list):
-        abort(500, message="get_field_options must return a list")
-    return {"options": [_normalise_option(o) for o in options]}
+    return plugin_field_options(importer, body)
 
 
 @datasets_staging_bp.route("/api/dataset/import/<importer_name>/suggested-name", methods=["POST"])

--- a/vtsearch/routes/labels/exporters.py
+++ b/vtsearch/routes/labels/exporters.py
@@ -8,6 +8,14 @@ Endpoints
 GET  /api/exporters
     List all registered exporters with their metadata and field definitions.
 
+POST /api/exporters/field-options/<exporter_name>
+    Return dropdown options for a ``dynamic_options`` field.  Delegates
+    to ``get_field_options(field_key, current_values)`` on the exporter,
+    the same contract the importer families use, so an exporter whose
+    destination list is only knowable at runtime (a mailbox, a bucket, a
+    remote queue) can populate its select in the Export modal and in the
+    Auto-Find results-exporter settings.
+
 POST /api/exporters/export
     Run a specific exporter on the payload supplied in the request body.
     ``payload_kind`` says whether that payload is a scored run
@@ -35,7 +43,15 @@ from flask_smorest import Blueprint, abort
 from vtscore.exporters import get_exporter, list_exporters
 from vtscore.exporters.base import ResultsExporter
 from vtscore.security.url_validation import validate_browser_url
-from vtsearch.routes._shared import validate_exporter_field_values
+from vtsearch.routes._shared import (
+    get_plugin_or_404,
+    plugin_field_options,
+    validate_exporter_field_values,
+)
+from vtsearch.schemas.datasets import (
+    ImporterFieldOptionsRequestSchema,
+    ImporterFieldOptionsResponseSchema,
+)
 from vtsearch.schemas.labels import (
     ExporterEntrySchema,
     RunExportRequestSchema,
@@ -78,6 +94,31 @@ def get_exporters():
     from vtsearch.settings import filter_visible_plugins
 
     return [exp.to_dict() for exp in filter_visible_plugins("exporters", list_exporters())]
+
+
+@exporters_bp.route("/api/exporters/field-options/<exporter_name>", methods=["POST"])
+@exporters_bp.arguments(ImporterFieldOptionsRequestSchema)
+@exporters_bp.response(200, ImporterFieldOptionsResponseSchema)
+@exporters_bp.alt_response(400, description="Unknown or non-dynamic field key.")
+@exporters_bp.alt_response(404, description="Unknown exporter name.")
+@exporters_bp.alt_response(500, description="get_field_options did not return a list.")
+@exporters_bp.alt_response(501, description="Exporter does not implement get_field_options.")
+@exporters_bp.alt_response(502, description="Remote service backing dynamic options raised an error.")
+def exporter_field_options(body: dict, exporter_name: str):
+    """Return dropdown options for a dynamic-options field on an exporter.
+
+    Same contract as ``POST /api/dataset/import/<name>/options``: the
+    exporter's ``get_field_options(field_key, current_values)`` is called
+    with the supplied snapshot of current form values, and plugin errors
+    (network failure, auth error, etc.) surface as a 502 with the
+    original message so the frontend can display them inline.
+    """
+    exporter, err = get_plugin_or_404(get_exporter, list_exporters, exporter_name, "exporter")
+    if err:
+        return err
+    assert exporter is not None  # narrowed by err check
+
+    return plugin_field_options(exporter, body)
 
 
 @exporters_bp.route("/api/exporters/export", methods=["POST"])

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -65,12 +65,10 @@ from flask_smorest import Blueprint
 
 logger = logging.getLogger(__name__)
 
-from flask_smorest import abort
-
 from vtscore.labels.importers import get_label_importer, list_label_importers
 from vtsearch.routes._shared import (
-    _normalise_option,
     get_plugin_or_404,
+    plugin_field_options,
     register_plugin_typed_routes,
     require_dataset_header,
     require_detector_header,
@@ -247,25 +245,7 @@ def label_importer_field_options(body: dict, importer_name: str):
         return err
     assert importer is not None
 
-    field_key = body["field_key"].strip()
-    values = body.get("values") or {}
-
-    field = next((f for f in importer.fields if f.key == field_key), None)
-    if field is None:
-        abort(400, message=f"Unknown field: {field_key!r}")
-    if not getattr(field, "dynamic_options", False):
-        abort(400, message=f"Field {field_key!r} is not dynamic")
-
-    try:
-        options = importer.get_field_options(field_key, values)
-    except NotImplementedError as exc:
-        abort(501, message=str(exc) or "Importer does not implement get_field_options")
-    except Exception as exc:  # noqa: BLE001
-        abort(502, message=str(exc) or type(exc).__name__)
-
-    if not isinstance(options, list):
-        abort(500, message="get_field_options must return a list")
-    return {"options": [_normalise_option(o) for o in options]}
+    return plugin_field_options(importer, body)
 
 
 # ---------------------------------------------------------------------------

--- a/vtsearch/routes/media/datasource.py
+++ b/vtsearch/routes/media/datasource.py
@@ -31,8 +31,8 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.datasource_importers import get_datasource_importer, list_datasource_importers
 from vtsearch.routes._shared import (
-    _normalise_option,
     get_plugin_or_404,
+    plugin_field_options,
     register_plugin_typed_routes,
     validate_plugin_args,
 )
@@ -137,25 +137,7 @@ def datasource_importer_field_options(body: dict, importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_key = body["field_key"].strip()
-    values = body.get("values") or {}
-
-    field = next((f for f in importer.fields if f.key == field_key), None)
-    if field is None:
-        abort(400, message=f"Unknown field: {field_key!r}")
-    if not getattr(field, "dynamic_options", False):
-        abort(400, message=f"Field {field_key!r} is not dynamic")
-
-    try:
-        options = importer.get_field_options(field_key, values)
-    except NotImplementedError as exc:
-        abort(501, message=str(exc) or "Importer does not implement get_field_options")
-    except Exception as exc:  # noqa: BLE001 (surface remote-service errors verbatim)
-        abort(502, message=str(exc) or type(exc).__name__)
-
-    if not isinstance(options, list):
-        abort(500, message="get_field_options must return a list")
-    return {"options": [_normalise_option(o) for o in options]}
+    return plugin_field_options(importer, body)
 
 
 # Per-plugin typed routes for /api/datasource-import/<name>, so each known

--- a/vtsearch/routes/media/seed.py
+++ b/vtsearch/routes/media/seed.py
@@ -30,8 +30,8 @@ from flask_smorest import Blueprint, abort
 
 from vtscore.seed_importers import get_seed_importer, list_seed_importers
 from vtsearch.routes._shared import (
-    _normalise_option,
     get_plugin_or_404,
+    plugin_field_options,
     register_plugin_typed_routes,
     validate_plugin_args,
 )
@@ -145,25 +145,7 @@ def seed_importer_field_options(body: dict, importer_name: str):
         return err
     assert importer is not None  # narrowed by err check
 
-    field_key = body["field_key"].strip()
-    values = body.get("values") or {}
-
-    field = next((f for f in importer.fields if f.key == field_key), None)
-    if field is None:
-        abort(400, message=f"Unknown field: {field_key!r}")
-    if not getattr(field, "dynamic_options", False):
-        abort(400, message=f"Field {field_key!r} is not dynamic")
-
-    try:
-        options = importer.get_field_options(field_key, values)
-    except NotImplementedError as exc:
-        abort(501, message=str(exc) or "Importer does not implement get_field_options")
-    except Exception as exc:  # noqa: BLE001 (surface remote-service errors verbatim)
-        abort(502, message=str(exc) or type(exc).__name__)
-
-    if not isinstance(options, list):
-        abort(500, message="get_field_options must return a list")
-    return {"options": [_normalise_option(o) for o in options]}
+    return plugin_field_options(importer, body)
 
 
 # Per-plugin typed routes for /api/seed-import/<name>, so each registered


### PR DESCRIPTION
A `PluginField` declared with `dynamic_options=True` has its select options computed at runtime by the plugin's `get_field_options()`. Every importer family had a route for that; **results exporters had none**, so an exporter whose destinations are only knowable at runtime rendered the (usually empty) list frozen into its plugin definition. Hard-coding the options at plugin-definition time was the only thing that worked — exactly what #3360 reported against the Auto-Find results exporter.

## Backend

- **`PluginBase.get_field_options(field_key, current_values)`** — the hook moves onto the shared plugin base, so every family inherits it. The default raises `NotImplementedError` naming the field, matching what the importer bases already did; their overrides are untouched, so no out-of-tree plugin changes behaviour.
- **`POST /api/exporters/field-options/<exporter_name>`**, the same contract the importer families use: 400 for an unknown or non-dynamic field key, 404 unknown exporter, 501 when the exporter has no hook, 502 for a plugin error with the message passed through verbatim.
- The five options routes (dataset / label / datasource / seed importers + the new exporter one) now share a single `plugin_field_options()` helper in `vtsearch/routes/_shared.py` instead of five byte-identical handler bodies.
- `PluginBase.add_cli_arguments` no longer pins a dynamic select's argparse `choices` to its declared `options`. Those are a seed for the first render, not the allowed set, so the generated flag rejected every value the plugin resolved at runtime. (The request schema already skipped them; this makes the CLI agree.)

## Frontend — both surfaces that render an exporter's fields

- **Settings › Auto-Find "Results Exporter"** fetches the live list for the exporter restored from settings (once the exporter list lands, which is the first moment its fields are known), on a tab switch, and again whenever a field named in a `depends_on` changes. An auto-selected option is committed back onto the field-value map so it is persisted like a typed one; a fetch guard keeps the parent's input round-trip from answering its own selection with another fetch.
- **The Export modal** does the same for its active exporter tab.
- Both surfaces disable the select while a fetch is in flight, show a fetch failure inline instead of a silently empty dropdown, and honour `allow_free_text` by rendering a combobox (previously ignored in exporter forms).

## Verification

- Full `./run-tests.sh`: `ALL 9421 TESTS PASSED`, `RUN PASSED`.
- New backend tests for the route (options, 400/404/501/502) plus one proving the export route accepts a value the declared options don't list.
- New Vitest specs for both surfaces: fetch on select, re-fetch on a `depends_on` change with the stale value replaced, inline error, and the auto-selected value being persisted.
- **In chromium**, against a temporary stub exporter: the Auto-Find tab issues `POST /api/exporters/field-options/tmp_dynamic` with `{"account":"personal"}` on select, re-issues it with `{"account":"team", …}` when the dependency changes, renders `Team Inbox` / `Team DLQ`, and `GET /api/settings` afterwards shows `{"tmp_dynamic": {"account": "team", "queue": "team-inbox"}}` — the auto-selected option persisted.

Settings importers/exporters (a different plugin family, `settings_io`) still have no options route; nothing reported one and no in-tree plugin declares a dynamic field there.

Closes #3360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrbBxCudThoNL5uTk4Ubbx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrbBxCudThoNL5uTk4Ubbx)_