### PR TITLE
hits: carry the importer's custom_metadata onto every scored hit

### DIFF
--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -1302,7 +1302,7 @@ class TestReportWholePageFigure:
         # Same contract as the provenance glosses: a kind with no swatch falls
         # back to grey and reads as "some other mark", which is the one thing
         # this figure is supposed to stop doing.
-        emitted = set(mods["spods"].MARK_CATEGORIES) | set(mods["spods"].CONTEXT_CATEGORIES)
+        emitted = set(mods["spods"].MARK_CATEGORIES) | set(mods["spods"].LOCALISED_CONTEXT_CATEGORIES)
         assert emitted <= set(mods["report"]._KIND_COLOURS)
         assert emitted <= set(mods["report"]._KIND_MEANING)
 

--- a/tests_lib/detectors/test_media_hit_metadata.py
+++ b/tests_lib/detectors/test_media_hit_metadata.py
@@ -1,0 +1,78 @@
+"""``build_media_hit`` carries the importer's ``custom_metadata`` onto the hit.
+
+An exporter's whole job is often to hand results back to the system the media
+came from, and the only thing on a media that names a row *in that system* is
+the importer-supplied ``custom_metadata`` (asset ids, catalogue keys, …).  It
+therefore travels with the hit, minus the ``embedding`` plumbing key.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from vtscore.utils.hits import build_media_hit
+
+
+class TestCustomMetadataOnHit:
+    def test_included_when_media_has_it(self):
+        media = {"filename": "a.wav", "category": "audio", "md5": "abc", "custom_metadata": {"asset_id": "XY-7"}}
+        hit = build_media_hit(1, media, 0.9)
+        assert hit["custom_metadata"] == {"asset_id": "XY-7"}
+
+    def test_absent_when_media_has_none(self):
+        hit = build_media_hit(1, {"filename": "a.wav", "category": "audio"}, 0.9)
+        assert "custom_metadata" not in hit
+
+    def test_absent_when_empty_or_null(self):
+        for value in ({}, None, "not-a-dict"):
+            hit = build_media_hit(1, {"filename": "a.wav", "custom_metadata": value}, 0.9)
+            assert "custom_metadata" not in hit, value
+
+    def test_embedding_key_is_stripped(self):
+        """A pre-computed vector shipped via ``custom_metadata_map`` stays out of the hit."""
+        media = {
+            "filename": "a.wav",
+            "category": "audio",
+            "custom_metadata": {"asset_id": "XY-7", "embedding": np.zeros(4, dtype=np.float32)},
+        }
+        hit = build_media_hit(1, media, 0.9)
+        assert hit["custom_metadata"] == {"asset_id": "XY-7"}
+        # The JSON exporters call json.dumps with no default=; a numpy array
+        # riding along inside custom_metadata would fail the whole export.
+        assert json.loads(json.dumps(hit))["custom_metadata"] == {"asset_id": "XY-7"}
+
+    def test_only_embedding_means_no_custom_metadata_key(self):
+        media = {"filename": "a.wav", "custom_metadata": {"embedding": np.zeros(4, dtype=np.float32)}}
+        assert "custom_metadata" not in build_media_hit(1, media, 0.9)
+
+    def test_hit_metadata_is_a_copy(self):
+        media = {"filename": "a.wav", "custom_metadata": {"asset_id": "XY-7"}}
+        hit = build_media_hit(1, media, 0.9)
+        hit["custom_metadata"]["asset_id"] = "mutated"
+        assert media["custom_metadata"] == {"asset_id": "XY-7"}
+
+    def test_extra_kwarg_still_wins(self):
+        media = {"filename": "a.wav", "custom_metadata": {"asset_id": "XY-7"}}
+        hit = build_media_hit(1, media, 0.9, custom_metadata={"asset_id": "override"})
+        assert hit["custom_metadata"] == {"asset_id": "override"}
+
+    def test_other_hit_fields_are_unchanged(self):
+        media = {
+            "filename": "a.wav",
+            "category": "audio",
+            "md5": "abc",
+            "origin": {"importer": "server_folder"},
+            "origin_name": "a.wav",
+            "custom_metadata": {"asset_id": "XY-7"},
+        }
+        hit = build_media_hit(7, media, 0.87312, label="good")
+        assert hit["id"] == 7
+        assert hit["filename"] == "a.wav"
+        assert hit["category"] == "audio"
+        assert hit["score"] == 0.8731
+        assert hit["md5"] == "abc"
+        assert hit["origin"] == {"importer": "server_folder"}
+        assert hit["origin_name"] == "a.wav"
+        assert hit["label"] == "good"

--- a/vtscore/docs/packages/utils.md
+++ b/vtscore/docs/packages/utils.md
@@ -58,15 +58,24 @@ The returned dict always has these keys:
 Optional keys are added only when the corresponding field is present
 on *media*:
 
-| Key            | Added when…                              |
-|----------------|------------------------------------------|
-| `origin`       | `media["origin"] is not None`            |
-| `origin_name`  | `media["origin_name"]` is truthy         |
-| `md5`          | `media["md5"]` is truthy                 |
-| `clip_start`   | `media["clip_start"] is not None`        |
-| `clip_end`     | `media["clip_end"] is not None`          |
-| `clip_box`     | `media["clip_box"] is not None`          |
-| `clip_index`   | `media["clip_index"] is not None`        |
+| Key               | Added when…                                        |
+|-------------------|----------------------------------------------------|
+| `custom_metadata` | `media["custom_metadata"]` is a non-empty dict      |
+| `origin`          | `media["origin"] is not None`                      |
+| `origin_name`     | `media["origin_name"]` is truthy                   |
+| `md5`             | `media["md5"]` is truthy                           |
+| `clip_start`      | `media["clip_start"] is not None`                  |
+| `clip_end`        | `media["clip_end"] is not None`                    |
+| `clip_box`        | `media["clip_box"] is not None`                    |
+| `clip_index`      | `media["clip_index"] is not None`                  |
+
+`custom_metadata` is the importer-supplied metadata the media carries
+(asset ids, catalogue rows, whatever the source system attached), and
+it is what lets an exporter correlate a hit back to that system. It is
+a fresh dict, so mutating it cannot reach back into the loaded media,
+and the `embedding` key is stripped: that key is the pre-computed
+vector channel of `custom_metadata_map`, consumed at load time, and a
+numpy array has no business in an export.
 
 The `clip_*` keys are how sub-medias produced by a clipper round-trip
 through scoring. They are passed through unchanged so the consumer
@@ -84,6 +93,7 @@ media = {
     "origin": {"importer": "server_folder", "params": {"folder": "/srv/sounds"}},
     "origin_name": "/srv/sounds/talk_01.wav",
     "md5": "abc123",
+    "custom_metadata": {"asset_id": "XY-7"},
     "clip_start": 12.5,
     "clip_end": 17.5,
     "clip_index": 2,
@@ -96,6 +106,7 @@ hit = build_media_hit(cid=42, media=media, score=0.873, label="good")
 #     "filename": "talk_01.wav",
 #     "category": "podcast",
 #     "score": 0.873,
+#     "custom_metadata": {"asset_id": "XY-7"},
 #     "origin": {"importer": "server_folder", "params": {"folder": "/srv/sounds"}},
 #     "origin_name": "/srv/sounds/talk_01.wav",
 #     "md5": "abc123",

--- a/vtscore/exporters/base.py
+++ b/vtscore/exporters/base.py
@@ -285,8 +285,10 @@ class ResultsExporter(PluginBase):
                      Each hit comes from
                      :func:`vtscore.utils.hits.build_media_hit`: ``id``,
                      ``filename``, ``category``, ``score``, plus ``origin`` /
-                     ``origin_name`` / ``md5`` and any clip bounds the media
-                     carries.
+                     ``origin_name`` / ``md5``, the importer-supplied
+                     ``custom_metadata`` (when the media carries any - this is
+                     how an exporter correlates a hit back to the caller's own
+                     system), and any clip bounds the media carries.
 
                      **``negative_hits`` is conventionally ignored.** Every
                      built-in exporter writes positives only, because "the

--- a/vtscore/utils/hits.py
+++ b/vtscore/utils/hits.py
@@ -4,6 +4,31 @@ from __future__ import annotations
 
 from typing import Any
 
+#: ``custom_metadata`` keys stripped before the dict reaches a hit.
+#:
+#: ``embedding`` is the pre-computed-vector channel an importer uses to ship a
+#: vector alongside a file (``custom_metadata_map``, see
+#: :func:`vtscore.datasets.loader_folder.load_dataset_from_folder`).  It is
+#: consumed at load time and has no business in an exported hit: it is a numpy
+#: array, so it would break ``json.dumps`` in every JSON exporter, and writing
+#: a vector into an export is exactly the persistence the no-persisted-vectors
+#: rule forbids.  ``_HitSchema`` relies on its media fields being an allowlist
+#: for the same reason, and ``custom_metadata`` is a free-form ``Dict`` that
+#: would wave the vector straight through.
+_CUSTOM_METADATA_EXCLUDED_KEYS = frozenset({"embedding"})
+
+
+def _hit_custom_metadata(media: dict[str, Any]) -> dict[str, Any]:
+    """Return the importer metadata to carry on a hit, or ``{}`` for none.
+
+    Always a fresh dict, so a consumer that mutates a hit's
+    ``custom_metadata`` cannot reach back into the loaded media.
+    """
+    custom = media.get("custom_metadata")
+    if not isinstance(custom, dict):
+        return {}
+    return {k: v for k, v in custom.items() if k not in _CUSTOM_METADATA_EXCLUDED_KEYS}
+
 
 def build_media_hit(
     cid: int,
@@ -24,7 +49,8 @@ def build_media_hit(
 
     Returns:
         A dict with ``id``, ``filename``, ``category``, ``score`` and,
-        when present on the media, ``origin``, ``origin_name``, ``md5``.
+        when present on the media, ``custom_metadata``, ``origin``,
+        ``origin_name``, ``md5``.
     """
     hit: dict[str, Any] = {
         "id": cid,
@@ -32,6 +58,12 @@ def build_media_hit(
         "category": media.get("category", "unknown"),
         "score": round(score, 4),
     }
+    # Importer-supplied metadata is how an exporter correlates a hit back to
+    # the caller's own system (asset ids, catalogue rows, …), so it travels
+    # with the hit whenever the media carries any.
+    custom = _hit_custom_metadata(media)
+    if custom:
+        hit["custom_metadata"] = custom
     if media.get("origin") is not None:
         hit["origin"] = media["origin"]
     if media.get("origin_name"):


### PR DESCRIPTION
`build_media_hit` is the single source of truth for the hit dicts that CLI autodetect results and `/api/labels/fill-from-sort` hand to exporters — but it dropped the one field that names the item in the *caller's* system: the importer-supplied `custom_metadata` (asset ids, catalogue keys, whatever the source attached). An exporter receiving a hit through `export_cli` had no way to correlate it back, which is what #3363 hit.

## What changed

`vtscore/utils/hits.py` now includes `custom_metadata` whenever the media carries a non-empty one, alongside the `origin` / `origin_name` / `md5` / `clip_*` fields it already passes through. Two details:

- **It is a copy.** A consumer mutating a hit's `custom_metadata` cannot reach back into the loaded media dict.
- **The `embedding` key is stripped.** That key is the pre-computed-vector channel of `custom_metadata_map` (consumed at load time by `loader_folder`). Left in, it would break `json.dumps` in every JSON exporter — the exporters call it with no `default=` — and would write a vector into an export, which is exactly what the no-persisted-vectors rule forbids. It is also the one thing `_HitSchema`'s allowlist can't stop, since `custom_metadata` is a free-form `fields.Dict`.

The issue offered a second option (let a `ResultsExporter` declare extra hit fields); this takes the first, which needs no new plugin surface and benefits every exporter, in-tree and out.

## Why this isn't a widened contract

The API's `_HitSchema` already declares `custom_metadata` (inherited from `MediaEntrySchema`), and the auto-detect route already served it — it builds hits via `_media_info_for_response`, which passes the whole media minus the heavyweight keys. So this closes a gap *between* the two hit-producing paths rather than adding a field to the API. `frontend/openapi.json` is unchanged.

The CSV exporter enumerates its columns explicitly and so is untouched; JSON/NDJSON exports and any custom exporter now see the field.

## Drive-by: a red test on `dev`

`tests_lib/datasets/test_docmarks_corpus.py::TestReportWholePageFigure::test_every_kind_the_sources_emit_has_a_colour_and_a_gloss` has been failing on `dev`. Two branches merged in parallel: one added the test, the other renamed `CONTEXT_CATEGORIES` → `LOCALISED_CONTEXT_CATEGORIES` in `sources/spods.py` (`5a359a95`). Neither diff touched the other's line, so the merge was clean and the break silent. Fixed here (second commit) since `run-tests.sh` is the only gate.

## Tests

New `tests_lib/detectors/test_media_hit_metadata.py`: inclusion, absence for empty/`None`/non-dict, the `embedding` strip (including a `json.dumps` round-trip with a numpy array present), copy semantics, `**extra` override, and that the other hit fields are untouched.

Full `./run-tests.sh`: **RUN PASSED** — 9448 passed, 6 skipped; pyright, pip-audit, npm audit and the Vitest suite all OK.

Closes #3363


---
_Generated by [Claude Code](https://claude.ai/code/session_01Quj9FV592N6cH4EpPCfvnS)_