### PR TITLE
Give simulate_voting_iterations a keyword-only boundary and named mirror anchors

### DIFF
--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -235,11 +235,11 @@ MIRRORS: list[Mirror] = [
     Mirror(
         id="training.blend_schedule_default",
         app="py:vtscore.detectors.training._blend_schedule_for_snap",
-        harness="vtscore/eval/voting_iterations.py::simulate_voting_iterations",
+        harness="vtscore/eval/voting_iterations.py::_resolve_production_defaults",
         kind="default",
         note=(
             "How the app picks a safe-threshold blend schedule when none is named (per voting "
-            "mode). simulate_voting_iterations resolves blend_schedule=None through "
+            "mode). _resolve_production_defaults resolves blend_schedule=None through "
             "production_schedule_for to match; if the app's choice becomes conditional on "
             "something else, that condition has to reach the harness too."
         ),
@@ -247,14 +247,14 @@ MIRRORS: list[Mirror] = [
     Mirror(
         id="training.split_fraction_default",
         app="py:vtscore.detectors.training.resolve_calibration_fraction",
-        harness="vtscore/eval/voting_iterations.py::simulate_voting_iterations",
+        harness="vtscore/eval/voting_iterations.py::_resolve_production_defaults",
         kind="default",
         note=(
             "How the app resolves calibration_fraction when the user has no explicit setting "
             "(#3287/#3290): the per-SPACE production split - 0.3 when the detector learns in a "
             "single-vector space, 0.5 on a patch grid, 0.5 when unknown - keyed on the "
             "embedder's supports_patch_regions capability, NOT on the voting mode. "
-            "simulate_voting_iterations resolves calibration_fraction=None through the same "
+            "_resolve_production_defaults resolves calibration_fraction=None through the same "
             "production_split_for table, keyed on whether any media carries a patch_grid (the "
             "harness's spelling of 'built by a patch embedder'). The values themselves cannot "
             "drift - both sides read PRODUCTION_SPLIT_BY_SPACE - so what this digest watches is "

--- a/tests_lib/detectors/test_eval_app_sync.py
+++ b/tests_lib/detectors/test_eval_app_sync.py
@@ -9,6 +9,7 @@ a logic change, and it stays quiet for everything else.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
@@ -188,3 +189,49 @@ class TestResolutionFailures:
     def test_deleted_harness_file_is_an_error(self):
         with pytest.raises(gate.MirrorError, match="does not exist"):
             gate._check_harness_side(self._mirror(harness="vtscore/eval/no_such_file.py::thing"))
+
+
+class TestHarnessAnchorsAreSpecific:
+    """A mirror's harness side must name the code that does the mirroring.
+
+    ``_check_harness_side`` is a substring test on the file, so *any* name that
+    survives in the text satisfies it.  That makes a coarse anchor two kinds of
+    useless at once: the gate's failure message points the reconciler at the
+    whole enclosing function instead of at the reproduction, and the existence
+    check passes even when the reproduction itself has been deleted, because the
+    function around it is still there.
+
+    Both ``training.*_default`` mirrors used to name the thousand-line
+    ``simulate_voting_iterations`` for exactly that reason (#3403).  They now
+    name the small helper that resolves the defaults, so deleting a resolution
+    trips the gate.  Pin the property rather than the helper's current name.
+    """
+
+    #: Mirror id -> the app-side call its harness anchor must contain.
+    RESOLUTION_CALLS = {
+        "training.blend_schedule_default": "production_schedule_for",
+        "training.split_fraction_default": "production_split_for",
+    }
+
+    def _harness_function_source(self, mirror) -> str:
+        rel, _, symbol = mirror.harness.partition("::")
+        tree = ast.parse((gate.REPO_ROOT / rel).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == symbol:
+                return ast.get_source_segment((gate.REPO_ROOT / rel).read_text(encoding="utf-8"), node) or ""
+        raise AssertionError(f"{symbol!r} is not a function in {rel}")
+
+    @pytest.mark.parametrize("mirror_id", sorted(RESOLUTION_CALLS))
+    def test_anchor_contains_the_resolution_it_claims_to_pin(self, mirror_id):
+        mirror = next(m for m in gate.MIRRORS if m.id == mirror_id)
+        source = self._harness_function_source(mirror)
+        assert self.RESOLUTION_CALLS[mirror_id] in source, (
+            f"{mirror_id} names {mirror.harness}, which no longer resolves the default it pins"
+        )
+
+    @pytest.mark.parametrize("mirror_id", sorted(RESOLUTION_CALLS))
+    def test_anchor_is_small_enough_to_read(self, mirror_id):
+        """The reconciler reads this function when the gate trips."""
+        mirror = next(m for m in gate.MIRRORS if m.id == mirror_id)
+        lines = self._harness_function_source(mirror).count("\n") + 1
+        assert lines < 120, f"{mirror_id} points at {lines} lines; a tripped gate should not need a tour"

--- a/tests_lib/detectors/test_voting_iterations_signature.py
+++ b/tests_lib/detectors/test_voting_iterations_signature.py
@@ -1,0 +1,73 @@
+"""The call surface of ``simulate_voting_iterations``.
+
+Forty-odd knobs is what a pre-registered experiment harness looks like, and
+that is fine - but only while they are *named*.  As plain positional-or-keyword
+parameters they were an ordering hazard with no error attached to it: inserting
+one mid-list rebinds every caller that passed the neighbours positionally, and
+the run does not crash, it silently measures a different arm.  Study code is the
+worst possible place for that failure mode, because a wrong-but-plausible
+trajectory is indistinguishable from a real result.
+
+So the keyword-only boundary is pinned here rather than left to review.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE = REPO_ROOT / "vtscore" / "eval" / "voting_iterations.py"
+
+#: The only three arguments a caller may pass positionally: the pool, the
+#: category it is detecting, and the seed that makes the cell reproducible.
+POSITIONAL = ("clips_dict", "target_category", "seed")
+
+
+def _signature() -> ast.arguments:
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "simulate_voting_iterations":
+            return node.args
+    raise AssertionError("simulate_voting_iterations not found in vtscore/eval/voting_iterations.py")
+
+
+class TestKeywordOnlyBoundary:
+    def test_only_the_three_core_arguments_are_positional(self):
+        args = _signature()
+        assert tuple(a.arg for a in args.args) == POSITIONAL
+        assert not args.posonlyargs
+
+    def test_every_experiment_knob_is_keyword_only(self):
+        """The knobs live after ``*``, so their order cannot be load-bearing."""
+        args = _signature()
+        assert len(args.kwonlyargs) > 30, (
+            "the experiment knobs moved back in front of the `*` marker; a new "
+            "parameter inserted mid-list would silently rebind positional callers"
+        )
+
+    def test_no_caller_relies_on_more_than_the_core_positionals(self):
+        """The boundary is only safe while nothing passes past it positionally.
+
+        Scanned over the tree rather than trusted: an experiment script that
+        spread a fourth positional argument would fail at import time in a
+        SLURM job rather than here.
+        """
+        offenders = []
+        for path in REPO_ROOT.rglob("*.py"):
+            if "node_modules" in path.parts:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+                if name != "simulate_voting_iterations":
+                    continue
+                if len(node.args) > len(POSITIONAL) or any(isinstance(a, ast.Starred) for a in node.args):
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+        assert not offenders, "callers passing past the keyword-only boundary: " + ", ".join(offenders)

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -366,7 +366,7 @@ def resolve_calibration_fraction(calibration_fraction: float | None, embedder_na
     space is unknown - see
     :func:`vtscore.training.thresholds.production_split_for`.
 
-    Mirrored by the eval harness: ``simulate_voting_iterations`` resolves
+    Mirrored by the eval harness: ``_resolve_production_defaults`` resolves
     ``calibration_fraction=None`` through the same
     :func:`~vtscore.training.thresholds.production_split_for` table, keyed on
     whether the dataset carries a ``patch_grid`` (its spelling of "built by a

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -3713,10 +3713,216 @@ def _apply_skyline_decomposition(rows: list[dict[str, Any]], skyline_rows: list[
 # ------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class _RunKnobs:
+    """The pre-registered knobs of one :func:`simulate_voting_iterations` cell.
+
+    A record rather than a tuple, so adding a knob cannot silently rebind the
+    existing ones at the unpacking call site - the same hazard the keyword-only
+    marker on :func:`simulate_voting_iterations` closes for its callers.
+    """
+
+    fold_schedule: "Callable[[int], int] | None"
+    startup_state: StartupState | None
+    skyline_arms: list[str]
+    head: str
+
+
+def _resolve_head(head: Optional[str], trainer: str) -> str:
+    """Validate an explicit MLP head name, or resolve ``None`` to the app's.
+
+    Raises:
+        ValueError: If *head* is not a known head, or is given for a trainer
+            that fits its own estimator rather than a head.
+    """
+
+    if head is not None:
+        if head not in HEADS:
+            raise ValueError(f"unknown head {head!r}; expected one of {HEADS}")
+        if trainer != "mlp":
+            raise ValueError(f"head={head!r} only applies to the production trainer; got trainer={trainer!r}")
+    # **The default arm must be the app's default.**  Production pins the linear
+    # SVM head on every fit (``hidden_dim = LINEAR_SVM_HEAD`` in
+    # ``vtscore.detectors.training.train_and_threshold``), so an unspecified head
+    # resolves to it — the same way *style* and *blend_schedule* resolve to the
+    # app's geometry and schedule below.  The head fits the final model *and*
+    # the calibration folds, so it moves the thresholds and, through the vote
+    # order, the whole trajectory: defaulting to a retired head would make every
+    # unqualified run measure a detector nobody ships.  ``head="linear"`` (the
+    # logistic head) and ``head="mlp"`` stay available as named legacy arms.
+    head = head or PRODUCTION_HEAD
+    return head
+
+
+def _resolve_startup_state(
+    startup_schedule: Optional[str],
+    seed_scores: Optional[dict[int, float]],
+    autopilot_fidelity: bool,
+    strategy: str,
+) -> StartupState | None:
+    """Parse an explicit startup schedule, checking the run can actually honour it.
+
+    Raises:
+        ValueError: If a schedule is named without the seed sort it addresses
+            positions on, or outside the faithful autopilot strategy it steers.
+    """
+
+    startup_state: StartupState | None = None
+    if startup_schedule:
+        if seed_scores is None:
+            raise ValueError(
+                "startup_schedule needs seed_scores: a schedule names positions on the "
+                "seed sort, and there is no sort to name them on without one"
+            )
+        if not autopilot_fidelity or strategy != "autopilot":
+            raise ValueError("startup_schedule requires autopilot_fidelity and the autopilot strategy")
+        startup_state = StartupState(parse_startup_schedule(startup_schedule))
+    return startup_state
+
+
+def _resolve_run_knobs(
+    *,
+    fold_count_schedule: str | None,
+    calibrate_count: int,
+    startup_schedule: Optional[str],
+    seed_scores: Optional[dict[int, float]],
+    autopilot_fidelity: bool,
+    strategy: str,
+    skyline_arms: Optional[list[str]],
+    emit_calibration_metrics: bool,
+    acq_inclusion_offset: int,
+    acq_rank_percentile: Optional[float],
+    head: Optional[str],
+    trainer: str,
+    style: Optional[str],
+) -> _RunKnobs:
+    """Validate a cell's pre-registered knobs and resolve the defaults among them.
+
+    Called from the top of :func:`simulate_voting_iterations`, before anything
+    expensive runs, and the only place these checks belong: a run that dies
+    forty minutes in on a typo has held a cluster slot for nothing, so a
+    malformed knob has to kill the cell at second zero.  Gathering them under
+    one name is what keeps that contract visible - a ``raise`` added deep in the
+    stepping loop now reads as an obvious departure rather than as one more line
+    among seven hundred.
+
+    Note this resolves only the defaults that can be decided from the arguments
+    alone.  The two that need the loaded pool - the detection *style* and the
+    pair in :func:`_resolve_production_defaults` - are keyed on ``region_aware``
+    and so are resolved later, once the medias have been read.
+
+    Raises:
+        ValueError: If a knob is malformed, or two knobs are mutually exclusive.
+    """
+
+    # These are pre-registered experiment knobs, so they are validated beside
+    # the other argument checks rather than deep in the loop: a run that dies
+    # forty minutes in on a typo has held a cluster slot for nothing.
+    # Parsed here, with the other pre-registered knobs, and not in the loop: a
+    # malformed schedule must kill the cell at second zero rather than forty
+    # minutes in, and the parse is what validates the spec at all.
+    _fold_schedule = parse_fold_count_schedule(fold_count_schedule, calibrate_count)
+
+    startup_state = _resolve_startup_state(startup_schedule, seed_scores, autopilot_fidelity, strategy)
+
+    skyline_arms = list(skyline_arms or [])
+    if skyline_arms:
+        unknown = [a for a in skyline_arms if a not in SKYLINE_ARMS]
+        if unknown:
+            raise ValueError(f"unknown skyline arm(s) {unknown}; expected a subset of {list(SKYLINE_ARMS)}")
+        if not emit_calibration_metrics:
+            raise ValueError(
+                "skyline_arms requires emit_calibration_metrics: the decomposition is defined "
+                "against the calibration frame's oracle_cost/regret columns, which the plain "
+                "frame does not carry"
+            )
+
+    if acq_rank_percentile is not None:
+        if acq_inclusion_offset != 0:
+            raise ValueError(
+                "acq_inclusion_offset and acq_rank_percentile are mutually exclusive; "
+                "pass acq_inclusion_offset=0 to run the rank-pinned arm "
+                f"(the default is {ACQUISITION_INCLUSION_OFFSET}, the shipped acquisition cut)"
+            )
+        if not 0.0 <= acq_rank_percentile <= 1.0:
+            raise ValueError(f"acq_rank_percentile must be in [0, 1], got {acq_rank_percentile}")
+
+    head = _resolve_head(head, trainer)
+
+    if style is not None and trainer != "mlp":
+        raise ValueError(f"detection styles only support the MLP trainer; got trainer={trainer!r}")
+    return _RunKnobs(
+        fold_schedule=_fold_schedule,
+        startup_state=startup_state,
+        skyline_arms=skyline_arms,
+        head=head,
+    )
+
+
+def _resolve_production_defaults(
+    *,
+    blend_schedule: Optional[str],
+    calibration_fraction: Optional[float],
+    region_aware: bool,
+) -> tuple[str, float]:
+    """Resolve the unnamed blend schedule and split fraction to the app's own.
+
+    **The eval default arm must be the app's default.**  Both ``default``
+    mirrors in ``scripts/check-eval-app-sync.py`` -
+    ``training.blend_schedule_default`` and ``training.split_fraction_default`` -
+    name *this* function as their harness side, so a tripped gate points the
+    reconciler at twenty lines instead of at the thousand that make up
+    :func:`simulate_voting_iterations`.  It also gives that gate something real
+    to check: its harness-side test is an existence check on the named symbol,
+    which the enclosing function would satisfy even if both resolutions below
+    were deleted outright.
+
+    Both resolutions are keyed on *region_aware* - whether any media in the pool
+    carries a ``patch_grid`` - which is why they run here rather than in
+    :func:`_resolve_run_knobs`, alongside the knobs that need no pool.
+
+    Args:
+        blend_schedule: The named schedule arm, or ``None`` for the default.
+        calibration_fraction: The explicit Train/Calibrate split, or ``None``.
+        region_aware: Whether the pool carries patch grids.
+
+    Returns:
+        The resolved ``(blend_schedule, calibration_fraction)`` pair.
+    """
+
+    # Mirror the app's per-mode schedule default (#2841): with no explicit arm, a
+    # patch dataset blends under the region schedule and a single-vector one
+    # under the binary schedule, exactly as `_blend_schedule_for_snap` decides in
+    # `vtscore.detectors.training`.  Without this the harness would measure a
+    # schedule no detector actually uses.
+    if blend_schedule is None:
+        from vtscore.training.blend_schedules import production_schedule_for  # noqa: PLC0415
+
+        blend_schedule = production_schedule_for(region_voting=region_aware)
+
+    # Mirror the app's per-space split default (#3287/#3290): with no explicit
+    # arm, the Train/Calibrate fraction of each fold is the one a live
+    # detector would resolve for this dataset's embedder.  ``region_aware``
+    # (any media carrying a ``patch_grid``) is the harness's spelling of "the
+    # pickle was built by a patch embedder" - the same capability the app
+    # reads off ``supports_patch_regions`` in
+    # ``vtscore.detectors.training.resolve_calibration_fraction``, which the
+    # ``training.split_fraction_default`` mirror in
+    # ``scripts/check-eval-app-sync.py`` pins against this block.  Note it is
+    # deliberately NOT the voting mode: ``dinov3_patch`` datasets take 0.5 in
+    # both their styles, including boxless ``whole_image``.
+    if calibration_fraction is None:
+        from vtscore.training.thresholds import production_split_for  # noqa: PLC0415
+
+        calibration_fraction = production_split_for(patch_space=region_aware)
+    return blend_schedule, calibration_fraction
+
+
 def simulate_voting_iterations(  # noqa: C901
     clips_dict: dict[int, dict[str, Any]],
     target_category: str,
     seed: int,
+    *,
     dataset_name: str = "",
     inclusion: int = 0,
     sim_fraction: float = 0.5,
@@ -3997,65 +4203,25 @@ def simulate_voting_iterations(  # noqa: C901
     # RNG seeding via fork_rng, keeping it thread-safe.
     start_time = time.monotonic()
 
-    # These are pre-registered experiment knobs, so they are validated beside
-    # the other argument checks rather than deep in the loop: a run that dies
-    # forty minutes in on a typo has held a cluster slot for nothing.
-    # Parsed here, with the other pre-registered knobs, and not in the loop: a
-    # malformed schedule must kill the cell at second zero rather than forty
-    # minutes in, and the parse is what validates the spec at all.
-    _fold_schedule = parse_fold_count_schedule(fold_count_schedule, calibrate_count)
-
-    startup_state: StartupState | None = None
-    if startup_schedule:
-        if seed_scores is None:
-            raise ValueError(
-                "startup_schedule needs seed_scores: a schedule names positions on the "
-                "seed sort, and there is no sort to name them on without one"
-            )
-        if not autopilot_fidelity or strategy != "autopilot":
-            raise ValueError("startup_schedule requires autopilot_fidelity and the autopilot strategy")
-        startup_state = StartupState(parse_startup_schedule(startup_schedule))
-
-    skyline_arms = list(skyline_arms or [])
-    if skyline_arms:
-        unknown = [a for a in skyline_arms if a not in SKYLINE_ARMS]
-        if unknown:
-            raise ValueError(f"unknown skyline arm(s) {unknown}; expected a subset of {list(SKYLINE_ARMS)}")
-        if not emit_calibration_metrics:
-            raise ValueError(
-                "skyline_arms requires emit_calibration_metrics: the decomposition is defined "
-                "against the calibration frame's oracle_cost/regret columns, which the plain "
-                "frame does not carry"
-            )
-
-    if acq_rank_percentile is not None:
-        if acq_inclusion_offset != 0:
-            raise ValueError(
-                "acq_inclusion_offset and acq_rank_percentile are mutually exclusive; "
-                "pass acq_inclusion_offset=0 to run the rank-pinned arm "
-                f"(the default is {ACQUISITION_INCLUSION_OFFSET}, the shipped acquisition cut)"
-            )
-        if not 0.0 <= acq_rank_percentile <= 1.0:
-            raise ValueError(f"acq_rank_percentile must be in [0, 1], got {acq_rank_percentile}")
-
-    if head is not None:
-        if head not in HEADS:
-            raise ValueError(f"unknown head {head!r}; expected one of {HEADS}")
-        if trainer != "mlp":
-            raise ValueError(f"head={head!r} only applies to the production trainer; got trainer={trainer!r}")
-    # **The default arm must be the app's default.**  Production pins the linear
-    # SVM head on every fit (``hidden_dim = LINEAR_SVM_HEAD`` in
-    # ``vtscore.detectors.training.train_and_threshold``), so an unspecified head
-    # resolves to it — the same way *style* and *blend_schedule* resolve to the
-    # app's geometry and schedule below.  The head fits the final model *and*
-    # the calibration folds, so it moves the thresholds and, through the vote
-    # order, the whole trajectory: defaulting to a retired head would make every
-    # unqualified run measure a detector nobody ships.  ``head="linear"`` (the
-    # logistic head) and ``head="mlp"`` stay available as named legacy arms.
-    head = head or PRODUCTION_HEAD
-
-    if style is not None and trainer != "mlp":
-        raise ValueError(f"detection styles only support the MLP trainer; got trainer={trainer!r}")
+    knobs = _resolve_run_knobs(
+        fold_count_schedule=fold_count_schedule,
+        calibrate_count=calibrate_count,
+        startup_schedule=startup_schedule,
+        seed_scores=seed_scores,
+        autopilot_fidelity=autopilot_fidelity,
+        strategy=strategy,
+        skyline_arms=skyline_arms,
+        emit_calibration_metrics=emit_calibration_metrics,
+        acq_inclusion_offset=acq_inclusion_offset,
+        acq_rank_percentile=acq_rank_percentile,
+        head=head,
+        trainer=trainer,
+        style=style,
+    )
+    _fold_schedule = knobs.fold_schedule
+    startup_state = knobs.startup_state
+    skyline_arms = knobs.skyline_arms
+    head = knobs.head
 
     prevalence_arm = "natural" if target_prevalence is None else f"rare_{target_prevalence:g}"
     if target_prevalence is not None:
@@ -4153,31 +4319,11 @@ def simulate_voting_iterations(  # noqa: C901
             stacklevel=2,
         )
         skyline_arms = []
-    # Mirror the app's per-mode schedule default (#2841): with no explicit arm, a
-    # patch dataset blends under the region schedule and a single-vector one
-    # under the binary schedule, exactly as `_blend_schedule_for_snap` decides in
-    # `vtscore.detectors.training`.  Without this the harness would measure a
-    # schedule no detector actually uses.
-    if blend_schedule is None:
-        from vtscore.training.blend_schedules import production_schedule_for  # noqa: PLC0415
-
-        blend_schedule = production_schedule_for(region_voting=region_aware)
-
-    # Mirror the app's per-space split default (#3287/#3290): with no explicit
-    # arm, the Train/Calibrate fraction of each fold is the one a live
-    # detector would resolve for this dataset's embedder.  ``region_aware``
-    # (any media carrying a ``patch_grid``) is the harness's spelling of "the
-    # pickle was built by a patch embedder" - the same capability the app
-    # reads off ``supports_patch_regions`` in
-    # ``vtscore.detectors.training.resolve_calibration_fraction``, which the
-    # ``training.split_fraction_default`` mirror in
-    # ``scripts/check-eval-app-sync.py`` pins against this block.  Note it is
-    # deliberately NOT the voting mode: ``dinov3_patch`` datasets take 0.5 in
-    # both their styles, including boxless ``whole_image``.
-    if calibration_fraction is None:
-        from vtscore.training.thresholds import production_split_for  # noqa: PLC0415
-
-        calibration_fraction = production_split_for(patch_space=region_aware)
+    blend_schedule, calibration_fraction = _resolve_production_defaults(
+        blend_schedule=blend_schedule,
+        calibration_fraction=calibration_fraction,
+        region_aware=region_aware,
+    )
 
     import torch  # noqa: PLC0415
 


### PR DESCRIPTION
Closes #3403

## The two hazards

**Forty-five positional-or-keyword parameters made argument order load-bearing with no error attached to it.** Inserting a knob mid-list rebinds the neighbours for any caller that passed them positionally — and a study run does not crash, it silently measures a different arm. That is the worst place for the failure mode, because a wrong-but-plausible trajectory is indistinguishable from a real result. An AST scan of every call site in the tree shows none passes more than `clips_dict` and `target_category` positionally, so a `*` after `seed` closes the hazard with no caller change.

**Both `training.*_default` mirrors named the whole thousand-line function as their harness side.** The issue frames this as navigability, which is true but undersells it: `_check_harness_side` is a plain substring test on the file text, so naming `simulate_voting_iterations` satisfied the check *even if both default resolutions were deleted outright*, because the enclosing function survives. The anchor was vacuous, not merely coarse. Both now name `_resolve_production_defaults` — twenty lines holding exactly what they pin — so a deleted resolution trips the gate, and a tripped gate points the reconciler at the reproduction instead of at a tour.

## Reconciliation

Done before re-pointing, which is the whole reason `--update` is not a checkbox. The app keys both defaults on the embedder's patch-grid capability (`_patch_embedder_for_snap` / `_patch_space_for`) and lets an explicit value win; the harness already did exactly that through `region_aware` (any media carrying a `patch_grid`). The predicates still agree, so nothing was owed — the extraction is a pure move, and `--update` re-pinned nothing. `check-eval-app-sync.py` reports 15 mirrors up to date.

## Also in the diff

The pre-registered knob validation moves out of the body as `_resolve_run_knobs`, with `_resolve_head` and `_resolve_startup_state` split off it (each is a cohesive resolution, and splitting them keeps every new helper under ruff's C901 limit rather than inheriting the old `# noqa`). This buys no gate strength — nothing mirrors it — but the block carries a real invariant that nothing enforced: *a malformed knob must kill the cell at second zero, because a run that dies forty minutes in on a typo has held a cluster slot for nothing*. Under one name, a `raise` added deep in the stepping loop now reads as a departure.

`simulate_voting_iterations` keeps its own `# noqa: C901`; at complexity 46 the extractions do not get it under the limit, and chasing that would mean restructuring the stepping loop, which is well outside this change.

## Tests

Two regressions, so neither improvement can erode silently:

- `tests_lib/detectors/test_voting_iterations_signature.py` — the keyword-only boundary holds, and no caller anywhere in the tree passes past it (scanned rather than trusted: an experiment script that spread a fourth positional would otherwise fail inside a SLURM job rather than here).
- `TestHarnessAnchorsAreSpecific` in `test_eval_app_sync.py` — each default mirror's harness anchor still *contains* the resolution it claims to pin, and stays small enough to read. Pins the property, not the helper's current name.

Full `./run-tests.sh`: 9488 passed, 6 skipped, 1 xfailed; pyright, pip-audit, npm audit and Vitest all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_014XjudeZ3zE6rXeogmDBygA)_