### PR TITLE
Centralize DatasetContext derived-cache invalidation

### DIFF
--- a/tests_lib/core/test_derived_cache_reset.py
+++ b/tests_lib/core/test_derived_cache_reset.py
@@ -1,0 +1,157 @@
+"""``DatasetContext.reset_derived_caches`` is the single derived-cache drop.
+
+Four call sites used to hand-write their own list of private slots to clear,
+and all four had drifted from ``__slots__`` (issue #3377).  Two invariants
+keep that from happening again:
+
+1. The derived-cache families and ``_NON_DERIVED_SLOTS`` **partition**
+   ``__slots__``, so a newly added slot has to be filed as one or the other
+   before this suite passes.
+2. ``reset_derived_caches`` actually restores every slot its families name to
+   the value a freshly constructed context has — the tables can't claim
+   coverage the method doesn't deliver.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.state import clear_medias
+from vtscore.state.core import DatasetContext, _iter_slots, thread_dataset_context
+
+_FAMILIES = DatasetContext._DERIVED_CACHE_SLOTS
+
+
+def _dirty(ctx: DatasetContext, names) -> None:
+    """Write a distinguishable non-default value into each of *names*."""
+    for i, name in enumerate(sorted(names)):
+        # Ints for the counter/revision slots, sentinel objects elsewhere; the
+        # assertions only care that the value differs from a fresh context's.
+        setattr(ctx, name, i + 1 if name.endswith(("_revision", "_version")) else object())
+
+
+class TestSlotPartition:
+    """The tables beside ``__slots__`` must account for every slot, once."""
+
+    def test_families_and_non_derived_partition_slots(self):
+        slots = set(_iter_slots(DatasetContext))
+        derived = set().union(*_FAMILIES.values())
+        assert derived & DatasetContext._NON_DERIVED_SLOTS == set(), (
+            "a slot is filed as both a derived cache and as state"
+        )
+        assert derived | DatasetContext._NON_DERIVED_SLOTS == slots, (
+            "unfiled slots (add them to a _DERIVED_CACHE_SLOTS family or to "
+            f"_NON_DERIVED_SLOTS): {slots ^ (derived | DatasetContext._NON_DERIVED_SLOTS)}"
+        )
+
+    def test_families_are_pairwise_disjoint(self):
+        seen: set[str] = set()
+        for name, slots in _FAMILIES.items():
+            assert not (seen & slots), f"{name} repeats slots from an earlier family"
+            seen |= slots
+
+
+class TestResetCoversItsFamilies:
+    """Every slot a family names is genuinely restored by the reset."""
+
+    @pytest.mark.parametrize("family", sorted(_FAMILIES))
+    def test_family_slots_return_to_fresh_values(self, family):
+        fresh = DatasetContext("")
+        ctx = DatasetContext("dirty")
+        _dirty(ctx, _FAMILIES[family])
+
+        ctx.reset_derived_caches(**{f: f == family for f in _FAMILIES})
+
+        for name in sorted(_FAMILIES[family]):
+            assert getattr(ctx, name) == getattr(fresh, name), f"{name} not reset"
+
+    @pytest.mark.parametrize("family", sorted(_FAMILIES))
+    def test_resetting_one_family_leaves_the_others_alone(self, family):
+        ctx = DatasetContext("dirty")
+        others = set().union(*(s for f, s in _FAMILIES.items() if f != family))
+        _dirty(ctx, others)
+        before = {name: getattr(ctx, name) for name in others}
+
+        ctx.reset_derived_caches(**{f: f == family for f in _FAMILIES})
+
+        for name, value in before.items():
+            assert getattr(ctx, name) is value, f"{name} was dropped by the {family} reset"
+
+    def test_default_resets_every_family(self):
+        fresh = DatasetContext("")
+        ctx = DatasetContext("dirty")
+        _dirty(ctx, set().union(*_FAMILIES.values()))
+
+        ctx.reset_derived_caches()
+
+        for name in sorted(set().union(*_FAMILIES.values())):
+            assert getattr(ctx, name) == getattr(fresh, name), f"{name} not reset"
+
+
+class TestResetLeavesStateAlone:
+    """Non-derived slots are state, not cache; a reset must not touch them."""
+
+    def test_state_slots_survive_a_full_reset(self):
+        ctx = DatasetContext("keepme")
+        ctx.medias[1] = {"id": 1}
+        ctx.coverage_atlas = object()
+        ctx.dataset_display_name = "Keep Me"
+        ctx.merge_near_duplicates = True
+        ctx._emb_sidecar_disabled = True  # a latch, not a cache
+        ctx._binding_explicit = True
+        revision = ctx.media_revision
+
+        ctx.reset_derived_caches()
+
+        assert ctx.dataset_id == "keepme"
+        assert dict(ctx.medias) == {1: {"id": 1}}
+        assert ctx.coverage_atlas is not None
+        assert ctx.dataset_display_name == "Keep Me"
+        assert ctx.merge_near_duplicates is True
+        assert ctx._emb_sidecar_disabled is True
+        assert ctx._binding_explicit is True
+        # Dropping a cache is not a change to the medias.
+        assert ctx.media_revision == revision
+
+
+class TestClearMediasDropsTheSubsetLayout:
+    """The concrete #3377 bug: ``clear_medias`` missed eleven slots.
+
+    A subset layout surviving a reload is served verbatim by
+    ``POST /api/projection/subset`` whenever the new dataset's requested id set
+    matches the stale ``_subset_ids`` — the same stale-pyramid failure the
+    ``clear_medias`` docstring already guarded against for the full layout.
+    """
+
+    def test_subset_lookup_and_job_slots_are_cleared(self):
+        ctx = DatasetContext("test_clear_subset")
+        with thread_dataset_context(ctx):
+            ctx.medias[1] = {"id": 1, "embedding": np.ones(4, dtype=np.float32)}
+            ctx._subset_projection = object()
+            ctx._subset_pyramids = {"hex": object()}
+            ctx._subset_ids = [1]
+            ctx._subset_job_id = "job-abc"
+            ctx._subset_content_version = 3
+            ctx._subset_region_labels = object()
+            ctx._origin_key_index = {"k": [1]}
+            ctx._md5_index = {"m": [1]}
+            ctx._name_index = {"n": [1]}
+            ctx._lookup_index_revision = 1
+            ctx._full_job_id = "job-def"
+            ctx._relabel_job_id = "job-ghi"
+
+            clear_medias()
+
+            assert ctx._subset_projection is None
+            assert ctx._subset_pyramids == {}
+            assert ctx._subset_ids is None
+            assert ctx._subset_job_id is None
+            assert ctx._subset_content_version == 0
+            assert ctx._subset_region_labels is None
+            assert ctx._origin_key_index is None
+            assert ctx._md5_index is None
+            assert ctx._name_index is None
+            assert ctx._lookup_index_revision is None
+            assert ctx._full_job_id is None
+            assert ctx._relabel_job_id is None

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -463,19 +463,17 @@ def invalidate_embedding_matrix(ctx: "DatasetContext") -> None:
     advance the counter (and free the cached arrays' RAM immediately).
     """
     with _state_lock:
-        ctx._emb_matrix_ids = None
-        ctx._emb_matrix = None
-        ctx._emb_matrix_revision = None
+        # Only the matrix family: the lookups and the browse layouts are
+        # revision-keyed too and invalidate themselves off the bump below,
+        # so dropping them here would throw away work for nothing.
+        ctx.reset_derived_caches(matrices=True, lookups=False, projection=False, subset=False)
         # An in-place rewrite can leave the id set (and dimension) unchanged,
         # which the sidecar's validity check alone cannot detect - permanently
         # stop trusting the on-disk mmap sidecar for this context so every
         # later rebuild reads live ``ctx.medias``, never a stale cached file.
+        # A latch, not a cache, which is why ``reset_derived_caches`` leaves
+        # it alone and this line stays here.
         ctx._emb_sidecar_disabled = True
-        ctx._region_matrix_ids = None
-        ctx._region_matrix = None
-        ctx._region_matrix_revision = None
-        ctx._region_media_index = None
-        ctx._region_index_per_row = None
         ctx.bump_media_revision()
 
 

--- a/vtscore/state/__init__.py
+++ b/vtscore/state/__init__.py
@@ -146,13 +146,14 @@ def get_media(media_id: int) -> dict[str, Any] | None:
 def clear_medias() -> None:
     """Clear all loaded medias from the active dataset's context.
 
-    Drops the cached embedding matrix, the 2-D projection + tile pyramids
-    (one per bin shape), coverage atlas, dataset display name override, and
-    the per-step progress model cache so RAM is released immediately rather
-    than waiting for the next access.
+    Drops every derived cache on the context (see
+    :meth:`~vtscore.state.core.DatasetContext.reset_derived_caches`) plus the
+    coverage atlas, dataset display name override, and the per-step progress
+    model cache, so RAM is released immediately rather than waiting for the
+    next access.
 
-    Clearing ``_projection``/``_pyramids`` is also a correctness guard: the
-    build route serves a cached pyramid without re-checking the media-id
+    Dropping the cached layouts is also a correctness guard: the build routes
+    serve a cached full / subset pyramid without re-checking the media-id
     signature, so a stale pyramid left over a reload-with-changed-contents
     would otherwise be returned for the new data.
     """
@@ -161,17 +162,7 @@ def clear_medias() -> None:
     with _state_lock:
         ctx = _core.get_active_context()
         ctx.medias.clear()  # bumps media_revision via MediasDict
-        ctx._emb_matrix_ids = None
-        ctx._emb_matrix = None
-        ctx._emb_matrix_revision = None
-        ctx._region_matrix_ids = None
-        ctx._region_matrix = None
-        ctx._region_matrix_revision = None
-        ctx._region_media_index = None
-        ctx._region_index_per_row = None
-        ctx._projection = None
-        ctx._pyramids = {}
-        ctx._region_labels = None
+        ctx.reset_derived_caches()
         ctx.coverage_atlas = None
         ctx.dataset_display_name = None
     # ``_progress_lock`` is acquired strictly outside ``_state_lock`` so the

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -505,6 +505,98 @@ class DatasetContext:
         "merge_near_duplicates",
     )
 
+    # ------------------------------------------------------------------
+    # Derived-cache families (deliberately adjacent to ``__slots__``)
+    # ------------------------------------------------------------------
+    # Every slot above is either a *source of truth* for this dataset or a
+    # *derived cache* - something rebuildable, at some cost, from the medias
+    # or from the persisted layout.  The four families below name the caches
+    # and :meth:`reset_derived_caches` drops them by family; every call site
+    # that used to hand-clear a list of private slots goes through it now.
+    #
+    # ``_NON_DERIVED_SLOTS`` names the rest explicitly so the two sets can be
+    # asserted to *partition* ``__slots__`` (see
+    # ``tests_lib/core/test_derived_cache_reset.py``).  That partition is the
+    # whole point: a slot added to ``__slots__`` fails the test until it is
+    # filed as a cache or as state, instead of being quietly missed the way
+    # every hand-written clear-list here had already missed eleven slots by
+    # the time issue #3377 counted them.
+    _DERIVED_CACHE_SLOTS: dict[str, frozenset[str]] = {
+        # Contiguous embedding / flattened-region matrices and their keys.
+        "matrices": frozenset(
+            {
+                "_emb_matrix_ids",
+                "_emb_matrix",
+                "_emb_matrix_revision",
+                "_region_matrix_ids",
+                "_region_matrix",
+                "_region_matrix_revision",
+                "_region_media_index",
+                "_region_index_per_row",
+            }
+        ),
+        # Secondary media lookups (origin key / md5 / name) and their key.
+        "lookups": frozenset(
+            {
+                "_origin_key_index",
+                "_md5_index",
+                "_name_index",
+                "_lookup_index_revision",
+            }
+        ),
+        # VTSBrowse full-dataset layout: projection, per-shape pyramids,
+        # signposts, and the in-flight build / relabel job ids that would
+        # otherwise keep pointing at a discarded layout.
+        "projection": frozenset(
+            {
+                "_projection",
+                "_pyramids",
+                "_full_job_id",
+                "_region_labels",
+                "_relabel_job_id",
+            }
+        ),
+        # VTSBrowse subset layout: the mirror of the above, plus the id list
+        # the cached subset was fit against and its tile-cache token.
+        "subset": frozenset(
+            {
+                "_subset_projection",
+                "_subset_pyramids",
+                "_subset_ids",
+                "_subset_job_id",
+                "_subset_content_version",
+                "_subset_region_labels",
+            }
+        ),
+    }
+
+    #: Slots that are state, not cache - never touched by
+    #: :meth:`reset_derived_caches`.  Each is here for a reason:
+    #:
+    #: * ``dataset_id`` / ``dataset_display_name`` / ``merge_near_duplicates``
+    #:   and the four embedder-binding slots are dataset identity + config.
+    #: * ``_medias`` / ``_media_revision`` are the source of truth the caches
+    #:   are derived *from*.
+    #: * ``coverage_atlas`` is derived, but it is persisted in the dataset
+    #:   pickle and restored by the load pipeline, which owns its lifetime.
+    #: * ``_emb_sidecar_disabled`` is a one-way latch, not a cache: it records
+    #:   that an in-place vector rewrite happened, which no rebuild undoes.
+    _NON_DERIVED_SLOTS: frozenset[str] = frozenset(
+        {
+            "dataset_id",
+            "_medias",
+            "_media_revision",
+            "coverage_atlas",
+            "dataset_display_name",
+            "_emb_sidecar_disabled",
+            "_text_embedder",
+            "_patch_embedder",
+            "_structural_embedder",
+            "_binding_explicit",
+            "merge_near_duplicates",
+        }
+    )
+
     def __init__(self, dataset_id: str = "") -> None:
         self.dataset_id: str = dataset_id
         # ``_media_revision`` must exist before ``_medias`` so the MediasDict's
@@ -596,6 +688,69 @@ class DatasetContext:
         ``invalidate_embedding_matrix``.
         """
         self._media_revision += 1
+
+    # ------------------------------------------------------------------
+    # Derived-cache invalidation
+    # ------------------------------------------------------------------
+
+    def reset_derived_caches(
+        self,
+        *,
+        matrices: bool = True,
+        lookups: bool = True,
+        projection: bool = True,
+        subset: bool = True,
+    ) -> None:
+        """Drop this context's derived caches, by family.
+
+        The single place any of the ``_DERIVED_CACHE_SLOTS`` above are
+        cleared.  Before issue #3377 four call sites each hand-wrote their
+        own list of private slots to ``None``, and all four had drifted from
+        ``__slots__``: ``clear_medias`` alone was missing the four lookup
+        slots, the two full-layout job ids, and all six subset slots, so a
+        reload left a stale subset layout that
+        ``POST /api/projection/subset`` would serve verbatim whenever the new
+        id set happened to match the old one - the exact failure the
+        ``clear_medias`` docstring already called out for ``_projection`` and
+        ``_pyramids``.
+
+        Each keyword drops one family; pass ``False`` to keep one. The
+        default (everything) is what a wholesale medias clear wants.
+
+        Does **not** bump :attr:`media_revision`. Dropping a cache is not a
+        change to the medias, and the revision-keyed caches distinguish the
+        two: a caller signalling an in-place vector rewrite (
+        :func:`vtscore.embedding.matrix.invalidate_embedding_matrix`) bumps
+        it itself.
+        """
+        with _state_lock:
+            if matrices:
+                self._emb_matrix_ids = None
+                self._emb_matrix = None
+                self._emb_matrix_revision = None
+                self._region_matrix_ids = None
+                self._region_matrix = None
+                self._region_matrix_revision = None
+                self._region_media_index = None
+                self._region_index_per_row = None
+            if lookups:
+                self._origin_key_index = None
+                self._md5_index = None
+                self._name_index = None
+                self._lookup_index_revision = None
+            if projection:
+                self._projection = None
+                self._pyramids = {}
+                self._full_job_id = None
+                self._region_labels = None
+                self._relabel_job_id = None
+            if subset:
+                self._subset_projection = None
+                self._subset_pyramids = {}
+                self._subset_ids = None
+                self._subset_job_id = None
+                self._subset_content_version = 0
+                self._subset_region_labels = None
 
     # ------------------------------------------------------------------
     # Role-typed embedder binding

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -423,11 +423,10 @@ def _reset_full_projection(ctx) -> None:
     the in-memory projection and every shape's cached pyramid, and drop the
     persisted entries from the container — otherwise a later load, or the
     not-yet-rebuilt other bin shape, would resurrect the stale coordinates
-    (which are shared across shapes).
+    (which are shared across shapes).  The subset layout is deliberately left
+    standing: it is an independent fit the user may still be browsing.
     """
-    ctx._projection = None
-    ctx._pyramids = {}
-    ctx._region_labels = None
+    ctx.reset_derived_caches(matrices=False, lookups=False, projection=True, subset=False)
     pkl_path = _pkl_path_for(ctx.dataset_id)
     if pkl_path is None:
         return
@@ -573,12 +572,10 @@ def _build_subset(ctx, requested_ids: list[int], bin_shape: str, *, force: bool 
         # A different subset — or a forced re-projection — drops the stale layout
         # before fitting.  ``force`` re-fits even when the ids are unchanged, so
         # the survivors of a cull re-spread instead of keeping their old slots.
-        ctx._subset_projection = None
-        ctx._subset_pyramids = {}
+        # Drops the layout, its pyramids, the in-flight job id, the tile-cache
+        # token, and the signposts anchored in the dropped layout.
+        ctx.reset_derived_caches(matrices=False, lookups=False, projection=False, subset=True)
         ctx._subset_ids = sorted_ids
-        ctx._subset_job_id = None
-        ctx._subset_content_version = 0  # fresh layout — reset the tile cache token
-        ctx._subset_region_labels = None  # signposts were anchored in the dropped layout
 
     return _start_subset_umap_build(ctx, sorted_ids, matrix, bin_shape, force=force)
 


### PR DESCRIPTION
Four call sites each hand-wrote their own list of private `DatasetContext` slots to clear, and all four had drifted from `__slots__`. `clear_medias()` alone was missing eleven slots: the four secondary-lookup slots, the two in-flight job ids, and all six subset-layout slots.

**The subset miss is a correctness bug**, of exactly the class the `clear_medias` docstring already guards against for the full layout: `POST /api/projection/subset` serves a cached subset pyramid without re-checking the media-id signature, so a layout surviving a reload is returned verbatim whenever the new dataset's requested id set happens to match the stale `_subset_ids`. The lookup and job-id misses left the docstring's "release RAM immediately" promise unmet.

## What changed

`DatasetContext.reset_derived_caches(*, matrices=True, lookups=True, projection=True, subset=True)`, defined beside `__slots__`, is now the single place any derived cache is dropped. All four sites route through it:

| Site | Call |
|---|---|
| `vtscore/state/__init__.py` › `clear_medias` | all four families (**+11 slots**) |
| `vtscore/embedding/matrix.py` › `invalidate_embedding_matrix` | `matrices` only — the rest are revision-keyed and self-invalidate off the bump it already does |
| `vtsearch/routes/projection.py` › `_reset_full_projection` | `projection` only — the subset is an independent fit the user may still be browsing (**+2 slots**) |
| `vtsearch/routes/projection.py` › subset-drop branch | `subset` only |

`vtscore/state/media_lookup.py:128-131` also writes these slots but is the cache *store*, not an invalidation, so there is nothing there to route.

## Why the method alone wasn't enough

A single method just relocates the drift — the next slot added to `__slots__` would go missing from it exactly as it went missing from the four lists. So the slots are also **filed**, beside `__slots__`, into `_DERIVED_CACHE_SLOTS` families and `_NON_DERIVED_SLOTS`, and `tests_lib/core/test_derived_cache_reset.py` asserts the two sets *partition* `__slots__`. A newly added slot fails the suite until it is filed as a cache or as state. Verified by adding a slot and watching the guard fire.

Companion tests pin that the tables can't over-claim: the method really does restore every slot its families name to a fresh context's value, each family is independently resettable without disturbing the others, and the state slots (medias, coverage atlas, the `_emb_sidecar_disabled` latch, the embedder binding) survive a full reset — as does `media_revision`, since dropping a cache is not a change to the medias.

`_emb_sidecar_disabled` stays out of the reset on purpose and is documented as such: it is a one-way latch recording that an in-place vector rewrite happened, which no rebuild undoes.

## Scope deliberately not taken

The issue also proposed splitting `core.py` into modules and grouping the browse/matrix slots into sub-objects. Both were dropped after investigation, and #3377 has been rescoped with the reasoning recorded:

- **The module split's stated precondition is false.** It assumed `vtscore/state/__init__.py`'s re-exports mean no external import changes; in fact 116 files import `vtscore.state.core` directly, and two test modules monkeypatch or read its *rebindable* hook globals (`_dataset_context_resolver`, `_request_context_predicate`). A `core.py` re-export shim binds those by value, so a later `register_*` rebind leaves the shim stale and the monkeypatch a silent no-op.

- **Sub-object grouping would be a regression.** `_freeze_into` substitutes a frozen container only for `dict` and `list` values, so a sub-object slot would land on the request-missing sentinel as a live mutable object. `sentinel.browse.projection = x` would then succeed, reopening the silent-mistarget failure mode (H13/H16) the sentinel exists to close.

## Testing

Full `./run-tests.sh`: **9494 passed**, 6 skipped, 1 xfailed, 1 xpassed. All gates green — every stage-1 check, plus pyright, pip-audit, npm audit and the Vitest suite.

Closes #3377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qXmb6s5c2c7rr2HoKQ6Bb

---
_Generated by [Claude Code](https://claude.ai/code/session_011qXmb6s5c2c7rr2HoKQ6Bb)_