### PR TITLE
Share one origin.params parser between the two clip-replay paths

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,6 +154,8 @@ VTSearch/
 │   │   │   structural_geometry.py  the geometric consistency check and
 │   │   │   structural_splg.py      the SPLG local-feature backend
 │   │   ├── lazy_clip.py            Replays converter/clipper recipes to rebuild bytes on demand
+│   │   ├── clip_recipe.py          One parser for the origin.params clip dialects, shared by
+│   │   │                           lazy_clip and the detector resolver's replay path
 │   │   ├── provenance.py           Human-readable Source / Derived Via / Imported Via lines
 │   │   ├── torch_setup.py          Process-wide torch thread + device configuration
 │   │   ├── audio/                  Audio media type, embedders (CLAP, CLAP-Music, CLAP-General,

--- a/tests/detectors/test_clippers.py
+++ b/tests/detectors/test_clippers.py
@@ -254,10 +254,10 @@ class TestWaveFormatExtensible:
         assert format_tag == 0xFFFE
 
     def test_wav_duration_handles_extensible(self):
-        from vtscore.media.audio.clipper import _wav_duration
+        from vtscore.media.audio.wav import wav_duration
 
         wavex = _generate_wavex(440, 3.0)
-        assert _wav_duration(wavex) == pytest.approx(3.0, abs=0.01)
+        assert wav_duration(wavex) == pytest.approx(3.0, abs=0.01)
 
     def test_tiling_clipper_handles_extensible(self):
         from vtscore.media.audio.clipper import SoundTilingClipper
@@ -294,16 +294,16 @@ class TestUndecodableAudio:
     _GARBAGE = b"RIFF\x00\x00\x00\x00WAVEjunk" + b"\x00" * 32
 
     def test_open_wav_raises_audio_decode_error(self):
-        from vtscore.media.audio.clipper import AudioDecodeError, _open_wav
+        from vtscore.media.audio.wav import AudioDecodeError, open_wav
 
         with pytest.raises(AudioDecodeError):
-            _open_wav(self._GARBAGE)
+            open_wav(self._GARBAGE)
 
     def test_wav_duration_raises_audio_decode_error(self):
-        from vtscore.media.audio.clipper import AudioDecodeError, _wav_duration
+        from vtscore.media.audio.wav import AudioDecodeError, wav_duration
 
         with pytest.raises(AudioDecodeError):
-            _wav_duration(self._GARBAGE)
+            wav_duration(self._GARBAGE)
 
     def test_tiling_clipper_returns_media_unchanged(self):
         from vtscore.media.audio.clipper import SoundTilingClipper
@@ -345,16 +345,16 @@ class TestZeroSampleRateWav:
             assert wf.getframerate() == 0
 
     def test_wav_duration_raises_audio_decode_error(self):
-        from vtscore.media.audio.clipper import AudioDecodeError, _wav_duration
+        from vtscore.media.audio.wav import AudioDecodeError, wav_duration
 
         with pytest.raises(AudioDecodeError):
-            _wav_duration(_zero_rate_wav())
+            wav_duration(_zero_rate_wav())
 
     def test_wav_slice_raises_audio_decode_error(self):
-        from vtscore.media.audio.clipper import AudioDecodeError, _wav_slice
+        from vtscore.media.audio.wav import AudioDecodeError, wav_slice
 
         with pytest.raises(AudioDecodeError):
-            _wav_slice(_zero_rate_wav(), 0.0, 1.0)
+            wav_slice(_zero_rate_wav(), 0.0, 1.0)
 
     def test_tiling_clipper_returns_media_unchanged(self):
         from vtscore.media.audio.clipper import SoundTilingClipper

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -322,7 +322,7 @@ class TestClippedReingest:
 
         from vtscore.datasets.ingest import _ingest_via_resolver
         from vtscore.media.audio.audio_generator import generate_wav
-        from vtscore.media.audio.clipper import _wav_slice
+        from vtscore.media.audio.wav import wav_slice
 
         rng = np.random.default_rng(42)
 
@@ -331,7 +331,7 @@ class TestClippedReingest:
         wav_path.write_bytes(wav)
 
         clip_start, clip_end = 0.0, 2.0
-        clip_bytes = _wav_slice(wav, clip_start, clip_end)
+        clip_bytes = wav_slice(wav, clip_start, clip_end)
         expected_clip_md5 = content_md5(clip_bytes)
         parent_md5 = content_md5(wav)
         assert expected_clip_md5 != parent_md5, "clip and parent MD5s must differ"
@@ -441,7 +441,7 @@ class TestClippedReingest:
 
         from vtscore.datasets.ingest import _ingest_via_resolver
         from vtscore.media.audio.audio_generator import generate_wav
-        from vtscore.media.audio.clipper import _wav_slice
+        from vtscore.media.audio.wav import wav_slice
 
         rng = np.random.default_rng(42)
 
@@ -450,7 +450,7 @@ class TestClippedReingest:
         wav_path.write_bytes(wav)
 
         clip_start, clip_end = 0.0, 2.0
-        expected_clip_bytes = _wav_slice(wav, clip_start, clip_end)
+        expected_clip_bytes = wav_slice(wav, clip_start, clip_end)
         assert len(expected_clip_bytes) < len(wav), "clip should be smaller than parent"
 
         origin = {

--- a/tests_lib/datasets/test_lazy_clips.py
+++ b/tests_lib/datasets/test_lazy_clips.py
@@ -20,7 +20,7 @@ import pytest
 
 from vtscore.datasets.clipper_chain import _content_hash
 from vtscore.datasets.stages import clipper as clipper_stage
-from vtscore.media.audio.clipper import _wav_slice
+from vtscore.media.audio.wav import wav_slice
 from vtscore.media.lazy_clip import _ByteBoundedLRU, clip_recipe, lazy_clip_bytes
 
 from tests_lib.helpers import make_png_bytes, make_wav_bytes
@@ -137,7 +137,7 @@ class TestLazyClipBytes:
             "origin": {"params": {"clip_start": "0.2", "clip_end": "0.6"}},
         }
         got = lazy_clip_bytes(media)
-        expected = _wav_slice(src.read_bytes(), 0.2, 0.6)
+        expected = wav_slice(src.read_bytes(), 0.2, 0.6)
         assert got == expected
         # And the slice is genuinely shorter than the source.
         with wave.open(__import__("io").BytesIO(got), "rb") as wf:
@@ -201,7 +201,7 @@ class TestResolveMediaBytes:
             "origin": {"params": {"clip_start": "0.3", "clip_end": "0.7"}},
         }
         resolved = media_registry.get("audio")._resolve_media_bytes(media)
-        assert resolved == _wav_slice(src.read_bytes(), 0.3, 0.7)
+        assert resolved == wav_slice(src.read_bytes(), 0.3, 0.7)
 
     def test_inline_bytes_take_precedence(self, tmp_path):
         import vtscore.media as media_registry
@@ -253,7 +253,7 @@ class TestClipperStageLazyClips:
             import vtscore.media as media_registry
 
             resolved = media_registry.get("audio")._resolve_media_bytes(clip)
-            expected = _wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
+            expected = wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
             assert resolved == expected
 
     def test_thin_image_tiling_produces_lazy_clips(self, tmp_path, _stub_clip_fixup):
@@ -344,7 +344,7 @@ class TestPickleRoundTrip:
             assert clip["media_path"] == str(src)
             params = clip["origin"]["params"]
             resolved = media_registry.get("audio")._resolve_media_bytes(clip)
-            expected = _wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
+            expected = wav_slice(src.read_bytes(), float(params["clip_start"]), float(params["clip_end"]))
             assert resolved == expected
 
 

--- a/tests_lib/detectors/test_clip_recipe_shared.py
+++ b/tests_lib/detectors/test_clip_recipe_shared.py
@@ -1,0 +1,175 @@
+"""The two clip-replay paths must read ``origin.params`` identically.
+
+``vtscore.media.lazy_clip`` (display bytes, cached, for the HTTP byte routes)
+and ``vtscore.detectors.resolver`` (rederive + embed, for cross-dataset
+training) rebuild content from the same ``origin.params`` dialects but keep
+their own replay and fallback policy.  These tests pin the half that must
+*not* diverge: the parse.  A disagreement here means one path serves a
+different region / sub-output than the other embeds - silently, on the
+load-bearing path of the origins-are-canonical invariant.
+
+See ``vtscore/media/clip_recipe.py``, and issue #3378.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.detectors.resolver import _converter_origin_to_chain
+from vtscore.media.clip_recipe import parse_clip_box, parse_converter_recipe
+from vtscore.media.lazy_clip import _converter_recipe, clip_recipe
+
+
+def _converter_params(**overrides) -> dict:
+    """A flat ``run_converters_on_folder`` origin's params, with overrides."""
+    params = {
+        "converter": "document2image",
+        "converter_param_dpi": "150",
+        "converter_param_fmt": "png",
+        "converter_out_index": "3",
+        "converter_n_out": "10",
+        "converter_content_hash": "abc123def456",
+    }
+    params.update(overrides)
+    return {k: v for k, v in params.items() if v is not None}
+
+
+class TestParseClipBox:
+    """The ``clip_box`` pixel-region dialect."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["1,2,30,40", "1.0,2.0,30.0,40.0", [1, 2, 30, 40], (1.7, 2.2, 30.9, 40.4)],
+    )
+    def test_accepts_every_recorded_spelling(self, raw):
+        # Floats truncate toward zero, matching int(float(...)) on the wire form.
+        assert parse_clip_box(raw) == (1, 2, 30, 40)
+
+    def test_ignores_empty_segments_in_the_string_form(self):
+        assert parse_clip_box("1,2,30,40,") == (1, 2, 30, 40)
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, 42, "1,2,3", "1,2,3,4,5", "a,b,c,d", "", [1, 2, 3], {"x": 1}],
+    )
+    def test_returns_none_rather_than_raising_on_anything_malformed(self, raw):
+        # A caller must be able to fall through to whole-file handling; a
+        # half-parsed box would crop to the wrong region.
+        assert parse_clip_box(raw) is None
+
+
+class TestParseConverterRecipe:
+    """The flat ``converter`` / ``converter_param_<key>`` dialect."""
+
+    def test_parses_the_full_dialect(self):
+        recipe = parse_converter_recipe(_converter_params())
+        assert recipe is not None
+        assert recipe.name == "document2image"
+        assert recipe.params == {"dpi": "150", "fmt": "png"}
+        assert (recipe.out_index, recipe.n_out) == (3, 10)
+        assert recipe.content_hash == "abc123def456"
+        assert recipe.is_replayable
+
+    def test_no_converter_key_is_not_a_converter_origin(self):
+        assert parse_converter_recipe({"clip_start": "0.0", "clip_end": "1.0"}) is None
+
+    @pytest.mark.parametrize("garbled", ["not-an-int", "", 1.5e400])
+    def test_uncoercible_index_reads_as_absent(self, garbled):
+        # A garbled index is indistinguishable from a missing one for
+        # selection: both must leave the output unpicked, never picked wrongly.
+        recipe = parse_converter_recipe(_converter_params(converter_out_index=garbled))
+        assert recipe is not None
+        assert recipe.out_index is None
+
+    def test_recipe_without_disambiguators_parses_but_is_not_replayable(self):
+        # "Not a converter media" and "a converter media we cannot replay" are
+        # different answers, and callers act on them differently.
+        recipe = parse_converter_recipe(_converter_params(converter_out_index=None, converter_content_hash=None))
+        assert recipe is not None
+        assert not recipe.is_replayable
+
+    @pytest.mark.parametrize("keep", ["converter_out_index", "converter_content_hash"])
+    def test_either_disambiguator_alone_is_enough(self, keep):
+        drop = {"converter_out_index": None, "converter_content_hash": None}
+        drop.pop(keep)
+        recipe = parse_converter_recipe(_converter_params(**drop))
+        assert recipe is not None and recipe.is_replayable
+
+    def test_chain_step_omits_absent_disambiguators(self):
+        recipe = parse_converter_recipe(_converter_params(converter_n_out=None))
+        assert recipe is not None
+        step = recipe.chain_step()
+        assert step == {
+            "kind": "converter",
+            "name": "document2image",
+            "params": {"dpi": "150", "fmt": "png"},
+            "out_index": 3,
+            "content_hash": "abc123def456",
+        }
+
+    def test_cache_key_is_hashable_and_order_independent(self):
+        a = parse_converter_recipe(_converter_params())
+        b = parse_converter_recipe({k: v for k, v in reversed(list(_converter_params().items()))})
+        assert a is not None and b is not None
+        assert a.cache_key() == b.cache_key()
+        assert len({a.cache_key(), b.cache_key()}) == 1
+
+
+class TestBothPathsAgree:
+    """The regression guard: one origin, two readers, one reading."""
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            _converter_params(),
+            _converter_params(converter_n_out=None),
+            _converter_params(converter_content_hash=None),
+            _converter_params(converter_out_index=None),
+            _converter_params(converter_out_index="bogus"),
+            {"converter": "video2image", "converter_out_index": "0"},
+        ],
+    )
+    def test_converter_dialect_reads_the_same_on_both_paths(self, params):
+        lazy = _converter_recipe(params)
+        chain = _converter_origin_to_chain(params)
+
+        # Both gate on replayability, so they agree on *whether* to replay.
+        assert (lazy is None) == (chain is None)
+        if lazy is None:
+            return
+
+        # ...and on what was recorded.  The shapes differ by design (a hashable
+        # cache key vs. a ChainStep); the content behind them must not.
+        _, name, param_items, out_index, n_out, content_hash = lazy
+        step = chain[0]
+        assert step["name"] == name
+        assert step["params"] == dict(param_items)
+        assert step.get("out_index") == out_index
+        assert step.get("n_out") == n_out
+        assert step.get("content_hash") == content_hash
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [("1,2,30,40", (1, 2, 30, 40)), ([5, 6, 7, 8], (5, 6, 7, 8)), ("bad", None)],
+    )
+    def test_clip_box_reads_the_same_on_both_paths(self, raw, expected):
+        # lazy_clip reads the box through clip_recipe; the resolver reads it
+        # through _clip_image_to_bytes.  Both now go via parse_clip_box, so
+        # pinning the parser pins both.
+        media = {"media_type": "image", "origin": {"params": {"clip_box": raw}}}
+        recipe = clip_recipe(media)
+        assert recipe == (("image", expected) if expected else None)
+        assert parse_clip_box(raw) == expected
+
+
+class TestReplayableGateSkipsPointlessWork:
+    """A recipe the selector could never resolve is refused before the run."""
+
+    def test_resolver_declines_a_chain_with_no_disambiguator(self):
+        # _select_chain_output refuses to guess without a handle, so building
+        # the chain would only run the converter to reach the same None.
+        params = _converter_params(converter_out_index=None, converter_content_hash=None)
+        assert _converter_origin_to_chain(params) is None
+
+    def test_resolver_still_declines_when_there_is_no_converter_at_all(self):
+        assert _converter_origin_to_chain({"clipper": "audio_tile"}) is None

--- a/tests_lib/detectors/test_clip_recipe_shared.py
+++ b/tests_lib/detectors/test_clip_recipe_shared.py
@@ -137,6 +137,7 @@ class TestBothPathsAgree:
         assert (lazy is None) == (chain is None)
         if lazy is None:
             return
+        assert chain is not None  # implied by the equality above; states it for the type checker
 
         # ...and on what was recorded.  The shapes differ by design (a hashable
         # cache key vs. a ChainStep); the content behind them must not.

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -468,22 +468,30 @@ def embed_file(file_path: Path, media_type: str, embedder_name: str = "") -> np.
 
 def _clip_audio_to_bytes(file_path: Path, clip_start: float, clip_end: float) -> tuple[bytes, str]:
     """Slice a WAV file to ``[clip_start, clip_end]`` seconds.  Returns ``(bytes, suffix)``."""
-    from vtscore.media.audio.clipper import _wav_slice
+    from vtscore.media.audio.wav import wav_slice
 
     wav_bytes = file_path.read_bytes()
-    return _wav_slice(wav_bytes, clip_start, clip_end), ".wav"
+    return wav_slice(wav_bytes, clip_start, clip_end), ".wav"
 
 
-def _clip_image_to_bytes(file_path: Path, clip_box: str) -> tuple[bytes, str]:
-    """Crop an image to the comma-separated ``clip_box``.  Returns ``(bytes, suffix)``."""
+def _clip_image_to_bytes(file_path: Path, clip_box: Any) -> tuple[bytes, str] | None:
+    """Crop an image to ``clip_box``.  Returns ``(bytes, suffix)``, or ``None`` if unparseable.
+
+    The box is read with the same parser the lazy-clip byte route uses
+    (:func:`~vtscore.media.clip_recipe.parse_clip_box`), so a region that
+    replays for display replays identically for embedding.  A malformed box
+    returns ``None``, which the caller turns into a whole-file embed — the
+    same "better the parent than the wrong region" stance the other branches
+    take.
+    """
     import io as _io
 
+    from vtscore.media.clip_recipe import parse_clip_box
     from vtscore.media.image.decode import open_upright
 
-    parts = [int(float(v)) for v in clip_box.split(",")]
-    if len(parts) != 4:
-        raise ValueError(f"clip_box must have 4 values, got {len(parts)}")
-    box: tuple[int, int, int, int] = (parts[0], parts[1], parts[2], parts[3])
+    box = parse_clip_box(clip_box)
+    if box is None:
+        return None
     # Upright decode, matching the clipper the box was recorded by.
     with open_upright(file_path) as img:
         cropped = img.crop(box)
@@ -551,30 +559,21 @@ def _converter_origin_to_chain(params: dict[str, Any]) -> list[dict[str, Any]] |
     shared sub-output selector, so a reference-converted label re-embeds from
     the source file + recipe exactly like a chain-converted one.
 
-    Returns ``None`` when no ``converter`` is recorded.
+    The dialect is decoded by
+    :func:`~vtscore.media.clip_recipe.parse_converter_recipe`, the same parser
+    the lazy-clip byte route reads it with, so the two replay paths cannot
+    disagree about what a given origin records.
+
+    Returns ``None`` when no ``converter`` is recorded, or when the recipe
+    carries no sub-output disambiguator - the selector would refuse to guess
+    anyway, so there is nothing to gain from running the converter first.
     """
-    converter = params.get("converter")
-    if not converter:
+    from vtscore.media.clip_recipe import parse_converter_recipe
+
+    recipe = parse_converter_recipe(params)
+    if recipe is None or not recipe.is_replayable:
         return None
-    prefix = "converter_param_"
-    conv_params = {k[len(prefix) :]: v for k, v in params.items() if k.startswith(prefix)}
-    entry: dict[str, Any] = {"kind": "converter", "name": str(converter), "params": conv_params}
-    out_index = params.get("converter_out_index")
-    if out_index is not None:
-        try:
-            entry["out_index"] = int(out_index)
-        except (TypeError, ValueError):
-            pass
-    n_out = params.get("converter_n_out")
-    if n_out is not None:
-        try:
-            entry["n_out"] = int(n_out)
-        except (TypeError, ValueError):
-            pass
-    content_hash = params.get("converter_content_hash")
-    if content_hash is not None:
-        entry["content_hash"] = content_hash
-    return [entry]
+    return [recipe.chain_step()]
 
 
 def _replay_chain(file_path: Path, chain_raw: Any, embedder_name: str) -> tuple[np.ndarray, bytes | None] | None:

--- a/vtscore/docs/packages/media.md
+++ b/vtscore/docs/packages/media.md
@@ -25,6 +25,7 @@ and is the foundation every other `vtscore` subsystem builds on.
 | `vtscore/media/cropping.py` | Shared normalised-box cropping helpers |
 | `vtscore/media/patch_embed.py` | Raw patch grids for image embedders (the MaxPatch region geometry) |
 | `vtscore/media/lazy_clip.py` | Derive a clip's bytes from its source on demand |
+| `vtscore/media/clip_recipe.py` | Parse the `origin.params` clip dialects, shared by both replay paths |
 | `vtscore/media/provenance.py` | Human-readable provenance for converter- and clipper-derived media |
 | `vtscore/media/structural.py` | Structural (instance-matching) features and geometric verification |
 | `vtscore/media/structural_geometry.py` | Parametrised geometric verification models |
@@ -37,7 +38,7 @@ and is the foundation every other `vtscore` subsystem builds on.
 
 | Sub-package | Embedders | Also holds |
 |-------------|-----------|------------|
-| `vtscore/media/audio/` | CLAP (general / music), AST, BEATs, ParaSpeechCLAP, Whisper | clipper, cleaner, ffmpeg + decode helpers, silence detection, speech extractor, synthetic audio generator |
+| `vtscore/media/audio/` | CLAP (general / music), AST, BEATs, ParaSpeechCLAP, Whisper | clipper, cleaner, ffmpeg + decode helpers, WAV byte slicing (`wav.py`), silence detection, speech extractor, synthetic audio generator |
 | `vtscore/media/image/` | SigLIP, SigLIP-L, SigLIP 2, SigLIP2-L, CLIP, DINOv2 (patch / single), DINOv3 (patch / single), EUPE (patch / single), SIFT-VLAD | clipper, cleaner, decode, edge trim, thumbnail, YOLO extractor, OCR extractor, face localizer, demo sources |
 | `vtscore/media/text/` | E5, BGE | clipper (paragraph / sentence), cleaner |
 | `vtscore/media/video/` | X-CLIP, LanguageBind, VideoMAE v2 | clipper (tile / scene-detect), cleaner, ffmpeg decode, frame sampling, `clip_box` crop |

--- a/vtscore/media/audio/cleaner.py
+++ b/vtscore/media/audio/cleaner.py
@@ -122,7 +122,7 @@ class AudioSilenceTrimCleaner(MediaCleaner):
         uniformly silent), or the two ends together account for less than
         :data:`_MIN_TRIM_SECONDS`.
         """
-        from vtscore.media.audio.clipper import _wav_duration, _wav_slice  # noqa: PLC0415
+        from vtscore.media.audio.wav import wav_duration, wav_slice  # noqa: PLC0415
         from vtscore.media.audio.silence import detect_nonsilent_segments  # noqa: PLC0415
 
         payload = media.get("media_bytes")
@@ -139,10 +139,10 @@ class AudioSilenceTrimCleaner(MediaCleaner):
             return media
 
         try:
-            total = _wav_duration(media_bytes)
+            total = wav_duration(media_bytes)
             if t0 < _MIN_TRIM_SECONDS and (total - t1) < _MIN_TRIM_SECONDS:
                 return media  # nothing meaningful at either end
-            trimmed = _wav_slice(media_bytes, t0, t1)
+            trimmed = wav_slice(media_bytes, t0, t1)
         except Exception:
             log.debug("audio_silence_trim: undecodable payload, leaving unchanged", exc_info=True)
             return media

--- a/vtscore/media/audio/clipper.py
+++ b/vtscore/media/audio/clipper.py
@@ -1,107 +1,21 @@
-"""Audio clippers - tile or pass-through audio media."""
+"""Audio clippers - tile or pass-through audio media.
+
+The WAV byte primitives these clippers run on (:func:`~vtscore.media.audio.wav.wav_slice`,
+:func:`~vtscore.media.audio.wav.wav_duration`) live in :mod:`vtscore.media.audio.wav`;
+:class:`~vtscore.media.audio.wav.AudioDecodeError` is imported here because this is where
+it is *caught* and turned into "leave the media unchanged", and stays importable from this
+module for callers that were already catching it here.
+"""
 
 from __future__ import annotations
 
-import io
 import math
 import os
-import wave
 from pathlib import Path
 from typing import Any
 
+from vtscore.media.audio.wav import AudioDecodeError, wav_duration, wav_slice
 from vtscore.media.clipper import MediaClipper
-
-
-class AudioDecodeError(Exception):
-    """Raised when WAV bytes can't be decoded by stdlib ``wave`` or ``soundfile``.
-
-    Signals a corrupt or unsupported audio payload (e.g. GTZAN's truncated
-    ``jazz.00054.wav``, or a non-audio blob).  Clippers catch this and fall
-    back to returning the media unchanged rather than aborting the whole load.
-    """
-
-
-def _to_pcm_wav(wav_bytes: bytes) -> bytes:
-    """Re-encode WAV bytes into plain PCM that stdlib ``wave`` can parse.
-
-    The stdlib ``wave`` module only understands ``WAVE_FORMAT_PCM`` (tag 1);
-    it raises ``wave.Error`` on ``WAVE_FORMAT_EXTENSIBLE`` (tag 0xFFFE, 65534),
-    which is what UrbanSound8K and many other real-world WAVs use.  ``soundfile``
-    reads those fine, so decode with it and re-write as 16-bit PCM.
-    """
-    import soundfile as sf  # noqa: PLC0415
-
-    data, sr = sf.read(io.BytesIO(wav_bytes), dtype="int16", always_2d=False)
-    buf = io.BytesIO()
-    sf.write(buf, data, sr, format="WAV", subtype="PCM_16")
-    return buf.getvalue()
-
-
-def _checked_wav(wf: wave.Wave_read) -> wave.Wave_read:
-    """Return *wf* if its header is usable, else close it and raise.
-
-    stdlib ``wave`` happily accepts a fmt chunk declaring a sample rate of 0,
-    so a corrupt or truncated header can open cleanly and then blow up with a
-    ``ZeroDivisionError`` in :func:`_wav_duration` (or a ``wave.Error`` from
-    ``setframerate`` in :func:`_wav_slice`).  Reject it up front as a decode
-    failure so callers hit the same graceful-degradation path as any other
-    undecodable payload.
-    """
-    if wf.getframerate() <= 0:
-        wf.close()
-        raise AudioDecodeError("WAV header declares a non-positive sample rate")
-    return wf
-
-
-def _open_wav(wav_bytes: bytes) -> wave.Wave_read:
-    """Open WAV bytes for reading, tolerating non-PCM formats.
-
-    Falls back to re-encoding via :func:`_to_pcm_wav` when stdlib ``wave``
-    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``) or parses it
-    into an unusable header.  Raises :class:`AudioDecodeError` when neither
-    path can decode the bytes (corrupt or unsupported payload) so callers can
-    degrade gracefully.
-    """
-    try:
-        return _checked_wav(wave.open(io.BytesIO(wav_bytes), "rb"))
-    except (wave.Error, EOFError, AudioDecodeError):
-        pass
-    try:
-        return _checked_wav(wave.open(io.BytesIO(_to_pcm_wav(wav_bytes)), "rb"))
-    except Exception as exc:  # soundfile LibsndfileError, wave.Error, EOFError, ...
-        raise AudioDecodeError("could not decode audio bytes") from exc
-
-
-def _wav_duration(wav_bytes: bytes) -> float:
-    """Return the duration in seconds of a WAV byte string."""
-    with _open_wav(wav_bytes) as wf:
-        return wf.getnframes() / wf.getframerate()
-
-
-def _wav_slice(wav_bytes: bytes, start: float, end: float) -> bytes:
-    """Extract a [start, end) slice from a WAV byte string.
-
-    Returns a new WAV byte string containing only the requested segment.
-    """
-    with _open_wav(wav_bytes) as wf:
-        sr = wf.getframerate()
-        n_channels = wf.getnchannels()
-        sampwidth = wf.getsampwidth()
-        start_frame = int(start * sr)
-        end_frame = int(end * sr)
-        total_frames = wf.getnframes()
-        start_frame = max(0, min(start_frame, total_frames))
-        end_frame = max(start_frame, min(end_frame, total_frames))
-        wf.setpos(start_frame)
-        frames = wf.readframes(end_frame - start_frame)
-
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as out:
-        out.setnchannels(n_channels)
-        out.setsampwidth(sampwidth)
-        out.setframerate(sr)
-        out.writeframes(frames)
-    return buf.getvalue()
 
 
 class SoundDefaultClipper(MediaClipper):
@@ -182,7 +96,7 @@ class SoundTilingClipper(MediaClipper):
             return [media]
 
         try:
-            total = _wav_duration(wav_bytes)
+            total = wav_duration(wav_bytes)
         except AudioDecodeError:
             return [media]
         seg = self._duration
@@ -202,7 +116,7 @@ class SoundTilingClipper(MediaClipper):
         results: list[dict[str, Any]] = []
         for idx, t0 in enumerate(starts):
             t1 = t0 + seg
-            sliced = _wav_slice(wav_bytes, t0, t1)
+            sliced = wav_slice(wav_bytes, t0, t1)
             tile = dict(media)
             tile["media_bytes"] = sliced
             tile["duration"] = round(t1 - t0, 6)
@@ -352,7 +266,7 @@ class SoundSilenceClipper(MediaClipper):
         try:
             results: list[dict[str, Any]] = []
             for idx, (t0, t1) in enumerate(segments):
-                sliced = _wav_slice(media_bytes, t0, t1)
+                sliced = wav_slice(media_bytes, t0, t1)
                 clip = dict(media)
                 clip["media_bytes"] = sliced
                 clip["duration"] = round(t1 - t0, 6)
@@ -469,7 +383,7 @@ class SoundClipClipper(MediaClipper):
             return [media]
 
         try:
-            total = _wav_duration(wav_bytes)
+            total = wav_duration(wav_bytes)
         except AudioDecodeError:
             return [media]
         t0 = max(0.0, min(self._start, total))
@@ -477,7 +391,7 @@ class SoundClipClipper(MediaClipper):
         if t1 <= t0:
             return [media]
 
-        sliced = _wav_slice(wav_bytes, t0, t1)
+        sliced = wav_slice(wav_bytes, t0, t1)
         clip = dict(media)
         clip["media_bytes"] = sliced
         clip["duration"] = round(t1 - t0, 6)
@@ -691,7 +605,7 @@ class SoundSpeechActivityClipper(MediaClipper):
         try:
             results: list[dict[str, Any]] = []
             for idx, (t0, t1) in enumerate(segments):
-                sliced = _wav_slice(media_bytes, t0, t1)
+                sliced = wav_slice(media_bytes, t0, t1)
                 clip = dict(media)
                 clip["media_bytes"] = sliced
                 clip["duration"] = round(t1 - t0, 6)

--- a/vtscore/media/audio/wav.py
+++ b/vtscore/media/audio/wav.py
@@ -1,0 +1,125 @@
+"""WAV byte-level helpers: duration and slicing, without decoding to a waveform.
+
+These are the low-level primitives the audio clipper, the silence cleaner and
+the two clip-replay paths (:mod:`vtscore.media.lazy_clip`,
+:mod:`vtscore.detectors.resolver`) all need: read a WAV byte string's duration,
+and cut a sub-range out of it *as WAV bytes*.  They live here rather than in the
+clipper because three modules outside that clipper — two of them in other
+packages — were reaching past the underscore to import them.
+
+This is deliberately **not** :mod:`vtscore.media.audio.decode`, whose job is the
+opposite: decode any container (via ``soundfile`` or ``ffmpeg``) down to a
+float32 waveform array.  Nothing here decodes samples; a slice goes WAV bytes in,
+WAV bytes out, so a clip keeps the source's exact sample data.  The one place the
+two meet is :func:`to_pcm_wav`, which re-encodes a non-PCM WAV so the stdlib
+``wave`` module can parse it.
+"""
+
+from __future__ import annotations
+
+import io
+import wave
+
+__all__ = [
+    "AudioDecodeError",
+    "open_wav",
+    "to_pcm_wav",
+    "wav_duration",
+    "wav_slice",
+]
+
+
+class AudioDecodeError(Exception):
+    """Raised when WAV bytes can't be decoded by stdlib ``wave`` or ``soundfile``.
+
+    Signals a corrupt or unsupported audio payload (e.g. GTZAN's truncated
+    ``jazz.00054.wav``, or a non-audio blob).  Clippers catch this and fall
+    back to returning the media unchanged rather than aborting the whole load.
+
+    Distinct from :class:`vtscore.media.audio.decode.AudioDecodeError`, which
+    reports a failure of the waveform decoder; catching one does not catch the
+    other.
+    """
+
+
+def to_pcm_wav(wav_bytes: bytes) -> bytes:
+    """Re-encode WAV bytes into plain PCM that stdlib ``wave`` can parse.
+
+    The stdlib ``wave`` module only understands ``WAVE_FORMAT_PCM`` (tag 1);
+    it raises ``wave.Error`` on ``WAVE_FORMAT_EXTENSIBLE`` (tag 0xFFFE, 65534),
+    which is what UrbanSound8K and many other real-world WAVs use.  ``soundfile``
+    reads those fine, so decode with it and re-write as 16-bit PCM.
+    """
+    import soundfile as sf  # noqa: PLC0415
+
+    data, sr = sf.read(io.BytesIO(wav_bytes), dtype="int16", always_2d=False)
+    buf = io.BytesIO()
+    sf.write(buf, data, sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+def _checked_wav(wf: wave.Wave_read) -> wave.Wave_read:
+    """Return *wf* if its header is usable, else close it and raise.
+
+    stdlib ``wave`` happily accepts a fmt chunk declaring a sample rate of 0,
+    so a corrupt or truncated header can open cleanly and then blow up with a
+    ``ZeroDivisionError`` in :func:`wav_duration` (or a ``wave.Error`` from
+    ``setframerate`` in :func:`wav_slice`).  Reject it up front as a decode
+    failure so callers hit the same graceful-degradation path as any other
+    undecodable payload.
+    """
+    if wf.getframerate() <= 0:
+        wf.close()
+        raise AudioDecodeError("WAV header declares a non-positive sample rate")
+    return wf
+
+
+def open_wav(wav_bytes: bytes) -> wave.Wave_read:
+    """Open WAV bytes for reading, tolerating non-PCM formats.
+
+    Falls back to re-encoding via :func:`to_pcm_wav` when stdlib ``wave``
+    can't parse the container (e.g. ``WAVE_FORMAT_EXTENSIBLE``) or parses it
+    into an unusable header.  Raises :class:`AudioDecodeError` when neither
+    path can decode the bytes (corrupt or unsupported payload) so callers can
+    degrade gracefully.
+    """
+    try:
+        return _checked_wav(wave.open(io.BytesIO(wav_bytes), "rb"))
+    except (wave.Error, EOFError, AudioDecodeError):
+        pass
+    try:
+        return _checked_wav(wave.open(io.BytesIO(to_pcm_wav(wav_bytes)), "rb"))
+    except Exception as exc:  # soundfile LibsndfileError, wave.Error, EOFError, ...
+        raise AudioDecodeError("could not decode audio bytes") from exc
+
+
+def wav_duration(wav_bytes: bytes) -> float:
+    """Return the duration in seconds of a WAV byte string."""
+    with open_wav(wav_bytes) as wf:
+        return wf.getnframes() / wf.getframerate()
+
+
+def wav_slice(wav_bytes: bytes, start: float, end: float) -> bytes:
+    """Extract a [start, end) slice from a WAV byte string.
+
+    Returns a new WAV byte string containing only the requested segment.
+    """
+    with open_wav(wav_bytes) as wf:
+        sr = wf.getframerate()
+        n_channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        start_frame = int(start * sr)
+        end_frame = int(end * sr)
+        total_frames = wf.getnframes()
+        start_frame = max(0, min(start_frame, total_frames))
+        end_frame = max(start_frame, min(end_frame, total_frames))
+        wf.setpos(start_frame)
+        frames = wf.readframes(end_frame - start_frame)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as out:
+        out.setnchannels(n_channels)
+        out.setsampwidth(sampwidth)
+        out.setframerate(sr)
+        out.writeframes(frames)
+    return buf.getvalue()

--- a/vtscore/media/clip_recipe.py
+++ b/vtscore/media/clip_recipe.py
@@ -66,12 +66,19 @@ def parse_clip_box(raw: Any) -> tuple[int, int, int, int] | None:
 
 
 def _as_int(raw: Any) -> int | None:
-    """Coerce a params value to ``int``, or ``None`` when it isn't one."""
+    """Coerce a params value to ``int``, or ``None`` when it isn't one.
+
+    ``OverflowError`` is caught alongside the usual coercion failures: a
+    non-finite float survives a pickle round-trip, and ``int(float("inf"))``
+    raises it.  Everything in this module degrades to ``None`` rather than
+    raising, so the replay paths can fall through to whole-file handling
+    instead of propagating out of a byte route.
+    """
     if raw is None:
         return None
     try:
         return int(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
 
 

--- a/vtscore/media/clip_recipe.py
+++ b/vtscore/media/clip_recipe.py
@@ -1,0 +1,161 @@
+"""One parser for the ``origin.params`` clip dialects, shared by both replay paths.
+
+An ``origin.params`` dict is the canonical, pickle-surviving record of how a
+derived media was produced (see the origins-are-canonical rule in
+``CLAUDE.md``).  Two independent code paths rederive content from it:
+
+* :mod:`vtscore.media.lazy_clip` — serves a lazy clip's **display bytes** on
+  demand, out of a process-scoped LRU, for the HTTP byte routes.
+* :func:`vtscore.detectors.resolver._apply_clip_and_embed` — rederives a label's
+  content on a resolved file and **embeds** it, for cross-dataset training.
+
+Those two have genuinely different contracts (cached bytes vs. an embedding via
+a tempfile; a media dict vs. an already-resolved ``Path``; fall through to
+whole-file *serving* vs. whole-file *embedding*), so they stay separate.  What
+they must **not** have separately is a reading of the params dialect: two
+parsers of one wire format is exactly how a replay path drifts into rederiving
+the wrong bytes, silently, on the load-bearing path of the invariant.
+
+So this module owns the *parsing* only — params in, a validated recipe out —
+and each caller keeps its own replay and fallback policy:
+
+* :func:`parse_clip_box` — the ``clip_box`` pixel-region dialect.
+* :func:`parse_converter_recipe` — the flat ``converter`` /
+  ``converter_param_<key>`` / ``converter_out_index`` / ``converter_n_out`` /
+  ``converter_content_hash`` dialect stamped by the importer-level converter
+  path (``run_converters_on_folder``), returned as a
+  :class:`FlatConverterRecipe` that can render itself into either caller's
+  shape — a hashable cache key or a one-step chain entry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "FlatConverterRecipe",
+    "parse_clip_box",
+    "parse_converter_recipe",
+]
+
+
+def parse_clip_box(raw: Any) -> tuple[int, int, int, int] | None:
+    """Parse a ``clip_box`` into a 4-int pixel tuple, or ``None`` if malformed.
+
+    Accepts the ``"x1,y1,x2,y2"`` string stored in ``origin.params`` as well
+    as a native list/tuple (the in-memory form on a freshly clipped media).
+
+    Returns ``None`` rather than raising on every malformed shape — wrong
+    arity, a non-numeric component, a value that is neither string nor
+    sequence — so a caller can fall through to whole-file handling instead of
+    cropping to a half-parsed region.
+    """
+    if isinstance(raw, (list, tuple)):
+        parts = list(raw)
+    elif isinstance(raw, str):
+        parts = [p for p in raw.split(",") if p != ""]
+    else:
+        return None
+    if len(parts) != 4:
+        return None
+    try:
+        return (int(float(parts[0])), int(float(parts[1])), int(float(parts[2])), int(float(parts[3])))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(raw: Any) -> int | None:
+    """Coerce a params value to ``int``, or ``None`` when it isn't one."""
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class FlatConverterRecipe:
+    """A flat (non-chain) converter origin, parsed.
+
+    ``out_index`` / ``n_out`` are ``None`` when absent *or* uncoercible — a
+    garbled index is indistinguishable from a missing one for selection
+    purposes, and both must leave the recorded output unpicked rather than
+    picked wrongly.
+    """
+
+    name: str
+    params: dict[str, Any]
+    out_index: int | None
+    n_out: int | None
+    content_hash: str | None
+
+    @property
+    def is_replayable(self) -> bool:
+        """True iff at least one sub-output disambiguator was recorded.
+
+        Without an ``out_index`` or a ``content_hash``,
+        :func:`~vtscore.datasets.clipper_chain._select_chain_output` has no
+        handle to pick the recorded output with and refuses to guess, so the
+        replay can only fail.  Callers check this to skip the converter run
+        entirely and fall through to their whole-file path — the same outcome
+        the selector would reach, reached without the work.
+        """
+        return self.out_index is not None or self.content_hash is not None
+
+    def cache_key(self) -> tuple:
+        """Render as a hashable tuple, for use as an LRU cache key."""
+        return (
+            "converter",
+            self.name,
+            tuple(sorted(self.params.items())),
+            self.out_index,
+            self.n_out,
+            self.content_hash,
+        )
+
+    def chain_step(self) -> dict[str, Any]:
+        """Render as a one-step ``clipper_chain`` entry.
+
+        Lets the flat dialect reuse
+        :func:`~vtscore.datasets.clipper_chain.replay_chain_on_file` and the
+        shared sub-output selector, so a reference-converted media replays
+        exactly like a chain-converted one.  Optional keys are omitted rather
+        than set to ``None``, because the selector treats a present-but-``None``
+        disambiguator as "not recorded" only by convention and a missing key
+        says it unambiguously.
+        """
+        entry: dict[str, Any] = {"kind": "converter", "name": self.name, "params": dict(self.params)}
+        if self.out_index is not None:
+            entry["out_index"] = self.out_index
+        if self.n_out is not None:
+            entry["n_out"] = self.n_out
+        if self.content_hash is not None:
+            entry["content_hash"] = self.content_hash
+        return entry
+
+
+#: Prefix under which the flat converter dialect stores the converter's own params.
+_PARAM_PREFIX = "converter_param_"
+
+
+def parse_converter_recipe(params: dict[str, Any]) -> FlatConverterRecipe | None:
+    """Parse a flat converter origin out of *params*, or ``None``.
+
+    ``None`` means "no converter recorded here" — the params describe a plain
+    clip, or nothing derived at all.  A recipe that parsed but carries no
+    disambiguator is *not* ``None``; it comes back with
+    :attr:`~FlatConverterRecipe.is_replayable` false, so a caller can tell
+    "not a converter media" from "a converter media we cannot replay".
+    """
+    name = params.get("converter")
+    if not name:
+        return None
+    return FlatConverterRecipe(
+        name=str(name),
+        params={k[len(_PARAM_PREFIX) :]: v for k, v in params.items() if k.startswith(_PARAM_PREFIX)},
+        out_index=_as_int(params.get("converter_out_index")),
+        n_out=_as_int(params.get("converter_n_out")),
+        content_hash=params.get("converter_content_hash"),
+    )

--- a/vtscore/media/lazy_clip.py
+++ b/vtscore/media/lazy_clip.py
@@ -13,7 +13,7 @@ Two recipe families participate:
 * **clip slices** - the media type's clipper re-slices the source bytes:
 
   * **audio** - ``clip_start`` / ``clip_end`` seconds, sliced via
-    :func:`~vtscore.media.audio.clipper._wav_slice`.
+    :func:`~vtscore.media.audio.wav.wav_slice`.
   * **image** - ``clip_box`` pixel box, cropped via Pillow.
 
   Text clips keep their (tiny) ``media_string`` materialized, and video clips
@@ -45,6 +45,8 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any
+
+from vtscore.media.clip_recipe import parse_clip_box, parse_converter_recipe
 
 log = logging.getLogger(__name__)
 
@@ -108,65 +110,21 @@ _CONV_CACHE_MAX_BYTES = 256 * 1024 * 1024
 _conv_cache = _ByteBoundedLRU(_CONV_CACHE_MAX_BYTES)
 
 
-def _parse_box(raw: Any) -> tuple[int, int, int, int] | None:
-    """Parse a ``clip_box`` into a 4-int pixel tuple, or ``None`` if malformed.
-
-    Accepts the ``"x1,y1,x2,y2"`` string stored in ``origin.params`` as well
-    as a native list/tuple (the in-memory form on a freshly clipped media).
-    """
-    if isinstance(raw, (list, tuple)):
-        parts = list(raw)
-    elif isinstance(raw, str):
-        parts = [p for p in raw.split(",") if p != ""]
-    else:
-        return None
-    if len(parts) != 4:
-        return None
-    try:
-        return (int(float(parts[0])), int(float(parts[1])), int(float(parts[2])), int(float(parts[3])))
-    except (TypeError, ValueError):
-        return None
-
-
 def _converter_recipe(params: dict[str, Any]) -> tuple | None:
-    """Build a converter recipe from ``origin.params``, or ``None``.
+    """Build a hashable converter recipe from ``origin.params``, or ``None``.
 
-    Returns ``("converter", name, params_items, out_index, n_out,
-    content_hash)`` where ``params_items`` is a hashable
-    ``tuple(sorted(...))`` of the reconstructed converter params (rebuilt
-    from the ``converter_param_<key>`` keys).  Requires at least one
-    sub-output disambiguator (``converter_out_index`` or
-    ``converter_content_hash``); without one, replay cannot pick the right
-    output, so it is treated as "not a lazy converter media" (``None``) and
-    the caller falls through to its normal resolution order.
+    Parsing is shared with the resolver's replay path via
+    :func:`~vtscore.media.clip_recipe.parse_converter_recipe`; what stays local
+    is the *gate*.  A recipe with no sub-output disambiguator cannot pick the
+    right output, so it is treated here as "not a lazy converter media"
+    (``None``) and the caller falls through to its normal resolution order,
+    rather than running the converter only to have the selector refuse to
+    guess.
     """
-    name = params.get("converter")
-    if not name:
+    recipe = parse_converter_recipe(params)
+    if recipe is None or not recipe.is_replayable:
         return None
-    out_index_raw = params.get("converter_out_index")
-    content_hash = params.get("converter_content_hash")
-    if out_index_raw is None and content_hash is None:
-        return None
-
-    prefix = "converter_param_"
-    conv_params = {k[len(prefix) :]: v for k, v in params.items() if k.startswith(prefix)}
-
-    def _as_int(raw: Any) -> int | None:
-        if raw is None:
-            return None
-        try:
-            return int(raw)
-        except (TypeError, ValueError):
-            return None
-
-    return (
-        "converter",
-        str(name),
-        tuple(sorted(conv_params.items())),
-        _as_int(out_index_raw),
-        _as_int(params.get("converter_n_out")),
-        content_hash,
-    )
+    return recipe.cache_key()
 
 
 def clip_recipe(media: dict[str, Any]) -> tuple | None:
@@ -222,7 +180,7 @@ def clip_recipe(media: dict[str, Any]) -> tuple | None:
             return None
 
     if media_type == "image":
-        box = _parse_box(params.get("clip_box"))
+        box = parse_clip_box(params.get("clip_box"))
         if box is None:
             return None
         return ("image", box)
@@ -236,9 +194,9 @@ def _apply_recipe(source_bytes: bytes, recipe: tuple, media: dict[str, Any]) -> 
     if kind == "converter":
         return _apply_converter_recipe(source_bytes, recipe, media)
     if kind == "audio":
-        from vtscore.media.audio.clipper import _wav_slice  # noqa: PLC0415
+        from vtscore.media.audio.wav import wav_slice  # noqa: PLC0415
 
-        return _wav_slice(source_bytes, recipe[1], recipe[2])
+        return wav_slice(source_bytes, recipe[1], recipe[2])
     if kind == "image":
         from vtscore.media.image.decode import open_upright  # noqa: PLC0415
 


### PR DESCRIPTION
Closes #3378.

Takes the narrow half of #3378 and explicitly declines the broad half. The reasoning is in a comment on the issue; summarised here.

## What was actually duplicated

The issue frames `lazy_clip` and `resolver` as "one clip-replay path implemented twice." They aren't — they have genuinely different contracts:

| | `lazy_clip` | `resolver` |
|---|---|---|
| input | media dict (path/url), read under per-user path confinement | an already-resolved `Path` |
| output | bytes, out of a process-scoped LRU | an embedding, via a tempfile |
| chain support | none | `replay_chain_on_file`, its primary path |
| on failure | fall through to whole-file **serving** | fall through to whole-file **embedding** |

What *is* duplicated, and is a real drift hazard, is the reading of the `origin.params` dialects. Two parsers of one wire format, on the load-bearing path of the origins-are-canonical invariant, is how one path starts serving a different region than the other embeds — silently.

They had already drifted: `lazy_clip._converter_recipe` required a sub-output disambiguator and returned `None` without one; `resolver._converter_origin_to_chain` didn't, and built a chain that `_select_chain_output` would then refuse to resolve. `lazy_clip._parse_box` accepted a list/tuple and tolerated empty segments; `resolver._clip_image_to_bytes` accepted only a string and raised on wrong arity.

## Changes

- **`vtscore/media/clip_recipe.py`** (new) owns the parsing only. `parse_clip_box` for the pixel-region dialect; `parse_converter_recipe` returning a `FlatConverterRecipe` that renders itself into either caller's shape (`cache_key()` → a hashable LRU key, `chain_step()` → a one-step chain entry). Each caller keeps its own replay and fallback policy.
- **`vtscore/media/audio/wav.py`** (new) holds `wav_slice` / `wav_duration` / `open_wav` / `to_pcm_wav`, which three modules — two in other packages — were importing past the underscore from the audio clipper. `AudioDecodeError` stays importable from `clipper`, which is where it is *caught* and turned into "leave the media unchanged". Deliberately not folded into `audio/decode.py`: that module decodes containers down to a float32 waveform, whereas these go WAV bytes in, WAV bytes out, and it already has a same-named, differently-based `AudioDecodeError`.
- The resolver now declines a flat converter origin carrying no disambiguator up front rather than running the converter and having the selector refuse to guess. Same outcome, without the work.
- `int(float("inf"))` raises `OverflowError`, which neither original parser caught, so a non-finite value surviving a pickle round-trip would have propagated out of a byte route instead of degrading. Now caught.

## What was deliberately left alone

The three divergences the issue names are, on inspection, two non-bugs and one mis-description:

- **Archive-member guard only in `lazy_clip`** — not a gap. A windowed archive member reaches the resolver as a `clipper_chain`, the WAV slicer can't cut its AAC, the clipper returns the media unchanged, the `clip_start` disambiguator then fails to match, and the replay falls through to a whole-member embed: the same answer the guard gives, reached through the existing degradation path. An explicit guard would be cosmetic, and its stated rationale ("we don't decode AAC server-side") is a serving concern, not an embedding one.
- **Text `clip_index` only in `resolver`** — deliberate and already documented in `lazy_clip`'s module docstring: text clips keep their (tiny) `media_string` materialized, so there is nothing to lazily resolve.
- **"Converter replay diverges completely"** — overstated. Both paths converge on `clipper_chain._select_chain_output`; only the params parsing differed, which is what this PR fixes.

The proposed direction — a new public clip-replay module under `vtscore/media/` covering all four kinds, with `resolver._apply_clip_and_embed` calling it — would build a *fourth* clip-replay home and move the resolver off `replay_chain_on_file`, which is already the general engine (clipper / cleaner / converter steps through the plugin registries, plus the shared selector). That trades a real engine for a hand-rolled one on the highest-risk path in the repo.

## Testing

`./run-tests.sh` full run green: 9515 passed, 6 skipped; pyright, pip-audit, npm audit and the Vitest suite all OK.

New `tests_lib/detectors/test_clip_recipe_shared.py` (34 tests) pins the dialects and, in `TestBothPathsAgree`, asserts across six param shapes that `lazy_clip._converter_recipe` and `resolver._converter_origin_to_chain` agree both on *whether* to replay and on *what was recorded* — the regression this PR exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GwUya7TmT96mBcBw8LPyNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GwUya7TmT96mBcBw8LPyNR)_