### PR TITLE
Extract autoSelectNext to a pure util and pin it as an eval mirror

### DIFF
--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -147,7 +147,7 @@ care.
 
 - [ ] #3417 — Extract browse-canvas's thumbnail store and animation controller (Opus 4.8)
 - [ ] #3423 — browse-bin-popup: split the member grid, then signalize (Sonnet 5 → Opus 4.8, staged)
-- [ ] #3428 — Promote `SortStateService` from anemic store to orchestrator; extract `autoSelectNext` (Opus 4.8)
+- [ ] #3428 — Promote `SortStateService` from anemic store to orchestrator (Opus 4.8)
 - [ ] #3433 — Promote `PanelResizeDirective` out of `label-view/` and document which drag shapes it covers (Sonnet 5)
 
 ## Frontend — duplication & dead code

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -26,7 +26,8 @@ import { LabelSessionService } from '../../services/label-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { LabelsetStateService } from '../../services/labelset-state.service';
-import { SortStateService, SortMode, SelectMode, SortedItem } from '../../services/sort-state.service';
+import { SortStateService, SortMode, SelectMode } from '../../services/sort-state.service';
+import { autoSelectNext as pickNextMedia } from '../../utils/auto-select-next';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { AutopilotStateService } from '../../services/autopilot-state.service';
 import { EmbedderCapabilityService } from '../../services/embedder-capability.service';
@@ -1453,46 +1454,27 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Helpers ---
 
+  /**
+   * Advance to the next media the current Sort + Select says to show.
+   *
+   * The rule itself lives in {@link autoSelectNext} (`utils/auto-select-next`)
+   * as a pure function so it can be unit-tested and so the eval harness's copy
+   * of it can be digest-pinned; this method is the side-effecting half —
+   * applying the selection, or firing the coverage-atlas probe the `new` mode
+   * asks for.
+   */
   private autoSelectNext(excludeId?: number): void {
-    const sortOrder = this.sortState.sortOrder;
-    if (!sortOrder || sortOrder.length === 0) return;
-    const goodVotes = this.voteState.goodVotes;
-    const badVotes = this.voteState.badVotes;
-
-    const isVoted = (id: number): boolean =>
-      id === excludeId || goodVotes.has(id) || badVotes.has(id);
-
-    if (this.sortState.selectMode === 'top') {
-      const next = sortOrder.find((s) => !isVoted(s.id));
-      if (next) this.mediaState.selectMedia(next.id);
-    } else if (this.sortState.selectMode === 'hard' && this.sortState.acqThreshold !== null) {
-      // The *acquisition* cut, not the decision line: this reads the threshold
-      // as a rank position, which is why it wants one further up the ranking
-      // than the one the user is shown (#2876).
-      const threshold = this.sortState.acqThreshold!;
-      // Find the index where the threshold falls in the sorted (descending) list.
-      // This is the first position whose score is at or below the threshold.
-      let thresholdIndex = sortOrder.length;
-      for (let i = 0; i < sortOrder.length; i++) {
-        if (sortOrder[i].score <= threshold) {
-          thresholdIndex = i;
-          break;
-        }
-      }
-      // Pick the unlabeled item whose index is closest to the threshold index.
-      // This avoids biasing toward one side when scores cluster unevenly.
-      let best: SortedItem | null = null;
-      let bestDist = Infinity;
-      for (let i = 0; i < sortOrder.length; i++) {
-        if (isVoted(sortOrder[i].id)) continue;
-        const dist = Math.abs(i - thresholdIndex);
-        if (dist < bestDist) {
-          bestDist = dist;
-          best = sortOrder[i];
-        }
-      }
-      if (best) this.mediaState.selectMedia(best.id);
-    } else if (this.sortState.selectMode === 'new') {
+    const pick = pickNextMedia({
+      sortOrder: this.sortState.sortOrder,
+      selectMode: this.sortState.selectMode,
+      acqThreshold: this.sortState.acqThreshold,
+      goodVotes: this.voteState.goodVotes,
+      badVotes: this.voteState.badVotes,
+      excludeId,
+    });
+    if (pick.kind === 'media') {
+      this.mediaState.selectMedia(pick.id);
+    } else if (pick.kind === 'diversity') {
       this.fetchDiversityNext();
     }
   }

--- a/frontend/src/app/utils/auto-select-next.spec.ts
+++ b/frontend/src/app/utils/auto-select-next.spec.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import { autoSelectNext } from './auto-select-next';
+import type { AutoSelectInput } from './auto-select-next';
+import type { SortedItem } from '../services/sort-state.service';
+
+/**
+ * Unit coverage for the auto-advance pick rule extracted out of
+ * `LabelViewComponent.autoSelectNext`. The Python eval harness reproduces this
+ * rule (`vtscore/eval/al_strategies._hard_pick_by_index`) and
+ * `scripts/check-eval-app-sync.py` pins it, so these cases double as the
+ * executable statement of what the harness has to keep matching — in
+ * particular that `hard` measures distance in **rank space**, not score space.
+ */
+describe('autoSelectNext', () => {
+  function rank(scores: number[]): SortedItem[] {
+    return scores.map((score, i) => ({ id: i + 1, score }));
+  }
+
+  function input(partial: Partial<AutoSelectInput> = {}): AutoSelectInput {
+    return {
+      sortOrder: rank([0.9, 0.8, 0.7, 0.6, 0.5]),
+      selectMode: 'top',
+      acqThreshold: null,
+      goodVotes: new Set<number>(),
+      badVotes: new Set<number>(),
+      ...partial,
+    };
+  }
+
+  describe('no ranking loaded', () => {
+    it('picks nothing when the sort order is null', () => {
+      expect(autoSelectNext(input({ sortOrder: null }))).toEqual({ kind: 'none' });
+    });
+
+    it('picks nothing when the sort order is empty', () => {
+      expect(autoSelectNext(input({ sortOrder: [] }))).toEqual({ kind: 'none' });
+    });
+
+    it('does not fire a diversity probe without a ranking', () => {
+      // The `new` mode still needs a loaded sort: the atlas probe is steered by
+      // the current scores and the acquisition cut.
+      expect(autoSelectNext(input({ sortOrder: null, selectMode: 'new' }))).toEqual({
+        kind: 'none',
+      });
+    });
+  });
+
+  describe('top', () => {
+    it('takes the highest-ranked item when nothing is voted', () => {
+      expect(autoSelectNext(input())).toEqual({ kind: 'media', id: 1 });
+    });
+
+    it('skips voted items on both sides', () => {
+      const pick = autoSelectNext(input({ goodVotes: new Set([1]), badVotes: new Set([2]) }));
+      expect(pick).toEqual({ kind: 'media', id: 3 });
+    });
+
+    it('skips the excluded id (the vote that has not landed yet)', () => {
+      expect(autoSelectNext(input({ excludeId: 1 }))).toEqual({ kind: 'media', id: 2 });
+    });
+
+    it('picks nothing once every item is voted', () => {
+      expect(autoSelectNext(input({ goodVotes: new Set([1, 2, 3, 4, 5]) }))).toEqual({
+        kind: 'none',
+      });
+    });
+  });
+
+  describe('hard', () => {
+    it('picks nothing when the sort carried no acquisition cut', () => {
+      // Neither an acquisition cut nor a reporting threshold to fall back to:
+      // there is no line to sample around, so the pick declines rather than
+      // guessing at one.
+      expect(autoSelectNext(input({ selectMode: 'hard', acqThreshold: null }))).toEqual({
+        kind: 'none',
+      });
+    });
+
+    it('takes the item at the cutoff index', () => {
+      // 0.7 is the first score at or below 0.75, so thresholdIndex = 2 → id 3.
+      expect(autoSelectNext(input({ selectMode: 'hard', acqThreshold: 0.75 }))).toEqual({
+        kind: 'media',
+        id: 3,
+      });
+    });
+
+    it('falls to the nearest unvoted neighbour when the cutoff item is voted', () => {
+      // thresholdIndex = 2; id 3 is voted, so ids 2 and 4 both sit at distance
+      // 1 and the earlier (higher-ranked) one wins the strict `<` comparison.
+      const pick = autoSelectNext(
+        input({ selectMode: 'hard', acqThreshold: 0.75, goodVotes: new Set([3]) }),
+      );
+      expect(pick).toEqual({ kind: 'media', id: 2 });
+    });
+
+    it('measures distance in rank space, not score space', () => {
+      // The separating case. Scores cluster tightly on each side of a wide gap
+      // that straddles the cut, so the two metrics disagree outright:
+      //
+      //   index:  0     1     2     3     4
+      //   score:  0.99  0.98  0.10  0.09  0.08     cut = 0.5, id 3 voted
+      //
+      // thresholdIndex = 2. In rank space ids 2 and 4 tie at distance 1 and the
+      // earlier index wins → id 2. In score space id 4 (|0.09-0.5| = 0.41) beats
+      // id 2 (|0.98-0.5| = 0.48) → id 4. Getting id 2 is what proves the rule is
+      // the rank-space one the harness mirrors.
+      const pick = autoSelectNext(
+        input({
+          sortOrder: rank([0.99, 0.98, 0.1, 0.09, 0.08]),
+          selectMode: 'hard',
+          acqThreshold: 0.5,
+          goodVotes: new Set([3]),
+        }),
+      );
+      expect(pick).toEqual({ kind: 'media', id: 2 });
+    });
+
+    it('uses the full ranking for the cutoff index, voted rows included', () => {
+      // Voting out the whole head must not slide the cutoff position: the
+      // threshold index is computed over every row, and voted rows are merely
+      // skipped when choosing among the candidates.
+      const pick = autoSelectNext(
+        input({ selectMode: 'hard', acqThreshold: 0.75, goodVotes: new Set([1, 2, 3]) }),
+      );
+      // thresholdIndex stays 2; the nearest unvoted row is index 3 (id 4).
+      expect(pick).toEqual({ kind: 'media', id: 4 });
+    });
+
+    it('takes the last item when every score is above the cut', () => {
+      // No score falls at or below the cut, so thresholdIndex = length and the
+      // final row is the nearest.
+      expect(autoSelectNext(input({ selectMode: 'hard', acqThreshold: 0.1 }))).toEqual({
+        kind: 'media',
+        id: 5,
+      });
+    });
+
+    it('takes the first item when every score is at or below the cut', () => {
+      expect(autoSelectNext(input({ selectMode: 'hard', acqThreshold: 0.95 }))).toEqual({
+        kind: 'media',
+        id: 1,
+      });
+    });
+
+    it('picks nothing once every item is voted', () => {
+      const pick = autoSelectNext(
+        input({
+          selectMode: 'hard',
+          acqThreshold: 0.75,
+          goodVotes: new Set([1, 2, 3, 4, 5]),
+        }),
+      );
+      expect(pick).toEqual({ kind: 'none' });
+    });
+
+    it('honours excludeId alongside the vote sets', () => {
+      const pick = autoSelectNext(input({ selectMode: 'hard', acqThreshold: 0.75, excludeId: 3 }));
+      expect(pick).toEqual({ kind: 'media', id: 2 });
+    });
+  });
+
+  describe('new', () => {
+    it('defers to the coverage atlas rather than picking from the ranking', () => {
+      expect(autoSelectNext(input({ selectMode: 'new' }))).toEqual({ kind: 'diversity' });
+    });
+
+    it('defers even when every loaded item is already voted', () => {
+      // The atlas probes the whole dataset, not just the loaded window, so an
+      // exhausted window is not a reason to decline.
+      const pick = autoSelectNext(
+        input({ selectMode: 'new', goodVotes: new Set([1, 2, 3, 4, 5]) }),
+      );
+      expect(pick).toEqual({ kind: 'diversity' });
+    });
+  });
+});

--- a/frontend/src/app/utils/auto-select-next.ts
+++ b/frontend/src/app/utils/auto-select-next.ts
@@ -1,0 +1,93 @@
+import type { SelectMode, SortedItem } from '../services/sort-state.service';
+
+/**
+ * What the auto-advance should do next, as data rather than as a side effect.
+ *
+ * `diversity` is deliberately *not* resolved here: the New pick is a server
+ * round-trip (`GET /api/coverage-atlas/next`), so the rule reports that a
+ * diversity probe is owed and the caller fires it. Keeping the request out
+ * means the whole pick rule stays synchronous and pure — which is what makes
+ * it unit-testable, and what lets `scripts/check-eval-app-sync.py` pin a
+ * digest of the rule alone rather than of the component plumbing around it.
+ */
+export type AutoSelectPick =
+  | { kind: 'media'; id: number }
+  | { kind: 'diversity' }
+  | { kind: 'none' };
+
+export interface AutoSelectInput {
+  /** The loaded sort window, descending by score. `null` before any sort. */
+  sortOrder: SortedItem[] | null;
+  selectMode: SelectMode;
+  /** The *acquisition* cut (`SortStateService.acqThreshold`), not the
+   *  reporting threshold the user is shown — see #2876. */
+  acqThreshold: number | null;
+  goodVotes: ReadonlySet<number>;
+  badVotes: ReadonlySet<number>;
+  /** Treated as already-voted. Set when advancing off the item just voted on,
+   *  whose vote has not yet landed in `goodVotes` / `badVotes`. */
+  excludeId?: number;
+}
+
+/**
+ * Pick the next media to show, given the current sort window and select mode.
+ *
+ * This is the app's auto-advance rule, and the Python eval harness reproduces
+ * it in `vtscore/eval/al_strategies.py` (`_hard_pick_by_index` for the `hard`
+ * branch) so a simulated Autopilot user clicks the way a real one does. That
+ * copy is pinned by the `autopilot.auto_select_next` mirror in
+ * `scripts/check-eval-app-sync.py`: changing the rule here trips the gate and
+ * asks whoever changed it to port the change. Keep the two in step.
+ *
+ * The three modes:
+ *
+ * - **top** — the highest-ranked unvoted item.
+ * - **hard** — the unvoted item nearest the cutoff *by rank index*, not by
+ *   score. Rank space is the point: a score-space `argmin |score - t|` biases
+ *   toward whichever side of the line happens to be denser, which on a
+ *   saturated cold-start model is exactly the failure being avoided. The
+ *   threshold index spans voted and unvoted rows alike (the full window is
+ *   ranked and voted rows are merely skipped), so the cutoff position does not
+ *   drift as votes accumulate.
+ * - **new** — defer to the coverage atlas; reported as `diversity`.
+ */
+export function autoSelectNext(input: AutoSelectInput): AutoSelectPick {
+  const { sortOrder, selectMode, acqThreshold, goodVotes, badVotes, excludeId } = input;
+  if (!sortOrder || sortOrder.length === 0) return { kind: 'none' };
+
+  const isVoted = (id: number): boolean =>
+    id === excludeId || goodVotes.has(id) || badVotes.has(id);
+
+  if (selectMode === 'top') {
+    const next = sortOrder.find((s) => !isVoted(s.id));
+    return next ? { kind: 'media', id: next.id } : { kind: 'none' };
+  }
+
+  if (selectMode === 'hard') {
+    if (acqThreshold === null) return { kind: 'none' };
+    // The first position whose score is at or below the cut, in the descending
+    // ranking; `length` when every row is above it.
+    let thresholdIndex = sortOrder.length;
+    for (let i = 0; i < sortOrder.length; i++) {
+      if (sortOrder[i].score <= acqThreshold) {
+        thresholdIndex = i;
+        break;
+      }
+    }
+    let best: SortedItem | null = null;
+    let bestDist = Infinity;
+    for (let i = 0; i < sortOrder.length; i++) {
+      if (isVoted(sortOrder[i].id)) continue;
+      const dist = Math.abs(i - thresholdIndex);
+      if (dist < bestDist) {
+        bestDist = dist;
+        best = sortOrder[i];
+      }
+    }
+    return best ? { kind: 'media', id: best.id } : { kind: 'none' };
+  }
+
+  if (selectMode === 'new') return { kind: 'diversity' };
+
+  return { kind: 'none' };
+}

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -54,6 +54,7 @@ PINS_PATH = REPO_ROOT / "scripts" / "eval-app-sync.pins.json"
 
 AUTOPILOT_TS = "frontend/src/app/services/autopilot-state.service.ts"
 LABEL_VIEW_TS = "frontend/src/app/components/label-view/label-view.component.ts"
+AUTO_SELECT_TS = "frontend/src/app/utils/auto-select-next.ts"
 
 
 @dataclass(frozen=True)
@@ -126,6 +127,40 @@ MIRRORS: list[Mirror] = [
             "mapping is the phase subscription in the same component, which additionally "
             "kicks off the sort request. This anchor is the one place the whole table is "
             "written out in one block, so it is what the digest watches."
+        ),
+    ),
+    Mirror(
+        id="autopilot.auto_select_next",
+        app=f"ts:{AUTO_SELECT_TS}::export function autoSelectNext(",
+        harness="vtscore/eval/al_strategies.py::_hard_pick_by_index",
+        kind="ported",
+        note=(
+            "The app's auto-advance rule - which item each Select mode shows next. `top` takes "
+            "the highest-ranked unvoted row; `hard` takes the unvoted row nearest the "
+            "acquisition cut BY RANK INDEX, not by score; `new` defers to the coverage atlas. "
+            "_hard_pick_by_index is the `hard` branch verbatim, and it is the branch every "
+            "simulated vote after the seed phase goes through, so a change to the rule that "
+            "does not reach the harness silently re-points every study's vote order. Rank space "
+            "is the load-bearing detail: a score-space argmin biases toward whichever side of "
+            "the line is denser, which is the whole reason the app measures in indices. Note "
+            "the cutoff index is computed over the FULL window, voted rows included, so it does "
+            "not slide as votes accumulate - the harness's `ordered` list must stay the full "
+            "ranking rather than the pool. Also re-check the tie rule: both sides scan "
+            "ascending by index with a strict `<`, so an exact tie takes the higher-ranked row. "
+            "Extracted out of the label-view component (#3428) so this digest covers the pick "
+            "rule alone rather than the component's sort plumbing; "
+            "frontend/src/app/utils/auto-select-next.spec.ts states the same cases executably."
+        ),
+        divergence=(
+            "The harness mirrors only the `hard` branch here. `top` is trivial and is "
+            "reproduced inline by the phase-faithful strategy; `new` is not ported at all - "
+            "_atlas_next DELEGATES to CoverageAtlas.next_sample, the same call the app's New "
+            "pick makes through /api/coverage-atlas/next, so it cannot drift and needs no pin. "
+            "The app's guard that a `new` pick still requires a loaded ranking is a UI "
+            "precondition (the window steers the probe's scores) with no harness counterpart, "
+            "as is `excludeId`: it covers the instant between casting a vote and that vote "
+            "landing in goodVotes/badVotes, which a simulation never observes because it "
+            "records the vote before asking for the next pick."
         ),
     ),
     Mirror(

--- a/scripts/eval-app-sync.pins.json
+++ b/scripts/eval-app-sync.pins.json
@@ -1,4 +1,5 @@
 {
+  "autopilot.auto_select_next": "6ea3115e16c12d9e370d8475d4b92b12ebafdc870c7513ca1de77faa6fbabb67",
   "autopilot.phase_machine": "8ad8a0c2a72103a3ca0061201f57977869225a458894d79efd41a18e5e342fc7",
   "autopilot.phase_sort_select": "f67f2a6f59fba5813aa1f284fefc83520c6675251256cfcd2ed5729a4a1566d6",
   "autopilot.startup_default": "6b15d45162cc406b8924e37a23286950d5e5dde551cbcd0d9d4c2500cec044f9",

--- a/vtscore/eval/al_strategies.py
+++ b/vtscore/eval/al_strategies.py
@@ -200,9 +200,12 @@ def _centroid_similarities(ctx: ALContext, ids: list[int]) -> Optional[dict[int,
 def _hard_pick_by_index(ctx: ALContext, ranking: dict[int, float], threshold: float) -> Optional[int]:
     """The app's ``hard`` select: the unlabeled item nearest the cutoff *by rank*.
 
-    Mirrors ``LabelViewComponent.autoSelectNext``: rank every item in the
-    current sort descending, find the first position whose score is at or below
-    *threshold*, and take the unlabeled item whose **index** is closest to it.
+    Mirrors the app's ``autoSelectNext`` pick rule
+    (``frontend/src/app/utils/auto-select-next.ts``, pinned by the
+    ``autopilot.auto_select_next`` mirror in
+    ``scripts/check-eval-app-sync.py``): rank every item in the current sort
+    descending, find the first position whose score is at or below *threshold*,
+    and take the unlabeled item whose **index** is closest to it.
 
     Distance is measured in rank space, not score space, and that is deliberate
     in the app — "avoids biasing toward one side when scores cluster unevenly".


### PR DESCRIPTION
Refs #3428 — lands the slice that issue says should land first, and reports back on the rest of it.

## The premise, checked

Two of the issue's three claims hold; the load-bearing one does not.

**Holds:** `SortStateService` really is anemic (20 getters, 12 setters, one `clear()`, zero transitions), and `label-view.component.ts` really does carry the sort block and the autopilot block.

**Does not hold:** the issue says `autoSelectNext` is an *unpinnable* mirror "precisely because it lives inside a god component", and that "landing the pure-function extraction is what makes it pinnable." It was pinnable as it stood. `check-eval-app-sync.py`'s `ts:<file>::<anchor>` form brace-matches an arbitrary block, and `private autoSelectNext(` was already a unique anchor in that file — and the `autopilot.phase_sort_select` mirror *already* pins `onAutopilotStop(`, a sibling method in the same component. The August audit says the surface is **unpinned** and its own direction is to add a `Mirror(...)` for `ts:...label-view.component.ts::autoSelectNext(`; nowhere does it say a refactor is a prerequisite. So the L-sized refactor was never blocking the thing the issue treats as its justification.

That matters for sequencing: the real gap — the eval harness reproduces this rule and nothing detects drift between the two — was closable immediately, and did not need to wait behind a regression-prone god-component refactor.

## What this PR does

Does the extraction anyway, on its actual merits (a tighter digest and unit coverage), and closes the drift gap.

- **`frontend/src/app/utils/auto-select-next.ts`** — the pick rule as a pure function returning a pick as *data* (`media` / `diversity` / `none`). The coverage-atlas request stays in the component, so the rule is synchronous and testable.
- **`label-view.component.ts`** — `autoSelectNext` becomes the side-effecting half: call the rule, then apply the selection or fire the atlas probe. No reactivity change; the same `sortState` getters are read in the same synchronous call.
- **`scripts/check-eval-app-sync.py`** — new `autopilot.auto_select_next` mirror pinning the extracted function against `al_strategies._hard_pick_by_index`. Verified the harness still matches line for line before `--update` (full ranking not pool for the cutoff index; strict `<` so ties take the higher-ranked row); re-pinning moved exactly one line in the pins file, so no other mirrored surface shifted. `divergence=` records that only the `hard` branch is ported, that `new` delegates to `CoverageAtlas.next_sample` and so cannot drift, and that `excludeId` has no harness counterpart.
- **`auto-select-next.spec.ts`** — 18 cases across the three modes, including the one that separates rank-space from score-space distance (the detail the harness has to keep matching).

The extraction earns its keep on the pin's *precision* rather than its possibility: the digest now covers the rule alone, so a change to the rule trips the gate and a change to the component's HTTP wiring does not.

## Verification

Rebased twice while `dev` moved underneath; the diff is unchanged at 7 files.

- The first rebase conflicted in the audit plan's pointer list: this branch retitled the #3428 pointer while `dev` retitled the adjacent #3433 pointer, so the two edits abutted with no unchanged line between them. Resolved by taking both. (This is the exact adjacency case CLAUDE.md's `<!-- item-sep -->` convention prevents; that pointer list predates it.)
- The second rebase conflicted in `scripts/check-extension-docs.py`. That gate was red on `dev`, blocking every `run-tests.sh` run, so this branch had carried a fix for it; `dev` has since landed its own (`186a7550`). The duplicate commit was dropped in favour of `dev`'s — which registers the same section against `("UserSyncState",)` where this branch had used `("UserSyncState", "UserSettingsStore")`. `dev`'s narrower tuple is the better of the two: extra classes only widen what counts as a valid member, so they can hide a bad reference but never invent one.

`./run-tests.sh` full, on the current head: **RUN PASSED** — 9668 passed, 6 skipped, 2 xfailed; pyright, pip-audit, vulture whitelist, npm audit and Vitest all OK.

Verified in real chromium against the running app (not just jsdom), per the issue's constraint — syn-imgs / doc-demo fixture, Manual tab, text sort over 60 rows with 9 existing votes, recomputing the expected pick independently from the `/api/sort` response and the DOM's vote classes:

```
[sort] 60 rows, threshold=0.0758, acq=null
[top ] 9 voted rows; active=0
  ✓ Top selected index 0 — the highest-ranked unvoted row
[hard] active=29, rule says 29
  ✓ Hard selected index 29 — nearest the cutoff in rank space
  ✓ New fired 1 coverage-atlas probe(s) — the diversity branch is wired
[vote] active 0 -> 1
  ✓ Voting advanced the selection off the voted item
```

No page errors or console errors during the run. Not re-run after the rebases: both left the `label-view` and `auto-select-next` changes byte-identical, and the eval-sync gate re-confirmed all 16 mirrors current against each new base — including across `dev`'s split of `voting_iterations` into `step_trainers` / `voting_columns`.

## What is deliberately not done

The orchestrator half — moving the learned-sort/text-sort/window transitions onto `SortStateService` and the autopilot transitions onto `AutopilotStateService` — is left open, and #3428 stays open (and unassigned) for it. Not merely deferred for size: the design question the issue treats as settled isn't.

Most of those lines are HTTP calls whose teardown is `takeUntil(this.pairScope$)`, and `pairScope$` is a *component* lifecycle concern. `SortStateService` and `AutopilotStateService` are both `providedIn: 'root'` singletons, so moving the transitions there means reinventing pair-scoped cancellation inside a singleton — for calls whose whole correctness argument is that a training job or a minutes-long scoring run must not apply its result to whatever pair is active when it finally settles. That is the highest-consequence code in the block, and moving it buys layering rather than behaviour. `autoSelectNext` itself also reads across `sortState`, `voteState` and `mediaState` and writes to a fourth, so hosting it on any one of them trades a god component for a god service.

Worth doing with a scope-management design decided first, rather than as a mechanical move. The issue body now records this, and the correction above, so the next session isn't re-misled.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PJWR6KnWFmwD2XMaQGpDH