### PR TITLE
Break the loader façade's circular bottom imports

### DIFF
--- a/scripts/check-extension-docs.py
+++ b/scripts/check-extension-docs.py
@@ -70,6 +70,11 @@ SECTIONS: list[tuple[str, str, tuple[str, ...]]] = [
         "Processor abstract interface reference",
         ("Processor", "Detector", "Localizer", "Extractor"),
     ),
+    # Not an ABC contract: this section spells out how ``dirty_keys`` on
+    # ``UserSyncState`` arbitrates between a local write and an upstream pull.
+    # It is registered because invariant 2 (rightly) flags any "The ... contract"
+    # heading, and the names it does cite are members worth checking.
+    ("docs/EXTENDING-plugins.md", "The dirty-key contract", ("UserSyncState",)),
     # --- library tier ---------------------------------------------------
     ("vtscore/docs/extending/clippers.md", "The contract", ("MediaClipper",)),
     ("vtscore/docs/extending/converters.md", "The contract", ("MediaConverter",)),

--- a/scripts/compute_demo_counts.py
+++ b/scripts/compute_demo_counts.py
@@ -106,7 +106,7 @@ def _count_via_collection(dataset_id: str) -> int:
         # The loader resolves EMBEDDINGS_DIR through the parent module at call
         # time; point it at a throwaway dir so we never read a stale real pkl
         # (forcing a fresh collection) nor write a stub-embedded one to the cache.
-        stack.enter_context(patch("vtscore.datasets.loader.EMBEDDINGS_DIR", tmp_dir))
+        stack.enter_context(patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", tmp_dir))
         _stub_embedders(stack)
         medias: dict[int, dict] = {}
         load_demo_dataset(dataset_id, medias, on_progress=lambda *a, **k: None)

--- a/scripts/experiments/calibration/pick_sheets.py
+++ b/scripts/experiments/calibration/pick_sheets.py
@@ -79,7 +79,7 @@ def main(argv: list[str] | None = None) -> int:
 
     from PIL import Image, ImageDraw, ImageFont
 
-    from vtscore.datasets import loader as _loader
+    from vtscore.config import EMBEDDINGS_DIR
     from vtscore.eval.labels import region_box_for_category
 
     from _cells_io import load_medias  # noqa: PLC0415
@@ -96,7 +96,7 @@ def main(argv: list[str] | None = None) -> int:
         missing = [m for m in args.expect.split(",") if m.strip() and not any(m.strip() in k for k in modes)]
         if missing:
             print(f"NOTE: no picks yet for {', '.join(missing)} -- not drawn")
-    medias = load_medias(_loader.EMBEDDINGS_DIR / "vg_scale__siglip.pkl")
+    medias = load_medias(EMBEDDINGS_DIR / "vg_scale__siglip.pkl")
     print(f"{args.category} seed {args.seed}: " + ", ".join(f"{m} {len(by_mode[m])} clicks" for m in modes))
 
     def path_of(mid: int):

--- a/scripts/experiments/calibration/prepare_data.py
+++ b/scripts/experiments/calibration/prepare_data.py
@@ -120,7 +120,7 @@ def _category_counts(medias: dict) -> dict[str, int]:
 
 
 def _prepare_pair(ds: str, emb_name: str, info: dict) -> None:
-    from vtscore.datasets import loader as _loader
+    from vtscore.config import EMBEDDINGS_DIR
     from vtscore.embedding.media_vectors import media_embedding
 
     from _cells_io import dump_medias, load_medias  # noqa: PLC0415
@@ -131,7 +131,7 @@ def _prepare_pair(ds: str, emb_name: str, info: dict) -> None:
     # it does need to EXIST, and to cover the same medias, or every cell will
     # die one at a time deep inside the array instead of here, once.
     learn_name = cfg.learn_embedder(emb_name)
-    pkl = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb_name)
+    pkl = EMBEDDINGS_DIR / cfg.pickle_name(ds, emb_name)
     crops_np = common.RESULTS / "crops" / f"{cfg.crops_basename(ds, emb_name)}.npz"
     crops_js = crops_np.with_suffix(".json")
 
@@ -162,7 +162,7 @@ def _prepare_pair(ds: str, emb_name: str, info: dict) -> None:
 
     text_pickle = None
     if cfg.is_paired(emb_name):
-        text_pkl = _loader.EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb_name)
+        text_pkl = EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb_name)
         if not text_pkl.exists():
             raise FileNotFoundError(f"{emb_name}: text half's pickle {text_pkl.name} does not exist")
         text_medias = load_medias(text_pkl)

--- a/scripts/experiments/calibration/probe_startup_cuts.py
+++ b/scripts/experiments/calibration/probe_startup_cuts.py
@@ -109,13 +109,13 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     from _cells_io import load_medias  # noqa: PLC0415
-    from vtscore.datasets import loader as _loader  # noqa: PLC0415
+    from vtscore.config import EMBEDDINGS_DIR  # noqa: PLC0415
 
     info = json.loads((common.RESULTS / "prepare_info.json").read_text())
     rows: list[dict] = []
     for ds, per_emb in info.get("datasets", {}).items():
         for emb, entry in per_emb.items():
-            medias = load_medias(_loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb))
+            medias = load_medias(EMBEDDINGS_DIR / cfg.pickle_name(ds, emb))
             for cat in entry.get("selected_categories") or []:
                 r = probe_cell(ds, emb, cat, medias)
                 if r is not None:

--- a/scripts/experiments/calibration/run_cells.py
+++ b/scripts/experiments/calibration/run_cells.py
@@ -86,11 +86,11 @@ def _text_seed_vectors(ds: str, emb: str, medias: dict) -> tuple[dict, str]:
         common.log(f"  paired opening: {text_emb} vectors already on the cell's medias")
         return medias, "multi_vector"
 
-    from vtscore.datasets import loader as _loader  # noqa: PLC0415
+    from vtscore.config import EMBEDDINGS_DIR  # noqa: PLC0415
 
     from _cells_io import load_medias  # noqa: PLC0415
 
-    text_pkl = _loader.EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb)
+    text_pkl = EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb)
     if not text_pkl.exists():
         raise FileNotFoundError(
             f"paired embedder {emb!r} needs {text_emb} vectors: neither the cell's medias nor "
@@ -236,11 +236,11 @@ def main(argv: list[str] | None = None) -> int:
         simulate_voting_iterations,
     )
 
-    from vtscore.datasets import loader as _loader  # isort: skip
+    from vtscore.config import EMBEDDINGS_DIR  # isort: skip
 
     from _cells_io import load_medias  # noqa: PLC0415
 
-    pkl = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
+    pkl = EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
     medias: dict[int, dict] = load_medias(pkl)
     common.log(f"loaded {len(medias)} medias from {pkl}")
 

--- a/scripts/experiments/calibration/text_baseline.py
+++ b/scripts/experiments/calibration/text_baseline.py
@@ -62,7 +62,7 @@ def main() -> int:
     from vtscore.eval.calibration_metrics import detection_metrics
     from vtscore.training.thresholds import calculate_gmm_threshold, inclusion_cost_weights
 
-    from vtscore.datasets import loader as _loader  # isort: skip
+    from vtscore.config import EMBEDDINGS_DIR  # isort: skip
 
     from _cells_io import load_medias  # noqa: PLC0415
 
@@ -90,7 +90,7 @@ def main() -> int:
             # the DINOv3 pickle would have been worse: two different spaces, and
             # a number rather than a blank.
             text_emb = cfg.text_embedder(emb)
-            pkl = _loader.EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb)
+            pkl = EMBEDDINGS_DIR / cfg.text_pickle_name(ds, emb)
             if not pkl.exists():
                 common.log(f"SKIP {ds} x {emb}: no text pickle {pkl.name}")
                 continue

--- a/scripts/experiments/max_patch/prepare_data.py
+++ b/scripts/experiments/max_patch/prepare_data.py
@@ -118,7 +118,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--embedders", nargs="+", default=cfg.EMBEDDERS)
     args = parser.parse_args(argv)
 
-    from vtscore.datasets import loader as _loader
+    from vtscore.config import EMBEDDINGS_DIR
     from vtscore.datasets.loader_demo import load_demo_dataset
     from vtscore.embedding import initialize_models
     from vtscore.embedding.media_vectors import media_embedding
@@ -172,7 +172,7 @@ def main(argv: list[str] | None = None) -> int:
             # every style scoring on the whole-image vector alone.
             from _cells_io import dump_medias  # noqa: PLC0415
 
-            dst = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb_name)
+            dst = EMBEDDINGS_DIR / cfg.pickle_name(ds, emb_name)
             nbytes = dump_medias(medias, dst)
             common.log(f"  wrote cell pickle {dst.name}: {nbytes / 1e6:.0f} MB")
 

--- a/scripts/experiments/max_patch/run_cells.py
+++ b/scripts/experiments/max_patch/run_cells.py
@@ -138,11 +138,11 @@ def main(argv: list[str] | None = None) -> int:
 
     from vtscore.eval.voting_iterations import _VOTING_COLUMNS, simulate_voting_iterations
 
-    from vtscore.datasets import loader as _loader  # isort: skip
+    from vtscore.config import EMBEDDINGS_DIR  # isort: skip
 
     from _cells_io import load_medias  # noqa: PLC0415
 
-    pkl = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
+    pkl = EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
     medias: dict[int, dict] = load_medias(pkl)
     common.log(f"loaded {len(medias)} medias from {pkl}")
 

--- a/scripts/experiments/pile/box_sheets.py
+++ b/scripts/experiments/pile/box_sheets.py
@@ -141,12 +141,12 @@ def main(argv: list[str] | None = None) -> int:
 
     from PIL import Image, ImageDraw, ImageFont
 
-    from vtscore.datasets import loader as _loader
+    from vtscore.config import EMBEDDINGS_DIR
     from vtscore.eval.labels import media_is_positive, region_box_for_category
 
     from _cells_io import load_medias  # noqa: PLC0415
 
-    medias = load_medias(_loader.EMBEDDINGS_DIR / f"{args.dataset}__{args.embedder}.pkl")
+    medias = load_medias(EMBEDDINGS_DIR / f"{args.dataset}__{args.embedder}.pkl")
     images = source_for(args.dataset)
     # Checked before the scan so the message names the *configuration* problem
     # rather than reporting it as an absence of positives.

--- a/scripts/experiments/preflight.sh
+++ b/scripts/experiments/preflight.sh
@@ -332,12 +332,12 @@ import common
 common.setup_env()
 import experiment_config as cfg
 from _cells_io import load_medias
-from vtscore.datasets import loader as _loader
+from vtscore.config import EMBEDDINGS_DIR
 
 # A paired arm (`siglip+dinov3_patch`) carries its patch grid in the LEARN
 # half's pickle; naming the file by hand here would look for a pickle that has
 # never existed and report the premise as MISSING rather than as held.
-pkl = _loader.EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
+pkl = EMBEDDINGS_DIR / cfg.pickle_name(ds, emb)
 if not pkl.exists():
     print(f"MISSING {pkl}")
     raise SystemExit(0)

--- a/scripts/experiments/structure/structure_fits_3329.py
+++ b/scripts/experiments/structure/structure_fits_3329.py
@@ -280,9 +280,9 @@ def load_matrix(dataset: str, embedder: str) -> tuple[np.ndarray, list[int], lis
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "calibration"))
     from _cells_io import load_medias  # noqa: PLC0415
 
-    from vtscore.datasets import loader as _loader  # noqa: PLC0415
+    from vtscore.config import EMBEDDINGS_DIR  # noqa: PLC0415
 
-    pkl = _loader.EMBEDDINGS_DIR / f"{dataset}__{embedder}.pkl"
+    pkl = EMBEDDINGS_DIR / f"{dataset}__{embedder}.pkl"
     medias = load_medias(pkl)
     ids = sorted(medias)
     vecs, keep, cats = [], [], []

--- a/scripts/experiments/toponymy_audio/prepare_dataset.py
+++ b/scripts/experiments/toponymy_audio/prepare_dataset.py
@@ -49,7 +49,7 @@ def discover_categories(source: str) -> list[str]:
     if source == "clotho":
         return ["sound"]
     if source == "urbansound8k":
-        from vtscore.datasets.loader import load_urbansound8k_metadata
+        from vtscore.datasets.metadata import load_urbansound8k_metadata
 
         us8k = downloader.download_urbansound8k()
         meta = load_urbansound8k_metadata(us8k)

--- a/scripts/experiments/umap_params/prepare_dataset.py
+++ b/scripts/experiments/umap_params/prepare_dataset.py
@@ -90,7 +90,7 @@ def prepare_image_reembed(spec: C.DatasetSpec):
 
 # --- image folder: Places365 (val.txt labels) --------------------------------
 def prepare_places365(spec: C.DatasetSpec):
-    from vtscore.datasets.loader import load_places365_metadata
+    from vtscore.datasets.metadata import load_places365_metadata
     from vtscore.media.image._demo_sources import PLACES365_CATEGORIES
 
     target_n = {"places365_s": 5110, "places365_m": 10220, "places365_l": 21170}[spec.name]

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -765,11 +765,11 @@ class TestLoadDemoWithConverter:
         assert "Invalid dataset" in resp.get_json()["message"]
 
     def test_apply_converter_to_demo_unknown_converter(self):
-        """_apply_converter_to_demo should raise for unknown converters."""
-        from vtscore.datasets.loader import _apply_converter_to_demo
+        """apply_converter_to_demo should raise for unknown converters."""
+        from vtscore.converters.runner import apply_converter_to_demo
 
         with pytest.raises(ValueError, match="Unknown converter"):
-            _apply_converter_to_demo(
+            apply_converter_to_demo(
                 converter_name="nonexistent_converter",
                 dataset_name="test",
                 medias={},
@@ -783,7 +783,7 @@ class TestLoadDemoWithConverter:
         parameter must keep accepting anything - including a name that does
         not resolve - without raising or changing the result.
         """
-        from vtscore.datasets.loader import _apply_converter_to_demo
+        from vtscore.converters.runner import apply_converter_to_demo
 
         pdf_bytes = _make_minimal_pdf("Convert me")
 
@@ -800,10 +800,10 @@ class TestLoadDemoWithConverter:
             }
 
         without: dict = _fresh()
-        _apply_converter_to_demo(converter_name="document2image", dataset_name="d", medias=without)
+        apply_converter_to_demo(converter_name="document2image", dataset_name="d", medias=without)
 
         with_bogus: dict = _fresh()
-        _apply_converter_to_demo(
+        apply_converter_to_demo(
             converter_name="document2image",
             dataset_name="d",
             medias=with_bogus,
@@ -815,11 +815,11 @@ class TestLoadDemoWithConverter:
         assert all(m.get("embedding") is None for m in with_bogus.values())
 
     def test_apply_converter_to_demo_empty_medias(self):
-        """_apply_converter_to_demo with empty medias should produce empty output."""
-        from vtscore.datasets.loader import _apply_converter_to_demo
+        """apply_converter_to_demo with empty medias should produce empty output."""
+        from vtscore.converters.runner import apply_converter_to_demo
 
         medias: dict = {}
-        _apply_converter_to_demo(
+        apply_converter_to_demo(
             converter_name="document2image",
             dataset_name="test",
             medias=medias,
@@ -827,8 +827,8 @@ class TestLoadDemoWithConverter:
         assert medias == {}
 
     def test_apply_converter_to_demo_converts_documents(self):
-        """_apply_converter_to_demo should convert document medias to images."""
-        from vtscore.datasets.loader import _apply_converter_to_demo
+        """apply_converter_to_demo should convert document medias to images."""
+        from vtscore.converters.runner import apply_converter_to_demo
 
         pdf_bytes = _make_minimal_pdf("Convert me")
         medias = {
@@ -841,7 +841,7 @@ class TestLoadDemoWithConverter:
                 "category": "test_cat",
             }
         }
-        _apply_converter_to_demo(
+        apply_converter_to_demo(
             converter_name="document2image",
             dataset_name="test_demo",
             medias=medias,

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1055,7 +1055,7 @@ class TestDemoCacheEmbedderMismatch:
         mock_mt.load_demo_source.return_value = "/fake/dir"
 
         with (
-            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", embeddings_dir),
             patch("vtscore.media.get_embedder", return_value=fake_embedder) as mock_get,
             patch("vtscore.media.get", return_value=mock_mt),
         ):
@@ -1096,8 +1096,8 @@ class TestDemoCacheEmbedderMismatch:
             m[1] = {"embedding": np.array([0.1, 0.2]), "file": "/fake/file.png"}
 
         with (
-            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
-            patch("vtscore.datasets.loader.load_dataset_from_pickle", side_effect=fake_load),
+            patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", embeddings_dir),
+            patch("vtscore.datasets.loader_demo.load_dataset_from_pickle", side_effect=fake_load),
         ):
             load_demo_dataset(demo_name, medias, embedder_name="clip")
 
@@ -1135,8 +1135,8 @@ class TestDemoCacheEmbedderMismatch:
             m[1] = {"embedding": np.array([0.1]), "file": "/fake/file.png"}
 
         with (
-            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
-            patch("vtscore.datasets.loader.load_dataset_from_pickle", side_effect=fake_load),
+            patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", embeddings_dir),
+            patch("vtscore.datasets.loader_demo.load_dataset_from_pickle", side_effect=fake_load),
         ):
             load_demo_dataset(demo_name, medias, embedder_name="siglip")
 
@@ -1208,7 +1208,7 @@ class TestDemoClipperApplied:
         demo_name = "fake_audio_demo"
         medias: dict = {}
         with (
-            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", embeddings_dir),
             patch.dict("vtscore.datasets.loader_demo.DEMO_DATASETS", {demo_name: self.FAKE_INFO}),
             patch("vtscore.media.embedders_for_type", return_value=[fake_embedder]),
             patch("vtscore.media.get", return_value=mock_mt),
@@ -1286,7 +1286,7 @@ class TestDemoCacheClipperMismatch:
         mock_mt.load_demo_source.return_value = "/fake/dir"
 
         with (
-            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", embeddings_dir),
             patch.dict("vtscore.datasets.loader_demo.DEMO_DATASETS", {demo_name: TestDemoClipperApplied.FAKE_INFO}),
             patch("vtscore.media.embedders_for_type", return_value=[fake_embedder]),
             patch("vtscore.media.get", return_value=mock_mt),
@@ -1312,9 +1312,9 @@ class TestDemoCacheClipperMismatch:
             m[1] = {"embedding": np.array([0.1]), "media_type": "audio"}
 
         with (
-            patch("vtscore.datasets.loader.EMBEDDINGS_DIR", embeddings_dir),
+            patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR", embeddings_dir),
             patch.dict("vtscore.datasets.loader_demo.DEMO_DATASETS", {demo_name: TestDemoClipperApplied.FAKE_INFO}),
-            patch("vtscore.datasets.loader.load_dataset_from_pickle", side_effect=fake_load),
+            patch("vtscore.datasets.loader_demo.load_dataset_from_pickle", side_effect=fake_load),
         ):
             medias: dict = {}
             load_demo_dataset(demo_name, medias, clipper_name="sound_tiling", clipper_params={"duration": 2.0})

--- a/tests/datasets/test_pickle_safety.py
+++ b/tests/datasets/test_pickle_safety.py
@@ -15,8 +15,8 @@ from vtscore.datasets.loader import (
     export_dataset_to_file,
     load_dataset_from_pickle,
     load_dataset_from_pickle_chunked,
-    safe_pickle_load,
 )
+from vtscore.security.pickle import safe_pickle_load
 
 
 # ---------------------------------------------------------------------------

--- a/tests_lib/datasets/test_cached_load_progress.py
+++ b/tests_lib/datasets/test_cached_load_progress.py
@@ -18,7 +18,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from vtscore.datasets import loader as _loader
+from vtscore.datasets import loader_demo as _loader_demo
 from vtscore.datasets.config import DEMO_DATASETS
 from vtscore.datasets.loader import export_dataset_to_file, load_demo_dataset
 
@@ -60,7 +60,7 @@ def _write_cached_demo(tmp_path: Path, monkeypatch, n: int = 120) -> dict[int, d
     """Plant a cached demo container in a redirected ``EMBEDDINGS_DIR``."""
     medias = _image_medias(n)
     container = export_dataset_to_file(medias, embedder="siglip", media_type="image")
-    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    monkeypatch.setattr(_loader_demo, "EMBEDDINGS_DIR", tmp_path)
     (tmp_path / f"{DEMO_ID}.pkl").write_bytes(container)
     return medias
 

--- a/tests_lib/detectors/test_paired_embedder_seeding.py
+++ b/tests_lib/detectors/test_paired_embedder_seeding.py
@@ -165,9 +165,9 @@ def test_pair_ranks_in_the_text_space_over_the_learn_ids(cfg, run_cells, queried
     learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
     text = {cid: _media({"siglip": v}, "siglip") for cid, v in _SIGLIP.items()}
 
-    from vtscore.datasets import loader as _loader
+    from vtscore import config as _vtconfig
 
-    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    monkeypatch.setattr(_vtconfig, "EMBEDDINGS_DIR", tmp_path)
     (tmp_path / "_paired_fixture__siglip.pkl").write_bytes(b"")  # existence only
     monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(text))
 
@@ -187,9 +187,9 @@ def test_pair_prefers_vectors_already_on_the_media(run_cells, queried, text_towe
     """A multi-vector media needs no second pickle — the production shape."""
     both = {cid: _media({"dinov3_patch": _DINOV3[cid], "siglip": _SIGLIP[cid]}, "dinov3_patch") for cid in _DINOV3}
 
-    from vtscore.datasets import loader as _loader
+    from vtscore import config as _vtconfig
 
-    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)  # empty: no side pickle exists
+    monkeypatch.setattr(_vtconfig, "EMBEDDINGS_DIR", tmp_path)  # empty: no side pickle exists
     monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(None))
 
     vectors, provenance = run_cells._text_seed_vectors(_DS, PAIR, both)
@@ -205,9 +205,9 @@ def test_pair_refuses_a_text_side_that_misses_medias(run_cells, monkeypatch, tmp
     learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
     partial = {1: _media({"siglip": _SIGLIP[1]}, "siglip")}
 
-    from vtscore.datasets import loader as _loader
+    from vtscore import config as _vtconfig
 
-    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    monkeypatch.setattr(_vtconfig, "EMBEDDINGS_DIR", tmp_path)
     (tmp_path / "_paired_fixture__siglip.pkl").write_bytes(b"")
     monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(partial))
 
@@ -218,9 +218,9 @@ def test_pair_refuses_a_text_side_that_misses_medias(run_cells, monkeypatch, tmp
 def test_pair_reports_a_missing_text_pickle_by_name(run_cells, monkeypatch, tmp_path):
     learn = {cid: _media({"dinov3_patch": v}, "dinov3_patch") for cid, v in _DINOV3.items()}
 
-    from vtscore.datasets import loader as _loader
+    from vtscore import config as _vtconfig
 
-    monkeypatch.setattr(_loader, "EMBEDDINGS_DIR", tmp_path)
+    monkeypatch.setattr(_vtconfig, "EMBEDDINGS_DIR", tmp_path)
     monkeypatch.setitem(sys.modules, "_cells_io", _cells_io_stub(None))
 
     with pytest.raises(FileNotFoundError, match="_paired_fixture__siglip.pkl"):

--- a/tests_lib/downloads/test_gtzan_download.py
+++ b/tests_lib/downloads/test_gtzan_download.py
@@ -212,7 +212,7 @@ class TestDownloadUrbansound8k:
 class TestLoadAudioMetadataFromFolders:
     def test_scans_category_subdirectories(self, tmp_path):
         """Finds WAV files in matching category subdirectories."""
-        from vtscore.datasets.loader import load_audio_metadata_from_folders
+        from vtscore.datasets.metadata import load_audio_metadata_from_folders
 
         for genre in ("blues", "rock"):
             d = tmp_path / genre
@@ -233,7 +233,7 @@ class TestLoadAudioMetadataFromFolders:
 
     def test_ignores_non_audio_files(self, tmp_path):
         """Non-audio files (like .txt) are not included."""
-        from vtscore.datasets.loader import load_audio_metadata_from_folders
+        from vtscore.datasets.metadata import load_audio_metadata_from_folders
 
         d = tmp_path / "blues"
         d.mkdir()
@@ -250,7 +250,7 @@ class TestLoadAudioMetadataFromFolders:
         '*.wav' glob matches them by extension, so without a dotfile guard
         the count would double and 1000 undecodable junk clips would load.
         """
-        from vtscore.datasets.loader import load_audio_metadata_from_folders
+        from vtscore.datasets.metadata import load_audio_metadata_from_folders
 
         d = tmp_path / "blues"
         d.mkdir()
@@ -271,7 +271,7 @@ class TestLoadAudioMetadataFromFolders:
 class TestLoadUrbansound8kMetadata:
     def test_loads_csv_metadata(self, tmp_path):
         """Reads UrbanSound8K.csv and maps filenames to metadata."""
-        from vtscore.datasets.loader import load_urbansound8k_metadata
+        from vtscore.datasets.metadata import load_urbansound8k_metadata
 
         meta_dir = tmp_path / "metadata"
         meta_dir.mkdir()
@@ -315,7 +315,7 @@ class TestLoadDemoSourceGtzan:
     def test_gtzan_source_populates_clips(self, tmp_path):
         """load_demo_source with source='gtzan' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.audio.media_type import AudioMediaType
 
         fake_metadata = {
@@ -334,7 +334,7 @@ class TestLoadDemoSourceGtzan:
 
         with (
             patch.object(dl_module, "download_gtzan", return_value=tmp_path),
-            patch.object(loader_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="gtzan",
@@ -359,7 +359,7 @@ class TestLoadDemoSourceGtzan:
         survive with ``embeddings={}`` so the clipper can re-embed its clips.
         """
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.audio.media_type import AudioMediaType
 
         fake_metadata = {
@@ -380,7 +380,7 @@ class TestLoadDemoSourceGtzan:
 
         with (
             patch.object(dl_module, "download_gtzan", return_value=tmp_path),
-            patch.object(loader_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="gtzan",
@@ -402,7 +402,7 @@ class TestLoadDemoSourceGtzan:
     def test_gtzan_slice_is_applied(self, tmp_path):
         """slice_start/slice_end limits files per category."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.audio.media_type import AudioMediaType
 
         fake_metadata = {}
@@ -418,7 +418,7 @@ class TestLoadDemoSourceGtzan:
 
         with (
             patch.object(dl_module, "download_gtzan", return_value=tmp_path),
-            patch.object(loader_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="gtzan",
@@ -449,7 +449,7 @@ class TestLoadDemoSourceSpeechCommands:
     def test_speech_commands_source_populates_clips(self, tmp_path):
         """load_demo_source with source='speech_commands_v2' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.audio.media_type import AudioMediaType
 
         fake_metadata = {
@@ -466,7 +466,7 @@ class TestLoadDemoSourceSpeechCommands:
 
         with (
             patch.object(dl_module, "download_speech_commands_v2", return_value=tmp_path),
-            patch.object(loader_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_audio_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="speech_commands_v2",
@@ -499,7 +499,7 @@ class TestLoadDemoSourceUrbansound8k:
     def test_urbansound8k_source_populates_clips(self, tmp_path):
         """load_demo_source with source='urbansound8k' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.audio.media_type import AudioMediaType
 
         f1 = tmp_path / "100032-3-0-0.wav"
@@ -519,7 +519,7 @@ class TestLoadDemoSourceUrbansound8k:
 
         with (
             patch.object(dl_module, "download_urbansound8k", return_value=tmp_path),
-            patch.object(loader_module, "load_urbansound8k_metadata", return_value=fake_metadata),
+            patch.object(metadata_module, "load_urbansound8k_metadata", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="urbansound8k",

--- a/tests_lib/downloads/test_image_sources_download.py
+++ b/tests_lib/downloads/test_image_sources_download.py
@@ -281,7 +281,7 @@ class TestLoadOxfordFlowersMetadata:
         """Reads imagelabels.mat and maps numeric labels to category names."""
         import scipy.io
 
-        from vtscore.datasets.loader import load_oxford_flowers_metadata
+        from vtscore.datasets.metadata import load_oxford_flowers_metadata
 
         jpg_dir = tmp_path / "jpg"
         jpg_dir.mkdir()
@@ -320,7 +320,7 @@ class TestLoadDemoSourceOxfordFlowers:
     def test_oxford_flowers_populates_clips(self, tmp_path):
         """load_demo_source with source='oxford_flowers_102' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         # Create stub image files.
@@ -338,7 +338,7 @@ class TestLoadDemoSourceOxfordFlowers:
 
         with (
             patch.object(dl_module, "download_oxford_flowers", return_value=tmp_path),
-            patch.object(loader_module, "load_oxford_flowers_metadata", return_value=fake_metadata),
+            patch.object(metadata_module, "load_oxford_flowers_metadata", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="oxford_flowers_102",
@@ -357,7 +357,7 @@ class TestLoadDemoSourceOxfordFlowers:
     def test_oxford_flowers_slice_is_applied(self, tmp_path):
         """slice_start/slice_end limits images per category."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         fake_metadata = {}
@@ -372,7 +372,7 @@ class TestLoadDemoSourceOxfordFlowers:
 
         with (
             patch.object(dl_module, "download_oxford_flowers", return_value=tmp_path),
-            patch.object(loader_module, "load_oxford_flowers_metadata", return_value=fake_metadata),
+            patch.object(metadata_module, "load_oxford_flowers_metadata", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="oxford_flowers_102",
@@ -401,7 +401,7 @@ class TestLoadDemoSourceFood101:
     def test_food101_populates_clips(self, tmp_path):
         """load_demo_source with source='food101' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -418,7 +418,7 @@ class TestLoadDemoSourceFood101:
 
         with (
             patch.object(dl_module, "download_food101", return_value=tmp_path),
-            patch.object(loader_module, "load_image_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_image_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="food101",
@@ -449,7 +449,7 @@ class TestLoadDemoSourceEurosat:
     def test_eurosat_populates_clips(self, tmp_path):
         """load_demo_source with source='eurosat' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -466,7 +466,7 @@ class TestLoadDemoSourceEurosat:
 
         with (
             patch.object(dl_module, "download_eurosat", return_value=tmp_path),
-            patch.object(loader_module, "load_image_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_image_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="eurosat",
@@ -566,7 +566,7 @@ class TestDownloadPlaces365:
 class TestLoadPlaces365Metadata:
     def test_maps_indices_to_categories(self, tmp_path):
         """Reads places365_val.txt and maps numeric indices to category names."""
-        from vtscore.datasets.loader import load_places365_metadata
+        from vtscore.datasets.metadata import load_places365_metadata
 
         val_dir = tmp_path / "val_256"
         val_dir.mkdir()
@@ -587,7 +587,7 @@ class TestLoadPlaces365Metadata:
 
     def test_out_of_range_indices_are_skipped(self, tmp_path):
         """Label indices outside the categories list are silently ignored."""
-        from vtscore.datasets.loader import load_places365_metadata
+        from vtscore.datasets.metadata import load_places365_metadata
 
         (tmp_path / "val_256").mkdir()
         (tmp_path / "places365_val.txt").write_text(
@@ -621,7 +621,7 @@ class TestLoadDemoSourcePlaces365:
     def test_places365_populates_clips(self, tmp_path):
         """load_demo_source with source='places365' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -638,7 +638,7 @@ class TestLoadDemoSourcePlaces365:
 
         with (
             patch.object(dl_module, "download_places365", return_value=tmp_path),
-            patch.object(loader_module, "load_places365_metadata", return_value=fake_metadata),
+            patch.object(metadata_module, "load_places365_metadata", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="places365",
@@ -657,7 +657,7 @@ class TestLoadDemoSourcePlaces365:
     def test_places365_filters_by_requested_categories(self, tmp_path):
         """Metadata entries whose category is not requested are dropped."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         (tmp_path / "img1.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 20)
@@ -674,7 +674,7 @@ class TestLoadDemoSourcePlaces365:
 
         with (
             patch.object(dl_module, "download_places365", return_value=tmp_path),
-            patch.object(loader_module, "load_places365_metadata", return_value=fake_metadata),
+            patch.object(metadata_module, "load_places365_metadata", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="places365",
@@ -692,7 +692,7 @@ class TestLoadDemoSourcePlaces365:
     def test_places365_slice_is_applied(self, tmp_path):
         """slice_start/slice_end limits images per category."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.image.media_type import ImageMediaType
 
         fake_metadata = {}
@@ -707,7 +707,7 @@ class TestLoadDemoSourcePlaces365:
 
         with (
             patch.object(dl_module, "download_places365", return_value=tmp_path),
-            patch.object(loader_module, "load_places365_metadata", return_value=fake_metadata),
+            patch.object(metadata_module, "load_places365_metadata", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="places365",

--- a/tests_lib/downloads/test_video_datasets_download.py
+++ b/tests_lib/downloads/test_video_datasets_download.py
@@ -426,7 +426,7 @@ class TestLoadDemoSourceHmdb51:
     def test_hmdb51_source_populates_clips(self, tmp_path):
         """load_demo_source with source='hmdb51' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.video.media_type import VideoMediaType
 
         fake_metadata = {
@@ -449,7 +449,7 @@ class TestLoadDemoSourceHmdb51:
 
         with (
             patch.object(dl_module, "download_hmdb51", return_value=tmp_path),
-            patch.object(loader_module, "load_video_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_video_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="hmdb51",
@@ -480,7 +480,7 @@ class TestLoadDemoSourceUcf101Full:
     def test_ucf101_full_source_populates_clips(self, tmp_path):
         """load_demo_source with source='ucf101_full' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.video.media_type import VideoMediaType
 
         fake_metadata = {
@@ -503,7 +503,7 @@ class TestLoadDemoSourceUcf101Full:
 
         with (
             patch.object(dl_module, "download_ucf101_full", return_value=tmp_path),
-            patch.object(loader_module, "load_video_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_video_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="ucf101_full",
@@ -534,7 +534,7 @@ class TestLoadDemoSourceKth:
     def test_kth_source_populates_clips(self, tmp_path):
         """load_demo_source with source='kth' fills the clips dict."""
         from vtscore.datasets import downloader as dl_module
-        from vtscore.datasets import loader as loader_module
+        from vtscore.datasets import metadata as metadata_module
         from vtscore.media.video.media_type import VideoMediaType
 
         fake_metadata = {
@@ -557,7 +557,7 @@ class TestLoadDemoSourceKth:
 
         with (
             patch.object(dl_module, "download_kth", return_value=tmp_path),
-            patch.object(loader_module, "load_video_metadata_from_folders", return_value=fake_metadata),
+            patch.object(metadata_module, "load_video_metadata_from_folders", return_value=fake_metadata),
         ):
             mt.load_demo_source(
                 source="kth",
@@ -596,7 +596,7 @@ class TestLoadVideoMetadataFromFolders:
 
     def test_scans_category_subdirectories(self, tmp_path):
         """Finds video files in matching category subdirectories."""
-        from vtscore.datasets.loader import load_video_metadata_from_folders
+        from vtscore.datasets.metadata import load_video_metadata_from_folders
 
         for cat in ("walking", "boxing"):
             d = tmp_path / cat
@@ -614,7 +614,7 @@ class TestLoadVideoMetadataFromFolders:
 
     def test_skips_appledouble_dotfiles(self, tmp_path):
         """macOS AppleDouble sidecars ('._clip.avi') are not counted."""
-        from vtscore.datasets.loader import load_video_metadata_from_folders
+        from vtscore.datasets.metadata import load_video_metadata_from_folders
 
         d = tmp_path / "walking"
         d.mkdir()

--- a/vtscore/datasets/downloader/video.py
+++ b/vtscore/datasets/downloader/video.py
@@ -15,7 +15,7 @@ def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Pa
     HuggingFace and extracts it into ``VIDEO_DIR / "ucf101"`` with one
     subdirectory per action class.  Videos from all splits (train/val/test) are
     merged into a single flat category structure so that
-    :func:`~vtscore.datasets.loader.load_video_metadata_from_folders` can
+    :func:`~vtscore.datasets.metadata.load_video_metadata_from_folders` can
     scan them directly.
 
     If the dataset is already present (at least one ``*.avi`` in a

--- a/vtscore/datasets/importers/pickle/__init__.py
+++ b/vtscore/datasets/importers/pickle/__init__.py
@@ -23,7 +23,7 @@ def _get_progress():
     messages to the dashboard row for *this* import.  Reporting straight to the
     global ``update_progress`` singleton (the previous behaviour) published on
     the ``dataset`` channel instead, where the row never reads it.  Mirrors
-    ``vtscore.datasets.loader._default_progress``.
+    ``vtscore.datasets.loader_common._default_progress``.
     """
     from vtscore.concurrency.progress import get_thread_progress, update_progress
 

--- a/vtscore/datasets/loader.py
+++ b/vtscore/datasets/loader.py
@@ -1,13 +1,18 @@
 """Dataset loading and management utilities.
 
 This module is the public façade for dataset loading.  Implementations
-live in dedicated sibling modules; this file holds the shared helpers,
-``export_dataset_to_file``, and re-exports so existing imports
+live in dedicated sibling modules; this file holds
+``export_dataset_to_file`` and re-exports the loaders so existing imports
 (``from vtscore.datasets.loader import ...``) continue to work.
 
+* :mod:`vtscore.datasets.loader_common` - helpers shared by all three
 * :mod:`vtscore.datasets.loader_folder` - folder loaders
 * :mod:`vtscore.datasets.loader_pickle` - pickle/container loaders, image embed
 * :mod:`vtscore.datasets.loader_demo` - demo dataset loader
+
+The façade re-exports *loaders* only.  Metadata parsers live in
+:mod:`vtscore.datasets.metadata` and pickle-safety names in
+:mod:`vtscore.security.pickle`; import them from there.
 
 All public functions that perform I/O accept an optional ``on_progress``
 callback with the signature
@@ -23,33 +28,27 @@ import io
 import pickle
 from typing import Any, Callable
 
-import numpy as np
-
+from vtscore.datasets.loader_common import (  # noqa: F401  - re-exported for consumers
+    ProgressCallback,
+    _embedding_for_pickle,
+    _embeddings_dict_for_pickle,
+)
+from vtscore.datasets.loader_demo import (  # noqa: F401  - re-exported for consumers
+    _stamp_demo_origin,
+    load_demo_dataset,
+)
+from vtscore.datasets.loader_folder import (  # noqa: F401  - re-exported for consumers
+    apply_custom_metadata_md5,
+    load_dataset_from_folder,
+    load_dataset_from_folder_chunked,
+)
+from vtscore.datasets.loader_pickle import (  # noqa: F401  - re-exported for consumers
+    load_dataset_from_pickle,
+    load_dataset_from_pickle_chunked,
+    read_pkl_clipper,
+    read_pkl_embedder,
+)
 from vtscore.embedding.stack import embedding_stack
-from vtscore.config import EMBEDDINGS_DIR  # noqa: F401  - re-exported & patched in tests
-from vtscore.datasets.metadata import (  # noqa: F401  - re-exported for consumers
-    load_audio_metadata_from_folders,
-    load_cifar10_batch,
-    load_esc50_metadata,
-    load_image_metadata_from_folders,
-    load_oxford_flowers_metadata,
-    load_paragraph_metadata_from_folders,
-    load_places365_metadata,
-    load_urbansound8k_metadata,
-    load_video_metadata_from_folders,
-)
-from vtscore.security.pickle import (  # noqa: F401  - re-exported for consumers
-    RestrictedUnpickler,
-    _PICKLE_SAFE_CLASSES,
-    safe_pickle_load,
-)
-
-ProgressCallback = Callable[[str, str, int, int], None]
-
-
-# ---------------------------------------------------------------------------
-# Shared helpers (used by loader_folder / loader_pickle / loader_demo)
-# ---------------------------------------------------------------------------
 
 
 def _loaded_embedder(name: str | None):
@@ -70,76 +69,6 @@ def _loaded_embedder(name: str | None):
     return emb if getattr(emb, "_processor", None) is not None else None
 
 
-def _default_progress() -> ProgressCallback:
-    """Lazily resolve the progress callback for the current thread.
-
-    Checks for a per-thread callback first (set during parallel dataset
-    loading) and falls back to the global singleton.
-    """
-    from vtscore.concurrency.progress import get_thread_progress
-
-    cb = get_thread_progress()
-    if cb is not None:
-        return cb
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
-
-
-def _pop_md5_key(d: dict[str, Any]) -> str:
-    """Pop and return the MD5 value from *d*, trying both ``"md5"`` and ``"MD5"`` keys.
-
-    Returns the value (or ``""`` if neither key is present) and removes the
-    matched key from *d* so it doesn't leak into downstream metadata.
-    """
-    for key in ("md5", "MD5"):
-        val = d.get(key)
-        if val:
-            del d[key]
-            return val
-    return ""
-
-
-def _get_md5_value(d: dict[str, Any]) -> str:
-    """Return the MD5 value from *d*, trying both ``"md5"`` and ``"MD5"`` keys.
-
-    Unlike :func:`_pop_md5_key` this does **not** mutate *d*.
-    """
-    return d.get("md5") or d.get("MD5") or ""
-
-
-def _get_embedding_value(d: dict[str, Any]) -> Any:
-    """Return the embedding value from *d* without mutating it.
-
-    Returns ``None`` when the key is absent.
-    """
-    return d.get("embedding")
-
-
-# ---------------------------------------------------------------------------
-# Public loaders - re-exported from sibling modules
-# ---------------------------------------------------------------------------
-
-from vtscore.datasets.loader_folder import (  # noqa: E402, F401
-    apply_custom_metadata_md5,
-    load_dataset_from_folder,
-    load_dataset_from_folder_chunked,
-)
-from vtscore.datasets.loader_pickle import (  # noqa: E402, F401
-    load_dataset_from_pickle,
-    load_dataset_from_pickle_chunked,
-    read_pkl_clipper,
-    read_pkl_embedder,
-)
-from vtscore.datasets.loader_demo import (  # noqa: E402, F401
-    _stamp_demo_origin,
-    load_demo_dataset,
-)
-
-# Backward-compat alias - canonical location is vtscore.converters.runner
-from vtscore.converters.runner import apply_converter_to_demo as _apply_converter_to_demo  # noqa: E402, F401
-
-
 # ---------------------------------------------------------------------------
 # Export
 # ---------------------------------------------------------------------------
@@ -148,38 +77,6 @@ from vtscore.converters.runner import apply_converter_to_demo as _apply_converte
 # making it both smaller and faster than the interpreter default (4 on 3.11).
 # Available on every Python we support (>=3.10), so pin it explicitly.
 _PICKLE_PROTOCOL = 5
-
-
-def _embedding_for_pickle(embedding: Any) -> np.ndarray | None:
-    """Coerce an embedding to a compact ``float32`` ndarray for serialisation.
-
-    Storing the vector as a contiguous ``float32`` array (rather than the old
-    Python ``list`` of boxed floats) roughly halves its pickled footprint and
-    avoids reconstructing hundreds of ``PyFloat`` objects per media on load —
-    the load side already runs every embedding through ``l2_normalize`` /
-    ``np.asarray``, so it accepts arrays and legacy lists alike.
-    """
-    if embedding is None:
-        return None
-    return np.ascontiguousarray(embedding, dtype=np.float32)
-
-
-def _embeddings_dict_for_pickle(embeddings: Any) -> dict[str, np.ndarray] | None:
-    """Coerce a per-embedder ``{name: vector}`` map to compact ``float32`` arrays.
-
-    Returns ``None`` when there is nothing to store (no dict / empty), so a
-    legacy single-vector media adds no key to the pickle and a v3 media carries
-    one entry per bound embedder.  Entries whose vector coerces to ``None`` are
-    dropped.
-    """
-    if not isinstance(embeddings, dict) or not embeddings:
-        return None
-    out: dict[str, np.ndarray] = {}
-    for name, vec in embeddings.items():
-        coerced = _embedding_for_pickle(vec)
-        if name and coerced is not None:
-            out[name] = coerced
-    return out or None
 
 
 def _copy_original_payload(entry: dict[str, Any], media: dict[str, Any]) -> None:

--- a/vtscore/datasets/loader_common.py
+++ b/vtscore/datasets/loader_common.py
@@ -1,0 +1,102 @@
+"""Shared helpers for the dataset loaders.
+
+A dependency-free leaf that :mod:`vtscore.datasets.loader` and each of its
+implementation siblings (``loader_folder`` / ``loader_pickle`` /
+``loader_demo``) import.  It exists so the façade can import its siblings at
+the *top* of the file: when these helpers lived in ``loader.py`` itself, every
+sibling imported back up into the partially-initialised façade, and the only
+way to make that work was to push the façade's own imports to the bottom of
+the file behind ``# noqa: E402``.
+
+Nothing here performs I/O or touches the media registry; the module-level
+imports are deliberately limited to numpy so importing it can never pull in a
+cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import numpy as np
+
+#: Signature of the progress reporter every public loader accepts:
+#: ``(status, message, current, total) -> None``.
+ProgressCallback = Callable[[str, str, int, int], None]
+
+
+def _default_progress() -> ProgressCallback:
+    """Lazily resolve the progress callback for the current thread.
+
+    Checks for a per-thread callback first (set during parallel dataset
+    loading) and falls back to the global singleton.
+    """
+    from vtscore.concurrency.progress import get_thread_progress
+
+    cb = get_thread_progress()
+    if cb is not None:
+        return cb
+    from vtscore.concurrency.progress import update_progress
+
+    return update_progress
+
+
+def _pop_md5_key(d: dict[str, Any]) -> str:
+    """Pop and return the MD5 value from *d*, trying both ``"md5"`` and ``"MD5"`` keys.
+
+    Returns the value (or ``""`` if neither key is present) and removes the
+    matched key from *d* so it doesn't leak into downstream metadata.
+    """
+    for key in ("md5", "MD5"):
+        val = d.get(key)
+        if val:
+            del d[key]
+            return val
+    return ""
+
+
+def _get_md5_value(d: dict[str, Any]) -> str:
+    """Return the MD5 value from *d*, trying both ``"md5"`` and ``"MD5"`` keys.
+
+    Unlike :func:`_pop_md5_key` this does **not** mutate *d*.
+    """
+    return d.get("md5") or d.get("MD5") or ""
+
+
+def _get_embedding_value(d: dict[str, Any]) -> Any:
+    """Return the embedding value from *d* without mutating it.
+
+    Returns ``None`` when the key is absent.
+    """
+    return d.get("embedding")
+
+
+def _embedding_for_pickle(embedding: Any) -> np.ndarray | None:
+    """Coerce an embedding to a compact ``float32`` ndarray for serialisation.
+
+    Storing the vector as a contiguous ``float32`` array (rather than the old
+    Python ``list`` of boxed floats) roughly halves its pickled footprint and
+    avoids reconstructing hundreds of ``PyFloat`` objects per media on load —
+    the load side already runs every embedding through ``l2_normalize`` /
+    ``np.asarray``, so it accepts arrays and legacy lists alike.
+    """
+    if embedding is None:
+        return None
+    return np.ascontiguousarray(embedding, dtype=np.float32)
+
+
+def _embeddings_dict_for_pickle(embeddings: Any) -> dict[str, np.ndarray] | None:
+    """Coerce a per-embedder ``{name: vector}`` map to compact ``float32`` arrays.
+
+    Returns ``None`` when there is nothing to store (no dict / empty), so a
+    legacy single-vector media adds no key to the pickle and a v3 media carries
+    one entry per bound embedder.  Entries whose vector coerces to ``None`` are
+    dropped.
+    """
+    if not isinstance(embeddings, dict) or not embeddings:
+        return None
+    out: dict[str, np.ndarray] = {}
+    for name, vec in embeddings.items():
+        coerced = _embedding_for_pickle(vec)
+        if name and coerced is not None:
+            out[name] = coerced
+    return out or None

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -4,10 +4,10 @@ Wraps each media type's :meth:`MediaType.load_demo_source` with pickle
 caching and origin-stamping.  Split out from
 :mod:`vtscore.datasets.loader` for navigability.
 
-To keep the existing test patches working
-(``patch("vtscore.datasets.loader.load_dataset_from_pickle", ...)`` and
-``patch("vtscore.datasets.loader.EMBEDDINGS_DIR", ...)``), the call sites
-go through the parent ``loader`` module so the lookup happens at call time.
+``EMBEDDINGS_DIR`` and ``load_dataset_from_pickle`` are bound here as
+module globals, so tests that need to redirect the demo pickle cache patch
+them on *this* module (``patch("vtscore.datasets.loader_demo.EMBEDDINGS_DIR",
+...)``) rather than reaching through the façade.
 """
 
 from __future__ import annotations
@@ -17,12 +17,15 @@ from typing import Any, Optional
 
 import numpy as np
 
+from vtscore.config import EMBEDDINGS_DIR
 from vtscore.embedding.stack import embedding_stack
 from vtscore.datasets.config import DEMO_DATASETS
-from vtscore.datasets.loader import (
+from vtscore.datasets.loader_common import (
     ProgressCallback,
     _default_progress,
+    _embeddings_dict_for_pickle,
 )
+from vtscore.datasets.loader_pickle import load_dataset_from_pickle
 
 
 def _effective_clipper(clipper_name: str, media_type_id: str) -> str:
@@ -109,8 +112,6 @@ def _try_load_cached(
     case the stale pickle (if any) has been unlinked and the caller should
     rebuild from scratch.
     """
-    from vtscore.datasets import loader as _loader
-
     if not pkl_file.exists():
         return False
 
@@ -147,7 +148,7 @@ def _try_load_cached(
     # entire load, which reads as "nothing is happening" right after the user
     # clicks Import.  ``load_dataset_from_pickle`` emits "Reading <file>…" and
     # then a per-item "Processing i of N items…" tick.
-    _loader.load_dataset_from_pickle(pkl_file, medias, on_progress=on_progress)
+    load_dataset_from_pickle(pkl_file, medias, on_progress=on_progress)
 
     # Check if any medias were actually loaded
     if len(medias) == 0:
@@ -239,10 +240,6 @@ def load_demo_dataset(
         ValueError: If ``dataset_name`` is not in ``DEMO_DATASETS``, or if the
             media type does not support the requested demo source.
     """
-    # Look up via the parent module so `patch("vtscore.datasets.loader.X")`
-    # in tests continues to take effect at call time.
-    from vtscore.datasets import loader as _loader
-
     if on_progress is None:
         on_progress = _default_progress()
 
@@ -256,7 +253,7 @@ def load_demo_dataset(
     cache_key = f"{dataset_name}__{converter_name}" if converter_name else dataset_name
 
     # Check if already embedded
-    pkl_file = _loader.EMBEDDINGS_DIR / f"{cache_key}.pkl"
+    pkl_file = EMBEDDINGS_DIR / f"{cache_key}.pkl"
     if _try_load_cached(
         pkl_file,
         dataset_name,
@@ -398,12 +395,6 @@ def _write_demo_cache(
     file the external dir resolves by name, so its bytes must ride in the
     pickle (dataset pickles are the one place persisted bytes are allowed).
     """
-    from vtscore.datasets import loader as _loader
-
-    # Local import avoids a circular import at module load (loader imports
-    # loader_demo before this helper is defined).
-    from vtscore.datasets.loader import _embeddings_dict_for_pickle
-
     store_external = external_dir is not None and not converter_name and not clipper_applied
 
     def _pickle_media(media: dict[str, Any]) -> dict[str, Any]:
@@ -420,7 +411,7 @@ def _write_demo_cache(
     if store_external:
         pkl_data[mt.dir_key] = external_dir
 
-    _loader.EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
+    EMBEDDINGS_DIR.mkdir(parents=True, exist_ok=True)
 
     resolved_name = getattr(embedder, "name", "") if embedder is not None else ""
 

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -20,7 +20,7 @@ from contextlib import closing
 from pathlib import Path
 from typing import Any, Callable, Generator, Iterator, Optional
 
-from vtscore.datasets.loader import (
+from vtscore.datasets.loader_common import (
     ProgressCallback,
     _default_progress,
     _get_embedding_value,

--- a/vtscore/datasets/loader_pickle.py
+++ b/vtscore/datasets/loader_pickle.py
@@ -12,9 +12,7 @@ import logging
 from pathlib import Path
 from typing import Any, Iterator
 
-from vtscore.datasets.loader import (
-    ProgressCallback,
-)
+from vtscore.datasets.loader_common import ProgressCallback
 from vtscore.embedding.normalize import l2_normalize
 from vtscore.utils.hashing import content_md5
 

--- a/vtscore/docs/packages/datasets.md
+++ b/vtscore/docs/packages/datasets.md
@@ -28,7 +28,8 @@ The largest package in the library. Every module, grouped by role.
 
 | Module | Concern |
 |--------|---------|
-| `vtscore/datasets/loader.py` | `export_dataset_to_file` and the shared loader surface |
+| `vtscore/datasets/loader.py` | `export_dataset_to_file` and the loader re-export façade |
+| `vtscore/datasets/loader_common.py` | Helpers shared by the three loader modules (leaf; no cycles) |
 | `vtscore/datasets/loader_folder.py` | Folder loaders (whole and chunked) |
 | `vtscore/datasets/loader_pickle.py` | Pickle loaders (whole and chunked) |
 | `vtscore/datasets/loader_demo.py` | Demo-dataset loader |
@@ -198,7 +199,14 @@ disagreeing labels across inputs are silently removed. See
 ## Loaders and exporter
 
 The public surface in `vtscore/datasets/loader.py` is a re-export façade
-over three sibling modules:
+over three sibling modules. It re-exports **loaders only** — the demo
+metadata parsers live in `vtscore/datasets/metadata.py` and the
+pickle-safety names in `vtscore/security/pickle.py`; import those from
+their own modules rather than through the façade. Helpers the three
+siblings share (`ProgressCallback`, `_default_progress`, the MD5 and
+embedding coercion helpers) live in `vtscore/datasets/loader_common.py`,
+a dependency-free leaf, so the façade can import its siblings at the top
+of the file instead of at the bottom to dodge a cycle.
 
 | Function                        | Module                    | Populates / returns                                  |
 |---------------------------------|---------------------------|------------------------------------------------------|

--- a/vtscore/media/audio/_demo_sources.py
+++ b/vtscore/media/audio/_demo_sources.py
@@ -777,7 +777,7 @@ def _collect_audio_files(
 
     if source == "gtzan":
         from vtscore.datasets.downloader import download_gtzan  # noqa: PLC0415
-        from vtscore.datasets.loader import load_audio_metadata_from_folders  # noqa: PLC0415
+        from vtscore.datasets.metadata import load_audio_metadata_from_folders  # noqa: PLC0415
 
         audio_dir = download_gtzan(on_progress=on_progress)
         metadata = load_audio_metadata_from_folders(audio_dir, categories)
@@ -786,7 +786,7 @@ def _collect_audio_files(
 
     if source == "speech_commands_v2":
         from vtscore.datasets.downloader import download_speech_commands_v2  # noqa: PLC0415
-        from vtscore.datasets.loader import load_audio_metadata_from_folders  # noqa: PLC0415
+        from vtscore.datasets.metadata import load_audio_metadata_from_folders  # noqa: PLC0415
 
         audio_dir = download_speech_commands_v2(on_progress=on_progress)
         metadata = load_audio_metadata_from_folders(audio_dir, categories)
@@ -795,7 +795,7 @@ def _collect_audio_files(
 
     if source == "urbansound8k":
         from vtscore.datasets.downloader import download_urbansound8k  # noqa: PLC0415
-        from vtscore.datasets.loader import load_urbansound8k_metadata  # noqa: PLC0415
+        from vtscore.datasets.metadata import load_urbansound8k_metadata  # noqa: PLC0415
 
         us8k_dir = download_urbansound8k(on_progress=on_progress)
         metadata = load_urbansound8k_metadata(us8k_dir)
@@ -834,7 +834,7 @@ def _collect_audio_files(
 
     if not source or source == "esc50":
         from vtscore.datasets.downloader import download_esc50  # noqa: PLC0415
-        from vtscore.datasets.loader import load_esc50_metadata  # noqa: PLC0415
+        from vtscore.datasets.metadata import load_esc50_metadata  # noqa: PLC0415
 
         audio_dir = download_esc50(on_progress=on_progress)
         esc_metadata = load_esc50_metadata(audio_dir.parent)

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -743,7 +743,7 @@ _FILE_SOURCE_DOWNLOADERS: dict[str, str] = {
 def _collect_simple_folder_files(source, categories, slice_args, on_progress) -> list:
     """Sources that just download → load_image_metadata_from_folders → group by category."""
     from vtscore.datasets import downloader  # noqa: PLC0415
-    from vtscore.datasets.loader import load_image_metadata_from_folders  # noqa: PLC0415
+    from vtscore.datasets.metadata import load_image_metadata_from_folders  # noqa: PLC0415
 
     download_fn = getattr(downloader, _FILE_SOURCE_DOWNLOADERS[source])
     img_dir = download_fn(on_progress=on_progress)
@@ -781,7 +781,7 @@ def _collect_vggface2_files(categories, slice_args, on_progress) -> list:
 
 def _collect_oxford_flowers_files(categories, slice_args, on_progress) -> list:
     from vtscore.datasets.downloader import download_oxford_flowers  # noqa: PLC0415
-    from vtscore.datasets.loader import load_oxford_flowers_metadata  # noqa: PLC0415
+    from vtscore.datasets.metadata import load_oxford_flowers_metadata  # noqa: PLC0415
 
     flowers_dir = download_oxford_flowers(on_progress=on_progress)
     metadata = load_oxford_flowers_metadata(flowers_dir, OXFORD_FLOWERS_CATEGORIES)
@@ -864,7 +864,7 @@ def _collect_enrico_files(categories, slice_args, on_progress) -> list:
 
 def _collect_places365_files(categories, slice_args, on_progress) -> list:
     from vtscore.datasets.downloader import download_places365  # noqa: PLC0415
-    from vtscore.datasets.loader import load_places365_metadata  # noqa: PLC0415
+    from vtscore.datasets.metadata import load_places365_metadata  # noqa: PLC0415
 
     places_dir = download_places365(on_progress=on_progress)
     metadata = load_places365_metadata(places_dir, PLACES365_CATEGORIES)
@@ -879,7 +879,7 @@ def _collect_places365_files(categories, slice_args, on_progress) -> list:
 def _collect_cifar10_images(categories, slice_args, on_progress) -> list:
     """Returns a list of (image_array, category) tuples."""
     from vtscore.datasets.downloader import download_cifar10  # noqa: PLC0415
-    from vtscore.datasets.loader import load_cifar10_batch  # noqa: PLC0415
+    from vtscore.datasets.metadata import load_cifar10_batch  # noqa: PLC0415
 
     cifar_dir = download_cifar10(on_progress=on_progress)
     images, labels, label_names = load_cifar10_batch(cifar_dir / "data_batch_1")

--- a/vtscore/media/video/_demo_sources.py
+++ b/vtscore/media/video/_demo_sources.py
@@ -470,7 +470,7 @@ def load_demo_source(  # noqa: C901 - flat per-item embed/defer branching
         raise ValueError(f"Unsupported video source: {source!r}")
 
     import vtscore.datasets.downloader as dl_module  # noqa: PLC0415
-    from vtscore.datasets.loader import load_video_metadata_from_folders  # noqa: PLC0415
+    from vtscore.datasets.metadata import load_video_metadata_from_folders  # noqa: PLC0415
 
     download_fn = getattr(dl_module, downloader_name)
     video_dir = download_fn(on_progress=on_progress)


### PR DESCRIPTION
`vtscore/datasets/loader.py` imported its three implementation siblings at the **bottom** of the file behind `# noqa: E402`, because each of them imported shared helpers back up from it — a genuine circular-import dance. The same cycle forced `loader_demo.py` to look `load_dataset_from_pickle` and `EMBEDDINGS_DIR` up through the parent module at call time, and to import `_embeddings_dict_for_pickle` inside a function with a comment explaining why.

## What changed

**The cycle is gone.** The shared helpers (`ProgressCallback`, `_default_progress`, the MD5 getters, the embedding-coercion helpers) move into a new dependency-free leaf, `vtscore/datasets/loader_common.py`, which the façade and all three siblings import. With nothing importing back up, the façade's own imports move to the top of the file, every `# noqa: E402` goes away, and `vtscore.datasets.loader` now imports cleanly whichever of the four modules is reached first.

`loader_demo.py` correspondingly binds `EMBEDDINGS_DIR` and `load_dataset_from_pickle` as ordinary module globals instead of reaching through `_loader.` at call time.

**Incidental re-exports dropped from the façade:**

- the demo **metadata parsers**, now imported from their real home (`vtscore.datasets.metadata`) by the nine lazy call sites in `vtscore/media/*/_demo_sources.py`, two experiment scripts, and the download tests that were patching them *through* the façade (`patch.object(loader_module, "load_places365_metadata", …)` → `patch.object(metadata_module, …)`);
- the `vtscore.security.pickle` names (`RestrictedUnpickler`, `_PICKLE_SAFE_CLASSES`, `safe_pickle_load`), which had **zero** in-tree consumers besides one test;
- the private `_apply_converter_to_demo` alias, referenced only by tests, which now call `vtscore.converters.runner.apply_converter_to_demo` directly.

Test/script patch targets follow the code: the demo pickle cache is redirected on `vtscore.datasets.loader_demo`, and the experiment-script helpers read `EMBEDDINGS_DIR` from `vtscore.config`.

## What deliberately did *not* change

The issue asks to "dissolve" the façade. The **loader** re-exports stay. `vtscore.datasets.loader` is a documented library entry point — it appears in `vtscore/docs/quickstart.md`, `integration.md`, `faq.md`, `tutorials/train-and-score.md`, `docs/EXTENDING-plugins.md` and `docs/ARCHITECTURE.md` — with ~50 in-tree call sites and ~140 test references. Repointing all of them at `loader_folder` / `loader_pickle` / `loader_demo` would be an extension-facing break (CLAUDE.md § Backwards Compatibility) bought with pure churn and no functional gain. What the façade should not be is a dumping ground for *unrelated* names, and that part is now fixed.

The issue's stated direction also predicted the bottom imports could move up once the metadata imports and `_loader.` lookups were repointed. That alone would not have done it: the cycle was caused by the **shared helpers** living in `loader.py`, which all three siblings import at module top and which the listed steps never touch. Hence `loader_common.py`.

## One unrelated fix, carried because it blocked the run

`scripts/check-extension-docs.py` fails on `dev` as of `90626277`: `docs/EXTENDING-plugins.md`'s "The dirty-key contract" heading matches the `^the .*contract$` pattern invariant 2 polices, but the section was never registered in `SECTIONS`, so the gate blocks *every* `./run-tests.sh` run — two PRs landing independently, one adding the gate and one adding the section. The last commit registers it against `UserSyncState` (the class whose `dirty_keys` the section documents); every name it cites resolves. Not part of #3393, but there is no CI backstop here and the gate is fail-fast, so it had to be fixed to test anything at all.

## Testing

Rebased onto `dev`@`90626277`. Full `./run-tests.sh`: 9668 passed, 6 skipped, 1 xfailed, 1 xpassed; pyright, pip-audit, npm audit, and the Vitest suite all green. `./run-tests.sh vtscore-clean` also green, confirming the new leaf module keeps the library tier import-clean.

Closes #3393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EF887bKpivUWWnZYXfmApn