### PR TITLE
Replace print() error reporting in shipped converters with logging

### DIFF
--- a/tests_lib/core/test_agpl_optional_extra.py
+++ b/tests_lib/core/test_agpl_optional_extra.py
@@ -16,6 +16,7 @@ message instead of a bare ``ImportError``.
 
 from __future__ import annotations
 
+import logging
 import sys
 import tomllib
 from pathlib import Path
@@ -167,18 +168,24 @@ def test_pdf_preview_reports_the_missing_package(without_module) -> None:
 )
 def test_document_converters_report_the_missing_package(
     without_module,
-    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
     module_path: str,
     class_name: str,
 ) -> None:
-    """Converters return no clips (their existing contract) but say why."""
+    """Converters return no clips (their existing contract) but say why.
+
+    The message goes through the module logger rather than ``print`` so the
+    embedding application can level and route it; see
+    ``vtscore/docs/extending/converters.md`` § Reporting failures.
+    """
     import importlib
 
     converter = getattr(importlib.import_module(module_path), class_name)()
     without_module("fitz")
 
-    assert converter.convert({"filename": "doc.pdf", "media_bytes": b"%PDF-1.4"}) == []
-    assert "PyMuPDF" in capsys.readouterr().out
+    with caplog.at_level(logging.WARNING, logger=module_path):
+        assert converter.convert({"filename": "doc.pdf", "media_bytes": b"%PDF-1.4"}) == []
+    assert any("PyMuPDF" in r.getMessage() for r in caplog.records)
 
 
 def test_yolo_extractor_reports_the_missing_package(without_module) -> None:

--- a/vtscore/converters/audio2image.py
+++ b/vtscore/converters/audio2image.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import io
+import logging
 from pathlib import Path
 from typing import Any
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 def _load_audio_array(media_bytes: bytes, filename: str, duration: float | None) -> tuple[Any, int] | None:
@@ -16,8 +19,8 @@ def _load_audio_array(media_bytes: bytes, filename: str, duration: float | None)
 
     try:
         audio_data, sr = decode_audio(media_bytes, sr=None, mono=True, duration=duration)
-    except Exception as e:
-        print(f"Audio2ImageMediaConverter: failed to load {filename}: {e}")
+    except Exception:
+        logger.error("Failed to decode audio %s", filename, exc_info=True)
         return None
 
     if audio_data is None or len(audio_data) == 0:
@@ -35,8 +38,8 @@ def _compute_spectrogram(
             return librosa.amplitude_to_db(cqt, ref=np.max), "cqt_note"
         mel = librosa.feature.melspectrogram(y=audio_data, sr=sr, n_mels=n_mels)
         return librosa.power_to_db(mel, ref=np.max), "mel"
-    except Exception as e:
-        print(f"Audio2ImageMediaConverter: failed to compute {spec_type} for {filename}: {e}")
+    except Exception:
+        logger.error("Failed to compute %s spectrogram for %s", spec_type, filename, exc_info=True)
         return None
 
 
@@ -62,8 +65,8 @@ def _render_spectrogram_png(spec_db, sr: int, y_axis: str, colormap: str, filena
         fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0)
         plt.close(fig)
         return buf.getvalue()
-    except Exception as e:
-        print(f"Audio2ImageMediaConverter: failed to render {filename}: {e}")
+    except Exception:
+        logger.error("Failed to render spectrogram for %s", filename, exc_info=True)
         return None
 
 
@@ -216,7 +219,7 @@ class Audio2ImageMediaConverter(MediaConverter):
             import numpy as np  # noqa: PLC0415
             from PIL import Image  # noqa: PLC0415
         except ImportError:
-            print("Audio2ImageMediaConverter requires librosa, matplotlib, and Pillow")
+            logger.warning("audio2image requires librosa, matplotlib, and Pillow; producing no images")
             return []
 
         duration = time_window_s if time_window_s > 0 else None

--- a/vtscore/converters/audio2text.py
+++ b/vtscore/converters/audio2text.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import tempfile
 from pathlib import Path
 from typing import Any
 
 from vtscore.converters.base import MediaConverter
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 class Audio2TextMediaConverter(MediaConverter):
@@ -86,7 +89,7 @@ class Audio2TextMediaConverter(MediaConverter):
         try:
             import whisper  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         except ImportError:
-            print("Audio2TextMediaConverter requires openai-whisper: pip install openai-whisper")
+            logger.warning("audio2text requires openai-whisper: pip install openai-whisper")
             if owns_temp:
                 audio_path.unlink(missing_ok=True)
             return []
@@ -101,8 +104,8 @@ class Audio2TextMediaConverter(MediaConverter):
 
         try:
             model = whisper.load_model(model_size, device=whisper_device)
-        except Exception as e:
-            print(f"Audio2TextMediaConverter: failed to load Whisper model '{model_size}': {e}")
+        except Exception:
+            logger.error("Failed to load Whisper model %r", model_size, exc_info=True)
             if owns_temp:
                 audio_path.unlink(missing_ok=True)
             return []
@@ -112,8 +115,8 @@ class Audio2TextMediaConverter(MediaConverter):
             if language:
                 kwargs["language"] = language
             result = model.transcribe(str(audio_path), **kwargs)
-        except Exception as e:
-            print(f"Audio2TextMediaConverter: transcription failed on {filename}: {e}")
+        except Exception:
+            logger.error("Transcription failed on %s", filename, exc_info=True)
             return []
         finally:
             if owns_temp:

--- a/vtscore/converters/base.py
+++ b/vtscore/converters/base.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from vtscore.plugins import PluginBase, PluginField
 
+logger = logging.getLogger(__name__)
+
 
 def resolve_media_bytes(media: dict[str, Any]) -> bytes | None:
     """Read raw bytes from ``media_bytes`` or, failing that, ``media_path``.
@@ -261,7 +263,7 @@ class MediaConverter(PluginBase, ABC):
         # typo or a field that was renamed/removed out from under a caller —
         # which would otherwise read as an empty string forever. Surface it
         # (L9) instead of swallowing it silently.
-        logging.getLogger(__name__).warning(
+        logger.warning(
             "get_param(%r) on converter %r: no field declares that key; returning ''. "
             "A renamed or removed field will silently read as empty.",
             key,

--- a/vtscore/converters/document2image.py
+++ b/vtscore/converters/document2image.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import io
+import logging
 from pathlib import Path
 from typing import Any
 
-
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.utils.optional_deps import agpl_unavailable_message
+
+logger = logging.getLogger(__name__)
 
 
 class Document2ImageMediaConverter(MediaConverter):
@@ -54,14 +56,14 @@ class Document2ImageMediaConverter(MediaConverter):
         try:
             import fitz  # noqa: PLC0415 - PyMuPDF
         except ImportError:
-            print(agpl_unavailable_message("PyMuPDF", "Converting documents to images"))
+            logger.warning("%s", agpl_unavailable_message("PyMuPDF", "Converting documents to images"))
             return []
 
         results: list[dict[str, Any]] = []
         try:
             doc = fitz.open(stream=media_bytes, filetype=Path(filename).suffix.lstrip(".") or "pdf")
-        except Exception as e:
-            print(f"Error opening document {filename}: {e}")
+        except Exception:
+            logger.error("Failed to open document %s", filename, exc_info=True)
             return []
 
         try:

--- a/vtscore/converters/document2text.py
+++ b/vtscore/converters/document2text.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, cast
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.utils.optional_deps import agpl_unavailable_message
+
+logger = logging.getLogger(__name__)
 
 
 class Document2TextMediaConverter(MediaConverter):
@@ -48,13 +51,13 @@ class Document2TextMediaConverter(MediaConverter):
         try:
             import fitz  # noqa: PLC0415 - PyMuPDF
         except ImportError:
-            print(agpl_unavailable_message("PyMuPDF", "Extracting text from documents"))
+            logger.warning("%s", agpl_unavailable_message("PyMuPDF", "Extracting text from documents"))
             return []
 
         try:
             doc = fitz.open(stream=media_bytes, filetype=Path(filename).suffix.lstrip(".") or "pdf")
-        except Exception as e:
-            print(f"Error opening document {filename}: {e}")
+        except Exception:
+            logger.error("Failed to open document %s", filename, exc_info=True)
             return []
 
         page_texts: list[str] = []

--- a/vtscore/converters/image2face.py
+++ b/vtscore/converters/image2face.py
@@ -16,10 +16,13 @@ degrades gracefully to producing no faces.
 from __future__ import annotations
 
 import io
+import logging
 from typing import Any, Optional
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 class Image2FaceMediaConverter(MediaConverter):
@@ -101,7 +104,7 @@ class Image2FaceMediaConverter(MediaConverter):
         try:
             from facenet_pytorch import MTCNN  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
         except ImportError:
-            print("Image2FaceMediaConverter requires facenet-pytorch; producing no faces")
+            logger.warning("image2face requires facenet-pytorch; producing no faces")
             return None
         from vtscore.config import resolve_device  # noqa: PLC0415
 

--- a/vtscore/converters/image2text.py
+++ b/vtscore/converters/image2text.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | None:
@@ -16,28 +19,28 @@ def _run_paddleocr(media_bytes: bytes, filename: str, language: str) -> list | N
 
         from vtscore.media.image.decode import decode_bounded_rgb  # noqa: PLC0415
     except ImportError:
-        print("Image2TextMediaConverter requires Pillow and numpy")
+        logger.warning("image2text requires Pillow and numpy; producing no text")
         return None
 
     try:
         from paddleocr import PaddleOCR  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
     except ImportError:
-        print("Image2TextMediaConverter requires PaddleOCR: pip install paddleocr paddlepaddle")
+        logger.warning("image2text requires PaddleOCR: pip install paddleocr paddlepaddle")
         return None
 
     try:
         # Bounded decode: OCR reads a transcript, not pixel coordinates, so a
         # huge scan can be capped without changing what comes back.
         image, _scale = decode_bounded_rgb(media_bytes)
-    except Exception as e:
-        print(f"Image2TextMediaConverter: failed to open {filename}: {e}")
+    except Exception:
+        logger.error("Failed to open image %s", filename, exc_info=True)
         return None
 
     try:
         model = _make_paddleocr(PaddleOCR, language)
         return model.ocr(np.array(image), cls=True)
-    except Exception as e:
-        print(f"Image2TextMediaConverter: PaddleOCR failed on {filename}: {e}")
+    except Exception:
+        logger.error("PaddleOCR failed on %s", filename, exc_info=True)
         return None
 
 

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -11,11 +11,14 @@ in after the importer returns.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
 from vtscore.utils.hashing import content_md5
+
+logger = logging.getLogger(__name__)
 
 ProgressCallback = Callable[[str, str, int, int], None]
 
@@ -173,8 +176,8 @@ def _run_converter_on_source(
             return None
     try:
         return converter.convert_normalized(source_media, conv_params)
-    except Exception as exc:
-        print(f"Converter {converter.name} failed on {source_rel}: {exc}")
+    except Exception:
+        logger.error("Converter %s failed on %s", converter.name, source_rel, exc_info=True)
         return None
 
 

--- a/vtscore/converters/video2audio.py
+++ b/vtscore/converters/video2audio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import tempfile
 from pathlib import Path
@@ -10,6 +11,8 @@ from typing import Any
 from vtscore.converters.base import MediaConverter
 from vtscore.media.audio.ffmpeg import get_ffmpeg_exe
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 class Video2AudioMediaConverter(MediaConverter):
@@ -104,16 +107,18 @@ class Video2AudioMediaConverter(MediaConverter):
                     check=True,
                 )
             except FileNotFoundError:
-                print("Video2AudioMediaConverter requires ffmpeg - install it or 'pip install imageio-ffmpeg'")
+                logger.warning("video2audio requires ffmpeg - install it or 'pip install imageio-ffmpeg'")
                 return []
             except subprocess.CalledProcessError as e:
                 stderr_text = (
                     e.stderr[:500].decode(errors="replace") if isinstance(e.stderr, bytes) else (e.stderr or "")[:500]
                 )
-                print(f"ffmpeg failed for {filename}: {stderr_text}")
+                # ``stderr_text`` is ffmpeg's own diagnostic; the CalledProcessError
+                # traceback adds only our three call frames, so no exc_info here.
+                logger.error("ffmpeg failed for %s: %s", filename, stderr_text)
                 return []
             except subprocess.TimeoutExpired:
-                print(f"ffmpeg timed out for {filename}")
+                logger.warning("ffmpeg timed out for %s", filename)
                 return []
 
             wav_file = Path(wav_path)

--- a/vtscore/converters/video2image.py
+++ b/vtscore/converters/video2image.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import io
+import logging
 from pathlib import Path
 from typing import Any
 
 from vtscore.converters.base import MediaConverter
 from vtscore.media.video import decode
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 def _compute_n_frames(frame_count: int, fps: float, n_clips: int, seconds_per_frame: float) -> int:
@@ -127,7 +130,7 @@ class Video2ImageMediaConverter(MediaConverter):
         try:
             from PIL import Image  # noqa: PLC0415
         except ImportError:
-            print("Video2ImageMediaConverter requires Pillow")
+            logger.warning("video2image requires Pillow; producing no images")
             return []
 
         # The decoder needs a seekable file path, not a buffer.

--- a/vtscore/docs/extending/converters.md
+++ b/vtscore/docs/extending/converters.md
@@ -93,6 +93,48 @@ output). Each dict must contain at minimum:
 are filled in by the caller. Don't compute embeddings inside
 `convert()`; the loader pipeline embeds the produced media afterwards.
 
+### Reporting failures
+
+Returning `[]` is how a converter says "no output" - but a *silent*
+`[]` is indistinguishable from "this file legitimately had nothing in
+it", and a corpus that fails on every item leaves the user with no
+idea why. So say what went wrong, **through `logging`, never
+`print()`**.
+
+`print()` writes to stdout unconditionally: it can't be levelled,
+filtered, routed to a file, or silenced by the embedding application,
+and one bad corpus turns into thousands of unlabelled lines
+interleaved with real output. `vtscore` is a library, so that choice
+belongs to the caller, not to the converter.
+
+Take a module-level logger and use it in every failure branch:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+| Situation | Call | Why |
+|-----------|------|-----|
+| Optional dependency missing | `logger.warning("audio2text requires openai-whisper: pip install openai-whisper")` | Expected and actionable; the traceback adds nothing |
+| A per-item conversion failed, exception in hand | `logger.error("Transcription failed on %s", filename, exc_info=True)` | Unexpected; the traceback is the diagnostic |
+| An external tool failed with its own diagnostic | `logger.error("ffmpeg failed for %s: %s", filename, stderr_text)` | The tool's stderr beats our call frames; skip `exc_info` |
+
+Two conventions that matter:
+
+- **Pass arguments lazily** (`logger.error("... %s", filename)`), not
+  as an f-string. The formatting is skipped entirely when the record is
+  filtered out.
+- **Don't repeat the module or class name in the message.** The logger
+  is already named `vtscore.converters.audio2text`, and every formatter
+  prints it. Where a message does need to name the converter (install
+  advice a user will read), use the registered `source2target` name
+  they see in the UI, not the Python class name.
+
+Every in-tree converter follows this; they are the templates worth
+copying.
+
 ### Reading the source bytes
 
 Read the input through `resolve_media_bytes(media)`
@@ -203,12 +245,15 @@ model size and language.
 # my_pkg/audio2text_whisper.py
 from __future__ import annotations
 
+import logging
 import tempfile
 from pathlib import Path
 from typing import Any
 
 from vtscore.converters.base import MediaConverter, resolve_media_bytes
 from vtscore.plugins import PluginField
+
+logger = logging.getLogger(__name__)
 
 
 class Audio2TextWhisperConverter(MediaConverter):
@@ -259,6 +304,7 @@ class Audio2TextWhisperConverter(MediaConverter):
         try:
             import whisper  # noqa: PLC0415
         except ImportError:
+            logger.warning("audio2text_whisper requires openai-whisper: pip install openai-whisper")
             return []
 
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:


### PR DESCRIPTION
All 21 `print()` calls in `vtscore/converters/` sat in failure branches that then `return []` — unlevelled, unfilterable stdout writes from a library tier whose modules are the templates third-party plugin authors copy. A corpus that fails on every item flooded stdout with thousands of lines the embedding application had no way to silence or route.

## What changed

Each module now takes a module-level `logging.getLogger(__name__)` and reports through it:

- **`logger.warning`** for a missing optional dependency (expected and actionable; the traceback adds nothing) and for an ffmpeg timeout.
- **`logger.error(..., exc_info=True)`** where an unexpected exception is in hand, so the traceback survives instead of being flattened to `{e}`.
- **`logger.error` without `exc_info`** for ffmpeg's `CalledProcessError`, whose own stderr is the diagnostic and whose traceback is only our three call frames. Noted inline so it doesn't read as an oversight.

Two message conventions came with the move:

- The redundant class-name prefix is gone. Both formatters in `vtsearch/logging_config.py` already print `record.name`, so `Audio2ImageMediaConverter: failed to load x.wav` under logger `vtscore.converters.audio2image` said it twice.
- Install advice now names the registered `source2target` converter name users actually see in the UI (`audio2text requires openai-whisper`), not the Python class name.

Arguments are passed lazily (`%s`) rather than f-string-interpolated.

`base.py`'s one inline `logging.getLogger(__name__)` call moves to the same module-level `logger`, so all ten modules in the package look alike.

## Docs

`vtscore/docs/extending/converters.md` gains a **Reporting failures** subsection under *The contract*, hung off the existing "empty list if conversion fails" claim: why `print()` is wrong in a library, the module-level logger idiom, and a per-situation table for the three cases above. It also states the two conventions (lazy args; don't repeat the module name).

The worked example is fixed in the same pass — it previously swallowed a missing `whisper` into a bare `return []` with no message at all, which is the failure mode one step worse than the `print()`s this PR removes.

## Test change

`tests_lib/core/test_agpl_optional_extra.py::test_document_converters_report_the_missing_package` asserted the PyMuPDF message via `capsys`. It now asserts via `caplog`, matching the convention already used for `base.py`'s warning in `tests/converters/test_converter_selection.py`. What the test pins is unchanged: the converter still returns `[]` and still says why.

## Verification

Full `./run-tests.sh`: **9481 passed, 6 skipped**, all gates green (pyright, pip-audit, npm audit, Vitest, and every stage-1 gate).

Closes #3399


---
_Generated by [Claude Code](https://claude.ai/code/session_01R3sgG4VCmemGML1MqMqfk6)_