### PR TITLE
Strip nested custom_metadata vectors from every surface that serves a media

### DIFF
--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -14911,7 +14911,7 @@
     },
     "/api/medias/batch": {
       "post": {
-        "description": "Callers request only the IDs they need (e.g. the ones currently visible\nin a virtual-scrolling viewport), keeping payload size bounded.  Use\n:func:`list_media_ids` (``GET /api/medias/ids``) to discover which\nmedia IDs exist in the loaded dataset.\n\nReturns a JSON array of media metadata dicts; unknown IDs are silently\nomitted.  Each item's ``custom_metadata`` is the media type's\n``display_metadata`` - including the curated \"Source\" / \"Derived Via\" /\n\"Imported Via\" provenance lines distilled from ``origin.params`` - with\nany importer-supplied ``custom_metadata`` layered on top.",
+        "description": "Callers request only the IDs they need (e.g. the ones currently visible\nin a virtual-scrolling viewport), keeping payload size bounded.  Use\n:func:`list_media_ids` (``GET /api/medias/ids``) to discover which\nmedia IDs exist in the loaded dataset.\n\nReturns a JSON array of media metadata dicts; unknown IDs are silently\nomitted.  Each item's ``custom_metadata`` is the media type's\n``display_metadata`` - including the curated \"Source\" / \"Derived Via\" /\n\"Imported Via\" provenance lines distilled from ``origin.params`` - with\nany importer-supplied ``custom_metadata`` layered on top, minus the\n``embedding`` plumbing key.",
         "operationId": "batch_medias",
         "requestBody": {
           "content": {

--- a/tests/api/test_custom_metadata_vector_leak.py
+++ b/tests/api/test_custom_metadata_vector_leak.py
@@ -1,0 +1,169 @@
+"""A pre-computed vector nested in ``custom_metadata`` never reaches a response.
+
+``custom_metadata_map`` is the documented plugin channel for shipping a
+pre-computed vector alongside a file, and ``load_dataset_from_folder`` reads
+that vector *without popping it* — so a media loaded that way carries
+``custom_metadata["embedding"]``.  Every route that strips a media by
+top-level key (``_HEAVYWEIGHT_KEYS``) is blind to it, and the response
+schemas' free-form ``fields.Dict`` waves it straight through, so the numpy
+array reaches Flask's JSON encoder and 500s the whole request.
+
+:func:`vtscore.utils.hits.hit_custom_metadata` is the single filter every one
+of those surfaces now runs the dict through.  One test per surface, asserting
+the observable outcome: the caller's own keys survive, the vector doesn't.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tests.helpers import setup_trainable_model_in_registry
+from vtscore.media.processors import Extractor
+from vtsearch.state import snapshot_medias
+
+
+@pytest.fixture
+def media_with_nested_vector():
+    """Stamp a ``custom_metadata_map``-shaped vector onto one loaded media.
+
+    Returns the media id.  ``reset_state`` re-copies every media dict before
+    the next test, so the new top-level key does not leak out of this one.
+    """
+    from vtsearch.state import medias
+
+    cid = sorted(medias.keys())[0]
+    medias[cid]["custom_metadata"] = {
+        "asset_id": "XY-7",
+        "embedding": np.zeros(4, dtype=np.float32),
+    }
+    return cid
+
+
+def _assert_sanitised(custom: dict, where: str) -> None:
+    assert custom.get("asset_id") == "XY-7", f"{where} dropped the importer's own metadata"
+    assert "embedding" not in custom, f"a pre-computed vector leaked into {where}"
+
+
+class _StubExtractor(Extractor):
+    """Audio extractor that fires on every media, so no dataset is needed."""
+
+    @property
+    def name(self) -> str:
+        return "stub-ext"
+
+    @property
+    def media_type(self) -> str:
+        return "audio"
+
+    def extract(self, media: dict) -> list[dict]:
+        return [{"confidence": 0.9, "label": "found"}]
+
+
+class TestAutoDetectHits:
+    """``POST /api/auto-detect`` — ``media_info_for_response`` builds each hit."""
+
+    def test_hit_custom_metadata_keeps_asset_id_and_drops_vector(self, client, media_with_nested_vector):
+        from vtsearch.settings import add_autofind_detector
+
+        setup_trainable_model_in_registry(
+            "auto-detect-nested-vector",
+            good_ids=[1, 2, 3],
+            bad_ids=[18, 19, 20],
+            snap=snapshot_medias(),
+        )
+        add_autofind_detector("auto-detect-nested-vector")
+
+        resp = client.post("/api/auto-detect", json={})
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+        result = resp.get_json()["results"]["auto-detect-nested-vector"]
+        hits = [h for h in result["hits"] + result["negative_hits"] if h["id"] == media_with_nested_vector]
+        assert hits, "the seeded media should be scored into one of the two hit lists"
+        _assert_sanitised(hits[0]["custom_metadata"], "an auto-detect hit")
+
+
+class TestProcessorScoringHits:
+    """``POST /api/extract`` — the same helper, via the processor routes."""
+
+    def test_extract_result_keeps_asset_id_and_drops_vector(self, client, monkeypatch, media_with_nested_vector):
+        from vtsearch.routes.processors import scoring as scoring_mod
+
+        monkeypatch.setattr(scoring_mod, "_build_extractor", lambda name, extractor_type, config: _StubExtractor())
+
+        resp = client.post(
+            "/api/extract",
+            json={"name": "stub-ext", "extractor_type": "any", "config": {}},
+        )
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        rows = [r for r in resp.get_json()["results"] if r["id"] == media_with_nested_vector]
+        assert rows, "the seeded media should have produced an extraction hit"
+        _assert_sanitised(rows[0]["custom_metadata"], "an extract result")
+
+
+class TestMediaBatch:
+    """``POST /api/medias/batch`` layers importer metadata over display metadata."""
+
+    def test_batch_keeps_asset_id_and_drops_vector(self, client, media_with_nested_vector):
+        resp = client.post("/api/medias/batch", json={"ids": [media_with_nested_vector]})
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+        rows = resp.get_json()
+        assert len(rows) == 1
+        _assert_sanitised(rows[0]["custom_metadata"], "a /api/medias/batch row")
+
+    def test_display_metadata_still_present(self, client, media_with_nested_vector):
+        """The importer layer is filtered, not replaced: the media type's own
+        display metadata still sits underneath it."""
+        resp = client.post("/api/medias/batch", json={"ids": [media_with_nested_vector]})
+        custom = resp.get_json()[0]["custom_metadata"]
+        assert len(custom) > 1, "display_metadata keys were lost along with the vector"
+
+
+class TestEnrichedLabelExport:
+    """``GET /api/labels/export?enrich=1`` — the metadata blob becomes an export column."""
+
+    def test_export_entry_keeps_asset_id_and_drops_vector(self, client, media_with_nested_vector):
+        from vtsearch.state import good_votes
+
+        good_votes[media_with_nested_vector] = None
+
+        resp = client.get("/api/labels/export?enrich=1")
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+
+        body = resp.get_json()
+        entries = [e for e in body["labels"] if e.get("custom_metadata")]
+        assert entries, "the voted media should have produced an enriched label entry"
+        _assert_sanitised(entries[0]["custom_metadata"], "an enriched label export entry")
+        assert "embedding" not in body["available_columns"]
+
+
+class TestMediaInfoForResponse:
+    """The shared helper, directly."""
+
+    def test_strips_both_layers(self):
+        from vtsearch.routes._shared import media_info_for_response
+
+        media = {
+            "id": 1,
+            "filename": "a.wav",
+            "embeddings": {"clap": np.zeros(4)},
+            "media_bytes": b"\x00",
+            "custom_metadata": {"asset_id": "XY-7", "embedding": np.zeros(4)},
+        }
+        info = media_info_for_response(media)
+        assert info == {"id": 1, "filename": "a.wav", "custom_metadata": {"asset_id": "XY-7"}}
+
+    def test_custom_metadata_is_a_copy(self):
+        from vtsearch.routes._shared import media_info_for_response
+
+        media = {"id": 1, "custom_metadata": {"asset_id": "XY-7"}}
+        info = media_info_for_response(media)
+        info["custom_metadata"]["asset_id"] = "mutated"
+        assert media["custom_metadata"] == {"asset_id": "XY-7"}
+
+    def test_leaves_a_media_without_custom_metadata_alone(self):
+        from vtsearch.routes._shared import media_info_for_response
+
+        assert media_info_for_response({"id": 1, "custom_metadata": None}) == {"id": 1, "custom_metadata": None}
+        assert media_info_for_response({"id": 1}) == {"id": 1}

--- a/tests/api/test_custom_metadata_vector_leak.py
+++ b/tests/api/test_custom_metadata_vector_leak.py
@@ -84,9 +84,18 @@ class TestAutoDetectHits:
 
 
 class TestProcessorScoringHits:
-    """``POST /api/extract`` — the same helper, via the processor routes."""
+    """``POST /api/extract`` — the same helper, via the processor routes.
 
-    def test_extract_result_keeps_asset_id_and_drops_vector(self, client, monkeypatch, media_with_nested_vector):
+    Two gates stack here, and only the inner one is this change's: the route
+    builds each row with ``media_info_for_response`` (pinned directly in
+    :class:`TestMediaInfoForResponse`), and ``_ProcessorHitSchema`` then dumps
+    only ``id`` / ``extractions`` / ``localizations``, so the row a client
+    receives carries no importer metadata at all.  Assert the observable
+    outcome — the route serializes at all, and nothing vector-shaped survives
+    — so a later widening of that schema can't quietly reopen the leak.
+    """
+
+    def test_extract_serializes_and_carries_no_vector(self, client, monkeypatch, media_with_nested_vector):
         from vtsearch.routes.processors import scoring as scoring_mod
 
         monkeypatch.setattr(scoring_mod, "_build_extractor", lambda name, extractor_type, config: _StubExtractor())
@@ -98,7 +107,8 @@ class TestProcessorScoringHits:
         assert resp.status_code == 200, resp.get_data(as_text=True)
         rows = [r for r in resp.get_json()["results"] if r["id"] == media_with_nested_vector]
         assert rows, "the seeded media should have produced an extraction hit"
-        _assert_sanitised(rows[0]["custom_metadata"], "an extract result")
+        assert "embedding" not in rows[0].get("custom_metadata", {})
+        assert "embedding" not in rows[0]
 
 
 class TestMediaBatch:

--- a/tests_lib/datasets/test_labelset_custom_metadata.py
+++ b/tests_lib/datasets/test_labelset_custom_metadata.py
@@ -1,0 +1,68 @@
+"""A pre-computed vector never reaches a ``LabeledElement``'s metadata.
+
+``LabelSet`` carries a media's importer ``custom_metadata`` onto every element
+it emits, and a detector's labelset is written to disk as JSON
+(``vtscore.detectors.store``).  ``custom_metadata_map`` lets an importer nest
+a pre-computed vector inside that dict, so reading it verbatim would both
+crash the detector write (``json.dump`` has no numpy encoder) and persist a
+vector - the one thing the no-persisted-vectors rule forbids outright.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from vtscore.datasets.labelset import LabelSet
+
+
+def _media(cid: int, custom: dict) -> dict:
+    return {
+        "id": cid,
+        "md5": f"md5-{cid}",
+        "filename": f"a{cid}.wav",
+        "category": "audio",
+        "origin_name": f"a{cid}.wav",
+        "custom_metadata": custom,
+    }
+
+
+class TestLabelSetCustomMetadata:
+    def test_importer_metadata_survives_without_the_vector(self):
+        medias = {1: _media(1, {"asset_id": "XY-7", "embedding": np.zeros(4, dtype=np.float32)})}
+        labelset = LabelSet.from_clips_and_votes(medias, {1: None}, {}, expand_dupes=False)
+
+        (element,) = labelset.elements
+        assert element.metadata == {"asset_id": "XY-7"}
+
+    def test_labelset_stays_json_writable(self):
+        """``_write_detector`` calls ``json.dump`` on exactly this dict."""
+        medias = {1: _media(1, {"asset_id": "XY-7", "embedding": np.zeros(4, dtype=np.float32)})}
+        labelset = LabelSet.from_clips_and_votes(medias, {1: None}, {}, expand_dupes=False)
+
+        round_tripped = json.loads(json.dumps(labelset.to_dict()))
+        assert round_tripped["labels"][0]["metadata"] == {"asset_id": "XY-7"}
+
+    def test_vector_only_metadata_becomes_none(self):
+        medias = {1: _media(1, {"embedding": np.zeros(4, dtype=np.float32)})}
+        labelset = LabelSet.from_clips_and_votes(medias, {1: None}, {}, expand_dupes=False)
+
+        (element,) = labelset.elements
+        assert element.metadata is None
+
+    def test_dupe_set_members_share_the_sanitised_metadata(self):
+        """The dupe-expansion branch clones the metadata onto every member."""
+        media = _media(1, {"asset_id": "XY-7", "embedding": np.zeros(4, dtype=np.float32)})
+        media["origin"] = {
+            "importer": "dupe_set",
+            "members": [
+                {"md5": "AAA", "filename": "a.wav", "origin_name": "a.wav"},
+                {"md5": "BBB", "filename": "b.wav", "origin_name": "b.wav"},
+            ],
+        }
+        labelset = LabelSet.from_clips_and_votes({1: media}, {1: None}, {})
+
+        assert len(labelset.elements) == 2
+        for element in labelset.elements:
+            assert element.metadata == {"asset_id": "XY-7"}

--- a/tests_lib/detectors/test_media_hit_metadata.py
+++ b/tests_lib/detectors/test_media_hit_metadata.py
@@ -12,7 +12,7 @@ import json
 
 import numpy as np
 
-from vtscore.utils.hits import build_media_hit
+from vtscore.utils.hits import build_media_hit, hit_custom_metadata
 
 
 class TestCustomMetadataOnHit:
@@ -76,3 +76,27 @@ class TestCustomMetadataOnHit:
         assert hit["origin"] == {"importer": "server_folder"}
         assert hit["origin_name"] == "a.wav"
         assert hit["label"] == "good"
+
+
+class TestHitCustomMetadataDirectly:
+    """The sanitiser is public because the app's route helpers reuse it.
+
+    ``vtsearch.routes._shared.media_info_for_response``, ``POST
+    /api/medias/batch`` and the enriched label export all call it, so its
+    contract is pinned here rather than only through ``build_media_hit``.
+    """
+
+    def test_strips_the_embedding_channel(self):
+        media = {"custom_metadata": {"asset_id": "XY-7", "embedding": np.zeros(4, dtype=np.float32)}}
+        assert hit_custom_metadata(media) == {"asset_id": "XY-7"}
+
+    def test_empty_dict_for_a_media_without_usable_metadata(self):
+        for value in ({}, None, "not-a-dict", 7):
+            assert hit_custom_metadata({"custom_metadata": value}) == {}, value
+        assert hit_custom_metadata({}) == {}
+
+    def test_result_is_a_fresh_dict(self):
+        media = {"custom_metadata": {"asset_id": "XY-7"}}
+        out = hit_custom_metadata(media)
+        out["asset_id"] = "mutated"
+        assert media["custom_metadata"] == {"asset_id": "XY-7"}

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -201,6 +201,17 @@ instead, since every commit on `dev` is effectively a new app release.)
   torchaudio's pure-PyTorch implementation rather than taken as a dependency,
   since torchaudio's wheels are built against a pinned torch.
 
+### Fixed
+
+- **A pre-computed vector nested in `custom_metadata` no longer reaches a
+  labelset** (issue #3368). `LabelSet.from_clips_and_votes` copied a media's
+  `custom_metadata` onto every `LabeledElement` verbatim, so a dataset
+  imported through `custom_metadata_map`'s vector channel wrote a numpy array
+  into the detector JSON - a hard `json.dump` failure, and the vector
+  persistence the no-persisted-vectors rule forbids. The dict now goes through
+  `hit_custom_metadata` (see Added above); `LabeledElement.metadata` is `None` when
+  the vector was its only key. No other importer metadata is affected.
+
 ### Changed
 
 - **`clap_general` is the default audio embedder**, replacing `clap`.

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -142,6 +142,17 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`vtscore.utils.hits.hit_custom_metadata(media)`** — the `custom_metadata`
+  sanitiser `build_media_hit` already applied is now a public export (issue
+  #3368). It returns a fresh copy of a media's importer metadata with the
+  `embedding` key stripped, and exists as a public name because every surface
+  that hands that dict to an outside caller — hits, the app's detector and
+  processor scoring routes, `POST /api/medias/batch`, the label-export blob —
+  has to agree on what it strips. A top-level key filter cannot: a
+  pre-computed vector shipped via `custom_metadata_map` rides *inside*
+  `custom_metadata`, where it would balloon the payload or fail JSON encoding
+  outright. Behaviour of `build_media_hit` is unchanged.
+
 - **`PluginBase.get_field_options(field_key, current_values)`** — the
   dynamic-select hook now lives on the shared plugin base instead of on the
   importer families alone, so every plugin family inherits it and a results

--- a/vtscore/datasets/labelset.py
+++ b/vtscore/datasets/labelset.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterator
 
+from vtscore.utils.hits import hit_custom_metadata
+
 
 @dataclass
 class LabeledElement:
@@ -42,7 +44,9 @@ class LabeledElement:
             serialisation.  Importers and external systems (e.g. Holder)
             can attach extra key-value data here (such as ``contentID``,
             ``mediaID``, ``media_url``).  ``None`` when no metadata is
-            present.
+            present.  Built from the media's ``custom_metadata`` through
+            :func:`vtscore.utils.hits.hit_custom_metadata`, so the
+            pre-computed-vector channel never lands in a persisted labelset.
         region_box: Normalised ``(x0, y0, x1, y1)`` box on the source
             image when the user drew a region as part of a yes-vote;
             ``None`` for image-level votes (the perpetual default for
@@ -462,7 +466,12 @@ def _clip_to_elements(
     right default.
     """
     origin = media.get("origin")
-    cm = media.get("custom_metadata") or None
+    # Sanitised, not read straight off the media: ``custom_metadata_map`` lets
+    # an importer nest a pre-computed vector in ``custom_metadata``, and this
+    # dict is persisted verbatim into the detector JSON.  A numpy array there
+    # is both a hard ``json.dump`` failure and exactly the vector persistence
+    # the no-persisted-vectors rule forbids.
+    cm = hit_custom_metadata(media) or None
     if expand_dupes and isinstance(origin, dict) and origin.get("importer") == "dupe_set":
         members = origin.get("members", [])
         if members:

--- a/vtscore/docs/packages/utils.md
+++ b/vtscore/docs/packages/utils.md
@@ -17,7 +17,7 @@ non-security, one non-finite score sentinel, one wording for the
 
 | Module | Concern |
 |--------|---------|
-| `vtscore/utils/hits.py` | `build_media_hit` - the scored-media hit-dict shape |
+| `vtscore/utils/hits.py` | `build_media_hit` - the scored-media hit-dict shape; `hit_custom_metadata` - the one filter for served importer metadata |
 | `vtscore/utils/hashing.py` | Content fingerprints (`content_md5`, `content_sha1`, `new_md5`, `file_md5`) |
 | `vtscore/utils/scores.py` | Non-finite score sanitisation, so a `NaN` logit can't produce invalid JSON |
 | `vtscore/utils/optional_deps.py` | Actionable errors when an opt-out AGPL dependency isn't installed |
@@ -120,6 +120,33 @@ hit = build_media_hit(cid=42, media=media, score=0.873, label="good")
 Extra keyword arguments are merged in last, so callers can attach
 detector-specific or call-site-specific fields (`label="good"`,
 `detector="my-detector"`) without needing to extend this function.
+
+## `vtscore.utils.hits.hit_custom_metadata`
+
+```python
+def hit_custom_metadata(media: dict[str, Any]) -> dict[str, Any]:
+```
+
+The filter `build_media_hit` applies to `media["custom_metadata"]`, exposed
+on its own for every other surface that serves that dict to an outside
+caller. Returns a **fresh** dict - mutating it cannot reach back into the
+loaded media - carrying the importer's metadata minus the `embedding` key,
+and `{}` when the media has no `custom_metadata` (or a non-dict one).
+
+Reach for it anywhere a media's `custom_metadata` leaves the process: an
+export row, an API response, a payload handed to a plugin. Filtering the
+media's *top-level* keys is not enough, because `custom_metadata_map` lets
+an importer ship a pre-computed vector **nested inside** `custom_metadata`
+(see `vtscore.datasets.loader_folder.load_dataset_from_folder`). That vector
+is consumed at load time and is a numpy array, so left in it breaks
+`json.dumps` in the JSON exporters and the response encoder alike - and
+persisting it would be exactly the vector persistence the no-persisted-vectors
+rule forbids.
+
+In the app this backs `vtsearch.routes._shared.media_info_for_response`,
+which the detector and processor scoring routes use to strip a media before
+it is serialized, as well as `POST /api/medias/batch` and the label-export
+metadata blob.
 
 ## `vtscore.utils.hashing` - content fingerprints
 

--- a/vtscore/utils/hits.py
+++ b/vtscore/utils/hits.py
@@ -4,25 +4,31 @@ from __future__ import annotations
 
 from typing import Any
 
-#: ``custom_metadata`` keys stripped before the dict reaches a hit.
+#: ``custom_metadata`` keys stripped before the dict reaches a caller.
 #:
 #: ``embedding`` is the pre-computed-vector channel an importer uses to ship a
 #: vector alongside a file (``custom_metadata_map``, see
 #: :func:`vtscore.datasets.loader_folder.load_dataset_from_folder`).  It is
-#: consumed at load time and has no business in an exported hit: it is a numpy
-#: array, so it would break ``json.dumps`` in every JSON exporter, and writing
-#: a vector into an export is exactly the persistence the no-persisted-vectors
-#: rule forbids.  ``_HitSchema`` relies on its media fields being an allowlist
-#: for the same reason, and ``custom_metadata`` is a free-form ``Dict`` that
-#: would wave the vector straight through.
+#: consumed at load time and has no business in anything served back out: it
+#: is a numpy array, so it would break ``json.dumps`` in every JSON exporter
+#: and in Flask's response encoder alike, and writing a vector into an export
+#: is exactly the persistence the no-persisted-vectors rule forbids.
+#: ``_HitSchema`` relies on its media fields being an allowlist for the same
+#: reason, and ``custom_metadata`` is a free-form ``Dict`` that would wave the
+#: vector straight through.
 _CUSTOM_METADATA_EXCLUDED_KEYS = frozenset({"embedding"})
 
 
-def _hit_custom_metadata(media: dict[str, Any]) -> dict[str, Any]:
-    """Return the importer metadata to carry on a hit, or ``{}`` for none.
+def hit_custom_metadata(media: dict[str, Any]) -> dict[str, Any]:
+    """Return *media*'s importer metadata, safe to serve, or ``{}`` for none.
 
-    Always a fresh dict, so a consumer that mutates a hit's
-    ``custom_metadata`` cannot reach back into the loaded media.
+    Public because every surface that hands a media's ``custom_metadata`` to
+    an outside caller — hits, the detector and processor scoring routes,
+    ``POST /api/medias/batch`` — has to agree on what it strips.  A top-level
+    key filter cannot do the job: the vector rides *inside* ``custom_metadata``.
+
+    Always a fresh dict, so a consumer that mutates the result cannot reach
+    back into the loaded media.
     """
     custom = media.get("custom_metadata")
     if not isinstance(custom, dict):
@@ -61,7 +67,7 @@ def build_media_hit(
     # Importer-supplied metadata is how an exporter correlates a hit back to
     # the caller's own system (asset ids, catalogue rows, …), so it travels
     # with the hit whenever the media carries any.
-    custom = _hit_custom_metadata(media)
+    custom = hit_custom_metadata(media)
     if custom:
         hit["custom_metadata"] = custom
     if media.get("origin") is not None:

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -15,7 +15,9 @@ from marshmallow import ValidationError
 from werkzeug.exceptions import HTTPException
 
 from vtscore.concurrency.progress import update_find_progress
+from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
 from vtscore.utils.hashing import content_md5, new_md5
+from vtscore.utils.hits import hit_custom_metadata
 
 if TYPE_CHECKING:
     from vtscore.plugins import PluginBase
@@ -641,6 +643,41 @@ def run_plugin_or_error(plugin: PluginBase, method: str, *args):
         verb = method.replace("_", " ").capitalize()
         return None, error_response(f"{verb} failed: {exc}", 500, detail=format_exception_detail(exc))
     return result, None
+
+
+#: Media keys never serialized into an API response (large binary/vector data).
+#: ``embeddings`` is the v3 dict-keyed vector store
+#: (:mod:`vtscore.embedding.media_vectors`); ``embedding`` is its dropped
+#: legacy singular form, kept here so a media dict rehydrated from an old
+#: pickle can't leak one either.
+_HEAVYWEIGHT_KEYS = (
+    EMBEDDINGS_KEY,
+    "embedding",
+    "media_bytes",
+    "media_string",
+    "thumbnail_bytes",
+)
+
+
+def media_info_for_response(media: dict) -> dict:
+    """Return a copy of *media* safe to serialize into an API response.
+
+    Two filters, because one is not enough.  The top-level
+    :data:`_HEAVYWEIGHT_KEYS` sweep drops the vectors and the raw bytes, and
+    then ``custom_metadata`` is re-derived through
+    :func:`vtscore.utils.hits.hit_custom_metadata`: an importer may ship a
+    pre-computed vector *nested* inside it via ``custom_metadata_map``, which
+    a top-level key filter cannot see and which the free-form
+    ``fields.Dict`` in the response schemas waves straight through.  Left in,
+    it either balloons the response or fails JSON encoding outright.
+
+    The re-derived dict is fresh, so a route that mutates the returned
+    ``custom_metadata`` cannot reach back into the loaded media.
+    """
+    info = {k: v for k, v in media.items() if k not in _HEAVYWEIGHT_KEYS}
+    if isinstance(info.get("custom_metadata"), dict):
+        info["custom_metadata"] = hit_custom_metadata(media)
+    return info
 
 
 def windowed_sort_extras(results: list[dict], threshold: float | None) -> dict[str, Any]:

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -19,10 +19,10 @@ from flask_smorest import Blueprint, abort
 from vtscore.concurrency.memory_budget import cap_workers_by_memory
 from vtscore.concurrency.progress import CancelledError, find_progress, update_find_progress
 from vtscore.detectors.model_loading import resolve_or_train_detector
-from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
 from vtsearch.routes._shared import (
     find_idle,
     find_idle_on_crash,
+    media_info_for_response,
     require_dataset_header,
     require_detector_header,
 )
@@ -45,18 +45,6 @@ detector_scoring_bp = Blueprint(
     __name__,
     description="Run a detector against the active dataset (find-label) "
     "or run every Auto-Find detector at once (auto-detect).",
-)
-
-# Keys excluded from API responses (large binary/vector data).  ``embeddings``
-# is the v3 dict-keyed vector store (``vtscore/embedding/media_vectors.py``);
-# ``embedding`` is its dropped legacy singular form, kept here so a media dict
-# rehydrated from an old pickle can't leak one either.
-_HEAVYWEIGHT_KEYS = (
-    EMBEDDINGS_KEY,
-    "embedding",
-    "media_bytes",
-    "media_string",
-    "thumbnail_bytes",
 )
 
 
@@ -115,11 +103,6 @@ def _type_incompatible_message(det_data: dict | None) -> str:
         f"This detector scores in a {label} embedder space, which the active "
         "dataset doesn't provide. Load a dataset that binds a matching embedder type."
     )
-
-
-def _media_info_for_response(media: dict) -> dict:
-    """Return a copy of *media* without heavyweight fields."""
-    return {k: v for k, v in media.items() if k not in _HEAVYWEIGHT_KEYS}
 
 
 def _abort_if_find_cancelled() -> None:
@@ -494,7 +477,7 @@ def _score_detector_for_auto_detect(
         positive_hits = []
         negative_hits = []
         for cid, score in zip(all_ids, scores, strict=True):
-            clip_info = _media_info_for_response(snap[cid])
+            clip_info = media_info_for_response(snap[cid])
             clip_info["score"] = round(score, 4)
             if score >= threshold:
                 positive_hits.append(clip_info)

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -28,7 +28,7 @@ from vtsearch.state import (
     get_active_detector_context,
     resolve_media_ids,
 )
-from vtscore.utils.hits import build_media_hit
+from vtscore.utils.hits import build_media_hit, hit_custom_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +141,11 @@ def _build_entry_metadata(media: dict) -> dict:
         for k, v in origin.get("params", {}).items():
             meta.setdefault(k, v)
 
-    importer_custom = media.get("custom_metadata")
+    # Sanitised rather than read straight off the media: an importer may ship
+    # a pre-computed vector nested inside ``custom_metadata`` via
+    # ``custom_metadata_map``, and this blob becomes both an export column and
+    # a JSON response field.
+    importer_custom = hit_custom_metadata(media)
     if importer_custom:
         meta.update(importer_custom)
     # Humanize "File Size" for export so rows read "8.0 KB" instead of raw

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -28,6 +28,7 @@ from vtscore.media.audio.ffmpeg import get_ffmpeg_exe
 from vtscore.media.base import MediaResponse
 from vtscore.security.path_validation import resolve_media_file_path
 from vtscore.utils.hashing import content_md5
+from vtscore.utils.hits import hit_custom_metadata
 from vtsearch.schemas.media import (
     MediaAddToPileResponseSchema,
     MediaBatchRequestSchema,
@@ -584,7 +585,8 @@ def batch_medias(body: dict):
     omitted.  Each item's ``custom_metadata`` is the media type's
     ``display_metadata`` - including the curated "Source" / "Derived Via" /
     "Imported Via" provenance lines distilled from ``origin.params`` - with
-    any importer-supplied ``custom_metadata`` layered on top.
+    any importer-supplied ``custom_metadata`` layered on top, minus the
+    ``embedding`` plumbing key.
     """
     from vtscore.datasets.archive_stream import archive_member_ref  # noqa: PLC0415
     from vtscore.media import get as get_media_type  # noqa: PLC0415
@@ -609,7 +611,11 @@ def batch_medias(body: dict):
             custom: dict[str, Any] = mt.display_metadata(c)
         except KeyError:
             custom = {}
-        importer_custom = c.get("custom_metadata")
+        # Re-derived rather than read straight off the media: an importer may
+        # ship a pre-computed vector nested inside ``custom_metadata`` via
+        # ``custom_metadata_map``, and a numpy array here would fail JSON
+        # encoding for the whole batch.
+        importer_custom = hit_custom_metadata(c)
         if importer_custom:
             custom.update(importer_custom)
         media_data["custom_metadata"] = custom

--- a/vtsearch/routes/processors/scoring.py
+++ b/vtsearch/routes/processors/scoring.py
@@ -11,7 +11,8 @@ from concurrent.futures import ThreadPoolExecutor
 from flask_smorest import Blueprint, abort
 
 from vtscore.concurrency.memory_budget import cap_workers_by_memory
-from vtscore.embedding.media_vectors import EMBEDDINGS_KEY, media_embedding
+from vtscore.embedding.media_vectors import media_embedding
+from vtsearch.routes._shared import media_info_for_response
 from vtsearch.routes.processors.crud import _build_extractor, _build_localizer
 from vtsearch.schemas.processors import (
     AutoExtractResponseSchema,
@@ -33,23 +34,6 @@ processors_scoring_bp = Blueprint(
     description="Run extractors / localizers against the active dataset, either one-off or via autorun.",
 )
 
-# Keys excluded from API responses (large binary/vector data).  ``embeddings``
-# is the v3 dict-keyed vector store (``vtscore/embedding/media_vectors.py``);
-# ``embedding`` is its dropped legacy singular form, kept here so a media dict
-# rehydrated from an old pickle can't leak one either.
-_HEAVYWEIGHT_KEYS = (
-    EMBEDDINGS_KEY,
-    "embedding",
-    "media_bytes",
-    "media_string",
-    "thumbnail_bytes",
-)
-
-
-def _media_info_for_response(media: dict) -> dict:
-    """Return a copy of *media* without heavyweight fields."""
-    return {k: v for k, v in media.items() if k not in _HEAVYWEIGHT_KEYS}
-
 
 def _apply_processor_to_medias(processor, snap: dict, method: str, result_key: str) -> list[dict]:
     """Run a processor (extractor or localizer) on all medias, returning hits.
@@ -66,7 +50,7 @@ def _apply_processor_to_medias(processor, snap: dict, method: str, result_key: s
         media = snap[media_id]
         hits = func(media)
         if hits:
-            info = _media_info_for_response(media)
+            info = media_info_for_response(media)
             info[result_key] = hits
             results.append(info)
     return results


### PR DESCRIPTION
Closes #3368

## The leak

`custom_metadata_map` is the documented plugin channel for shipping a pre-computed vector alongside a file, and `loader_folder._get_embedding_value` reads that vector out **without popping it** — so a media loaded that way carries `custom_metadata["embedding"]`. Every helper that strips a media by *top-level* key is blind to it, and the response schemas' free-form `fields.Dict` waves it straight through to Flask's JSON encoder.

## What changed

`vtscore.utils.hits._hit_custom_metadata` (added in #3367 for `build_media_hit`) is promoted to a public **`hit_custom_metadata`**, and every surface that hands a media's `custom_metadata` to an outside caller now runs the dict through it:

- `POST /api/auto-detect` hits
- the extractor / localizer scoring routes
- `POST /api/medias/batch`
- the enriched label export (`GET /api/labels/export?enrich=1`) — same bug, same one-line fix; the blob becomes both an export column and a JSON response field
- **`LabelSet.from_clips_and_votes`** — see below

The two verbatim-duplicated `_HEAVYWEIGHT_KEYS` / `_media_info_for_response` blocks in `vtsearch/routes/detectors/scoring.py` and `vtsearch/routes/processors/scoring.py` collapse into one `media_info_for_response` in `vtsearch/routes/_shared.py`, which applies both filters (top-level sweep, then the nested re-derive).

## One extra find: a *persisted* vector

Writing the first test surfaced a worse instance than the issue described. `LabelSet.from_clips_and_votes` copied `media["custom_metadata"]` onto every `LabeledElement` verbatim, and a detector's labelset is `json.dump`'d to disk by `vtscore.detectors.store`. So on a dataset imported through the vector channel, **saving a detector crashed outright** (`TypeError: Object of type ndarray is not JSON serializable`) — and had `json` accepted it, the result would have been exactly the vector persistence the no-persisted-vectors rule forbids. Fixed with the same helper; `LabeledElement.metadata` is `None` when the vector was its only key.

## Not affected

`POST /api/find-label` returns `{id, score}` rows only — the issue lists it, but it never went through `_media_info_for_response`. The processor scoring routes turn out to be double-covered: `_ProcessorHitSchema` dumps only `id` / `extractions` / `localizations`, so no importer metadata reaches a client there today; the helper is still the inner gate should that schema widen.

## Tests

`tests/api/test_custom_metadata_vector_leak.py` — one per route surface, plus `media_info_for_response` directly. `tests_lib/datasets/test_labelset_custom_metadata.py` covers the labelset fix (including the dupe-set expansion branch and a `json.dumps` round-trip standing in for the detector write). `tests_lib/detectors/test_media_hit_metadata.py` gains a class pinning `hit_custom_metadata`'s contract now that it is public.

Full `./run-tests.sh`: **9463 passed, 6 skipped, 2 xpassed**, all gates green.

## Docs

`vtscore/CHANGELOG.md` gets an Added entry for the new public export and a Fixed entry for the labelset persistence bug; `vtscore/docs/packages/utils.md` documents `hit_custom_metadata`. The `/api/medias/batch` docstring change re-generates one line of `frontend/openapi.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9mnrKn7tbdqLU5cuY6G8W)_