### PR TITLE
Cross-link the two extension doc sets and gate them against the plugin ABCs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,7 @@ A flow can legitimately carry both: a nested view shows `← Back` at the top to
 - **Check eval/app sync**: `python scripts/check-eval-app-sync.py` (also a `./run-tests.sh` gate; re-pin with `--update` after reconciling the harness)
 - **Check for a stale tree**: `python scripts/check-phantom-base.py` (also the first `./run-tests.sh` gate; fails when the branch deletes files it never created, or carries none of what `dev` gained across two or more consecutive commits. Override a deliberate deletion with `VTSEARCH_ALLOW_DELETIONS=1`, a deliberate revert with `VTSEARCH_ALLOW_REVERTS=1`)
 - **Check documentation**: `python scripts/check-docs.py` (also a `./run-tests.sh` gate; validates relative links, `#anchors`, backticked repo paths, absolute-path leaks, `docs/plans/*.md` citations anywhere in the tree, and code fences. Pure invariants — nothing to re-pin. Fix the doc, or add an allowlist entry with a reason if the path is runtime-generated or a deliberately fictional example)
+- **Check extension docs**: `python scripts/check-extension-docs.py` (also a `./run-tests.sh` gate; proves the app-tier and library-tier extension guides still describe members that exist on the plugin ABCs, and that neither names a public wrapper as the override point. Pure invariants — nothing to re-pin. Fix the doc, or register a new contract section in `SECTIONS`)
 - **Regenerate doc inventories**: `python scripts/gen-docs-inventories.py` (fills the `<!-- BEGIN GENERATED: ... -->` regions in the docs from the live registries — embedders, plugin families, demo datasets; `--check` is a `./run-tests.sh` gate, so registry changes require rerunning this and committing the result)
 - **Install deps**: `bash scripts/install.sh` (auto-detects CPU vs GPU; pass `cpu`/`gpu` to force, or a `cuXYZ` tag to override the GPU wheel, e.g. `bash scripts/install.sh cu121`)
 - **Build frontend**: `cd frontend && npm install && npm run build:prod` (builds Angular app to `static/`)
@@ -426,6 +427,7 @@ Wrapping everything: a wall-clock cap (`VTSEARCH_TEST_TIMEOUT`, default **1800s 
 | Dockerfiles | `scripts/check-dockerfiles.py` | |
 | User-docs screenshot wiring | `scripts/screenshots/wiring-check.py` | Browser-free; the pixel-diff (`check.sh`) stays a manual chore. Also what makes the reshoot queue un-rottable. |
 | vtscore package docs | `scripts/check-vtscore-docs.py` | |
+| Extension docs | `scripts/check-extension-docs.py` | Holds `docs/EXTENDING-*.md` and `vtscore/docs/extending/` to the plugin ABCs they both document: every member named in a contract table must exist, and neither set may present a public wrapper as the override point when the class defines an `_impl` hook behind it. AST sweep, imports nothing. Register a new contract section in `SECTIONS` — an unregistered one fails the gate rather than going unchecked. |
 | Slide decks | `slides/build.py --check` | Preflights every deck manifest: fragments exist, figures resolve. Marp only warns on a missing figure and exits 0, so a rotted deck is otherwise silent. |
 | Eval/app sync | `scripts/check-eval-app-sync.py` | Re-pin with `--update` **after** reconciling the harness. |
 

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -60,6 +60,13 @@ Media types define how VTSearch handles a particular kind of content: how
 to serve clips over HTTP, what file extensions to scan for, what demo
 datasets are available, and how to load media-specific fields from files.
 
+**Library contract:**
+[`vtscore/docs/extending/media-types.md`](../vtscore/docs/extending/media-types.md)
+states the same contract from the library side, and is the guide to follow
+when shipping a media type as a separate distribution rather than adding one
+to this repo. This section is the in-repo path: the same contract plus the
+app-tier wiring.
+
 ### File structure
 
 ```
@@ -291,6 +298,13 @@ def pickle_extra_fields(self) -> list[str]:
 Media embedders produce fixed-size vector embeddings from media files and
 text queries. Each embedder is associated with exactly one media type but a
 media type may have multiple embedders.
+
+**Library contract:**
+[`vtscore/docs/extending/embedders.md`](../vtscore/docs/extending/embedders.md)
+states the same contract from the library side, and is the guide to follow
+when shipping an embedder as a separate distribution rather than adding one
+to this repo. This section is the in-repo path: the same contract plus the
+app-tier wiring.
 
 ### File structure
 
@@ -629,7 +643,7 @@ def supports_text(self) -> bool:
 | Flag | Default | When to override |
 |---|---|---|
 | `supports_text: bool` | **True** | Return `False` for vision-only or patch-based encoders with no text tower (DINOv2/v3, EUPE, SIFT/VLAD, FaceNet, BEATs, AST, Whisper-encoder). The default is `True` because most shipped embedders are cross-modal (CLIP, SigLIP, CLAP, E5, BGE); leaving it unset on a vision-only encoder wrongly advertises `POST /api/sort` text queries. |
-| `supports_patch_regions: bool` | False | Return `True` for image embedders that implement `_patch_forward(image) -> PatchEmbedOutput`. Loaders that see this flag run the patch pass after the standard CLS pass and store a hierarchical region set plus the raw patch grid. |
+| `supports_patch_regions: bool` | False | Return `True` for image embedders that implement `_patch_forward_impl(media) -> PatchEmbedOutput` (the hook behind the public `patch_forward`, which takes the `_embed_lock` for you). Loaders that see this flag run the patch pass after the standard CLS pass and store a hierarchical region set plus the raw patch grid. |
 | `supports_geometric_verification: bool` | False | Return `True` for structural embedders that produce local features for instance matching (SIFT/VLAD). The loader then asks for a `StructuralFeatures` per image and stores it as `media["local_features"]`, enabling the geometric re-rank and match-stat verification paths. Deliberately media-agnostic, so an audio fingerprint backend can reuse it. |
 | `license_notice: Optional[str]` | None | Return a short human-readable string when the upstream weights carry a usage restriction (e.g. FAIR Noncommercial). The frontend embedder picker surfaces this as a warning chip; the dataset-create flow surfaces it inline. |
 
@@ -642,6 +656,13 @@ All four are included in `MediaEmbedder.to_dict()` and exposed via `GET /api/emb
 Media clippers split a single media item into one or more items of the
 **same** type. Unlike processors which return metadata about media,
 clippers return **new media dicts** that can replace the original.
+
+**Library contract:**
+[`vtscore/docs/extending/clippers.md`](../vtscore/docs/extending/clippers.md)
+states the same contract from the library side, and is the guide to follow
+when shipping a clipper as a separate distribution rather than adding one to
+this repo. This section is the in-repo path: the same contract plus the
+app-tier wiring.
 
 ### Built-in clippers
 
@@ -993,6 +1014,13 @@ Media converters transform content from one media type to another (e.g.
 document pages to images, video to audio). Converters are
 **auto-discovered** via `PluginRegistry` with the `CONVERTER` sentinel,
 just like other plugin families.
+
+**Library contract:**
+[`vtscore/docs/extending/converters.md`](../vtscore/docs/extending/converters.md)
+states the same contract from the library side, and is the guide to follow
+when shipping a converter as a separate distribution rather than adding one
+to this repo. This section is the in-repo path: the same contract plus the
+app-tier wiring.
 
 ### Built-in converters
 

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -410,6 +410,13 @@ Data importers let users load datasets from new sources (S3 buckets,
 databases, APIs, etc.). The system auto-discovers importers at runtime; no
 changes to routes or core code are needed.
 
+**Library contract:**
+[`vtscore/docs/extending/dataset-importers.md`](../vtscore/docs/extending/dataset-importers.md)
+states the same contract from the library side, and is the guide to follow
+when shipping an importer as a separate distribution rather than adding one
+to this repo. This section is the in-repo path: the same contract plus the
+app-tier wiring.
+
 ### File structure
 
 ```
@@ -510,7 +517,6 @@ class S3Importer(DatasetImporter):
         # Delegate to the standard folder loader
         from vtscore.datasets.loader import load_dataset_from_folder
         load_dataset_from_folder(download_dir, media_type, medias, thin=thin)
-
 
 # This module-level instance is what the registry discovers.
 IMPORTER = S3Importer()
@@ -1428,6 +1434,13 @@ needs no changes; it is credited with both kinds (nothing can tell which it
 handles) and logs a line at import pointing at the named methods. New exporters
 should implement those instead.
 
+**Library contract:**
+[`vtscore/docs/extending/results-exporters.md`](../vtscore/docs/extending/results-exporters.md)
+states the same contract from the library side, and is the guide to follow
+when shipping an exporter as a separate distribution rather than adding one
+to this repo. This section is the in-repo path: the same contract plus the
+app-tier wiring.
+
 ### File structure
 
 ```
@@ -1666,6 +1679,13 @@ every import is declared there. They are picked up the next time you run
 
 Label importers let users import pre-existing labels (good/bad votes) from
 external sources. Auto-discovered at runtime.
+
+**Library contract:**
+[`vtscore/docs/extending/label-importers.md`](../vtscore/docs/extending/label-importers.md)
+states the same contract from the library side, and is the guide to follow
+when shipping a label importer as a separate distribution rather than adding
+one to this repo. This section is the in-repo path: the same contract plus
+the app-tier wiring.
 
 ### File structure
 
@@ -2065,6 +2085,13 @@ change and imports them on sync.
 
 Use a **Label Importer** (above) for one-shot label import. Use a
 **Labelset Source** when you want ongoing automatic sync per-detector.
+
+**Library contract:**
+[`vtscore/docs/extending/labelset-sources.md`](../vtscore/docs/extending/labelset-sources.md)
+states the same contract from the library side, and is the guide to follow
+when shipping a labelset source as a separate distribution rather than
+adding one to this repo. This section is the in-repo path: the same contract
+plus the app-tier wiring.
 
 ### File structure
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -5,16 +5,43 @@ cross-cutting sections: authentication, dependencies, and a one-stop
 checklist for every extension type. Start here; open the child doc that
 matches what you want to build.
 
+## Two doc sets, one contract
+
+Most extension points are documented **twice**, on purpose, for two
+different readers:
+
+- **These `docs/EXTENDING-*.md` guides are the in-repo front door.** They
+  are self-contained: interface contract, where the file goes, how
+  discovery works, app-tier wiring (routes, forms, the pickers the
+  frontend renders), and a complete worked example. Read these if you are
+  adding a plugin *to this repository*.
+- **[`vtscore/docs/extending/`](../vtscore/docs/extending/README.md) is
+  the library contract.** It ships inside the semver'd `vtscore` package
+  and covers the same ABCs from the library side, plus the things only an
+  out-of-tree author needs: `importlib.metadata` entry-point registration,
+  packaging, and the Flask-free import rules. Read these if you are
+  shipping a plugin as a **separate distribution**.
+
+Where the two overlap, they describe one class, so they can contradict
+each other. `scripts/check-extension-docs.py` (a `./run-tests.sh` gate)
+holds them to the code: every member either set names in a contract table
+must exist, and neither may present a public wrapper as the override point
+when the class defines an `_impl` hook behind it. When you change a plugin
+ABC, update both sides and let the gate confirm it.
+
 ## Extension guides
 
-| Guide | What you build |
-|-------|----------------|
-| [EXTENDING-plugins.md](EXTENDING-plugins.md) | Data importers, datasource importers, results exporters, label importers, settings importers/exporters/sources, labelset sources: the form-driven auto-discovered plugin families that share a common registry-based architecture (the generated family inventory lives there too). |
-| [EXTENDING-media.md](EXTENDING-media.md) | Media types, embedders, clippers, cleaners, converters, and media sources (anything in `vtscore/media/` or `vtscore/converters/`). |
-| [EXTENDING-processors.md](EXTENDING-processors.md) | Detectors, localizers, and extractors: the three kinds of `Processor`. |
+| Guide | What you build | Library contract |
+|-------|----------------|------------------|
+| [EXTENDING-plugins.md](EXTENDING-plugins.md) | Data importers, datasource importers, results exporters, label importers, settings importers/exporters/sources, labelset sources: the form-driven auto-discovered plugin families that share a common registry-based architecture (the generated family inventory lives there too). | [dataset-importers](../vtscore/docs/extending/dataset-importers.md), [results-exporters](../vtscore/docs/extending/results-exporters.md), [label-importers](../vtscore/docs/extending/label-importers.md), [labelset-sources](../vtscore/docs/extending/labelset-sources.md) |
+| [EXTENDING-media.md](EXTENDING-media.md) | Media types, embedders, clippers, cleaners, converters, and media sources (anything in `vtscore/media/` or `vtscore/converters/`). | [media-types](../vtscore/docs/extending/media-types.md), [embedders](../vtscore/docs/extending/embedders.md), [clippers](../vtscore/docs/extending/clippers.md), [converters](../vtscore/docs/extending/converters.md) |
+| [EXTENDING-processors.md](EXTENDING-processors.md) | Detectors, localizers, and extractors: the three kinds of `Processor`. | — (app tier only; processors are not auto-discovered) |
 
 Each guide explains the interface contract, where files go, how
-discovery/registration works, and includes a complete example.
+discovery/registration works, and includes a complete example. The
+library-tier index — including the families with no app-tier guide of
+their own (datasource importers, seed importers, media sources) — is
+[`vtscore/docs/extending/README.md`](../vtscore/docs/extending/README.md).
 
 ## Cross-cutting reference
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -422,6 +422,18 @@ if ! $_is_slides_run; then
         _blocked "vtscore package docs check failed"
         exit 1
     fi
+
+    # Extension docs: docs/EXTENDING-*.md and vtscore/docs/extending/ state the
+    # contract for the same plugin ABCs in their own words, so each can drift
+    # from the code and from the other. This holds both to the class: every
+    # member named in a contract table exists, and neither presents a public
+    # wrapper as the override point when an _impl hook sits behind it. AST
+    # sweep, imports nothing, ~1s. See scripts/check-extension-docs.py.
+    echo "Checking extension docs..."
+    if ! python scripts/check-extension-docs.py ; then
+        _blocked "extension docs check failed"
+        exit 1
+    fi
 fi
 
 # Slide decks: every deck manifest names fragments that exist and figures that

--- a/scripts/check-extension-docs.py
+++ b/scripts/check-extension-docs.py
@@ -97,9 +97,7 @@ IGNORE: dict[tuple[str, str], frozenset[str]] = {
     # The "Not on the ABC, but required by the app" table: `from_config` is an
     # app-side factory convention implemented by concrete processors, and the
     # section says so in as many words.
-    ("docs/EXTENDING-processors.md", "Processor abstract interface reference"): frozenset(
-        {"from_config"}
-    ),
+    ("docs/EXTENDING-processors.md", "Processor abstract interface reference"): frozenset({"from_config"}),
     # Parameter-dict keys tabulated alongside the `parameters` member.
     ("docs/EXTENDING-media.md", "MediaClipper abstract interface reference"): frozenset(
         {"key", "label", "type", "default", "min", "max", "step"}
@@ -107,9 +105,7 @@ IGNORE: dict[tuple[str, str], frozenset[str]] = {
     ("vtscore/docs/extending/clippers.md", "The contract"): frozenset(
         {"key", "label", "type", "default", "min", "max", "step"}
     ),
-    ("vtscore/docs/extending/converters.md", "The contract"): frozenset(
-        {"key", "label", "type", "default", "options"}
-    ),
+    ("vtscore/docs/extending/converters.md", "The contract"): frozenset({"key", "label", "type", "default", "options"}),
 }
 
 _HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
@@ -205,11 +201,7 @@ def _members_of(node: ast.ClassDef) -> set[str]:
         elif isinstance(sub, ast.AnnAssign):
             targets = [sub.target]
         for target in targets:
-            if (
-                isinstance(target, ast.Attribute)
-                and isinstance(target.value, ast.Name)
-                and target.value.id == "self"
-            ):
+            if isinstance(target, ast.Attribute) and isinstance(target.value, ast.Name) and target.value.id == "self":
                 members.add(target.attr)
     return members
 
@@ -265,9 +257,7 @@ def _documented_members(body: list[str]) -> list[tuple[str, str]]:
     return found
 
 
-def _check_sections(
-    classes: dict[str, dict[str, set[str]]], module_level: set[str]
-) -> list[str]:
+def _check_sections(classes: dict[str, dict[str, set[str]]], module_level: set[str]) -> list[str]:
     """Invariants 1 and 3, which both walk the same sections.
 
     1. Every member named in a contract table exists on one of the section's

--- a/scripts/check-extension-docs.py
+++ b/scripts/check-extension-docs.py
@@ -1,0 +1,363 @@
+"""Check that the extension guides describe members that actually exist.
+
+The two extension doc sets — ``docs/EXTENDING-*.md`` (app tier) and
+``vtscore/docs/extending/`` (library tier) — both spell out the contract for
+the same plugin ABCs, in their own words. Independent prose over one shared
+class is exactly the thing that rots: each set can drift from the code, and
+from the other, without anything failing. Issue #3442 found three live
+instances at once, each half of a contradicting pair:
+
+* ``embedders.md`` told authors to override ``embed_text``; the real hook is
+  ``_embed_text_impl`` (the public method L2-normalizes, so an override there
+  ships un-normalized query vectors).
+* ``EXTENDING-media.md`` documented ``_patch_forward(image)``; the real hook
+  is ``_patch_forward_impl(media)``, so a plugin following it defined a method
+  nothing ever calls.
+* ``vtscore/docs/extending/README.md`` still named the ``LabelsetExporter``
+  base class after the rename to ``ResultsExporter``, contradicting its own
+  per-family page.
+
+All three are *member-name* errors, and a member name is mechanically
+checkable. This script does that, in the spirit of
+``scripts/check-vtscore-docs.py``: two cheap invariants, stdlib only, no
+imports of the package under test (so it runs before the venv is warm and
+can't be broken by a heavy optional dependency).
+
+1. **Every member named in a contract table exists on the class.** Members are
+   resolved through the in-repo base chain, so inherited names count.
+2. **Every contract section is registered in :data:`SECTIONS`.** Without this,
+   a new "abstract interface reference" heading would ship unchecked — the
+   coverage hole that makes invariant 1 look healthier than it is.
+
+What this deliberately does *not* check: that the prose is accurate, that
+signatures match, or that every member is documented. Those need a reader.
+This checks the mechanical half — the half that rots silently.
+
+Run from the repo root:
+    python scripts/check-extension-docs.py
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: Packages scanned for class definitions. A documented member counts as real
+#: if it is defined anywhere in this tree, on the class or on one of its
+#: in-repo bases.
+PACKAGES = ("vtscore", "vtsearch")
+
+#: Which classes each contract section describes, as
+#: ``(doc path, exact heading text, classes)``. A section is the run of lines
+#: from its heading to the next heading of the same or shallower level; every
+#: markdown table inside it is checked. Several classes may be listed when one
+#: section tabulates an ABC and its subtypes together — a documented member
+#: need only exist on one of them.
+SECTIONS: list[tuple[str, str, tuple[str, ...]]] = [
+    # --- app tier -------------------------------------------------------
+    ("docs/EXTENDING-media.md", "MediaType abstract interface reference", ("MediaType",)),
+    ("docs/EXTENDING-media.md", "MediaEmbedder abstract interface reference", ("MediaEmbedder",)),
+    ("docs/EXTENDING-media.md", "Embedder capability flags", ("MediaEmbedder",)),
+    ("docs/EXTENDING-media.md", "MediaClipper abstract interface reference", ("MediaClipper",)),
+    ("docs/EXTENDING-media.md", "MediaConverter abstract interface reference", ("MediaConverter",)),
+    ("docs/EXTENDING-media.md", "MediaSource abstract interface reference", ("MediaSource",)),
+    (
+        "docs/EXTENDING-processors.md",
+        "Processor abstract interface reference",
+        ("Processor", "Detector", "Localizer", "Extractor"),
+    ),
+    # --- library tier ---------------------------------------------------
+    ("vtscore/docs/extending/clippers.md", "The contract", ("MediaClipper",)),
+    ("vtscore/docs/extending/converters.md", "The contract", ("MediaConverter",)),
+    ("vtscore/docs/extending/dataset-importers.md", "The minimum contract", ("DatasetImporter",)),
+    ("vtscore/docs/extending/embedders.md", "The contract", ("MediaEmbedder",)),
+    ("vtscore/docs/extending/embedders.md", "Capability flags", ("MediaEmbedder",)),
+    ("vtscore/docs/extending/label-importers.md", "The contract", ("LabelImporter",)),
+    ("vtscore/docs/extending/labelset-sources.md", "The contract", ("LabelsetSource",)),
+    ("vtscore/docs/extending/media-types.md", "The `MediaType` contract", ("MediaType",)),
+    ("vtscore/docs/extending/results-exporters.md", "The contract", ("ResultsExporter",)),
+]
+
+#: Headings that look like a contract section and must therefore appear in
+#: :data:`SECTIONS`. Checked across every file either doc set owns.
+_CONTRACT_HEADING = re.compile(r"(abstract interface reference|^the .*contract$|^capability flags$)", re.I)
+
+#: Doc trees whose contract headings invariant 2 polices.
+DOC_GLOBS = ("docs/EXTENDING-*.md", "vtscore/docs/extending/*.md")
+
+#: Names that a contract section may mention without them being members of
+#: that section's classes: parameter-dict keys, payload fields, and members
+#: the prose explicitly marks as living off the ABC. Keyed by section so one
+#: family's vocabulary can never excuse a typo in another's.
+IGNORE: dict[tuple[str, str], frozenset[str]] = {
+    # The "Not on the ABC, but required by the app" table: `from_config` is an
+    # app-side factory convention implemented by concrete processors, and the
+    # section says so in as many words.
+    ("docs/EXTENDING-processors.md", "Processor abstract interface reference"): frozenset(
+        {"from_config"}
+    ),
+    # Parameter-dict keys tabulated alongside the `parameters` member.
+    ("docs/EXTENDING-media.md", "MediaClipper abstract interface reference"): frozenset(
+        {"key", "label", "type", "default", "min", "max", "step"}
+    ),
+    ("vtscore/docs/extending/clippers.md", "The contract"): frozenset(
+        {"key", "label", "type", "default", "min", "max", "step"}
+    ),
+    ("vtscore/docs/extending/converters.md", "The contract"): frozenset(
+        {"key", "label", "type", "default", "options"}
+    ),
+}
+
+_HEADING = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+#: Every backticked code span on a line.
+_SPAN = re.compile(r"`([^`]+)`")
+#: The leading identifier of a member reference: ``foo``, ``foo()``,
+#: ``foo(bar)``, ``foo: int``, ``foo (property)``.
+_IDENT = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)")
+#: A span that reads as a member reference wherever it sits in a table row,
+#: not just in the first cell: a call (``_patch_forward(image) -> Out``) or a
+#: private name (``_embed_text_impl``). Public bare words are excluded here
+#: because ``str`` and ``dict`` look exactly like ``name`` — those are caught
+#: in the first cell, where a bare word can only be a member.
+_INLINE_MEMBER = re.compile(r"^(_[a-z][A-Za-z0-9_]*|[a-z][A-Za-z0-9_]*\()")
+
+
+def _index_module_level() -> set[str]:
+    """Return every module-level function and constant name in the tree.
+
+    A contract section may legitimately point at a free function
+    (``set_progress_callback()``, ``embedders_for_type()``) rather than a
+    method. Those are real, greppable symbols, so they satisfy the invariant —
+    what the gate is proving is that a documented name still exists somewhere,
+    not that it is a method.
+    """
+    names: set[str] = set()
+    for pkg in PACKAGES:
+        for path in sorted((ROOT / pkg).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for stmt in tree.body:
+                if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    names.add(stmt.name)
+                elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                    names.add(stmt.target.id)
+                elif isinstance(stmt, ast.Assign):
+                    names.update(t.id for t in stmt.targets if isinstance(t, ast.Name))
+    return names
+
+
+def _index_classes() -> dict[str, dict[str, set[str]]]:
+    """Return ``{class name: {"members": {...}, "bases": {...}}}`` for the tree.
+
+    Classes are keyed by bare name and merged across files. Two same-named
+    classes therefore pool their members, which can only *hide* a bad doc
+    reference, never invent one — the conservative direction for a gate.
+    """
+    classes: dict[str, dict[str, set[str]]] = {}
+    for pkg in PACKAGES:
+        for path in sorted((ROOT / pkg).rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    entry = classes.setdefault(node.name, {"members": set(), "bases": set()})
+                    entry["members"] |= _members_of(node)
+                    entry["bases"] |= _base_names(node)
+    return classes
+
+
+def _base_names(node: ast.ClassDef) -> set[str]:
+    """Return the bare names of *node*'s bases, unwrapping generic subscripts."""
+    names: set[str] = set()
+    for base in node.bases:
+        if isinstance(base, ast.Subscript):  # SyncSource[list[dict], LabelSet]
+            base = base.value
+        if isinstance(base, ast.Name):
+            names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.add(base.attr)
+    return names
+
+
+def _members_of(node: ast.ClassDef) -> set[str]:
+    """Return every name *node* defines: methods, class attrs, and ``self.x``."""
+    members: set[str] = set()
+    for stmt in node.body:
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            members.add(stmt.name)
+        elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+            members.add(stmt.target.id)
+        elif isinstance(stmt, ast.Assign):
+            members.update(t.id for t in stmt.targets if isinstance(t, ast.Name))
+    # Attributes bound in __init__ (or any method) are members too.
+    for sub in ast.walk(node):
+        targets: list[ast.expr] = []
+        if isinstance(sub, ast.Assign):
+            targets = list(sub.targets)
+        elif isinstance(sub, ast.AnnAssign):
+            targets = [sub.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "self"
+            ):
+                members.add(target.attr)
+    return members
+
+
+def _resolve(name: str, classes: dict[str, dict[str, set[str]]], seen: set[str] | None = None) -> set[str]:
+    """Return every member of *name*, following its in-repo base chain."""
+    seen = seen if seen is not None else set()
+    if name in seen or name not in classes:
+        return set()
+    seen.add(name)
+    members = set(classes[name]["members"])
+    for base in sorted(classes[name]["bases"]):
+        members |= _resolve(base, classes, seen)
+    return members
+
+
+def _section_lines(lines: list[str], heading: str) -> tuple[int, list[str]] | None:
+    """Return the 1-based start line and body of the section titled *heading*."""
+    for i, line in enumerate(lines):
+        match = _HEADING.match(line)
+        if not match or match.group(2) != heading:
+            continue
+        depth = len(match.group(1))
+        body: list[str] = []
+        for follow in lines[i + 1 :]:
+            nxt = _HEADING.match(follow)
+            if nxt and len(nxt.group(1)) <= depth:
+                break
+            body.append(follow)
+        return i + 1, body
+    return None
+
+
+def _documented_members(body: list[str]) -> list[tuple[str, str]]:
+    """Return ``(identifier, raw span)`` for every member reference in *body*.
+
+    Only table rows are scanned, which keeps the sweep bounded to the places a
+    contract is actually tabulated. Within a row, the first cell's span counts
+    whatever it looks like; later cells count only when the span is a call or a
+    private name, so a type in a signature column isn't mistaken for a member.
+    """
+    found: list[tuple[str, str]] = []
+    for line in body:
+        if not line.lstrip().startswith("|"):
+            continue
+        for index, raw in enumerate(_SPAN.findall(line)):
+            first_cell = index == 0 and line.lstrip().startswith("| `")
+            if not first_cell and not _INLINE_MEMBER.match(raw):
+                continue
+            ident = _IDENT.match(raw)
+            if ident:
+                found.append((ident.group(1), raw))
+    return found
+
+
+def _check_sections(
+    classes: dict[str, dict[str, set[str]]], module_level: set[str]
+) -> list[str]:
+    """Invariants 1 and 3, which both walk the same sections.
+
+    1. Every member named in a contract table exists on one of the section's
+       classes (or is itself a class — docs legitimately tabulate types).
+    3. A documented wrapper is documented alongside its hook: if a section
+       names a public ``X`` for which the class defines ``_X_impl``, it must
+       name ``_X_impl`` too, or it is presenting the wrapper as the override
+       point.
+    """
+    problems: list[str] = []
+    for doc, heading, class_names in SECTIONS:
+        path = ROOT / doc
+        if not path.exists():
+            problems.append(f"{doc}: listed in SECTIONS but the file is missing")
+            continue
+        section = _section_lines(path.read_text(encoding="utf-8").splitlines(), heading)
+        if section is None:
+            problems.append(f"{doc}: no section titled {heading!r} (SECTIONS is stale)")
+            continue
+        members: set[str] = set()
+        missing = [name for name in class_names if not _resolve(name, classes)]
+        if missing:
+            joined = ", ".join(repr(name) for name in missing)
+            problems.append(f"{doc}: class(es) {joined} not found under {'/, '.join(PACKAGES)}/")
+            continue
+        for name in class_names:
+            members |= _resolve(name, classes)
+
+        start, body = section
+        ignore = IGNORE.get((doc, heading), frozenset())
+        documented = _documented_members(body)
+        names = {ident for ident, _ in documented}
+
+        for ident, raw in documented:
+            if ident in members or ident in ignore or ident in classes or ident in module_level:
+                continue
+            problems.append(
+                f"{doc}:{start} § {heading}: `{raw}` is not a member of "
+                f"{'/'.join(class_names)} (nor of its bases, nor a class or module-level "
+                f"symbol). Fix the "
+                f"doc, or add it to this section's IGNORE entry if it names a dict "
+                f"key rather than a member."
+            )
+
+        for ident in sorted(names):
+            hook = f"_{ident}_impl"
+            if ident.startswith("_") or hook not in members or hook in names:
+                continue
+            problems.append(
+                f"{doc}:{start} § {heading}: `{ident}` is a wrapper — the class "
+                f"defines `{hook}`, which is the real override point — but the "
+                f"section never names `{hook}`. Readers will override `{ident}` and "
+                f"lose whatever the wrapper does (locking, normalization, progress). "
+                f"Document the hook here, or stop naming the wrapper."
+            )
+    return problems
+
+
+def _check_coverage() -> list[str]:
+    """Invariant 2: every contract-shaped heading is registered in SECTIONS."""
+    registered = {(doc, heading) for doc, heading, _ in SECTIONS}
+    problems: list[str] = []
+    for glob in DOC_GLOBS:
+        for path in sorted(ROOT.glob(glob)):
+            doc = path.relative_to(ROOT).as_posix()
+            for line in path.read_text(encoding="utf-8").splitlines():
+                match = _HEADING.match(line)
+                if not match:
+                    continue
+                heading = match.group(2)
+                if _CONTRACT_HEADING.search(heading) and (doc, heading) not in registered:
+                    problems.append(
+                        f"{doc}: section {heading!r} looks like a contract table but is "
+                        f"not in SECTIONS — add it (with the class it documents) so its "
+                        f"member names are checked."
+                    )
+    return problems
+
+
+def main() -> int:
+    problems = _check_sections(_index_classes(), _index_module_level()) + _check_coverage()
+    if problems:
+        print("Extension-doc check failed:\n")
+        for problem in problems:
+            print(f"  - {problem}")
+        print(f"\n{len(problems)} problem(s). See the module docstring for what this checks.")
+        return 1
+    print(f"Extension docs OK ({len(SECTIONS)} contract sections checked).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_lib/core/test_extension_docs_gate.py
+++ b/tests_lib/core/test_extension_docs_gate.py
@@ -1,0 +1,293 @@
+"""The extension-doc drift gate itself: `scripts/check-extension-docs.py`.
+
+Two doc sets state the contract for the same plugin ABCs in their own words,
+so each can drift from the code and from the other with nothing failing. The
+gate exists because that already happened three times at once (issue #3442).
+A gate that stops noticing is worse than no gate — the repo now *believes* its
+two extension guides agree — so pin both halves: every invariant fires on a
+real defect, and stays quiet on the legitimate shapes the docs actually use.
+
+The historical defects are pinned as regression tests below, reconstructed as
+synthetic sections, so a future rewrite of either doc set cannot quietly
+reintroduce them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-extension-docs.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("_extension_docs_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate()
+CLASSES = gate._index_classes()
+MODULE_LEVEL = gate._index_module_level()
+
+
+def check(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    body: str,
+    classes: tuple[str, ...] = ("MediaEmbedder",),
+    heading: str = "The contract",
+    ignore: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Run the section invariants over a synthetic doc; return the problems.
+
+    The class index still comes from the real tree — the point is to check
+    prose against the shipped ABCs — but the doc under test is synthetic, so a
+    test can describe a defect without editing a real guide.
+    """
+    doc = tmp_path / "synthetic.md"
+    doc.write_text(f"## {heading}\n\n{body}\n", encoding="utf-8")
+    monkeypatch.setattr(gate, "ROOT", tmp_path)
+    monkeypatch.setattr(gate, "SECTIONS", [("synthetic.md", heading, classes)])
+    monkeypatch.setattr(gate, "IGNORE", {("synthetic.md", heading): ignore} if ignore else {})
+    return gate._check_sections(CLASSES, MODULE_LEVEL)
+
+
+class TestRepoIsClean:
+    """The gate passes on the repo as committed."""
+
+    def test_no_drift(self):
+        assert gate.main() == 0
+
+    def test_runs_fast_enough_to_gate(self):
+        """It runs on every `./run-tests.sh`, so it must stay cheap.
+
+        The bound is deliberately loose: this asserts on wall clock, and the
+        suite runs under ``pytest -n auto`` on whatever machine is free. It is
+        here to catch an order-of-magnitude regression (an accidental import of
+        the package under test, a quadratic sweep), not to police tenths.
+        """
+        start = time.monotonic()
+        gate._check_sections(gate._index_classes(), gate._index_module_level())
+        assert time.monotonic() - start < 20.0
+
+    def test_every_section_is_reachable(self):
+        """Each configured section resolves to a real heading in a real file."""
+        for doc, heading, _ in gate.SECTIONS:
+            path = REPO_ROOT / doc
+            assert path.exists(), f"{doc} is in SECTIONS but missing"
+            lines = path.read_text(encoding="utf-8").splitlines()
+            assert gate._section_lines(lines, heading) is not None, f"{doc}: no § {heading}"
+
+    def test_both_doc_sets_are_covered(self):
+        """Neither tier may drop out of the config wholesale."""
+        docs = {doc for doc, _, _ in gate.SECTIONS}
+        assert any(d.startswith("docs/EXTENDING-") for d in docs)
+        assert any(d.startswith("vtscore/docs/extending/") for d in docs)
+
+
+class TestMemberExtraction:
+    """What counts as a member reference inside a contract table."""
+
+    def test_first_cell_bare_name(self):
+        found = gate._documented_members(["| `name` | `str` | Unique key |"])
+        assert [ident for ident, _ in found] == ["name"]
+
+    def test_first_cell_strips_signature_and_annotation(self):
+        rows = [
+            "| `clip(media)` | x | y |",
+            "| `supports_text: bool` | x | y |",
+            "| `media_type` (property) | x | y |",
+        ]
+        assert [i for i, _ in gate._documented_members(rows)] == ["clip", "supports_text", "media_type"]
+
+    def test_later_cells_yield_private_names_and_calls(self):
+        """The `_patch_forward` defect lived in a description column, not cell one."""
+        row = "| `supports_patch_regions` | False | implement `_patch_forward_impl(media)` |"
+        assert [i for i, _ in gate._documented_members([row])] == [
+            "supports_patch_regions",
+            "_patch_forward_impl",
+        ]
+
+    def test_later_cells_ignore_bare_types(self):
+        """`str` in a signature column is a type, not a member named `str`."""
+        row = "| `name` | `str` | Returns a `dict` of `bool` |"
+        assert [i for i, _ in gate._documented_members([row])] == ["name"]
+
+    def test_space_before_paren_is_not_a_call(self):
+        """`classmethod (str, dict) -> Self` is an annotation, not a member."""
+        row = "| `from_config(name, config)` | `classmethod (str, dict) -> Self` | Build |"
+        assert [i for i, _ in gate._documented_members([row])] == ["from_config"]
+
+    def test_prose_outside_tables_is_ignored(self):
+        assert gate._documented_members(["Do not override `embed_media()` here."]) == []
+
+
+class TestMemberInvariant:
+    """Invariant 1: a documented member must exist on the class."""
+
+    def test_real_member_passes(self, monkeypatch, tmp_path):
+        assert check(monkeypatch, tmp_path, "| `_embed_media_impl(media)` | x | y |") == []
+
+    def test_invented_member_fails(self, monkeypatch, tmp_path):
+        problems = check(monkeypatch, tmp_path, "| `_embed_nonsense_impl(media)` | x | y |")
+        assert len(problems) == 1
+        assert "_embed_nonsense_impl" in problems[0]
+
+    def test_inherited_member_passes(self, monkeypatch, tmp_path):
+        """`MediaCleaner` inherits from `MediaClipper`; the base's members count."""
+        assert check(monkeypatch, tmp_path, "| `clip(media)` | x | y |", ("MediaCleaner",)) == []
+
+    def test_class_name_passes(self, monkeypatch, tmp_path):
+        """Docs legitimately tabulate types alongside members."""
+        assert check(monkeypatch, tmp_path, "| `FetchedItem` | `path` | y |", ("MediaSource",)) == []
+
+    def test_module_level_function_passes(self, monkeypatch, tmp_path):
+        """A free function is a real symbol, just not a method."""
+        assert check(monkeypatch, tmp_path, "| `x` | y | set via `set_progress_callback()` |") == []
+
+    def test_ignore_entry_excuses_a_dict_key(self, monkeypatch, tmp_path):
+        body = "| `step` | int | A parameter-dict key |"
+        assert check(monkeypatch, tmp_path, body, ("MediaClipper",)) != []
+        assert check(monkeypatch, tmp_path, body, ("MediaClipper",), ignore=frozenset({"step"})) == []
+
+    def test_unknown_class_is_reported(self, monkeypatch, tmp_path):
+        problems = check(monkeypatch, tmp_path, "| `x` | y | z |", ("NoSuchAbc",))
+        assert len(problems) == 1 and "NoSuchAbc" in problems[0]
+
+    def test_multi_class_section_accepts_any_member(self, monkeypatch, tmp_path):
+        """`detect` is on `Detector`, not on the `Processor` base."""
+        body = "| `detect(media)` | `(dict) -> bool` | y |"
+        assert check(monkeypatch, tmp_path, body, ("Processor",)) != []
+        assert check(monkeypatch, tmp_path, body, ("Processor", "Detector")) == []
+
+
+class TestWrapperInvariant:
+    """Invariant 3: a documented wrapper must be shown beside its hook."""
+
+    def test_wrapper_alone_fails(self, monkeypatch, tmp_path):
+        """The `embed_text` defect: the wrapper presented as the override point."""
+        problems = check(monkeypatch, tmp_path, "| `embed_text(text)` | `None` | Override to sort |")
+        assert len(problems) == 1
+        assert "_embed_text_impl" in problems[0] and "wrapper" in problems[0]
+
+    def test_wrapper_beside_its_hook_passes(self, monkeypatch, tmp_path):
+        body = "| `embed_text(text)` | x | wraps `_embed_text_impl(text)` |"
+        assert check(monkeypatch, tmp_path, body) == []
+
+    def test_hook_alone_passes(self, monkeypatch, tmp_path):
+        assert check(monkeypatch, tmp_path, "| `_embed_text_impl(text)` | x | y |") == []
+
+    def test_method_without_a_hook_is_not_a_wrapper(self, monkeypatch, tmp_path):
+        """`embed_medias` has no `_embed_medias_impl`, so it is safe to name."""
+        assert check(monkeypatch, tmp_path, "| `embed_medias(medias)` | x | y |") == []
+
+
+class TestCoverageInvariant:
+    """Invariant 2: a contract-shaped heading must be registered."""
+
+    def test_repo_has_no_unregistered_sections(self):
+        assert gate._check_coverage() == []
+
+    @pytest.mark.parametrize(
+        "heading",
+        ["MediaFoo abstract interface reference", "The contract", "Capability flags"],
+    )
+    def test_unregistered_heading_is_flagged(self, monkeypatch, tmp_path, heading):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "EXTENDING-synthetic.md").write_text(f"## {heading}\n", encoding="utf-8")
+        monkeypatch.setattr(gate, "ROOT", tmp_path)
+        monkeypatch.setattr(gate, "SECTIONS", [])
+        problems = gate._check_coverage()
+        assert len(problems) == 1 and heading in problems[0]
+
+    def test_ordinary_heading_is_not_flagged(self, monkeypatch, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "EXTENDING-synthetic.md").write_text("## Worked example\n", encoding="utf-8")
+        monkeypatch.setattr(gate, "ROOT", tmp_path)
+        monkeypatch.setattr(gate, "SECTIONS", [])
+        assert gate._check_coverage() == []
+
+
+class TestHistoricalDrift:
+    """The three defects that motivated the gate, pinned so they can't return."""
+
+    def test_embed_text_override_point(self):
+        """`embedders.md` told authors to override the L2-normalizing wrapper."""
+        text = (REPO_ROOT / "vtscore" / "docs" / "extending" / "embedders.md").read_text()
+        assert "| `embed_text(text)` | `None` |" not in text
+        assert "`_embed_text_impl(text)`" in text
+
+    def test_patch_forward_hook_name(self):
+        """`EXTENDING-media.md` named a hook nothing calls."""
+        text = (REPO_ROOT / "docs" / "EXTENDING-media.md").read_text()
+        assert "`_patch_forward(image)" not in text
+        assert "_patch_forward_impl" in text
+
+    def test_exporter_base_class_name(self):
+        """The library index still named the pre-rename alias as the base class.
+
+        Not mechanically checkable — `LabelsetExporter` is a real, permanently
+        supported alias, so no member check can tell "outdated preferred name"
+        from "deliberate compatibility alias". Pinned as text instead.
+        """
+        text = (REPO_ROOT / "vtscore" / "docs" / "extending" / "README.md").read_text()
+        assert "| `EXPORTER` | `LabelsetExporter` |" not in text
+        assert "`ResultsExporter`" in text
+
+
+class TestCrossLinks:
+    """Each doc set names the other, in both directions (issue #3442)."""
+
+    def test_front_door_links_to_the_library_set(self):
+        text = (REPO_ROOT / "docs" / "EXTENDING.md").read_text()
+        assert "../vtscore/docs/extending/README.md" in text
+
+    def test_library_index_links_back_to_the_front_door(self):
+        text = (REPO_ROOT / "vtscore" / "docs" / "extending" / "README.md").read_text()
+        assert "../../../docs/EXTENDING.md" in text
+
+    @pytest.mark.parametrize(
+        ("doc", "guide"),
+        [
+            ("docs/EXTENDING-media.md", "media-types"),
+            ("docs/EXTENDING-media.md", "embedders"),
+            ("docs/EXTENDING-media.md", "clippers"),
+            ("docs/EXTENDING-media.md", "converters"),
+            ("docs/EXTENDING-plugins.md", "dataset-importers"),
+            ("docs/EXTENDING-plugins.md", "results-exporters"),
+            ("docs/EXTENDING-plugins.md", "label-importers"),
+            ("docs/EXTENDING-plugins.md", "labelset-sources"),
+        ],
+    )
+    def test_app_guide_points_at_its_library_counterpart(self, doc, guide):
+        text = (REPO_ROOT / doc).read_text()
+        assert f"../vtscore/docs/extending/{guide}.md" in text
+
+    @pytest.mark.parametrize(
+        "guide",
+        [
+            "media-types",
+            "embedders",
+            "clippers",
+            "converters",
+            "dataset-importers",
+            "results-exporters",
+            "label-importers",
+            "labelset-sources",
+        ],
+    )
+    def test_library_guide_points_at_its_app_counterpart(self, guide):
+        text = (REPO_ROOT / "vtscore" / "docs" / "extending" / f"{guide}.md").read_text()
+        assert "App-side counterpart:" in text
+        assert "../../../docs/EXTENDING-" in text

--- a/tests_lib/core/test_extension_docs_gate.py
+++ b/tests_lib/core/test_extension_docs_gate.py
@@ -152,7 +152,8 @@ class TestMemberInvariant:
 
     def test_module_level_function_passes(self, monkeypatch, tmp_path):
         """A free function is a real symbol, just not a method."""
-        assert check(monkeypatch, tmp_path, "| `x` | y | set via `set_progress_callback()` |") == []
+        body = "| `_on_progress` | callback | process-wide via `set_progress_callback()` |"
+        assert check(monkeypatch, tmp_path, body) == []
 
     def test_ignore_entry_excuses_a_dict_key(self, monkeypatch, tmp_path):
         body = "| `step` | int | A parameter-dict key |"

--- a/vtscore/docs/extending/README.md
+++ b/vtscore/docs/extending/README.md
@@ -8,10 +8,20 @@ registers every sub-package or flat module that exposes a sentinel
 attribute (`IMPORTER`, `EXPORTER`, `EMBEDDER`, …), and then walks the
 matching `importlib.metadata` entry-point group so third-party
 distributions can drop plugins in without forking the repo. Each
-plugin subclasses one base ABC (`DatasetImporter`, `LabelsetExporter`,
+plugin subclasses one base ABC (`DatasetImporter`, `ResultsExporter`,
 `MediaEmbedder`, …) that inherits from `PluginBase`, declares its
 user-facing inputs as a list of `PluginField`s, and implements one or
 two abstract methods.
+
+**This doc set is the library contract**, written for someone shipping a
+plugin as a separate distribution against the semver'd `vtscore` package.
+The repo's own front door is
+[`docs/EXTENDING.md`](../../../docs/EXTENDING.md), whose
+`EXTENDING-*.md` guides cover the same ABCs plus the app-tier wiring
+(routes, forms, the pickers the frontend renders) that an in-repo
+contributor needs. Every page here names its app-side counterpart, and
+`scripts/check-extension-docs.py` holds both sets to the code so they
+cannot drift apart unnoticed.
 
 If you're contributing a plugin to the `vtscore` source tree, drop it
 in the family's package; if you're shipping a separate distribution,
@@ -37,7 +47,7 @@ group to pick.
 | Dataset importers | `vtscore.importers` | `IMPORTER` | `DatasetImporter` | Pull media into a dataset from a source (folder, archive, API, etc.) |
 | Datasource importers | `vtscore.datasource_importers` | `DATASOURCE_IMPORTER` | `DataSourceImporter` | Fetch *one* media item on demand, so a user can supply an exemplar from a URL, a server path, a service |
 | Seed importers | `vtscore.seed_importers` | `SEED_IMPORTER` | `SeedImporter` | Contribute a *batch* of unlabeled seed media ("close but not quite") to a new blank detector |
-| Results exporters | `vtscore.exporters` | `EXPORTER` | `LabelsetExporter` | Send autodetect results or labels somewhere (file, webhook, email, …) |
+| Results exporters | `vtscore.exporters` | `EXPORTER` | `ResultsExporter` | Send autodetect results or labels somewhere (file, webhook, email, …). `LabelsetExporter` is a permanent alias for the old name |
 | Label importers | `vtscore.label_importers` | `LABEL_IMPORTER` | `LabelImporter` | One-shot pull of `(md5, label)` pairs from an external source |
 | Labelset sources | `vtscore.labelset_sources` | `LABELSET_SOURCE` | `LabelsetSource` | Bidirectional sync of a detector's labelset with an external store |
 | Media converters | `vtscore.converters` | `CONVERTER` | `MediaConverter` | Cross-format access: image → text (OCR), audio → image (spectrogram), … |
@@ -57,7 +67,8 @@ directories are loaded via `importlib.util.spec_from_file_location`
 
 ### App tier (in `vtsearch`)
 
-These are documented in the repo-level [`EXTENDING-plugins.md`](../../../docs/EXTENDING-plugins.md);
+These are documented in the repo-level [`EXTENDING-plugins.md`](../../../docs/EXTENDING-plugins.md)
+(indexed from [`docs/EXTENDING.md`](../../../docs/EXTENDING.md));
 their library counterparts (`vtscore.labels.sources`) handle bidirectional
 sync at the model layer.
 

--- a/vtscore/docs/extending/embedders.md
+++ b/vtscore/docs/extending/embedders.md
@@ -44,14 +44,15 @@ Optional but commonly overridden:
 |--------|---------|---------|
 | `display_name` | `name` | Friendlier label for the picker UI |
 | `is_default` | `False` | Exactly one embedder per media type should return `True` - that one is what `embedders_for_type(t)[0]` returns |
-| `embed_text(text)` | `None` | Return `None` to disable text-query sort, or a vector in the same space as `_embed_media_impl` |
+| `_embed_text_impl(text)` | `None` | Text-query hook - override this, NOT `embed_text`, which L2-normalizes the result for you. Leave the default to disable text-query sort; otherwise return a vector in the same space as `_embed_media_impl` |
 | `description_wrappers` | `[]` | Templates with `{text}` for enriched text embedding (e.g. `["the sound of {text}"]`). Keep the default unless you have measured that the ensemble beats the typed query on your checkpoint - it is a loss on most (#3127/#3341) |
 | `_embed_media_bulk_impl(medias)` | per-item loop | Native bulk hook for service embedders or batched GPU forward passes |
 | `_patch_forward_impl(media)` | `None` | For patch-capable image encoders; required when `supports_patch_regions = True` |
 
-Don't override the public methods `embed_media`, `embed_media_bulk`,
-`load_models`, or `patch_forward` - they wrap the `_impl` hooks with
-shared locking and progress dispatch.
+Don't override the public methods `embed_media`, `embed_text`,
+`embed_media_bulk`, `load_models`, or `patch_forward` - they wrap the
+`_impl` hooks with shared locking, L2-normalization, and progress
+dispatch.
 
 ## Where the file goes
 


### PR DESCRIPTION
`docs/EXTENDING-*.md` and `vtscore/docs/extending/` state the contract for the same plugin ABCs in their own words. Investigation for #3442 confirmed the premise and found the predicted drift had **already happened, three ways** — each set right where the other was wrong, which is precisely the failure mode prose discipline doesn't catch.

## The three defects, verified against source

| Where | Said | Actually | Consequence |
|---|---|---|---|
| `vtscore/docs/extending/embedders.md` | override `embed_text(text)` | `_embed_text_impl`; `embed_text` L2-normalizes | Query vectors ship un-normalized into the dot-product scoring in `vtscore.training.region_similarity` |
| `docs/EXTENDING-media.md` | `_patch_forward(image) -> PatchEmbedOutput` | `_patch_forward_impl(media)` | Method is never called; an embedder advertising `supports_patch_regions` yields all-`None` patches |
| `vtscore/docs/extending/README.md` | base class `LabelsetExporter` | renamed `ResultsExporter` (alias kept) | Contradicts its own `results-exporters.md` |

All three contradict the code's own docstrings, which say "Override this instead of …" in as many words.

## What this changes

**Fixes the three defects.**

**Adds `scripts/check-extension-docs.py`**, a stage-1 `./run-tests.sh` gate — AST sweep, stdlib only, imports nothing (so it runs before the venv is warm and can't be broken by a heavy optional dependency), ~1s. Three invariants:

1. Every member named in a contract table exists on the class or its bases. Class names and module-level symbols count too, since docs legitimately tabulate types and free functions.
2. Every contract-shaped heading is registered in `SECTIONS` — without this a new "abstract interface reference" would ship unchecked, the coverage hole that makes invariant 1 look healthier than it is.
3. A documented public wrapper must be shown beside its `_impl` hook. This is the one that catches the `embed_text` shape, and it catches it at the moment the hook is introduced rather than whenever someone next reads the table.

The exporter rename is deliberately **not** gated: `LabelsetExporter` is a permanent, policy-protected alias, so no member check can distinguish "outdated preferred name" from "deliberate compatibility alias". It's pinned as a regression test instead.

**States the division of labour in both front doors** — in-repo contributors read `docs/EXTENDING-*.md` (contract plus app-tier wiring), out-of-tree authors read `vtscore/docs/extending/` (contract plus entry-point packaging) — and adds the missing links: a "Library contract" column on `EXTENDING.md`'s guide table, a per-family pointer in each app-tier section mirroring the library set's existing "App-side counterpart", and a back-link from the library index.

## Scope decision

Stripping the app-tier guides down to "only app-tier wiring", as the issue's Direction proposed, was **considered and declined**. Those guides are the in-repo contributor's front door and are worth keeping self-contained; their contract tables are not redundant for that reader. The rot is addressed mechanically instead, which is more durable than a division of labour nothing enforces. The issue body records this rescoping.

Per the issue's constraint, **no guide or anchor is removed** — every existing path and heading still resolves, so external bookmarks keep working.

## Testing

`tests_lib/core/test_extension_docs_gate.py` (48 tests) pins both halves, following `test_docs_gate.py`'s conventions: each invariant fires on a real defect and stays quiet on the legitimate shapes the docs actually use (types in signature columns, `classmethod (…)` annotations, parameter-dict keys, inherited members, multi-class sections). The three historical defects are pinned as regression tests.

The gate was verified non-vacuous end-to-end by reintroducing both mechanically-checkable defects into the real docs and confirming it fails on them.

Full `./run-tests.sh`: **RUN PASSED** — 9529 passed, 6 skipped, 1 xfailed; pyright, pip-audit, npm audit and Vitest all green.

Closes #3442

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEKCeZZgqY1ZUvurVZwDCz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEKCeZZgqY1ZUvurVZwDCz)_