### PR TITLE
Promote the detector-JSON write lock and labelset merge to public names

### DIFF
--- a/docs/plans/scalability.md
+++ b/docs/plans/scalability.md
@@ -220,7 +220,7 @@ merge the double-walk (populate then build_xy) into a single pass.
 `labels/sync.py` has `_DEBOUNCE_DELAY = 0.2` and a timer-based `_PendingSync`.
 
 **Still open:** `label_sync.sync_labels_to_loaded_detector` still does a full
-read-merge-write of the detector JSON per vote (under `_label_sync_write_lock`).
+read-merge-write of the detector JSON per vote (under `label_sync_write_lock`).
 At 100 k labels the serialised labelset is ~50–100 MB; writing it on every vote
 stalls the handler for seconds.
 

--- a/tests/detectors/test_detector_json_lock.py
+++ b/tests/detectors/test_detector_json_lock.py
@@ -1,7 +1,7 @@
 """Regression tests: every detector-JSON read→merge→write runs under the sync lock.
 
 Audit follow-up (ninth pass): ``sync_labels_to_loaded_detector`` serialises its
-RMW of ``detectors/<slug>.json`` under ``_label_sync_write_lock``, but four
+RMW of ``detectors/<slug>.json`` under ``label_sync_write_lock``, but four
 route-layer writers (``save_detector_labels``, ``vote_detector_label``,
 ``import_labels_into_detector``, ``find_corrections_to_detector``) did the
 same file's RMW unlocked — a concurrent locked sync and an unlocked route
@@ -18,7 +18,7 @@ detector's labelset with an empty one.
 
 from __future__ import annotations
 
-from vtscore.detectors.label_sync import _label_sync_write_lock
+from vtscore.detectors.labelset_ops import label_sync_write_lock
 from vtscore.detectors.store import _detector_path, _read_detector
 from vtsearch.state import medias
 
@@ -29,7 +29,7 @@ def _record_locked_writes(monkeypatch, module, attr="_write_detector"):
     locked_at_write: list[bool] = []
 
     def recording_write(path, data):
-        locked_at_write.append(_label_sync_write_lock.locked())
+        locked_at_write.append(label_sync_write_lock.locked())
         return real_write(path, data)
 
     monkeypatch.setattr(module, attr, recording_write)

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1938,7 +1938,7 @@ class TestValidatedVoteSnapshot:
 
         # Simulate the race: votes_dataset_id mismatches active dataset, and
         # the rehydrate hook is bypassed (so the mismatch survives).  Without
-        # the safe=False guard, ``_merge_labelsets_across_datasets`` would
+        # the safe=False guard, ``merge_labelsets_across_datasets`` would
         # drop the active dataset's existing entries and replace them with an
         # empty composition, erasing labels from disk.
         original = _ds_sync.ensure_votes_match_active_dataset

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -142,6 +142,22 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **The detector-JSON write lock and the cross-dataset labelset merge are now
+  public, and re-exported from the `labelset_ops` façade** (issue #3398).
+  `vtscore.detectors.label_sync._label_sync_write_lock` and
+  `_merge_labelsets_across_datasets` are now
+  `label_sync_write_lock` and `merge_labelsets_across_datasets`, exported from
+  `vtscore.detectors.labelset_ops` alongside the rest of the detector-labelset
+  surface. Neither is new behaviour — the lock's contract has always bound
+  out-of-module writers (any caller doing its own read-modify-write of a
+  detector JSON file must hold it for the whole pass, acquired *before*
+  `_state_lock`), and `sync_labels_to_loaded_detector` and the app's four route
+  writers all merge with the same function. The private names simply said
+  otherwise, which made the seam unenforceable and the symbols un-renameable.
+  Both old names are gone rather than aliased, per this repo's rule that
+  `_`-prefixed symbols carry no compatibility promise; an out-of-tree writer
+  that was reaching for them should import from `labelset_ops`.
+
 - **`vtscore.utils.hits.hit_custom_metadata(media)`** — the `custom_metadata`
   sanitiser `build_media_hit` already applied is now a public export (issue
   #3368). It returns a fresh copy of a media's importer metadata with the

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -30,7 +30,11 @@ from vtscore.state.core import DetectorContext
 # read-modify-write.  Every taker acquires this lock *before* ``_state_lock``
 # (via ``validated_vote_snapshot`` or an explicit ``with _state_lock`` inside
 # the body), so no ordering cycle is possible.
-_label_sync_write_lock = threading.Lock()
+#
+# Public because those out-of-module takers are part of the contract: an
+# out-of-package writer that does its own detector-JSON RMW *must* hold this
+# lock.  Reach it through :mod:`vtscore.detectors.labelset_ops`.
+label_sync_write_lock = threading.Lock()
 
 
 def _get_loaded_detector_state() -> tuple[dict[str, Any], Path, dict[str, Any], DetectorContext] | None:
@@ -64,7 +68,7 @@ def _get_loaded_detector_state() -> tuple[dict[str, Any], Path, dict[str, Any], 
     return entry, path, data, det_ctx
 
 
-def _merge_labelsets_across_datasets(
+def merge_labelsets_across_datasets(
     existing_ls: LabelSet,
     current_ls: LabelSet,
     current_dataset_medias: dict[int, dict[str, Any]],
@@ -154,7 +158,7 @@ def sync_labels_to_loaded_detector() -> None:
     because the global votes reflect scoring results on a different dataset,
     not the detector's original training labels.
     """
-    with _label_sync_write_lock:
+    with label_sync_write_lock:
         _sync_labels_to_loaded_detector_locked()
 
 
@@ -191,7 +195,7 @@ def _sync_labels_to_loaded_detector_locked() -> None:
     # Existing labelset entries that resolve into the active dataset are
     # "owned" by it and get reconciled against the current votes; entries that
     # resolve to nothing are cross-dataset and are preserved verbatim.
-    merged = _merge_labelsets_across_datasets(existing_ls, current_ls, snap)
+    merged = merge_labelsets_across_datasets(existing_ls, current_ls, snap)
     data["labelset"] = merged.to_dict()
     _write_detector(path, data)
 

--- a/vtscore/detectors/labelset_ops.py
+++ b/vtscore/detectors/labelset_ops.py
@@ -24,12 +24,24 @@ import :mod:`vtscore.detectors.labelset_ops` once and reach the whole
 surface through it, instead of remembering which of the five sibling
 modules a given function lives in.  The sibling modules remain the
 implementation homes; this is the discoverable seam.
+
+That includes the concurrency contract: any caller doing its own
+read-modify-write of a detector JSON file must hold
+:data:`~vtscore.detectors.label_sync.label_sync_write_lock` across the whole
+pass, and will usually want
+:func:`~vtscore.detectors.label_sync.merge_labelsets_across_datasets` to
+reconcile the result.  Both are re-exported here so a writer never has to
+reach into a sibling module for them.
 """
 
 from __future__ import annotations
 
 from vtscore.detectors.label_restoration import restore_labels_from_detector
-from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
+from vtscore.detectors.label_sync import (
+    label_sync_write_lock,
+    merge_labelsets_across_datasets,
+    sync_labels_to_loaded_detector,
+)
 from vtscore.detectors.labelset_elements import (
     apply_element_vote_in_data,
     build_element_view,
@@ -54,6 +66,8 @@ __all__ = [
     # label_restoration
     "restore_labels_from_detector",
     # label_sync
+    "label_sync_write_lock",
+    "merge_labelsets_across_datasets",
     "sync_labels_to_loaded_detector",
     # labelset_elements
     "apply_element_vote_in_data",

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -472,6 +472,39 @@ active votes (replaced, flipped, or removed). Skipped entirely when
 `is_find_mode()` is True - find-mode votes are scoring hits on a
 different dataset and don't belong in the training set.
 
+### `label_sync.label_sync_write_lock`
+
+The lock that serialises every read → merge → write pass over a
+detector JSON file. It is public because the contract binds callers
+outside this module: **if you do your own RMW of a detector JSON, hold
+this lock across the whole pass**, or a concurrent sync merges against
+a stale base and one side's just-written entries are lost. (The write
+itself is atomic via `os.replace`, but atomicity doesn't serialise a
+read-modify-write.) Acquire it *before* `_state_lock` - every existing
+taker does, so that ordering is what keeps the pair cycle-free. The
+app's four detector-JSON route writers and
+`sync_labels_to_loaded_detector` are the in-tree takers.
+
+### `label_sync.merge_labelsets_across_datasets(existing_ls, current_ls, current_dataset_medias)`
+
+Merge a freshly-composed per-dataset labelset into the cross-dataset
+one already on disk, and the companion to the lock above: a writer that
+composes a labelset from the active dataset's votes wants this to
+reconcile it. Existing entries that resolve to a media in
+*current_dataset_medias* are dropped (they are re-emitted by
+`current_ls`, the authoritative record of what the user voted there);
+entries that resolve to nothing were accumulated under other datasets
+and are kept verbatim. Ownership is decided by the same origin-or-md5
+resolution `restore_labels_from_detector` uses, so an element that
+becomes a vote on load is one `current_ls` re-emits. Duplicate
+identities in the result are collapsed, first occurrence winning.
+*current_dataset_medias* must be the snapshot *current_ls* was composed
+from, so the two halves can't straddle a dataset switch.
+
+Both names are re-exported from
+[`vtscore.detectors.labelset_ops`](../../detectors/labelset_ops.py);
+prefer importing them from there with the rest of the surface.
+
 ### `label_restoration.restore_labels_from_detector(det_data)` (line 11)
 
 Take a detector-JSON dict, resolve every labelset element against the

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -134,11 +134,11 @@ def save_detector_labels(name: str):
     from vtscore.datasets.labelset import LabelSet
     from vtscore.detectors.dataset_sync import validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
-    from vtscore.detectors.label_sync import _label_sync_write_lock, _merge_labelsets_across_datasets
+    from vtscore.detectors.labelset_ops import label_sync_write_lock, merge_labelsets_across_datasets
 
     # The read→compose→write below races the loaded-detector label sync (and
     # the other detector-JSON writers), so it runs under the same lock.
-    with _label_sync_write_lock:
+    with label_sync_write_lock:
         path = _detector_path(name)
         data = _read_detector(path)
         if data is None:
@@ -165,7 +165,7 @@ def save_detector_labels(name: str):
         # that resolve to nothing were accumulated under other datasets and are
         # preserved verbatim by the merge.
         existing_ls = LabelSet.from_dict(data.get("labelset") or {})
-        labelset = _merge_labelsets_across_datasets(existing_ls, current_ls, medias_snap)
+        labelset = merge_labelsets_across_datasets(existing_ls, current_ls, medias_snap)
         data["labelset"] = labelset.to_dict()
 
         # Capture the active dataset's clipper into the detector's input_spec
@@ -280,15 +280,15 @@ def _merge_labels_into_detector_file(path: Path, label_entries: list[dict]):
     """Merge *label_entries* into the detector JSON at *path* under the sync lock.
 
     The read→merge→write races the loaded-detector label sync (and the other
-    detector-JSON writers), so it runs under ``_label_sync_write_lock``.  The
+    detector-JSON writers), so it runs under ``label_sync_write_lock``.  The
     file is re-read inside the lock (the route's earlier read only served its
     404 check).  Returns ``(existing_ls, applied, skipped, new_entries)``, or
     ``None`` if the detector file vanished.
     """
     from vtscore.datasets.labelset import LabelSet
-    from vtscore.detectors.label_sync import _label_sync_write_lock
+    from vtscore.detectors.labelset_ops import label_sync_write_lock
 
-    with _label_sync_write_lock:
+    with label_sync_write_lock:
         data = _read_detector(path)
         if data is None:
             return None
@@ -660,12 +660,12 @@ def vote_detector_label(body: dict, name: str, element_id: str):
     target = body["target"]
 
     from vtscore.datasets.labelset import LabelSet
-    from vtscore.detectors.label_sync import _label_sync_write_lock
     from vtscore.detectors.labelset_elements import find_element_by_id
+    from vtscore.detectors.labelset_ops import label_sync_write_lock
 
     # read→apply→write races the loaded-detector label sync (and the other
     # detector-JSON writers), so it runs under the same lock.
-    with _label_sync_write_lock:
+    with label_sync_write_lock:
         path = _detector_path(name)
         data = _read_detector(path)
         if data is None:

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -740,7 +740,7 @@ def find_corrections_to_detector():
     from vtscore.datasets.labelset import LabelSet, element_identity_keys
     from vtscore.detectors.dataset_sync import _detector_file_mtime, validated_vote_snapshot
     from vtscore.detectors.input_spec import extract_input_spec_from_medias
-    from vtscore.detectors.label_sync import _label_sync_write_lock
+    from vtscore.detectors.labelset_ops import label_sync_write_lock
     from vtscore.detectors.registry import get_detector as reg_get_detector
     from vtscore.detectors.registry import update_detector
     from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
@@ -756,7 +756,7 @@ def find_corrections_to_detector():
     # read→merge→write races the loaded-detector label sync (and the other
     # detector-JSON writers), so it runs under the same lock — acquired
     # before ``_state_lock``, matching label_sync's ordering.
-    with _label_sync_write_lock:
+    with label_sync_write_lock:
         path = _detector_path(name)
         data = _read_detector(path)
         if data is None:


### PR DESCRIPTION
Closes #3398.

## The defect

Four `vtsearch/routes/detectors/` call sites (three in `labels.py`, one in `scoring.py`) plus a regression test imported `_label_sync_write_lock` and `_merge_labelsets_across_datasets` from `vtscore.detectors.label_sync` — reaching across the package boundary, past the `labelset_ops` façade, for symbols marked private.

The premise holds, and the lock makes it plain: its own comment already names the route-layer writers (`save_detector_labels`, `vote_detector_label`, `import_labels_into_detector`, `find_corrections_to_detector`) as required takers, and `tests/detectors/test_detector_json_lock.py` exists specifically to pin that they hold it. So the contract was public — cross-package, load-bearing, and regression-tested — while the names said "module-private". That mismatch is what made the symbols un-renameable (a rename that trusted the underscore would silently break four RMW paths' mutual exclusion) and the seam unenforceable.

## The change

Pure rename plus re-export; no behaviour change.

- `vtscore/detectors/label_sync.py` — `_label_sync_write_lock` → `label_sync_write_lock`, `_merge_labelsets_across_datasets` → `merge_labelsets_across_datasets`. The lock's comment now says why it is public and where to import it from.
- `vtscore/detectors/labelset_ops.py` — both re-exported and added to `__all__`; the module docstring gains a paragraph stating the concurrency contract, since that is now part of the surface the façade covers.
- `vtsearch/routes/detectors/labels.py`, `scoring.py` — all four call sites import from `vtscore.detectors.labelset_ops`.
- `tests/detectors/test_detector_json_lock.py` — imports the public name through the façade, so the test exercises the same seam the routes do.
- Docs: an `[Unreleased] → Added` entry in `vtscore/CHANGELOG.md`, and both names written up under "Sync helpers" in `vtscore/docs/packages/detectors.md` (the lock's ordering rule against `_state_lock` included, since an out-of-tree writer needs it). Stale mentions of the old names in `docs/plans/scalability.md` and two test docstrings updated.

Deleting the façade was explicitly out of scope, and it stays.

### On backwards compatibility

The old private names are dropped rather than aliased, per this repo's rule that `_`-prefixed symbols carry no compatibility promise. The façade itself — the documented, discoverable name an out-of-tree consumer would actually import — is untouched and strictly gains two exports. The `CHANGELOG` entry points anyone who *was* reaching for the private names at `labelset_ops`.

## Testing

Full `./run-tests.sh`: **9481 passed, 6 skipped**, every gate green (pyright, pip-audit, npm audit, Vitest, and the stage-1 serial gates). `./run-tests.sh detectors` green separately at 2659 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018moLHNG4VinGJ4rgnL413U)_