### PR TITLE
Converge subscription teardown on takeUntilDestroyed(), and document teardown vs. cancellation

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -307,6 +307,9 @@ this codebase, and it is silent.
   reading a signal auto-disposes with the component, which is why the
   `takeUntil(destroy$)` / `ngOnDestroy` plumbing has been dropped wherever it
   was the last user.
+- **Where a subscription is still needed, tear it down with
+  `takeUntilDestroyed()`** — see "Subscription teardown vs. cancellation"
+  below for the one distinction that decides it.
 - **Reads go through `rxResource`.** The read path is being migrated onto
   Angular's reactive resource primitives (`SettingsStateService`,
   `MediaStateService`, several picker modals so far). `rxResource({ params,
@@ -494,6 +497,52 @@ rather than a signal, and `ToastService` subscribes to turn each into a toast
 of the matching level. See [`api/events.md`](api/events.md) for the payload
 and [`EXTENDING-plugins.md`](EXTENDING-plugins.md#notifying-the-user-toasts)
 for the producing side.
+
+### Subscription teardown vs. cancellation
+
+Two different jobs get done with the same RxJS machinery, and conflating them
+is how a working poller gets swept into a bug. Name which one you are doing
+before reaching for an idiom.
+
+**Teardown** — "stop this when the component dies." There is exactly one
+sanctioned idiom, and new code must use it:
+
+```ts
+private destroyRef = inject(DestroyRef);
+...
+this.someService.thing$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(...);
+```
+
+Drop the explicit `destroyRef` argument only in an injection context (a field
+initializer or the constructor body); anywhere else — `ngOnInit`,
+`ngAfterViewInit`, an event handler — it must be passed. The point of the
+idiom is that teardown is *declared at the subscription*, so adding a
+subscription can never forget to add a matching `unsubscribe()`. Two older
+idioms survive in the tree and are converted opportunistically, never
+introduced: a hand-rolled `destroy$ = new Subject<void>()` fired from
+`ngOnDestroy`, and a `subs: Subscription[]` array drained in `ngOnDestroy`.
+Both are strictly worse — the bookkeeping is manual and the compiler does not
+check it.
+
+**Cancellation** — "stop the *previous* one because a newer one supersedes
+it." This is not teardown and `takeUntilDestroyed()` cannot express it; the
+component is very much still alive. It legitimately takes one of two shapes,
+and both are correct as written:
+
+- A **scope subject** fired on each reset, for a family of streams that share
+  a lifetime shorter than the component's: `pairScope$` (`find-view`,
+  `label-view`) tears down everything belonging to the dataset/detector pair
+  being left, `findPolling$` (`dashboard`) and `stopPolling$`
+  (`VoteStateService`) cancel a superseded poll. Name it for the scope it
+  bounds, never `destroy$`.
+- A **re-assigned `Subscription` field** that unsubscribes the previous value
+  before storing the next: `text-viewer`'s `sub`, `folder-browser`'s
+  `currentSub`, `browse-bin-popup`'s `scrollSub` (re-keyed to the viewport
+  *instance*), `label-importer-modal`'s `ingestSub`.
+
+A `Subscription` field is only a teardown idiom when it is written once and
+read only by `ngOnDestroy`. If it is re-assigned anywhere, it is cancellation
+— leave it alone.
 
 Where a real poll is still needed, use `adaptivePoll()` from
 `services/adaptive-poll.ts` rather than `timer(0, n)` + `switchMap`. It runs

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,5 +1,6 @@
-import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, Injector, input, OnDestroy, output, untracked, viewChild } from '@angular/core';
+import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, effect, ElementRef, HostListener, inject, Injector, input, OnDestroy, output, untracked, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { Subscription } from 'rxjs';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
@@ -192,6 +193,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
   private cdr = inject(ChangeDetectorRef);
   private injector = inject(Injector);
+  private destroyRef = inject(DestroyRef);
 
   /** Member media ids of the bin the popup was summoned over. */
   readonly memberIds = input<number[]>([]);
@@ -328,7 +330,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** Ids whose full-res ``/image`` failed; the preview falls back to the
    *  thumbnail for these so it still shows something. */
   private readonly failedPreviews = new Set<number>();
-  private readonly subs: Subscription[] = [];
   private scrollSub: Subscription | null = null;
   /** The viewport instance whose ``scrolledIndexChange`` is currently subscribed. */
   private scrollSubscribedViewport: CdkVirtualScrollViewport | null = null;
@@ -509,10 +510,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    this.subs.push(
-      // Names/thumbnails arrive asynchronously; repaint the visible rows.
-      this.metadataCache.version$.subscribe(() => this.cdr.markForCheck()),
-    );
+    // Names/thumbnails arrive asynchronously; repaint the visible rows.
+    this.metadataCache.version$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.cdr.markForCheck());
     this.settingsState.load();
     this.prefetchVisible();
     setTimeout(() => this.place());
@@ -536,7 +537,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    for (const sub of this.subs) sub.unsubscribe();
     this.scrollSub?.unsubscribe();
     // Drop any in-flight metadata-divider drag listeners (destroyed mid-drag).
     document.removeEventListener('pointermove', this.boundMetaMove);

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, NgZone, OnDestroy, output, untracked, viewChild } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, effect, ElementRef, inject, input, NgZone, OnDestroy, output, untracked, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { BrowseViewportService } from '../../services/browse-viewport.service';
@@ -101,6 +101,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   private viewport = inject(BrowseViewportService);
   private selection = inject(BrowseSelectionService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
+  private destroyRef = inject(DestroyRef);
 
   private readonly canvasRef = viewChild.required<ElementRef<HTMLCanvasElement>>('canvas');
   readonly meta = input<ProjectionMeta | null>(null);
@@ -465,7 +466,6 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   private lastClientY = 0;
   private pointerInside = false;
 
-  private tileLoadSub: Subscription | null = null;
   private rafId = 0;
   /** Set in ngOnDestroy: late async callbacks (thumbnail loads, tile
    *  responses) must not schedule new rAF / idle work on a dead component. */
@@ -578,8 +578,6 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   private boundCanvasMouseLeave = this.onCanvasMouseLeave.bind(this);
   private boundDblClick = this.onDblClick.bind(this);
   private boundContextMenu = this.onContextMenu.bind(this);
-
-  private recenterSub: Subscription | null = null;
 
   // Repaint when the selection changes so the per-cell selection rings track
   // the live set. An effect (not a subscription) so a signal write — including
@@ -713,13 +711,13 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     this.ctx = this.canvasRef().nativeElement.getContext('2d')!;
 
-    this.tileLoadSub = this.tileCache.tileLoaded$.subscribe(() => {
+    this.tileCache.tileLoaded$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.requestRedraw();
     });
 
     // The minimap publishes recenter requests when the user clicks/drags it;
     // jump the viewport centre there (keeping zoom) and redraw.
-    this.recenterSub = this.viewport.recenter$.subscribe(({ x, y }) => {
+    this.viewport.recenter$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ x, y }) => {
       // A minimap jump is a programmatic move, not an elastic gesture: cancel any
       // snap-back / directional glide and hard-clamp straight to the bounds.
       this.cancelSettle();
@@ -770,8 +768,6 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.destroyed = true;
-    this.tileLoadSub?.unsubscribe();
-    this.recenterSub?.unsubscribe();
     this.viewport.setViewport(null);
     this.resizeObserver?.disconnect();
     this.dprListenerTeardown?.();

--- a/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
+++ b/frontend/src/app/components/browse-minimap/browse-minimap.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, model, NgZone, OnDestroy, output, untracked, viewChild } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, effect, ElementRef, inject, input, model, NgZone, OnDestroy, output, untracked, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TileCacheService } from '../../services/tile-cache.service';
 import { BrowseViewportService, ViewportBounds } from '../../services/browse-viewport.service';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
@@ -48,6 +48,7 @@ export class BrowseMinimapComponent implements AfterViewInit, OnDestroy {
   private tileCache = inject(TileCacheService);
   private viewport = inject(BrowseViewportService);
   private selection = inject(BrowseSelectionService);
+  private destroyRef = inject(DestroyRef);
   private host = inject<ElementRef<HTMLElement>>(ElementRef);
 
   // Repaint whenever the selection mutates, so the overview's tristate tint
@@ -135,8 +136,6 @@ export class BrowseMinimapComponent implements AfterViewInit, OnDestroy {
   private dpr = 1;
   private viewportBounds: ViewportBounds = null;
 
-  private tileLoadSub: Subscription | null = null;
-  private viewportSub: Subscription | null = null;
   private rafId = 0;
   private needsRedraw = false;
   // Repaints when the document theme flips, matching the main canvas.
@@ -171,8 +170,10 @@ export class BrowseMinimapComponent implements AfterViewInit, OnDestroy {
 
     // Overview tiles arrive asynchronously; repaint as the cache fills. The
     // viewport box updates on every pan/zoom the main canvas publishes.
-    this.tileLoadSub = this.tileCache.tileLoaded$.subscribe(() => this.requestRedraw());
-    this.viewportSub = this.viewport.viewport$.subscribe((b) => {
+    this.tileCache.tileLoaded$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.requestRedraw());
+    this.viewport.viewport$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((b) => {
       this.viewportBounds = b;
       this.requestRedraw();
     });
@@ -188,8 +189,6 @@ export class BrowseMinimapComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.tileLoadSub?.unsubscribe();
-    this.viewportSub?.unsubscribe();
     this.themeObserver?.disconnect();
     this.resizeObserver?.disconnect();
     this.dprListenerTeardown?.();

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { Subscription } from 'rxjs';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -58,6 +58,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   private activeContext = inject(ActiveContextService);
   private settingsState = inject(SettingsStateService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
+  private destroyRef = inject(DestroyRef);
 
   /** Active media type, used to resolve the per-type view-mode + size prefs. */
   readonly mediaType = input('');
@@ -106,7 +107,6 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   private ids: number[] = [];
   private gridIconSizeRightDict: Record<string, string> = {};
   private readonly thumbnailFailedUrls = new Set<string>();
-  private readonly subs: Subscription[] = [];
 
   // --- Audio audition state machine (mirrors browse-hover-preview) -----------
   /** Never mounted in the DOM — audio here is heard, not shown; the top-left
@@ -159,16 +159,13 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.subs.push(
-      this.metadataCache.version$.subscribe(() => {
-        this.sortedEntries.set(this.buildSortedEntries());
-      }),
-    );
+    this.metadataCache.version$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.sortedEntries.set(this.buildSortedEntries());
+    });
     this.settingsState.load();
   }
 
   ngOnDestroy(): void {
-    for (const sub of this.subs) sub.unsubscribe();
     this.cancelDwell();
     this.stopSweep();
     this.stopAudio();

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
 import { KeyValuePipe, TitleCasePipe } from '@angular/common';
-import { Subscription } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EmbedderInfo, Media, PayloadVariant } from '../../models/api.models';
 import { MediasApiService } from '../../services/medias-api.service';
 import { KeyboardService } from '../../services/keyboard.service';
@@ -44,6 +44,7 @@ export class CenterPanelComponent implements OnDestroy {
   private settingsState = inject(SettingsStateService);
   private sortState = inject(SortStateService);
   private datasetsListingsApi = inject(DatasetsListingsApiService);
+  private destroyRef = inject(DestroyRef);
 
   readonly media = input<Media | null>(null);
   readonly disabled = input(false);
@@ -104,7 +105,6 @@ export class CenterPanelComponent implements OnDestroy {
   private spinTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _pausedByVisibility = false;
-  private subs: Subscription[] = [];
 
   constructor() {
     effect(() => {
@@ -150,7 +150,6 @@ export class CenterPanelComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.stopPlayback();
     this.keyboard.stop();
-    this.subs.forEach((s) => s.unsubscribe());
     if (this.spinTimer) clearTimeout(this.spinTimer);
     if (this.undoToastTimer) clearTimeout(this.undoToastTimer);
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
@@ -172,52 +171,53 @@ export class CenterPanelComponent implements OnDestroy {
   init(): void {
     this.loadSettings();
     this.keyboard.start();
-    this.subs.push(
-      this.datasetsListingsApi.getEmbedders().subscribe({
+    this.datasetsListingsApi
+      .getEmbedders()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
         next: (embedders) => (this.embedderInfos = embedders),
-      }),
-    );
+      });
     document.addEventListener('visibilitychange', this.onVisibilityChange);
-    this.subs.push(
-      this.keyboard.action$.subscribe((action) => {
-        switch (action.type) {
-          case 'vote':
-            if (this.media() && action.direction && !this.disabled()) {
-              this.castVote(action.direction);
-            }
-            break;
-          case 'volume':
-            this.adjustVolume(action.volumeDelta ?? 0);
-            break;
-          case 'playback':
-            this.togglePlayback();
-            break;
-          case 'zoom': {
-            const imageViewer = this.imageViewer();
-            if (imageViewer && action.zoomDirection) {
-              if (action.zoomDirection === 'in') imageViewer.zoomIn();
-              else imageViewer.zoomOut();
-            }
-            break;
+    this.keyboard.action$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((action) => {
+      switch (action.type) {
+        case 'vote':
+          if (this.media() && action.direction && !this.disabled()) {
+            this.castVote(action.direction);
           }
-          case 'rotate': {
-            const imageViewer = this.imageViewer();
-            if (imageViewer && action.rotateDirection) {
-              if (action.rotateDirection === 'left') imageViewer.rotateLeft();
-              else imageViewer.rotateRight();
-            }
-            break;
+          break;
+        case 'volume':
+          this.adjustVolume(action.volumeDelta ?? 0);
+          break;
+        case 'playback':
+          this.togglePlayback();
+          break;
+        case 'zoom': {
+          const imageViewer = this.imageViewer();
+          if (imageViewer && action.zoomDirection) {
+            if (action.zoomDirection === 'in') imageViewer.zoomIn();
+            else imageViewer.zoomOut();
           }
-          case 'undo':
-            if (!this.disabled() && !this.isVoting()) this.voteState.undo();
-            break;
-          case 'redo':
-            if (!this.disabled() && !this.isVoting()) this.voteState.redo();
-            break;
+          break;
         }
-      }),
-      this.voteState.toast$.subscribe((t) => this.showUndoToast(t.action, t.mediaName)),
-    );
+        case 'rotate': {
+          const imageViewer = this.imageViewer();
+          if (imageViewer && action.rotateDirection) {
+            if (action.rotateDirection === 'left') imageViewer.rotateLeft();
+            else imageViewer.rotateRight();
+          }
+          break;
+        }
+        case 'undo':
+          if (!this.disabled() && !this.isVoting()) this.voteState.undo();
+          break;
+        case 'redo':
+          if (!this.disabled() && !this.isVoting()) this.voteState.redo();
+          break;
+      }
+    });
+    this.voteState.toast$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((t) => this.showUndoToast(t.action, t.mediaName));
   }
 
   /** Persist the first-vote hint as dismissed once the first vote lands. */


### PR DESCRIPTION
Refs #3450 — lands the mechanical stage, and corrects two of the issue's premises (details below).

## What the audit actually found

The headline count is right — four idioms coexist — but two of the issue's claims did not survive contact with the tree:

- **"~5 `destroy$` subjects double as scope resets and must be renamed."** Already done. Every one of the 20 `destroy$` subjects is teardown-only, fired exclusively from `ngOnDestroy`. The scope-reset subjects are already separate *and* already named for their scope: `pairScope$` (`find-view`, `label-view`), `findPolling$` (`dashboard`), `stopWatchingProgress$` (`progress-modal`), `stopPolling$` (`VoteStateService`). There is no renaming owed.
- **"`subs[]` is the leakiest."** No it isn't — all three `subs[]` files drain the array correctly in `ngOnDestroy`. A sweep of every `.subscribe()` in the SPA found **no leaked subscription anywhere**: every long-lived stream is torn down by one of the four idioms. This is a consistency problem, not a correctness one.

The issue's "7 manual `Subscription` fields" bucket also conflates two different jobs. Only **two** of those fields are teardown (write-once, read only by `ngOnDestroy`). The rest implement *cancel-the-previous* — a live component superseding its own in-flight work — which `takeUntilDestroyed()` cannot express and which must not be swept.

## What changed

Converted the genuine teardown cases, eliminating the `subs[]` idiom entirely:

| File | Was | Now |
|---|---|---|
| `browse-selection-panel` | `subs[]` | `takeUntilDestroyed(destroyRef)` (`ngOnDestroy` kept for audio/dwell teardown) |
| `browse-bin-popup` | `subs[]` | `takeUntilDestroyed(destroyRef)`; `scrollSub` kept — it is re-keyed to the viewport *instance* |
| `center-panel` | `subs[]` | `takeUntilDestroyed(destroyRef)` ×3 |
| `browse-canvas` | `tileLoadSub`, `recenterSub` | `takeUntilDestroyed(destroyRef)` |
| `browse-minimap` | `tileLoadSub`, `viewportSub` | `takeUntilDestroyed(destroyRef)` |

Deliberately untouched: `text-viewer.sub`, `folder-browser.currentSub`, `browse-bin-popup.scrollSub`, `label-importer-modal.ingestSub`, and the pollers in `find-view` / `label-view` / `media-list`. All are cancel-the-previous.

Net: four teardown idioms become two — `destroy$` (20 files) and `takeUntilDestroyed()` (8).

`docs/FRONTEND.md` §5 grows a **"Subscription teardown vs. cancellation"** section stating the one sanctioned teardown idiom, when the explicit `DestroyRef` argument is required, and the rule that separates the two jobs (*a `Subscription` field is teardown only if it is written once and read only by `ngOnDestroy`; if it is re-assigned anywhere, it is cancellation*). This is the part that actually stops a new component picking by coin flip — a ratio shift alone would not.

## Verification

Full `./run-tests.sh`: **RUN PASSED** — 9481 passed, 6 skipped; pyright, pip-audit, npm audit, Vitest, and the frontend `build:prod` (zero warnings) all green.

Every converted subscription is a repaint/notification path, so per the issue's constraint they were driven in **real chromium** (`launchChromium()`, `/opt/pw-browsers/chromium-1194`) against a live app with the `syn-imgs` / `doc-demo` fixtures — not only in jsdom. 5/5 clean runs:

- `browse-canvas` and `browse-minimap` both repaint on `tileLoaded$` (canvas pixels sampled, not just element presence)
- `browse-minimap` still tracks `viewport$` after a pan/zoom
- `browse-canvas` still honours the minimap's `recenter$`
- `center-panel`'s `keyboard.action$` still drives votes (ArrowRight moves the Goods counter 7→8)
- `center-panel`'s `voteState.toast$` still renders the undo toast on Ctrl+Z ("Undid vote on shapes_0047.png"), and the undo rolls the count back
- `browse-bin-popup` still fills its rows from `metadataCache.version$`
- no uncaught console errors

One run initially showed the undo count not rolling back within the probe's 2.5s window; it did not reproduce in 5 subsequent runs, and the pre-change baseline was re-built and re-driven to confirm the diff was not responsible. It was a probe-timing artifact, in `label-list` code this PR does not touch.

## Not in this PR

The 20 `destroy$` files. That stage is the issue's own stage 2 and is a large diff across the app's most complex components (`dashboard`, `browse-view`, `label-view` have 10+ call sites each) for no functional gain — worth a deliberate decision rather than a ride-along. Nothing here blocks it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk8atc5XoAC1piAG7f3m64)_