### PR TITLE
Document the settings-source sync engine; correct the .syncmark rationale

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -538,7 +538,9 @@ modules on the right.
   for detector labels) both inherit from the generic
   `SyncSource[LoadT, SaveT]` in `vtscore/sync/`, which captures the
   shared `load()`/`save()` shape; each concrete source plugin is still
-  pure I/O.
+  pure I/O.  The *engine* driving settings sources is not — it lives in
+  `vtsearch/settings_store.py` and is documented in
+  [EXTENDING-plugins.md § How the sync engine works](EXTENDING-plugins.md#how-the-sync-engine-works).
 - **datasets/ functions accept an optional `on_progress` callback.**
   When `None`, they lazily resolve the app's `update_progress`; when
   provided, they use the caller's callback.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -460,7 +460,7 @@ VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
 ```
 
 `VTSEARCH_SERVER_INIT=1` runs the same startup sequence (model
-initialization, autoload preloading, settings-source sync) that `python
+initialization, embedder preloading) that `python
 app.py` runs; gunicorn imports `app.py` rather than executing its
 `__main__` block, so the env var is what triggers initialization. The
 bundled Docker images already run gunicorn this way. See

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -172,7 +172,7 @@ These are read by the installer, not the running app.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn. Triggers model init / autoload / settings-source sync at import time (the Flask `__main__` block is skipped under WSGI). Set automatically in the Dockerfiles. |
+| `VTSEARCH_SERVER_INIT` | unset | Set to `1` when running under gunicorn. Triggers model init / embedder preload at import time (the Flask `__main__` block is skipped under WSGI). Settings-source sync is *not* part of it — that is per-user and lazy, on each user's first settings access. Set automatically in the Dockerfiles. |
 | `VTSEARCH_BIND` | `0.0.0.0:5000` | Gunicorn bind address (`host:port`) |
 | `VTSEARCH_THREADS` | `8` | Threads per gunicorn worker |
 | `VTSEARCH_TIMEOUT` | `0` | Worker request timeout in seconds; `0` (default) disables. Long imports, training, and evaluation runs routinely exceed any short timeout; overriding to anything below ~1800 risks SIGKILL mid-operation. |
@@ -214,8 +214,8 @@ outside Docker.
 
 ### Why `VTSEARCH_SERVER_INIT=1`?
 
-`app.py` runs its startup sequence (model init, embedder preload,
-settings-source sync) from its `if __name__ == "__main__":` block.
+`app.py` runs its startup sequence (model init, embedder preload) from
+its `if __name__ == "__main__":` block.
 Gunicorn **imports** `app.py` rather than executing it, so that block
 never runs. Setting `VTSEARCH_SERVER_INIT=1` tells `app.py` to also run
 `initialize_server()` at import time. The Dockerfiles set this env var

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -2012,13 +2012,204 @@ variable list and the sanitisation guarantees. The built-in
 
 ### How it gets invoked
 
-1. `GET /api/settings-sources` lists all discovered sources.
-2. `PUT /api/settings-sources/active` sets which source is active.
-3. **At startup**, `sync_from_settings_source()` auto-imports settings
-   from the active source (so the source takes precedence over the local
-   `data/settings.json` file).
-4. When settings change, `settings._save()` auto-calls `source.save()`.
-5. `POST /api/settings-sources/sync` manually re-imports from the source.
+A settings source is not a one-shot import. Once configured it is
+consulted on an ongoing basis from three places:
+
+1. **On every settings read**, through `_ensure_user_loaded`
+   (`vtsearch/settings.py`) and the `UserSettingsStore.ensure_user_loaded`
+   it delegates to (`vtsearch/settings_store.py`) — rate-limited, see [the freshness
+   probe](#the-freshness-probe-and-its-cost) below. This is what makes a
+   source pick up an out-of-band edit without a restart, and it is also
+   what performs the *first* import: the first settings access after a
+   process starts pulls from the source, so the source's values take
+   precedence over the local per-user file.
+2. **On every settings write**, through `sync_to_source` — the per-user
+   settings dict (minus the excluded keys below) is pushed to `save()`
+   after the local file is written.
+3. **On demand**, via `POST /api/settings-sources/sync` — see
+   [the dirty-key contract](#the-dirty-key-contract) for how this differs
+   from an automatic pull.
+
+**There is no boot-time sync**, and that is deliberate: a settings source
+binds to a *user*, and at server start there is no current user to sync
+for (`initialize_server` in `app.py` loads models and preloads embedders,
+nothing more). Sync is per-user and lazy. A source whose values you expect
+to see immediately after a restart will be read on the first request that
+touches settings, not before.
+
+The endpoints that manage the binding itself are listed under
+[the REST surface](#the-settings-source-rest-surface).
+
+### How the sync engine works
+
+The engine lives in `UserSettingsStore` (`vtsearch/settings_store.py`).
+Everything below is contract a new source binds to, not implementation
+detail you may ignore: a source that violates it will appear to work and
+then lose a user's edits under load.
+
+#### Which source a user is bound to
+
+`resolve_settings_source` is the single precedence resolver — every sync
+path (initial load, freshness check, pull, push, and the active-source
+route) reads it, so they cannot disagree about which source a user is on:
+
+1. the user's own `settings_source` key, when it names a source;
+   `{"source_name": "none"}` is an explicit opt-out that wins even over a
+   deployment default;
+2. otherwise the deployment-wide `default_settings_source` server setting,
+   which the user *inherits* (the `inherited` flag on
+   `GET /api/settings-sources/active` reports this);
+3. otherwise no source.
+
+Two keys are never exported to a source: `settings_source` and
+`default_settings_source` (`_EXCLUDE_FROM_SOURCE_EXPORT` in
+`vtsearch/settings.py`). Pushing the binding through the binding would
+let a source rewrite which source is active.
+
+#### The freshness probe and its cost
+
+Sync-from-source sits on the hot path of *every* settings read, so the
+engine is built around making the common case not touch your source at
+all. A read walks three tiers:
+
+| Tier | When | Cost |
+|---|---|---|
+| Fast path | A sync succeeded within the freshness window (`_FRESHNESS_CHECK_INTERVAL`, **1.0 s**) | No probe, no per-user lock — an in-memory dict read |
+| Probe | Window elapsed | One `peek_version()` call; on an unchanged token, refresh the timestamp and return |
+| Full sync | `peek_version()` reports a *different* token, or this process has never synced this user | `load()` + `_apply_settings` |
+
+This is why **`peek_version()` must be cheap and must not raise for
+transient reasons.** It is the only thing standing between a busy read
+path and a full `load()`. The built-in `server_json_file` source returns
+`st_mtime_ns` from a single `stat()`. A network-backed source should use
+an ETag, a `Last-Modified` header, or a HEAD request — never a full GET.
+
+Three `peek_version()` return values have distinct meanings:
+
+- **A token that differs from the last one** — the source changed; a full
+  re-sync is due.
+- **The same token** — unchanged; skip the load.
+- **`None`** — "I cannot cheaply tell." The engine treats this as *no
+  re-sync* and keeps serving the local cache. A source that returns
+  `None` unconditionally is therefore imported once per process and then
+  never auto-refreshed. That is a legitimate choice for a write-mostly
+  target, but it must be a deliberate one.
+
+A `peek_version()` that *raises* is treated as unchanged and backs off
+until the next window, so a source outage degrades to "serve local" rather
+than hammering a dead endpoint.
+
+#### The dirty-key contract
+
+The engine has to reconcile two writers: the user clicking a toggle, and
+an upstream value arriving from `load()`. `dirty_keys` on `UserSyncState`
+is what arbitrates.
+
+**What marks a key dirty:** any local write through `mutate_user_locked`
+registers the keys it touched (minus the excluded ones above) as dirty —
+*inside the cross-process file lock*, before it is released. That
+ordering is the point: a syncing thread can never observe a key as
+"written but not yet dirty" and clobber it.
+
+**What a source may overwrite** depends on which pull it is:
+
+| Pull | Honors `dirty_keys`? | Rationale |
+|---|---|---|
+| Automatic re-sync (version bump on the source) | **Yes** — dirty keys are skipped | A freshly clicked local toggle must not be silently reverted by an upstream value |
+| Explicit `POST /api/settings-sources/sync` | **No** — everything is overwritten and the dirty set is cleared | The user pressed "Sync now" precisely to take the source's values |
+
+**When dirty keys clear:** on a successful `sync_to_source` push (the
+source now matches local, so there is nothing left to protect) or on an
+explicit manual pull. They deliberately survive an automatic re-sync.
+
+The skip set handed to `_apply_settings` is a **live view**
+(`_LiveDirtyKeys`), not a snapshot taken before `load()` — because
+`load()` may be a slow network round-trip, and a user write landing
+mid-flight must still be honored. `mutate_user_locked` re-checks it under
+the file lock, which is where the decision actually becomes atomic against
+the racing write.
+
+#### The cross-process dedup marker
+
+After any successful sync the engine stamps a `<user_settings>.syncmark`
+sibling file recording the `peek_version` token it applied. A later
+process whose first read finds the source unchanged at that token adopts
+it and skips the load entirely — the values are already on disk.
+
+Because `_sync_state` is in-memory but the marker is not, this is what
+makes a **container restart** cheap: the data directory is a persistent
+volume, so a restart against an unchanged source costs one `peek_version`
+instead of a full `load()`. It dedups a second process sharing the data
+directory (a `python app.py --autodetect` CLI run, a dev server) the same
+way. It is *not* primarily about concurrent gunicorn workers —
+`gunicorn.conf.py` pins `workers = 1` — and it should not be read as dead
+code on that basis; see the comment above `_sync_marker_path`.
+
+The marker is best-effort: every read, write, and serialisation failure is
+swallowed and the caller falls back to the full load. It is a performance
+hint, never a correctness input. It is deleted when the user's source is
+cleared, so a later re-configure cannot consult a stale token.
+
+#### Lock ordering a new source must respect
+
+The store has three locks, and the canonical order is
+**cross-process `file_lock` → in-process `settings_lock`**, with the
+per-user sync `RLock` taken outside both:
+
+| Lock | Guards |
+|---|---|
+| `file_lock(path)` | Cross-process (`flock`) exclusion on one settings file; also serialises threads in this process |
+| `settings_lock` | The in-memory caches (`_user_caches`, `_sync_state`, `_syncing`) — held briefly, never across I/O |
+| `per_user_sync_lock(username)` | Serialises the whole probe + `load()` + apply sequence for one user |
+
+What this means for a source author:
+
+- **Your `load()` / `save()` / `peek_version()` are called with no settings
+  file lock held.** `sync_to_source` runs *outside* the file lock on
+  purpose, so a slow target (NFS, a webhook, a cold S3 bucket) cannot block
+  unrelated settings writes. Do not assume you are in a critical section.
+- **Never call back into `vtsearch.settings` from a source method.** A
+  setter re-enters `_ensure_user_loaded`, which re-enters the sync path.
+  The `_syncing` set is a re-entrancy guard for the engine's own
+  `_apply_settings` pass, not a general licence to recurse.
+- **`settings_lock` is reentrant**, so an ordering inversion will *not*
+  fail locally — it deadlocks later against a concurrent writer. This is
+  why `resolve_settings_source` is documented as "must not be called while
+  holding `settings_lock`": the deployment-default read may take the
+  server file lock.
+- **Assume you are on an arbitrary thread**, called concurrently for
+  different users. Per-user serialisation is guaranteed; cross-user is not.
+
+#### Failure semantics
+
+A source that raises is never fatal. `load()` failures log and leave
+`last_sync_succeeded` untouched, so a transient outage after a previous
+success does not erase the success flag or invalidate the local cache; the
+slow path retries once the rate-limit window elapses. `save()` failures
+log and return, leaving the keys dirty so the next successful push carries
+them. This is deliberate: settings sync is an availability-sensitive side
+channel, and the local file is always the fallback.
+
+### The settings-source REST surface
+
+Four endpoints manage the settings-source binding
+(`vtsearch/routes/settings/sources.py`):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/settings-sources` | List the registered source plugins |
+| `GET /api/settings-sources/active` | The active config, with `inherited` |
+| `PUT /api/settings-sources/active` | Set, clear, or opt out (`"none"`) |
+| `POST /api/settings-sources/sync` | Force a manual import |
+
+**These are an operator/API surface by design, and the Angular SPA does not
+call them.** That is not an oversight and they are not orphaned: a settings
+source is deployment configuration — an admin points a fleet at a shared
+JSON file, or a script provisions a user — not something an end user
+toggles mid-session. The equivalent server-side configuration is
+`default_settings_source` in the server settings file. Do not delete them
+for being unreferenced by the frontend, and do not add SPA UI for them
+without a product reason.
 
 ### Making your source the active auto-import
 
@@ -2045,14 +2236,14 @@ curl -X PUT http://localhost:5000/api/settings-sources/active \
   -d '{"source_name": "s3", "field_values": {"bucket": "my-bucket", "key": "settings.json"}}'
 ```
 
-On the next app startup, VTSearch will call `source.load()` and apply
-the returned settings before starting the server. The built-in
-`server_json_file` source does this with a local file path; your
-custom source can fetch from S3, a database, a remote API, etc.
+On that user's next settings access, VTSearch calls `source.load()` and
+applies the returned settings. The built-in `server_json_file` source
+does this with a local file path; your custom source can fetch from S3, a
+database, a remote API, etc.
 
-If the source is unavailable at startup (file missing, network error),
-the import is silently skipped and the local settings file is used as
-fallback.
+If the source is unavailable (file missing, network error) the import is
+logged and skipped, and the local settings file is used as the fallback —
+see [Failure semantics](#failure-semantics).
 
 ---
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -197,11 +197,17 @@ See [EXTENDING-plugins.md § Adding a Label Importer](EXTENDING-plugins.md#addin
 ### New Settings Source Checklist
 
 See [EXTENDING-plugins.md § Adding a Settings Source](EXTENDING-plugins.md#adding-a-settings-source).
+Unlike the one-shot families, a source stays bound to a user and is
+consulted on every settings read and write, so read
+[§ How the sync engine works](EXTENDING-plugins.md#how-the-sync-engine-works)
+before you start — it carries the contracts (cheap freshness probe,
+dirty-key protection, lock ordering) that the base class cannot express.
 
 - [ ] Create `vtsearch/settings_io/sources/<name>/__init__.py`
 - [ ] Subclass `SettingsSource`, set `name`, `display_name`, `description`, `fields`
 - [ ] Implement `_do_load(self, field_values)`: return a settings dict (override the underscored hook, not `load`)
 - [ ] Implement `_do_save(self, settings_data, field_values)`: persist settings (override the underscored hook, not `save`)
+- [ ] Implement `_do_peek_version(self, field_values)`: a **cheap** freshness token (mtime, ETag, HEAD) — it runs on the hot path of every settings read
 - [ ] Expose `SETTINGS_SOURCE = YourSource()` at module level
 - [ ] If the plugin needs extra packages, add them to `[project.dependencies]` in `pyproject.toml` and re-run your editable install
 - [ ] Test: start the app and check `GET /api/settings-sources` includes your source

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -316,7 +316,7 @@ Open `http://localhost:5000` in your browser. The server binds to `0.0.0.0:5000`
 VTSEARCH_SERVER_INIT=1 gunicorn -c gunicorn.conf.py app:app
 ```
 
-`VTSEARCH_SERVER_INIT=1` triggers the same startup sequence (model init, autoload preloading, settings-source sync) that `python app.py` runs, since gunicorn imports `app.py` rather than executing its `__main__` block. `gunicorn.conf.py` pins a single worker with 8 threads; VTSearch keeps all dataset/model state in-process, so multiple workers would each hold their own copy. See [DEPLOYMENT.md](DEPLOYMENT.md#tuning) for tuning.
+`VTSEARCH_SERVER_INIT=1` triggers the same startup sequence (model init, embedder preloading) that `python app.py` runs, since gunicorn imports `app.py` rather than executing its `__main__` block. `gunicorn.conf.py` pins a single worker with 8 threads; VTSearch keeps all dataset/model state in-process, so multiple workers would each hold their own copy. See [DEPLOYMENT.md](DEPLOYMENT.md#tuning) for tuning.
 
 The Docker images already use this configuration (see [Docker](#docker) below).
 

--- a/tests/core/test_settings_store.py
+++ b/tests/core/test_settings_store.py
@@ -1,7 +1,7 @@
 """Direct unit tests for :mod:`vtsearch.settings_store` primitives.
 
 The settings routes exercise the store end-to-end, but its low-level file
-I/O and cross-worker sync-marker helpers are worth pinning directly: they are
+I/O and cross-process sync-marker helpers are worth pinning directly: they are
 pure, path-keyed functions with several error-swallowing branches (unreadable
 file, malformed JSON, non-serialisable token) that route-level tests don't
 reliably hit.

--- a/tests/io/test_sync_sources.py
+++ b/tests/io/test_sync_sources.py
@@ -58,9 +58,9 @@ def _multi_user_mode(user_dir):
 def _force_cold_sync(user_path, username: str = "default") -> None:
     """Guarantee the next settings read runs a real sync-from-source pass.
 
-    Dropping ``_sync_state`` alone is **not** enough: the cross-worker dedup
+    Dropping ``_sync_state`` alone is **not** enough: the cross-process dedup
     marker (``<user_settings>.syncmark``) lives on disk and survives an
-    in-memory reset.  ``_adopt_sync_marker_if_current`` compares it against
+    in-memory reset (which is exactly what a process restart is).  ``_adopt_sync_marker_if_current`` compares it against
     the source's current ``peek_version`` and, when they match, stamps the
     state as freshly synced and skips ``source.load()`` entirely.
 

--- a/vtscore/docs/packages/sync.md
+++ b/vtscore/docs/packages/sync.md
@@ -201,5 +201,7 @@ pick it up.
 - [`labels.md`](labels.md) - the `LabelsetSource` subclass and the
   auto-sync helpers in `vtscore/labels/sync.py`.
 - `vtsearch.settings_io.sources` (app tier) - the `SettingsSource`
-  subclass with per-user template variables (`{username}`) and
-  startup-time auto-import.
+  subclass with per-user template variables (`{username}`) and lazy,
+  per-user auto-import. Its engine (freshness probing, the dirty-key
+  contract, lock ordering) is documented in
+  [EXTENDING-plugins.md § How the sync engine works](../../../docs/EXTENDING-plugins.md#how-the-sync-engine-works).

--- a/vtsearch/settings_io/__init__.py
+++ b/vtsearch/settings_io/__init__.py
@@ -1,1 +1,16 @@
-"""Settings import/export plugin system."""
+"""Settings import/export plugin system.
+
+Three families live here: one-shot ``importers`` and ``exporters``, and
+``sources`` - bidirectional sync targets that stay bound to a user and are
+consulted on every settings read and write.
+
+Sources are the subtle one. The engine behind them (freshness probing, the
+dirty-key contract that decides whether an upstream value may overwrite a
+local edit, the cross-process dedup marker, and the lock ordering a source
+method runs under) is documented in
+``docs/EXTENDING-plugins.md`` under "Adding a Settings Source" ->
+"How the sync engine works". Read it before writing a new source; the
+contract is not discoverable from :class:`SettingsSource` alone, and a
+source that violates it fails by losing user edits under load rather than
+by raising.
+"""

--- a/vtsearch/settings_io/sources/base.py
+++ b/vtsearch/settings_io/sources/base.py
@@ -2,11 +2,20 @@
 
 A settings source is a bidirectional sync target: it can both *load*
 settings (like an importer) and *save* them back (like an exporter).
-When an active source is configured, settings are auto-imported on
-startup and auto-exported whenever they change.
+When an active source is configured, settings are auto-imported on a
+user's first settings access (and re-imported whenever the source's
+freshness token changes) and auto-exported whenever they change.
 
 Standalone importers and exporters remain fully functional regardless
 of whether a source is active.
+
+The three methods a source implements (``_do_load``, ``_do_save``,
+``_do_peek_version``) are called by a sync engine with contracts this
+class cannot express: ``peek_version`` sits on the hot path of every
+settings read and must be cheap, local edits are protected from upstream
+values by a dirty-key set, and no settings file lock is held while your
+code runs. See ``docs/EXTENDING-plugins.md`` -> "Adding a Settings
+Source" -> "How the sync engine works" before implementing one.
 """
 
 from __future__ import annotations

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -90,18 +90,40 @@ def _atomic_write(path: Path, data: dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Cross-worker sync-dedup marker (H28 residual follow-up)
+# Cross-process sync-dedup marker (H28 residual follow-up)
 #
-# On a fresh container every Gunicorn worker independently runs
-# sync-from-source once per user, duplicating the (potentially expensive)
-# ``source.load()`` read.  A worker that finishes its sync stamps a small
-# sibling marker next to the user's settings file recording the source
-# ``peek_version`` it applied.  A later worker whose first read finds the
-# source *unchanged* at that version skips its own load: the synced values
-# are already on disk in the user file (which it loaded into its cache),
-# so re-reading the source would be pure duplicate I/O.  The marker is a
-# best-effort optimisation only - any read/write/serialisation failure is
-# swallowed and the worker falls back to the full load.
+# ``_sync_state`` is in-memory, so every fresh process runs sync-from-source
+# once per user, duplicating the (potentially expensive, potentially
+# network-bound) ``source.load()`` read.  A process that finishes its sync
+# stamps a small sibling marker next to the user's settings file recording
+# the source ``peek_version`` it applied.  A later process whose first read
+# finds the source *unchanged* at that version skips its own load: the
+# synced values are already on disk in the user file (which it loaded into
+# its cache), so re-reading the source would be pure duplicate I/O.
+#
+# "A later process" is deliberately not "a sibling Gunicorn worker".  This
+# layer started life guarding the concurrent-worker case, and that case does
+# not arise in any shipped deployment: ``gunicorn.conf.py`` pins
+# ``workers = 1`` because all dataset/model state is in-process.  What keeps
+# the marker load-bearing is that it *outlives the process*.  The data
+# directory is a persistent volume (``VOLUME /app/data``; see
+# ``docker/Dockerfile``), so the marker survives a container restart or a
+# worker recycle and the next start adopts it instead of re-reading the
+# source.  A second process sharing the same data directory - a
+# ``python app.py --autodetect`` CLI run, a dev server - is deduped the same
+# way; that shared-directory topology is also why every settings write here
+# goes through the cross-process ``file_lock``.
+#
+# Do not read ``workers = 1`` as evidence that this code is unreachable (a
+# structure audit did, and proposed deleting it).  The clearest counter-proof
+# is in the test suite: ``_force_cold_sync`` in
+# ``tests/io/test_sync_sources.py`` has to *delete* the marker to make a test
+# perform a real load, precisely because dropping the in-memory state - the
+# thing a restart does - is not enough on its own.
+#
+# The marker is a best-effort optimisation only - any read/write/
+# serialisation failure is swallowed and the caller falls back to the full
+# load.
 # ---------------------------------------------------------------------------
 
 
@@ -135,7 +157,7 @@ def _write_sync_marker(user_path: Path, version: Any) -> None:
 
     Best-effort: a ``None`` token (source can't cheaply report a version),
     a non-JSON-serialisable token, or any write failure is swallowed - the
-    marker is a pure cross-worker dedup hint, never a correctness input.
+    marker is a pure cross-process dedup hint, never a correctness input.
     """
     if version is None:
         return
@@ -403,7 +425,7 @@ class UserSettingsStore:
 
         The first load runs under the cross-process *server* file lock so the
         one-shot legacy migration's ``_atomic_write`` calls are protected
-        against a sibling worker migrating the same files concurrently (H28
+        against another process migrating the same files concurrently (H28
         residual follow-up). The file lock is taken *before* ``settings_lock``
         (the canonical file-lock -> settings-lock order), so this must never
         be called while already holding ``settings_lock``: callers that need
@@ -533,7 +555,7 @@ class UserSettingsStore:
             # No state, or state exists only because a setter populated it
             # via ``mark_user_keys_dirty`` before we'd ever talked to the
             # source.  Either way: this process's first sync attempt is due -
-            # unless a sibling worker already synced this user's file at the
+            # unless an earlier process already synced this user's file at the
             # source's current version, in which case adopt that (the values
             # are already on disk) and skip the duplicate load.
             if self._adopt_sync_marker_if_current(username, cache_cfg):
@@ -588,7 +610,7 @@ class UserSettingsStore:
         return True
 
     def _adopt_sync_marker_if_current(self, username: str, cache_cfg: dict[str, Any]) -> bool:
-        """Skip the first sync-from-source load if a sibling worker already did it.
+        """Skip the first sync-from-source load if an earlier process already did it.
 
         Returns ``True`` (and stamps ``_sync_state`` as freshly synced) when
         an on-disk marker records that *username*'s file was synced at the
@@ -597,6 +619,11 @@ class UserSettingsStore:
         follow-up).  Returns ``False`` (caller does the full load) when there
         is no marker, the source is unknown, it can't cheaply report a
         version, or the versions differ.
+
+        This is the path a container restart takes: the marker outlives the
+        process on the persistent data volume, so a restart with an unchanged
+        source costs one ``peek_version`` instead of a full ``load()``.  See
+        the module comment above ``_sync_marker_path``.
         """
         marker_version = _read_sync_marker(self._user_path(username))
         if marker_version is None:
@@ -615,8 +642,8 @@ class UserSettingsStore:
         if current_version is None or current_version != marker_version:
             return False
 
-        # The user file already reflects the source at this version (a sibling
-        # worker applied it and stamped the marker).  Adopt it without a load.
+        # The user file already reflects the source at this version (an earlier
+        # process applied it and stamped the marker).  Adopt it without a load.
         with self._lock:
             self._sync_state[username] = UserSyncState(
                 last_version=current_version,
@@ -737,8 +764,8 @@ class UserSettingsStore:
             # confirms the source matches local (which clears them) or a
             # manual POST sync clears them on purpose.
 
-        # Stamp the cross-worker dedup marker so a sibling worker can skip
-        # its own first load while the source stays at this version.
+        # Stamp the cross-process dedup marker so the next process to start
+        # can skip its own first load while the source stays at this version.
         _write_sync_marker(self._user_path(username), new_version)
 
     def _maybe_migrate_legacy_settings(self, server_cache: dict[str, Any], server_path: Path) -> None:


### PR DESCRIPTION
Closes #3453

## Part A — the `.syncmark` layer is live; the comment was the problem

The issue proposed deleting the cross-worker dedup layer as "dead by configuration" (`gunicorn.conf.py` pins `workers = 1`), or else making `workers` configurable. **Neither, after checking: the layer is not dead, and deleting it would be a behaviour regression.**

`_sync_state` is in-memory but the marker is on disk, and the data directory is a persistent volume (`VOLUME /app/data` in `docker/Dockerfile`, a named volume in every compose file). So the marker *outlives the process*: a container restart or worker recycle against an unchanged source adopts it and skips a full `source.load()`, paying one `peek_version` instead.

The test suite demonstrates this directly. `_force_cold_sync` in `tests/io/test_sync_sources.py` exists solely because dropping `_sync_state` — which is exactly what a restart does — is *not* enough to force a real load; the helper has to `unlink` the marker. A flake (#2858) was traced to this.

A second process sharing the data directory (a `python app.py --autodetect` CLI run, a dev server) is deduped the same way, which is also why every settings write here goes through a cross-process `flock`.

What *was* misleading is the comment, which justified the layer solely by the one case `workers = 1` rules out — so a reader who checked the config concluded the whole thing was unreachable, which is precisely what happened. This PR rewrites it to state the real rationale, names the audit trap explicitly, and renames "cross-worker"/"sibling worker" to "cross-process"/"earlier process" throughout `settings_store.py` and the two test modules. **No behaviour change; no code deleted.**

The `gunicorn.conf.py` note the issue asked for is not added, since it was contingent on deleting the layer.

## Part B — the sync engine is now written down

New `docs/EXTENDING-plugins.md` section, **How the sync engine works**, covering what a new source binds to and cannot discover from `SettingsSource` alone:

- **Source precedence** via `resolve_settings_source`, including the `"none"` opt-out, deployment-default inheritance, and the two keys never exported to a source.
- **The freshness probe and its cost** — the three tiers a settings read walks, the 1.0 s window, why `peek_version()` must be cheap (ETag/HEAD, never a full GET), and the distinct meanings of a changed token, an unchanged token, `None`, and a raise.
- **The dirty-key contract** — what marks a key dirty and that it happens inside the file lock, which pulls honor it (automatic yes, explicit "Sync now" no), when it clears, and why the skip set is a live view rather than a snapshot.
- **The dedup marker**, with the reading above so the next audit does not re-derive the wrong conclusion.
- **Lock ordering** — the three locks, the canonical `file_lock → settings_lock` order, and the four consequences for a source author (no file lock held during your I/O, never call back into `vtsearch.settings`, a reentrant lock hides inversions until they deadlock, assume an arbitrary thread).
- **Failure semantics** — why a raising source degrades to "serve local" rather than failing a request.

Plus a **settings-source REST surface** section stating plainly that the four `/api/settings-sources` endpoints are an operator/API surface by design and that the SPA not calling them is not an oversight — so the next structure audit does not re-flag them as orphaned.

Pointers added from `vtsearch/settings_io/__init__.py`, `sources/base.py`, `docs/EXTENDING.md`'s checklist (with a new `_do_peek_version` line), `docs/ARCHITECTURE.md`, and `vtscore/docs/packages/sync.md`.

## Incidental: a boot-time sync the docs described but the app never did

Writing Part B surfaced that five places claimed the active source is imported at startup. `app.py:359` says the opposite in so many words — `initialize_server` loads models and preloads embedders, and settings-source sync is per-user and lazy, on each user's first settings access, because there is no server-wide user to sync for. Corrected in `docs/EXTENDING-plugins.md`, `docs/DEPLOYMENT.md` (×2), `docs/SETUP.md`, `docs/CLI.md`, `vtsearch/settings_io/sources/base.py`, and `vtscore/docs/packages/sync.md`.

## Not in scope

Unchanged, as the issue requires: the routes, the plugin family registration, and the sync engine itself.

## Testing

Full `./run-tests.sh`: **9481 passed**, 6 skipped, 2 xpassed; pyright, pip-audit, npm audit, and the Vitest suite all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_012GFi9JDG7jsqJuToFWZn2o)_