### PR TITLE
Delete the legacy global dataset-progress system

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -100,12 +100,10 @@ secret_key  # noqa: F821
 # ---------------------------------------------------------------------------
 # Public-API forwarders in ``vtscore.concurrency.progress`` that mirror
 # their ``update_<tracker>_progress`` partners. The corresponding
-# trackers (``sort_progress``, ``find_progress``, ``dataset_progress``)
-# are imported and read directly in tests / routes; the helper wrappers
-# stay for API symmetry and are tabulated in
-# ``vtscore/docs/packages/concurrency.md``.
+# trackers (``sort_progress``, ``find_progress``) are imported and read
+# directly in tests / routes; the helper wrappers stay for API symmetry
+# and are tabulated in ``vtscore/docs/packages/concurrency.md``.
 # ---------------------------------------------------------------------------
-check_dataset_cancelled  # noqa: F821
 get_sort_progress  # noqa: F821
 get_eval_progress  # noqa: F821
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,7 +596,7 @@ A `for i in range(100): sleep(0.05)` loop finishes in 5 seconds — but on a loa
 def slow_load():
     started.set()
     while True:                            # exits ONLY via CancelledError
-        dataset_progress.check_cancelled()
+        tracker.check_cancelled()
         time.sleep(0.05)
 ```
 
@@ -605,7 +605,7 @@ def slow_load():
 def slow_load():
     started.set()
     for i in range(100):                   # FLAKY; can finish before cancel arrives
-        dataset_progress.check_cancelled()
+        tracker.check_cancelled()
         time.sleep(0.05)
 ```
 

--- a/app.py
+++ b/app.py
@@ -112,6 +112,11 @@ from vtscore.concurrency.progress import update_progress
 # Wire media types into the Flask app's progress reporting system.
 # Without this call, media types use a silent no-op callback and can run
 # standalone (e.g. in a CLI tool or notebook) without Flask.
+#
+# ``update_progress`` is itself a per-thread resolution, so this installs a
+# *router* rather than a destination: a media type reporting from inside a
+# load lands on that load's own tracker, and one reporting from a thread that
+# bound nothing is dropped rather than published to a channel with no owner.
 set_progress_callback(update_progress)
 
 app = Flask(__name__)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -336,7 +336,7 @@ VTSearch/
 │   │   │                           publishes on the `notification` SSE channel and is what
 │   │   │                           `PluginBase.notify()` calls when a plugin wants to surface a
 │   │   │                           user-visible message without failing the run
-│   │   └── progress.py             ProgressTracker, update_progress, cancel_dataset_progress
+│   │   └── progress.py             ProgressTracker, loading_tasks, cancel_dataset_progress
 │   │
 │   ├── state/                      Multi-dataset / multi-detector global state (library tier)
 │   │   ├── core.py                 DatasetContext, DetectorContext, _state_lock, context registries,
@@ -660,15 +660,20 @@ dataset loads share one embedder without their trackers crossing — a mis-route
 callback would not merely mis-draw a bar, since trackers call `check_cancelled()`
 and would abort the wrong load.
 
-That process-wide default is the app's *dataset* progress channel, which nothing
-else terminates: a sink cannot see when the work it is narrating ends.  So
-`load_models()` terminates it itself — an unscoped load reports as usual and
-then sends one `idle` tick on the way out (`MediaEmbedder._orphan_progress`).
-Background warm-ups that should not appear on any channel say so explicitly with
-`with emb.silent_progress():` (the smart-preload threads, the post-import
-embedder warm-up).  Skipping either is how a *finished* import came to look
-identical to a wedged one, with the dataset channel parked on "Loading SigLIP
-processor…" and no loader thread anywhere in the process (#3167).
+That process-wide default is `update_progress`, which resolves *per thread* in
+turn: an unscoped load on a thread that bound no tracker reaches a no-op, and
+one inside a load reaches that load's own tracker.  It used to be a global
+`dataset_progress` singleton instead — a channel nothing else terminates, since
+a sink cannot see when the work it is narrating ends — and `load_models()` had
+to append a synthetic `idle` tick on the way out to compensate.  Both the
+singleton and the compensating tick are gone (#3376); what remains is that
+background warm-ups which should not appear on *any* channel say so explicitly
+with `with emb.silent_progress():` (the smart-preload threads, the post-import
+embedder warm-up), so a warm-up running at the tail of an import does not
+narrate itself onto that import's row after it has finished.  Skipping that is
+how a *finished* import came to look identical to a wedged one, with the
+dataset channel parked on "Loading SigLIP processor…" and no loader thread
+anywhere in the process (#3167).
 
 ### The plugin systems
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -193,8 +193,8 @@ is the current snapshot; no separate bootstrap call is needed.
 POST /api/dataset/cancel
 ```
 
-Cancels all active loading tasks and the legacy global tracker, then waits
-briefly (~2 s) for one of them to act on the flag.
+Cancels every active loading task, then waits briefly (~2 s) for one of them
+to act on the flag.
 
 Cancellation is **cooperative**: the endpoint sets an event that a running
 worker has to observe. `ok` therefore reports whether the cancel actually
@@ -205,7 +205,7 @@ worker left to see it stops nothing.
 
 | Field | Meaning |
 |---|---|
-| `targets` | Everything that claimed to be working when the cancel arrived (loading-task ids, plus `"dataset_progress"` for the global tracker). |
+| `targets` | The loading-task ids that claimed to be working when the cancel arrived. |
 | `acknowledged` | Targets that reached a terminal state within the grace period. |
 | `pending` | Targets still running, whose live worker will observe the flag. |
 | `unresponsive` | Targets whose progress claimed work no live thread was doing — stale trackers, now cleared. Not operations that were stopped. |

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -22,7 +22,6 @@ tracker, so clients do not need a separate REST bootstrap call.
 
 | Event name | Payload | Source |
 |---|---|---|
-| `dataset` | progress object | singleton `dataset_progress` tracker (legacy single-op fallback) |
 | `loading-tasks` | array of task objects | `loading_tasks` (parallel dataset loads and staging imports; a staging task carries `staging_result`) |
 | `detector-loading-tasks` | array of task objects | `detector_loading_tasks` |
 | `sort` | progress object | `sort_progress` (text sort) |
@@ -126,7 +125,7 @@ tab — there is no per-session routing.
 ## Frame format
 
 ```
-event: dataset
+event: sort
 data: {"status":"loading",...}
 
 ```
@@ -140,7 +139,7 @@ comments are invisible to the browser's `EventSource` API. Each heartbeat tick
 also re-emits **every** channel's current snapshot. For `loading-tasks` and
 `detector-loading-tasks` that is what makes finished tasks vanish from the UI
 once they pass their stale-prune window, without a server-side timer. For the
-single-tracker channels (`dataset`, `sort`, `find`, `eval`) it is a self-heal:
+single-tracker channels (`sort`, `find`, `eval`) it is a self-heal:
 each client's queue is bounded and drops frames when the client stalls, so a
 channel's single terminal `idle`/`error` frame can be lost and would otherwise
 leave a progress bar stuck at its last percentage until the next operation
@@ -158,7 +157,7 @@ instead of a full heartbeat period.
 
 ```ts
 const es = new EventSource('/api/events');
-es.addEventListener('dataset', (e) => {
+es.addEventListener('sort', (e) => {
   const { current, total, message } = JSON.parse(e.data);
   setProgress(current / total, message);
 });

--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -60,7 +60,7 @@ A genuine removal is a deliberate library break: raise it with the user first.
   importable from its old path via a package `__init__` re-export or a shim.
 
 **Suggested first wave** (high value, low risk): #3441 and #3434 (verified-dead
-frontend code and repo hygiene), #3389/#3392/#3399 (mechanical vtscore dedup and
+frontend code and repo hygiene), #3389/#3399 (mechanical vtscore dedup and
 converter logging), #3400 (eval defaults that no longer match the shipped
 algorithm), #3382/#3402/#3404. The god-module splits (#3381, #3377, #3405, #3417)
 and the settings rework (#3412) are the highest-payoff items but need Opus-tier
@@ -87,7 +87,6 @@ care.
 - [ ] #3383 — Deduplicate the clipper family: tiling math, segment emission, six no-op clippers (Sonnet 5)
 - [ ] #3386 — Collapse the near-synonymous embedder-resolution wrappers (Sonnet 5)
 - [ ] #3389 — Deduplicate the media registries, the atomic-write ritual, and JSON label extraction (Haiku 4.5)
-- [ ] #3392 — Centralize `_default_progress()` and the `ProgressCallback` alias (Haiku 4.5)
 - [ ] #3394 — Extract one background-import harness shared by both import pipelines (Sonnet 5)
 
 ## Library tier — dead code & unkept promises
@@ -102,7 +101,6 @@ care.
 
 ## Concurrency & progress
 
-- [ ] #3376 — Delete the legacy global dataset-progress system in favour of the per-task registry (Opus 4.8)
 - [ ] #3380 — Back `AsyncJob` with a `ProgressTracker` instead of re-implementing it (Opus 4.8)
 - [ ] #3382 — Route the raw staging thread through `vtsearch.threading.spawn` (Haiku 4.5)
 

--- a/frontend/src/app/services/progress-events.service.spec.ts
+++ b/frontend/src/app/services/progress-events.service.spec.ts
@@ -101,7 +101,7 @@ describe('ProgressEventsService liveness wiring', () => {
   it('treats a real progress frame as proof of life too', () => {
     const es = connectedSource();
     recordSuccess.mockClear();
-    es.emit('dataset', { status: 'loading', current: 5, total: 10 });
+    es.emit('sort', { status: 'loading', current: 5, total: 10 });
     expect(recordSuccess).toHaveBeenCalledTimes(1);
   });
 
@@ -238,7 +238,7 @@ describe('ProgressEventsService liveness wiring', () => {
  * Zoneless staleness canary. The six SSE channels are signals, so a frame
  * arriving on the EventSource (which fires *outside* Angular's NgZone)
  * schedules change detection via the signal write — no `zone.run` re-entry.
- * This component reads the `dataset` channel signal in its template; driving
+ * This component reads the `sort` channel signal in its template; driving
  * a frame through the fake EventSource and asserting the rendered DOM after
  * `settleZoneless()`, with no manual `detectChanges()`, proves the SSE pump
  * repaints bound views under zoneless.
@@ -246,7 +246,7 @@ describe('ProgressEventsService liveness wiring', () => {
 @Component({
   selector: 'app-progress-canary',
   standalone: true,
-  template: `<span class="status">{{ progress.dataset().status ?? 'none' }}</span>`,
+  template: `<span class="status">{{ progress.sort().status ?? 'none' }}</span>`,
 })
 class ProgressCanaryComponent {
   readonly progress = inject(ProgressEventsService);
@@ -300,11 +300,11 @@ describe('ProgressEventsService (zoneless view canary)', () => {
 
   it('repaints when an SSE frame lands, with no manual detectChanges', async () => {
     const es = FakeEventSource.instances[0];
-    es.emit('dataset', { status: 'loading', current: 5, total: 10 });
+    es.emit('sort', { status: 'loading', current: 5, total: 10 });
     await settleZoneless(fixture);
     expect(statusText()).toBe('loading');
 
-    es.emit('dataset', { status: 'idle' });
+    es.emit('sort', { status: 'idle' });
     await settleZoneless(fixture);
     expect(statusText()).toBe('idle');
   });

--- a/frontend/src/app/services/progress-events.service.ts
+++ b/frontend/src/app/services/progress-events.service.ts
@@ -25,7 +25,6 @@ import { ConnectionStateService } from './connection-state.service';
  *    `boot_id` between connects means the backend restarted, which fires
  *    `serverReset$` so consumers can drop any state keyed on stale
  *    `task_id`s from the previous process)
- *  - `dataset` -> ProgressEvent (singleton tracker; staging operations)
  *  - `loading-tasks` -> LoadingTask[] (per-task progress for dataset loads)
  *  - `detector-loading-tasks` -> LoadingTask[]
  *  - `sort` -> ProgressEvent (text-sort)
@@ -49,7 +48,6 @@ export class ProgressEventsService implements OnDestroy {
   // callback notifies Angular's scheduler directly, so the SSE pump triggers
   // change detection on bound templates with no NgZone re-entry — correct under
   // both zone-based and zoneless change detection.
-  private readonly _dataset = signal<ProgressEvent>({});
   private readonly _loadingTasks = signal<LoadingTask[]>([]);
   private readonly _detectorLoadingTasks = signal<LoadingTask[]>([]);
   private readonly _sort = signal<ProgressEvent>({});
@@ -58,7 +56,6 @@ export class ProgressEventsService implements OnDestroy {
 
   // Read-only signal views: the canonical reads (also the synchronous
   // latest-value accessors — call them, e.g. `loadingTasks()`).
-  readonly dataset = this._dataset.asReadonly();
   readonly loadingTasks = this._loadingTasks.asReadonly();
   readonly detectorLoadingTasks = this._detectorLoadingTasks.asReadonly();
   readonly sort = this._sort.asReadonly();
@@ -67,7 +64,6 @@ export class ProgressEventsService implements OnDestroy {
   // Observable bridges for the consumers that compose channel updates with
   // RxJS operators (takeUntil/filter/take/…). Each is a `toObservable` view of
   // the backing signal, so a signal write still drives them.
-  readonly dataset$ = toObservable(this._dataset);
   readonly loadingTasks$ = toObservable(this._loadingTasks);
   readonly detectorLoadingTasks$ = toObservable(this._detectorLoadingTasks);
   readonly sort$ = toObservable(this._sort);
@@ -171,9 +167,6 @@ export class ProgressEventsService implements OnDestroy {
     this.source = es;
 
     this.listen(es, 'server', (e) => this.handleServerFrame(e));
-    this.listen(es, 'dataset', (e) =>
-      this._dataset.set(this.parse<ProgressEvent>(e, {})),
-    );
     this.listen(es, 'loading-tasks', (e) =>
       this._loadingTasks.set(this.parse<LoadingTask[]>(e, [])),
     );

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -20,7 +20,6 @@ from vtscore.concurrency.notifications import notifications, notify
 from vtscore.concurrency.progress import (
     LoadingTasksTracker,
     ProgressTracker,
-    dataset_progress,
     loading_tasks,
     sort_progress,
 )
@@ -403,17 +402,26 @@ class TestEventsRoute:
         finally:
             gen.close()
 
-    def test_initial_dataset_snapshot_reflects_current_state(self):
-        dataset_progress.update("loading", "snap", 7, 8)
+    def test_initial_tracker_snapshot_reflects_current_state(self):
+        sort_progress.update("loading", "snap", 7, 8)
         try:
             frames = initial_snapshot()
-            ds_frame = next(f for f in frames if f.startswith("event: dataset\n"))
-            data_line = [ln for ln in ds_frame.splitlines() if ln.startswith("data: ")][0]
+            frame = next(f for f in frames if f.startswith("event: sort\n"))
+            data_line = [ln for ln in frame.splitlines() if ln.startswith("data: ")][0]
             payload = json.loads(data_line.removeprefix("data: "))
             assert payload["current"] == 7
             assert payload["total"] == 8
         finally:
-            dataset_progress.update("idle", "", 0, 0)
+            sort_progress.update("idle", "", 0, 0)
+
+    def test_no_legacy_dataset_channel(self):
+        """The global dataset tracker is gone; so is the channel it backed.
+
+        Per-task progress rides ``loading-tasks``.  A stray ``dataset`` frame
+        would be a tracker nothing terminates, which is the phantom-progress
+        bug class #3167 named.
+        """
+        assert not any(f.startswith("event: dataset\n") for f in initial_snapshot())
 
     def test_heartbeat_reemits_tracker_channels(self):
         """A client whose bounded queue overflowed can lose a tracker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,7 +305,7 @@ def _stub_embedding_models():
 
 import vtscore.state.core as _core
 from vtscore.concurrency.progress import (
-    dataset_progress as _dataset_progress,
+    clear_thread_progress as _clear_thread_progress,
     eval_progress as _eval_progress,
     find_progress as _find_progress,
     loading_tasks as _loading_tasks,
@@ -376,7 +376,10 @@ def reset_state():
     # fully seeded threshold fixture order-dependent (issue #3101).
     config.TRAIN_EPOCHS = TEST_TRAIN_EPOCHS
 
-    _dataset_progress.reset_cancel()
+    # A test that bound a per-thread progress sink must not leak it into the
+    # next one: with the global fallback gone, resolve_progress_callback() reads
+    # this and nothing else.
+    _clear_thread_progress()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _sort_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _eval_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)

--- a/tests/datasets/test_combine_datasets.py
+++ b/tests/datasets/test_combine_datasets.py
@@ -869,18 +869,32 @@ class TestClearStagingEndpoint:
 
 
 class TestProgressStagingResult:
-    def test_staging_result_in_progress(self):
-        """update_progress stores staging_result and get_progress returns it."""
-        from vtscore.concurrency.progress import get_progress, update_progress
+    def test_staging_result_rides_the_tasks_own_tracker(self):
+        """``staging_result`` is a per-task field, not a global one.
+
+        It used to live on the ``dataset_progress`` singleton, where two
+        concurrent stagings were last-writer-wins and the loser's staged pkl
+        was orphaned.  Declaring it as an extra field on the staging task's own
+        tracker is what makes the results disjoint.
+        """
+        from tests.helpers import current_loading_progress
+        from vtscore.concurrency.progress import loading_tasks
 
         staging = {"path": "/tmp/test.pkl", "name": "test", "count": 5, "media_type": "audio"}
-        update_progress("idle", "done", 100, 100, staging_result=staging)
-        progress = get_progress()
-        assert progress["staging_result"] == staging
+        tracker = loading_tasks.create_task("_staging_probe", "Staging", extra_fields={"staging_result": None})
+        try:
+            tracker.update("loading", "staging", 100, 100, staging_result=staging)
+            assert current_loading_progress()["staging_result"] == staging
 
-        # Clean up; explicitly clear staging_result (update has merge semantics)
-        update_progress("idle", "", 0, 0, staging_result=None)
-        assert get_progress()["staging_result"] is None
+            # Merge semantics: an update that omits it leaves it in place.
+            tracker.update("loading", "still staging", 100, 100)
+            assert tracker.get()["staging_result"] == staging
+
+            # ...and it can be cleared explicitly.
+            tracker.update("idle", "", 0, 0, staging_result=None)
+            assert tracker.get()["staging_result"] is None
+        finally:
+            loading_tasks.remove_task("_staging_probe")
 
 
 class _FakeStagingImporter:
@@ -925,8 +939,8 @@ def _sync_thread_factory(store: list):
 class TestStagingPerTaskIsolation:
     """Two concurrent staging imports must each publish their own
     ``staging_result`` on their own per-task tracker; the terminal result is
-    no longer last-writer-wins on the global ``dataset_progress`` singleton
-    (which orphaned the loser's staged pkl).
+    not last-writer-wins on one shared channel (which orphaned the loser's
+    staged pkl).
 
     Grouped with ``TestClearStagingEndpoint``: the existence assertions below
     read the repo-shared ``data/staging/`` dir, which that class wipes."""

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1612,7 +1612,7 @@ class TestLoadProgressRaceCondition:
         """After POST to load a registered dataset, progress must not be 'idle'."""
         import time
 
-        from vtscore.concurrency.progress import get_progress
+        from tests.helpers import current_loading_progress
 
         # Register the current medias as a dataset entry so we can load it
         saved = dict(app_module.medias)
@@ -1639,17 +1639,12 @@ class TestLoadProgressRaceCondition:
             )
             dataset_id = entry["id"]
 
-            # Set progress to idle (simulating a previous completed load)
-            from vtscore.concurrency.progress import update_progress
-
-            update_progress("idle", "Ready")
-
             # POST to load the dataset
             resp = client.post(f"/api/datasets/registry/{dataset_id}/load")
             assert resp.status_code == 200
 
             # Immediately check progress; it must NOT be 'idle'
-            progress = get_progress()
+            progress = current_loading_progress()
             assert progress["status"] != "idle", (
                 "Progress must be set to 'loading' before the thread starts "
                 "to prevent the frontend from seeing a stale 'idle' state"
@@ -1658,7 +1653,7 @@ class TestLoadProgressRaceCondition:
             # Wait for the background thread to finish (up to 12s for slow CI)
             for _ in range(120):
                 time.sleep(0.1)
-                if get_progress()["status"] == "idle":
+                if current_loading_progress()["status"] == "idle":
                     break
         finally:
             app_module.medias.clear()
@@ -1731,15 +1726,24 @@ class TestLoadProgressRaceCondition:
             if dataset_id:
                 unregister_dataset(dataset_id)
 
-    def test_origin_load_clears_stale_error(self):
-        """_run_origin_load_in_background must clear old error on new load."""
+    def test_origin_load_starts_clean_after_a_failed_load(self):
+        """A new load must not inherit the previous load's error.
+
+        Each load owns a fresh per-task tracker, so a failure can no longer
+        bleed into the next import the way it did when every load shared one
+        global tracker.  ``current_loading_progress()`` prefers the *active*
+        task, so the new load is what a watching client sees.
+        """
         from unittest.mock import patch
 
-        from vtscore.concurrency.progress import get_progress, update_progress
+        from tests.helpers import current_loading_progress
+        from vtscore.concurrency.progress import loading_tasks
 
-        # Simulate a previous load that left a stale error
-        update_progress("idle", "", error="Previous load failed", step=None, total_steps=None)
-        assert get_progress()["error"] == "Previous load failed"
+        # Simulate a previous load that failed and left its error behind.
+        stale = loading_tasks.create_task("_stale_load", "Previous load")
+        stale.update("idle", "", 0, 0, error="Previous load failed")
+        loading_tasks.mark_finished("_stale_load")
+        assert current_loading_progress()["error"] == "Previous load failed"
 
         # Start a new load (mock the thread so it doesn't actually run)
         from vtscore.datasets.load_pipeline import _run_origin_load_in_background
@@ -1750,8 +1754,8 @@ class TestLoadProgressRaceCondition:
                 {"importer": "test", "params": {}},
             )
 
-        progress = get_progress()
-        assert progress["error"] is None, "Starting a new load must clear the stale error from a previous load"
+        progress = current_loading_progress()
+        assert progress["error"] is None, "a new load must not inherit the previous load's error"
         assert progress["status"] == "loading"
 
     def test_origin_load_records_last_embedder_per_media_type(self, isolated_settings):
@@ -1946,7 +1950,7 @@ class TestEmptyLoadBackstop:
         an error and must not register a dataset."""
         from unittest import mock
 
-        from vtscore.concurrency.progress import get_progress
+        from tests.helpers import current_loading_progress
         from vtscore.datasets.load_pipeline import _run_origin_load_in_background
         from vtscore.datasets.registry import list_datasets
 
@@ -1967,7 +1971,7 @@ class TestEmptyLoadBackstop:
         assert list_datasets() == [], (
             "an empty load must not register a dataset; the dashboard would otherwise show a green row with 0 items"
         )
-        progress = get_progress()
+        progress = current_loading_progress()
         assert progress["error"] == "Import produced no medias.", (
             f"empty load should report the standard 'no medias' error, got {progress['error']!r}"
         )
@@ -1990,39 +1994,46 @@ class TestCancelIngest:
         assert data["targets"] == []
         assert "nothing to cancel" in data["message"].lower()
 
-    def test_cancel_sets_event(self, client):
-        """POST /api/dataset/cancel should set the cancellation event."""
-        from vtscore.concurrency.progress import dataset_progress
+    def test_cancel_sets_event_on_every_running_task(self, client):
+        """POST /api/dataset/cancel sets the flag on each live loading task.
 
-        dataset_progress.reset_cancel()
-        assert not dataset_progress.is_cancelled
+        There is no global tracker to cancel any more: cancellation is per
+        task, so the endpoint has to reach every one of them.
+        """
+        from vtscore.concurrency.progress import loading_tasks
+
+        tracker = loading_tasks.create_task("_cancel_probe", "Probe")
+        tracker.update("loading", "working", 0, 10)
+        assert not tracker.is_cancelled
 
         client.post("/api/dataset/cancel")
-        assert dataset_progress.is_cancelled
-
-        # Clean up
-        dataset_progress.reset_cancel()
+        assert tracker.is_cancelled
 
     def test_cancel_clears_medias_on_background_load(self, client):
         """Cancelling during a background load should clean up medias."""
         import threading
         import time
 
-        from vtscore.concurrency.progress import dataset_progress, get_progress
+        from tests.helpers import current_loading_progress
+        from vtscore.concurrency.progress import resolve_progress_callback
 
         saved = dict(app_module.medias)
         try:
             started = threading.Event()
 
-            # Simulate a slow importer that checks cancellation via progress.
+            # Simulate a slow importer that reports progress the way any
+            # importer does — through the thread-bound sink the load installed.
+            # That sink is what raises ``CancelledError``, so this exercises the
+            # real cancellation path rather than a global flag nothing reads.
             # Use ``while True`` so the function can only exit via
             # CancelledError; a bounded loop (e.g. ``range(100)``) can
             # finish before the cancel is processed on a loaded machine,
             # making the test flaky.
             def slow_load():
                 started.set()
+                on_progress = resolve_progress_callback()
                 while True:
-                    dataset_progress.check_cancelled()
+                    on_progress("loading", "working", 0, 0)
                     time.sleep(0.05)
 
             from vtscore.datasets.load_pipeline import _run_origin_load_in_background
@@ -2042,44 +2053,52 @@ class TestCancelIngest:
             # Wait for the thread to notice the cancellation
             for _ in range(80):
                 time.sleep(0.1)
-                progress = get_progress()
+                progress = current_loading_progress()
                 if progress["status"] == "idle":
                     break
 
-            progress = get_progress()
+            progress = current_loading_progress()
             assert progress["status"] == "idle"
             assert progress["error"] == "Cancelled"
         finally:
-            dataset_progress.reset_cancel()
             app_module.medias.clear()
             app_module.medias.update(saved)
 
-    def test_new_load_resets_cancel_flag(self, client):
-        """Starting a new load should clear any previous cancellation."""
+    def test_new_load_is_not_born_cancelled(self, client):
+        """A cancelled load must not abort the *next* one.
+
+        This used to need an explicit ``reset_cancel()`` on the shared global
+        tracker, guarded by "unless other loads are running" so the reset did
+        not steal a cancel still owed to an in-flight load.  A per-task tracker
+        makes it structural: the new load's flag is its own and starts clear.
+        """
         from unittest.mock import patch
 
-        from vtscore.concurrency.progress import dataset_progress
+        from vtscore.concurrency.progress import loading_tasks
 
-        # Set cancel from a previous operation
-        dataset_progress.cancel()
-        assert dataset_progress.is_cancelled
+        # A previous operation that was cancelled.
+        cancelled = loading_tasks.create_task("_cancelled_load", "Cancelled")
+        cancelled.update("loading", "", 0, 0)
+        cancelled.cancel()
+        assert cancelled.is_cancelled
 
         saved = dict(app_module.medias)
         try:
-            # Start a new load; should reset the flag
             from vtscore.datasets.load_pipeline import _run_origin_load_in_background
 
             with patch("vtscore.datasets.load_pipeline._warmup_embedder_async"):
-                _run_origin_load_in_background(
+                task_id = _run_origin_load_in_background(
                     lambda: None,
                     {"importer": "test", "params": {}},
                     created_by="test",
                 )
 
-            # Cancel flag should have been cleared
-            assert not dataset_progress.is_cancelled
+            fresh = loading_tasks.get_tracker(task_id)
+            assert fresh is not None
+            assert not fresh.is_cancelled
+            # ...and the older cancel is still owed to the task it was aimed at.
+            assert cancelled.is_cancelled
         finally:
-            dataset_progress.reset_cancel()
             app_module.medias.clear()
             app_module.medias.update(saved)
 

--- a/tests/datasets/test_load_terminal_state.py
+++ b/tests/datasets/test_load_terminal_state.py
@@ -7,8 +7,14 @@ channel — kept whatever an unscoped model load had written into it.  Nothing
 cleared either, because only the failure paths wrote a terminal state.  The
 only way to learn the truth was to attach a profiler to the process.
 
+Half of that is now structural: the global tracker is gone, so an unscoped
+model load resolves to a no-op instead of parking a channel nobody could
+clear.  What is left to test is the half that still has to be got right —
+the load's own per-task tracker reaching a terminal state — plus a guard
+that no new process-wide sink has appeared to take the old one's place.
+
 These drive a real load through ``_run_origin_load_in_background`` on the
-calling thread and assert both channels come to rest.
+calling thread and assert it comes to rest.
 """
 
 from __future__ import annotations
@@ -17,7 +23,7 @@ from unittest import mock
 
 import numpy as np
 
-from vtscore.concurrency.progress import dataset_progress, loading_tasks
+from vtscore.concurrency.progress import loading_tasks
 
 
 def _sync_thread_factory():
@@ -98,20 +104,34 @@ class TestSuccessfulLoadParksItsChannels:
         finally:
             loading_tasks.remove_task(task_id)
 
-    def test_global_dataset_channel_is_left_idle(self, isolated_settings, tmp_path):
-        """The SSE ``dataset`` channel must not keep narrating a finished import.
+    def test_a_finished_load_leaves_no_channel_narrating(self, isolated_settings, tmp_path):
+        """No SSE channel may outlive the load it was describing.
 
-        Anything that reports progress without a per-thread callback lands on
-        this singleton — the observed symptom was it stuck on "Loading SigLIP
-        processor…" for forty minutes with no loader thread in the process.
+        The observed symptom was the ``dataset`` channel stuck on "Loading
+        SigLIP processor…" for forty minutes with no loader thread in the
+        process, because anything reporting progress without a per-thread
+        callback landed on a singleton that had no idea when the work ended.
+        There is no such singleton now, so the guarantee is checked at the
+        stream: once the load is over, every snapshot frame is terminal.
         """
-        dataset_progress.update("loading", "Loading SigLIP processor…", 0, 0)
+        import json
+
+        from vtscore.concurrency.events import initial_snapshot
 
         task_id = _run_load(tmp_path)
         try:
-            snapshot = dataset_progress.get()
-            assert snapshot["status"] == "idle", (
-                f"the last load out of the door parks an orphaned dataset channel; got {snapshot!r}"
-            )
+            for frame in initial_snapshot():
+                assert not frame.startswith("event: dataset\n"), (
+                    "the legacy dataset channel is back; it is a sink nothing terminates"
+                )
+                lines = frame.splitlines()
+                channel = lines[0].removeprefix("event: ")
+                payload = json.loads([ln for ln in lines if ln.startswith("data: ")][0].removeprefix("data: "))
+                if channel in ("loading-tasks", "detector-loading-tasks"):
+                    assert all(t.get("status") == "idle" for t in payload), (
+                        f"{channel} still claims work after the load finished: {payload!r}"
+                    )
+                elif isinstance(payload, dict) and "status" in payload:
+                    assert payload["status"] == "idle", f"{channel} is still narrating: {payload!r}"
         finally:
             loading_tasks.remove_task(task_id)

--- a/tests/datasets/test_memory_errors.py
+++ b/tests/datasets/test_memory_errors.py
@@ -9,10 +9,7 @@ import pytest
 import app as app_module
 from vtscore.datasets.config import DEMO_DATASETS
 from vtsearch.state import medias
-from vtscore.concurrency.progress import (
-    get_progress,
-    update_progress,
-)
+from tests.helpers import current_loading_progress
 from vtsearch.state import clear_medias
 
 
@@ -225,9 +222,6 @@ class TestBackgroundImportMemoryError:
         mock_importer.supports_chunked = False
         mock_importer.run.side_effect = MemoryError("simulated")
 
-        # Reset progress
-        update_progress("idle", "")
-
         # Patch threading.Thread to run synchronously so we don't race
         with mock.patch("vtscore.datasets.load_pipeline.threading") as mock_threading:
             captured_target = {}
@@ -241,7 +235,7 @@ class TestBackgroundImportMemoryError:
             mock_threading.Thread.side_effect = fake_thread
             _run_importer_in_background(mock_importer, {})
 
-        progress = get_progress()
+        progress = current_loading_progress()
         assert progress["error"] is not None
         assert "Out of memory" in progress["error"]
         assert progress["status"] == "idle"
@@ -251,7 +245,6 @@ class TestBackgroundImportMemoryError:
 
     def test_demo_load_oom_reports_error(self, client):
         """When loading a demo dataset OOMs, the progress shows the error."""
-        update_progress("idle", "")
 
         def sync_thread(target, daemon=True):
             thread = mock.MagicMock()
@@ -274,7 +267,7 @@ class TestBackgroundImportMemoryError:
             )
             assert resp.status_code == 200
 
-            progress = get_progress()
+            progress = current_loading_progress()
             assert progress["error"] is not None
             assert "Out of memory" in progress["error"]
 

--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -7,10 +7,10 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from tests.helpers import current_loading_progress
 from vtscore.concurrency.progress import (
     CancelledError,
     LoadingTasksTracker,
-    get_progress,
     loading_tasks,
     set_thread_progress,
     get_thread_progress,
@@ -208,19 +208,24 @@ class TestThreadLocalProgress:
 
 
 # ---------------------------------------------------------------------------
-# get_progress() integration with loading tasks
+# The loading-task registry is the only dataset progress there is
 # ---------------------------------------------------------------------------
 
 
-class TestGetProgressWithLoadingTasks:
-    """Verify that get_progress() checks loading tasks first."""
+class TestLoadingTaskProgressIsAuthoritative:
+    """Every dataset-progress read resolves to a per-task tracker.
+
+    The global ``dataset_progress`` singleton these used to fall back to is
+    gone, along with the ``get_progress()`` free function that merged the two:
+    a load that has no task has no progress, rather than progress that belongs
+    to nothing and that nothing terminates (#3167).
+    """
 
     def test_returns_active_loading_task(self):
-        """get_progress() should return the active loading task, not the global tracker."""
         pt = loading_tasks.create_task("test_gp", "TestDS")
         pt.update("loading", "Embedding files", 42, 100, step=3, total_steps=4)
         try:
-            progress = get_progress()
+            progress = current_loading_progress()
             assert progress["status"] == "loading"
             assert progress["message"] == "Embedding files"
             assert progress["current"] == 42
@@ -229,24 +234,33 @@ class TestGetProgressWithLoadingTasks:
             loading_tasks.remove_task("test_gp")
 
     def test_returns_errored_task(self):
-        """get_progress() should return an errored task even when idle."""
         pt = loading_tasks.create_task("test_err", "FailDS")
         pt.update("idle", "", error="Something went wrong")
         try:
-            progress = get_progress()
+            progress = current_loading_progress()
             assert progress["error"] == "Something went wrong"
             assert progress["task_id"] == "test_err"
         finally:
             loading_tasks.remove_task("test_err")
 
-    def test_falls_back_to_global(self):
-        """With no loading tasks, get_progress() returns the global tracker."""
-        from vtscore.concurrency.progress import update_progress
+    def test_no_global_fallback_survives(self):
+        """The removed singleton and its accessors must stay removed.
 
-        update_progress("idle", "Ready")
-        progress = get_progress()
-        assert progress["status"] == "idle"
-        assert "task_id" not in progress
+        A re-introduced process-wide sink would look harmless — it renders
+        nowhere — right up until it parked on a message no worker could clear.
+        """
+        import vtscore.concurrency.progress as progress_mod
+
+        for gone in ("dataset_progress", "get_progress", "check_dataset_cancelled", "LEGACY_PROGRESS_TARGET"):
+            assert not hasattr(progress_mod, gone), f"{gone} is back; the legacy global progress system is not"
+
+    def test_unbound_thread_reports_into_a_noop(self):
+        """With nothing bound, the resolved sink discards rather than parks."""
+        from vtscore.concurrency.progress import noop_progress, resolve_progress_callback
+
+        assert resolve_progress_callback() is noop_progress
+        # And it accepts the four-argument contract without raising.
+        resolve_progress_callback()("loading", "nobody is watching", 1, 2)
 
 
 # ---------------------------------------------------------------------------
@@ -515,23 +529,23 @@ class TestErrorVisibility:
             loading_tasks.remove_task("fail_task")
 
 
-class TestResetCancelSafety:
-    """Verify that starting a new load does not interfere with running loads."""
+class TestCancelIsolation:
+    """Starting a new load must not disturb any other load's cancel flag.
 
-    def test_reset_cancel_skipped_when_tasks_active(self):
-        """dataset_progress.reset_cancel() must not fire when loads are in progress."""
-        from vtscore.concurrency.progress import dataset_progress
+    This used to be enforced by a guard around a global ``reset_cancel()``
+    ("only if no other loads are running"), which had to be right for both
+    halves: reset too eagerly and an in-flight cancel was silently revoked;
+    never reset and a new load aborted the instant it started.  Per-task
+    trackers remove the trade-off, so the property is asserted directly.
+    """
 
-        # Create an active task
+    def test_new_load_leaves_a_running_task_cancelled(self):
         pt = loading_tasks.create_task("active_task", "Running")
         pt.update("loading", "Downloading", 10, 100)
-
-        # Cancel the global tracker (simulating user cancel of a previous load)
-        dataset_progress.cancel()
-        assert dataset_progress.is_cancelled
+        pt.cancel()
+        assert pt.is_cancelled
 
         try:
-            # Start a new load; should NOT reset global cancel since a task is active
             from unittest.mock import patch
 
             from vtscore.datasets.load_pipeline import _run_origin_load_in_background
@@ -542,22 +556,19 @@ class TestResetCancelSafety:
                     {"importer": "test", "params": {}},
                 )
 
-            # The global cancel should still be set (not reset)
-            assert dataset_progress.is_cancelled
+            # The cancel is still owed to the task it was aimed at.
+            assert pt.is_cancelled
         finally:
             loading_tasks.remove_task("active_task")
-            dataset_progress.reset_cancel()
 
-    def test_reset_cancel_allowed_when_no_tasks_active(self):
-        """dataset_progress.reset_cancel() fires when no loads are in progress."""
-        from vtscore.concurrency.progress import dataset_progress
-
-        dataset_progress.cancel()
-        assert dataset_progress.is_cancelled
-
+    def test_new_load_starts_uncancelled(self):
         from unittest.mock import patch
 
         from vtscore.datasets.load_pipeline import _run_origin_load_in_background
+
+        stale = loading_tasks.create_task("stale_task", "Cancelled earlier")
+        stale.update("loading", "", 0, 0)
+        stale.cancel()
 
         with patch("vtscore.datasets.load_pipeline.threading.Thread"):
             task_id = _run_origin_load_in_background(
@@ -566,11 +577,12 @@ class TestResetCancelSafety:
             )
 
         try:
-            # The global cancel should have been reset
-            assert not dataset_progress.is_cancelled
+            fresh = loading_tasks.get_tracker(task_id)
+            assert fresh is not None
+            assert not fresh.is_cancelled
         finally:
             loading_tasks.remove_task(task_id)
-            dataset_progress.reset_cancel()
+            loading_tasks.remove_task("stale_task")
 
 
 class TestConcurrentModelLoading:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -236,3 +236,31 @@ def wire_mock_progress_scope(emb):
 
     emb.progress_scope = _scope
     return emb
+
+
+# ---------------------------------------------------------------------------
+# Progress helpers
+# ---------------------------------------------------------------------------
+
+
+def current_loading_progress() -> dict:
+    """Return the dataset-load snapshot a client would currently be watching.
+
+    Stands in for the removed ``vtscore.concurrency.progress.get_progress()``:
+    the first active loading task if one is running, else the first task still
+    carrying an error, else an idle stub.  Tests use it to assert on "the"
+    in-flight load without having to thread its task id through.
+
+    Unlike the old free function there is no global singleton behind it — the
+    per-task registry is the only progress there is.
+    """
+    from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
+
+    tasks = loading_tasks.list_tasks()
+    active = [t for t in tasks if t.get("status") != "idle"]
+    if active:
+        return active[0]
+    errored = [t for t in tasks if t.get("error")]
+    if errored:
+        return errored[0]
+    return {"status": "idle", "message": "", "current": 0, "total": 0, "error": None}

--- a/tests_lib/cli/test_tqdm_progress.py
+++ b/tests_lib/cli/test_tqdm_progress.py
@@ -314,15 +314,69 @@ class TestProgressTrackerUpdate:
         assert snap["staging_result"] == {"path": "/tmp/x"}
         assert snap["error"] is None  # was never set, stays at default
 
-    def test_free_function_preserves_extra_fields(self):
-        """The update_progress() wrapper should also preserve unspecified extras."""
-        from vtscore.concurrency.progress import dataset_progress, get_progress, update_progress
+    def test_free_function_forwards_extras_to_the_bound_tracker(self):
+        """``update_progress`` reports into whatever the thread bound.
 
-        # Set error via the free function
-        update_progress("loading", error="whoops")
-        # Update without mentioning error
-        update_progress("loading", message="progress")
-        snap = get_progress()
+        It is the public spelling of ``resolve_progress_callback()`` for plugin
+        authors, so an importer that calls it from inside a load lands on that
+        load's tracker — and the tracker's merge semantics (an omitted extra
+        keeps its previous value) survive the hop.
+        """
+        from vtscore.concurrency.progress import (
+            ProgressTracker,
+            clear_thread_progress,
+            set_thread_progress,
+            update_progress,
+        )
+
+        tracker = ProgressTracker(extra_fields={"error": None})
+        set_thread_progress(tracker.update)
+        try:
+            update_progress("loading", error="whoops")
+            update_progress("loading", message="progress")
+        finally:
+            clear_thread_progress()
+
+        snap = tracker.get()
         assert snap["error"] == "whoops"
-        # Clean up for other tests
-        dataset_progress.update("idle", error=None, staging_result=None)
+        assert snap["message"] == "progress"
+
+    def test_free_function_is_a_noop_with_nothing_bound(self):
+        """No thread callback means no sink: the call must be inert, not fatal."""
+        from vtscore.concurrency.progress import clear_thread_progress, update_progress
+
+        clear_thread_progress()
+        update_progress("loading", "nobody is watching", 1, 2, error="ignored")
+
+    def test_free_function_drops_extras_a_plain_callback_cannot_take(self):
+        """The pipeline binds four-argument callbacks; extras must not crash them."""
+        from vtscore.concurrency.progress import clear_thread_progress, set_thread_progress, update_progress
+
+        seen: list[tuple] = []
+
+        def four_arg(status, message="", current=0, total=0):
+            seen.append((status, message, current, total))
+
+        set_thread_progress(four_arg)
+        try:
+            update_progress("loading", "hi", 1, 2, step=3, total_steps=4)
+        finally:
+            clear_thread_progress()
+
+        assert seen == [("loading", "hi", 1, 2)]
+
+    def test_free_function_propagates_a_typeerror_from_inside_the_sink(self):
+        """Arity probing must not swallow a real bug in the callback."""
+        import pytest
+
+        from vtscore.concurrency.progress import clear_thread_progress, set_thread_progress, update_progress
+
+        def exploding(status, message="", current=0, total=0, **kwargs):
+            raise TypeError("boom from inside")
+
+        set_thread_progress(exploding)
+        try:
+            with pytest.raises(TypeError, match="boom from inside"):
+                update_progress("loading", "hi", 1, 2, step=3)
+        finally:
+            clear_thread_progress()

--- a/tests_lib/conftest.py
+++ b/tests_lib/conftest.py
@@ -268,7 +268,7 @@ def _stub_embedding_models():
 
 import vtscore.state.core as _core  # noqa: E402
 from vtscore.concurrency.progress import (  # noqa: E402
-    dataset_progress as _dataset_progress,
+    clear_thread_progress as _clear_thread_progress,
     eval_progress as _eval_progress,
     find_progress as _find_progress,
     loading_tasks as _loading_tasks,
@@ -336,7 +336,10 @@ def reset_contexts(tmp_path, monkeypatch):
     _config.resolve_device.cache_clear()
     _emb_loader.resolve_device.cache_clear()
 
-    _dataset_progress.reset_cancel()
+    # A test that bound a per-thread progress sink must not leak it into the
+    # next one: with the global fallback gone, resolve_progress_callback() reads
+    # this and nothing else.
+    _clear_thread_progress()
     _find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _sort_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     _eval_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)

--- a/tests_lib/datasets/test_progress_termination.py
+++ b/tests_lib/datasets/test_progress_termination.py
@@ -3,16 +3,19 @@
 A ``server_folder`` import that had *succeeded* was indistinguishable from a
 wedged one: the SSE ``dataset`` channel sat on ``"Loading SigLIP processor…"``
 indefinitely, with no loader thread anywhere in the process.  Two mechanisms
-produced that, and both are covered here.
+produced that.
 
-* **An unscoped model load narrates itself on a channel nobody terminates.**
+* **An unscoped model load narrated itself on a channel nobody terminates.**
   A thread that installs no ``progress_scope`` reports through the embedder's
-  process-wide default sink, which the app wires to the global
-  ``dataset_progress`` tracker.  The sink cannot see when the work it is
-  narrating ends, so ``load_models`` says so itself.
+  process-wide default sink, which the app used to wire to a global
+  ``dataset_progress`` tracker that could not see when the work ended.  That
+  is now closed at the root rather than patched at the load: the default sink
+  the app installs resolves *per thread*, so an unscoped load on a thread that
+  bound no tracker reaches a no-op and there is no channel left parked.
 * **The load task's success path wrote no terminal state.**  Only the failure
   paths parked the tracker; a clean finish left it on its last "loading …"
-  message until the finished entry aged out.
+  message until the finished entry aged out.  Still a live requirement, and
+  still tested below.
 """
 
 from __future__ import annotations
@@ -67,41 +70,59 @@ def _fresh_embedder(default_sink) -> _NoisyEmbedder:
 
 
 class TestUnscopedModelLoad:
-    """``load_models`` terminates the sink it borrowed."""
+    """An unscoped load cannot leave a channel parked, because it has none."""
 
-    def test_unscoped_load_ends_on_idle(self):
+    def test_unscoped_load_reaches_the_default_sink_verbatim(self):
+        """No synthetic terminal tick is appended any more.
+
+        ``load_models`` used to send one because the sink it borrowed was a
+        process-wide tracker that nothing else would ever clear.  Now the sink
+        resolves per thread, so the load has nothing to clean up and reports
+        exactly what it did.
+        """
         sink = _RecordingSink()
         emb = _fresh_embedder(sink)
 
         emb.load_models()
 
-        assert sink.ticks[0] == ("loading", "Loading Noisy processor…"), (
-            f"the load should still narrate itself on the default sink, got {sink.ticks!r}"
-        )
-        assert sink.statuses[-1] == "idle", (
-            "an unscoped model load must park the sink it borrowed; leaving it on "
-            f"'loading' is the #3167 phantom, got {sink.ticks!r}"
+        assert sink.ticks == [("loading", "Loading Noisy processor…")], (
+            f"the load should narrate itself on the default sink and nothing more, got {sink.ticks!r}"
         )
 
-    def test_terminal_tick_fires_even_when_the_load_raises(self):
+    def test_app_default_sink_drops_ticks_from_an_unwatched_thread(self):
+        """The sink the app installs is ``update_progress``, itself per-thread.
+
+        With no tracker bound this is where an unscoped model load lands, and
+        it has to be a no-op: a process-wide destination is exactly the #3167
+        phantom, whoever writes to it.
+        """
+        from vtscore.concurrency.progress import clear_thread_progress, update_progress
+
+        clear_thread_progress()
+        emb = _fresh_embedder(update_progress)
+
+        emb.load_models()  # must not raise, and must reach nothing
+
+        assert emb._model is True
+
+    def test_app_default_sink_reaches_a_bound_tracker(self):
+        """Bound a tracker, and the same unscoped load lands on it."""
+        from vtscore.concurrency.progress import (
+            clear_thread_progress,
+            set_thread_progress,
+            update_progress,
+        )
+
         sink = _RecordingSink()
-        emb = _fresh_embedder(sink)
-
-        def _boom() -> None:
-            emb._on_progress("loading", "Loading Noisy processor…", 0, 0)
-            raise RuntimeError("model download failed")
-
-        emb._load_models_impl = _boom  # type: ignore[method-assign]
-
+        emb = _fresh_embedder(update_progress)
+        set_thread_progress(sink)
         try:
             emb.load_models()
-        except RuntimeError:
-            pass
-        else:  # pragma: no cover - the stub always raises
-            raise AssertionError("the failing load should have propagated")
+        finally:
+            clear_thread_progress()
 
-        assert sink.statuses[-1] == "idle", (
-            f"a failed load leaves the same phantom as a successful one, got {sink.ticks!r}"
+        assert sink.ticks == [("loading", "Loading Noisy processor…")], (
+            f"a thread that bound a tracker must see the load it started, got {sink.ticks!r}"
         )
 
     def test_scoped_load_leaves_the_default_sink_alone(self):

--- a/tests_lib/helpers.py
+++ b/tests_lib/helpers.py
@@ -236,3 +236,31 @@ def wire_mock_progress_scope(emb):
 
     emb.progress_scope = _scope
     return emb
+
+
+# ---------------------------------------------------------------------------
+# Progress helpers
+# ---------------------------------------------------------------------------
+
+
+def current_loading_progress() -> dict:
+    """Return the dataset-load snapshot a client would currently be watching.
+
+    Stands in for the removed ``vtscore.concurrency.progress.get_progress()``:
+    the first active loading task if one is running, else the first task still
+    carrying an error, else an idle stub.  Tests use it to assert on "the"
+    in-flight load without having to thread its task id through.
+
+    Unlike the old free function there is no global singleton behind it — the
+    per-task registry is the only progress there is.
+    """
+    from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
+
+    tasks = loading_tasks.list_tasks()
+    active = [t for t in tasks if t.get("status") != "idle"]
+    if active:
+        return active[0]
+    errored = [t for t in tasks if t.get("error")]
+    if errored:
+        return errored[0]
+    return {"status": "idle", "message": "", "current": 0, "total": 0, "error": None}

--- a/tests_lib/integration/test_docs_quickstart.py
+++ b/tests_lib/integration/test_docs_quickstart.py
@@ -549,7 +549,7 @@ class TestNamespacePackageImports:
         from vtscore.concurrency.progress import (  # noqa: F401
             LoadingTasksTracker,
             ProgressTracker,
-            check_dataset_cancelled,
+            resolve_progress_callback,
             update_progress,
         )
         from vtscore.security.path_validation import validate_server_filepath  # noqa: F401

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -80,7 +80,74 @@ instead, since every commit on `dev` is effectively a new app release.)
   has **not** moved: it exports a process-global mutable singleton with its
   own lock, which is state by any reading.
 
+### Removed
+
+- **The global dataset-progress system: `dataset_progress`, `get_progress()`
+  and `check_dataset_cancelled()`** (issue #3376). Dataset and import progress
+  now lives entirely in the per-task `loading_tasks` registry, one
+  `ProgressTracker` per operation. The SSE `dataset` channel these fed is gone
+  with them; per-task progress rides `loading-tasks`, which the dashboard has
+  read for some time.
+
+  A process-wide progress sink has no owner, and that turned out to be the
+  whole bug class: nothing could say when the work it was narrating had ended,
+  so a finished import and a wedged one produced identical output (#3167). The
+  workarounds it needed were the tell — a `_park_global_progress_if_orphaned()`
+  sweep on the last load out of the door, a synthetic terminal tick appended to
+  every unscoped `load_models()`, and a `LEGACY_PROGRESS_TARGET` special case
+  threaded through cancellation. All are deleted rather than fixed. Removed
+  alongside them: `MediaEmbedder._orphan_progress` (the terminal-tick wrapper),
+  `LoadingTasksTracker.any_worker_alive()`, and `LEGACY_PROGRESS_TARGET`.
+
+  `cancel_dataset_progress()` keeps its name and contract and now cancels
+  exactly the active loading tasks. Its `targets` list no longer contains the
+  string `"dataset_progress"` — every entry is a real task id — so a client
+  that special-cased that value can drop the branch. Cancellation also stopped
+  needing a `reset_cancel()` guard on each new load: a per-task flag starts
+  clear, and a cancel aimed at an earlier load stays with it.
+
+  **For plugin authors:** if you read `dataset_progress` directly or called
+  `get_progress()`, switch to `loading_tasks` — `list_tasks()` for a snapshot
+  of every operation, `get_tracker(task_id)` for one. If you polled
+  `check_dataset_cancelled()`, call `check_cancelled()` on the tracker your
+  operation owns; reporting progress through the thread's sink usually does it
+  for you, since the callbacks the load pipeline binds check cancellation
+  before recording each tick.
+
+### Added
+
+- **`ProgressCallback`, `noop_progress()` and `resolve_progress_callback()` are
+  exported from `vtscore.concurrency.progress`** (issue #3392). The
+  `(status, message, current, total)` type alias had been redeclared in ten
+  modules and the "use the thread's callback, else a default" resolution copied
+  byte-identically into eight; both now have one definition.
+  `resolve_progress_callback()` returns the calling thread's progress callback,
+  or `noop_progress` when none is bound. `vtscore.media.base` re-exports the
+  alias and the no-op, so existing imports from there keep working.
+
 ### Changed
+
+- **`update_progress()` reports into the calling thread's tracker instead of a
+  global one** (issue #3376). It stays public and stays the documented way for
+  an importer to report progress without accepting an `on_progress` argument —
+  it is now the free-function spelling of `resolve_progress_callback()`.
+
+  This **fixes** out-of-tree importers that followed
+  `docs/extending/dataset-importers.md`. Writing straight to the global meant
+  their ticks landed on a channel the dashboard does not render, so the row for
+  their import never moved, and the `"embedding"` status that swaps the
+  download concurrency-gate for the embed gate never reached the pipeline.
+  Both work now with no change to the calling code. Two in-tree importers
+  (`recaller`, and `DatasetImporter`'s default record loop) had the same bug.
+
+  Two narrower changes to its signature: the `staging_result=` parameter is
+  gone (that field belongs to the staging task's own tracker, declared via
+  `create_task(..., extra_fields={"staging_result": None})`), and the remaining
+  extras (`error`, `step`, `total_steps`) are forwarded only when the bound
+  sink's signature accepts them — the four-argument callbacks the load pipeline
+  installs get the four positional arguments alone. Acceptance is decided by
+  inspecting the signature, not by catching `TypeError` from the call, so a
+  `TypeError` raised *inside* a sink still propagates.
 
 - **`description_wrappers` is now a per-embedder, measured choice, and four
   built-in embedders return `[]`** (issue #3341, following #3127). Issue

--- a/vtscore/concurrency/events.py
+++ b/vtscore/concurrency/events.py
@@ -30,7 +30,6 @@ from vtscore.concurrency.notifications import Notification, notifications
 from vtscore.concurrency.progress import (
     LoadingTasksTracker,
     ProgressTracker,
-    dataset_progress,
     detector_loading_tasks,
     eval_progress,
     find_progress,
@@ -77,7 +76,6 @@ BOOT_ID = uuid.uuid4().hex
 
 #: Single-channel trackers (key = SSE event name).
 _TRACKER_CHANNELS: dict[str, ProgressTracker] = {
-    "dataset": dataset_progress,
     "sort": sort_progress,
     "find": find_progress,
     "eval": eval_progress,

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -1,5 +1,6 @@
 """Progress tracking for long-running operations."""
 
+import inspect
 import math
 import time
 import threading
@@ -479,13 +480,29 @@ class ProgressTracker:
 # Thread-local progress callback
 # ---------------------------------------------------------------------------
 # Background loading threads set a per-thread progress callback via
-# set_thread_progress().  The _default_progress() functions in loader.py,
-# downloader.py, etc. check this first, falling back to the global
-# update_progress() when no per-thread callback is set.  This avoids
-# monkey-patching module-level defaults and allows parallel loads to each
-# report to their own ProgressTracker.
+# set_thread_progress(); every library module that reports progress without an
+# explicit callback resolves one through resolve_progress_callback().  This
+# avoids monkey-patching module-level defaults and allows parallel loads to
+# each report to their own ProgressTracker.
+#
+# There is deliberately no process-wide fallback sink.  One used to exist (the
+# ``dataset_progress`` singleton behind the SSE ``dataset`` channel), and it
+# was a standing source of phantom progress bars: work that finished, died, or
+# never had a watcher still left the channel parked on its last message, and
+# nothing downstream could tell that apart from a wedged import (#3167).  Work
+# that wants to be seen binds a tracker for its thread; work that binds nothing
+# is, by construction, work nobody is watching, so it reports into a no-op.
+
+#: The shape every progress sink in the library implements:
+#: ``(status, message, current, total) -> None``.
+ProgressCallback = Callable[[str, str, int, int], None]
 
 _thread_progress = threading.local()
+
+
+def noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
+    """Progress sink that discards everything.  The default when none is bound."""
+    return None
 
 
 def set_thread_progress(callback) -> None:
@@ -501,6 +518,19 @@ def get_thread_progress():
 def clear_thread_progress() -> None:
     """Remove the per-thread progress callback."""
     _thread_progress.callback = None
+
+
+def resolve_progress_callback() -> ProgressCallback:
+    """Return the progress sink the calling thread should report into.
+
+    The per-thread callback installed by :func:`set_thread_progress` when one
+    is bound, else :func:`noop_progress`.  Library code that takes an optional
+    ``on_progress`` argument calls this to fill in the ``None`` case, so a
+    caller that supplied nothing still reaches whichever tracker the enclosing
+    load bound for its thread.
+    """
+    cb = get_thread_progress()
+    return cb if cb is not None else noop_progress
 
 
 # ---------------------------------------------------------------------------
@@ -691,12 +721,6 @@ class LoadingTasksTracker:
         worker = entry.get("worker") if entry else None
         return bool(worker is not None and worker.is_alive())
 
-    def any_worker_alive(self) -> bool:
-        """Return ``True`` if any registered worker thread is still running."""
-        with self._lock:
-            entries = list(self._tasks.values())
-        return any(e.get("worker") is not None and e["worker"].is_alive() for e in entries)
-
     def active_task_ids(self) -> list[str]:
         """Return the ids of tasks whose tracker still claims to be working.
 
@@ -793,11 +817,6 @@ detector_loading_tasks = LoadingTasksTracker()
 # Application-wide singleton trackers
 # ---------------------------------------------------------------------------
 
-#: Dataset / import progress (used by dataset loading, downloading, embedding).
-#: Adds ``staging_result`` on top of the common extras for the combine-datasets
-#: staging flow.
-dataset_progress = ProgressTracker(extra_fields={**_PROGRESS_COMMON_EXTRAS, "staging_result": None})
-
 #: Sort-specific progress (used by text-sort operations).
 sort_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
 
@@ -833,51 +852,56 @@ def _common_extras_kwargs(
     return kwargs
 
 
+def _accepts_extras(cb: Callable[..., None], kwargs: dict[str, Any]) -> bool:
+    """Return ``True`` when *cb* can be called with every key in *kwargs*.
+
+    A sink that declares ``**kwargs`` takes anything; otherwise every key must
+    name a real keyword parameter.  A callable whose signature cannot be read
+    (a C builtin, an exotic wrapper) is assumed not to accept them, so the
+    four-argument call is what runs.
+    """
+    try:
+        params = inspect.signature(cb).parameters
+    except (TypeError, ValueError):
+        return False
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return True
+    return all(key in params and params[key].kind is not inspect.Parameter.POSITIONAL_ONLY for key in kwargs)
+
+
 def update_progress(
     status: str,
     message: str = "",
     current: int = 0,
     total: int = 0,
     error: Any = _UNSET,
-    staging_result: Any = _UNSET,
     step: Any = _UNSET,
     total_steps: Any = _UNSET,
 ) -> None:
-    """Update the global dataset progress tracker.
+    """Report dataset/import progress into the calling thread's sink.
 
-    All write access is serialised internally so that background threads
-    can safely report progress while the Flask request thread polls
-    :func:`get_progress`.
+    The public free-function spelling of :func:`resolve_progress_callback` for
+    plugin authors (see ``vtscore/docs/extending/dataset-importers.md``): an
+    importer that calls this from inside a running load reports onto that
+    load's own :class:`ProgressTracker`, exactly as if it had accepted an
+    ``on_progress`` argument.  Called with no tracker bound to the thread it is
+    a no-op.
 
-    Only extra fields explicitly supplied by the caller are forwarded;
-    omitted fields are left unchanged (true update/merge semantics).
+    ``error``, ``step`` and ``total_steps`` are forwarded only when supplied,
+    and only when the bound sink accepts them (a :class:`ProgressTracker`'s
+    ``update`` does; the plain four-argument callbacks the load pipeline
+    installs do not, and would raise on them).  Acceptance is decided by
+    inspecting the sink's signature rather than by catching :class:`TypeError`
+    from the call, so a ``TypeError`` raised *inside* a sink still propagates
+    instead of being retried as an arity mismatch.
     """
+    cb = resolve_progress_callback()
     kwargs = _common_extras_kwargs(step, total_steps, error)
-    if staging_result is not _UNSET:
-        kwargs["staging_result"] = staging_result
-    dataset_progress.update(status, message, current, total, **kwargs)
+    if kwargs and _accepts_extras(cb, kwargs):
+        cb(status, message, current, total, **kwargs)  # type: ignore[call-arg]
+        return
+    cb(status, message, current, total)
 
-
-def get_progress() -> dict[str, Any]:
-    """Return a snapshot of the current dataset progress data.
-
-    Checks per-task loading trackers first (used by parallel dataset
-    loading) and falls back to the legacy global singleton.
-    """
-    tasks = loading_tasks.list_tasks()
-    active = [t for t in tasks if t.get("status") != "idle"]
-    if active:
-        return active[0]
-    # Check if any just-finished task has an error to report
-    errored = [t for t in tasks if t.get("error")]
-    if errored:
-        return errored[0]
-    return dataset_progress.get()
-
-
-#: Name used for the legacy global :data:`dataset_progress` singleton in a
-#: cancellation report, where every other entry is a loading-task id.
-LEGACY_PROGRESS_TARGET = "dataset_progress"
 
 #: How long :func:`cancel_dataset_progress` waits for a worker to act on the
 #: flag before reporting what it saw. Cooperative cancellation normally lands
@@ -893,8 +917,6 @@ _CANCEL_POLL_SECONDS = 0.02
 
 def _cancel_acknowledged(target: str) -> bool:
     """Return ``True`` once *target* has reached a terminal state."""
-    if target == LEGACY_PROGRESS_TARGET:
-        return dataset_progress.get()["status"] == "idle"
     if loading_tasks.is_finished(target):
         return True
     tracker = loading_tasks.get_tracker(target)
@@ -910,9 +932,6 @@ def _park_unresponsive(target: str) -> None:
     tomorrow. Nothing is going to clear it — that is what "no worker" means —
     so the request that proved it stale clears it.
     """
-    if target == LEGACY_PROGRESS_TARGET:
-        dataset_progress.update("idle", "", 0, 0)
-        return
     tracker = loading_tasks.get_tracker(target)
     if tracker is not None:
         tracker.update(
@@ -949,9 +968,8 @@ def _cancel_report(targets: list[str], grace_seconds: float) -> dict[str, Any]:
 
     still = set(outstanding)
     report["acknowledged"] = [t for t in targets if t not in still]
-    any_alive = loading_tasks.any_worker_alive()
     for target in outstanding:
-        alive = any_alive if target == LEGACY_PROGRESS_TARGET else loading_tasks.worker_alive(target)
+        alive = loading_tasks.worker_alive(target)
         report["pending" if alive else "unresponsive"].append(target)
     for target in report["unresponsive"]:
         _park_unresponsive(target)
@@ -981,9 +999,8 @@ def _cancel_report(targets: list[str], grace_seconds: float) -> dict[str, Any]:
 def cancel_dataset_progress(grace_seconds: float = CANCEL_ACK_GRACE_SECONDS) -> dict[str, Any]:
     """Signal the current dataset operation(s) to cancel, and report the outcome.
 
-    Cancels all active per-task loading trackers as well as the legacy global
-    singleton (used by staging operations), then waits up to *grace_seconds*
-    for someone to act on the flag.
+    Cancels every active per-task loading tracker, then waits up to
+    *grace_seconds* for someone to act on the flag.
 
     Cancellation is cooperative — :meth:`ProgressTracker.cancel` sets an event
     and :meth:`ProgressTracker.check_cancelled` has to be *reached* by a
@@ -995,8 +1012,7 @@ def cancel_dataset_progress(grace_seconds: float = CANCEL_ACK_GRACE_SECONDS) -> 
     Returns a report with:
 
     ``targets``
-        every id that claimed to be working when the cancel arrived, using
-        :data:`LEGACY_PROGRESS_TARGET` for the global singleton.
+        every task id that claimed to be working when the cancel arrived.
     ``acknowledged``
         targets that reached a terminal state within the grace period.
     ``pending``
@@ -1011,12 +1027,7 @@ def cancel_dataset_progress(grace_seconds: float = CANCEL_ACK_GRACE_SECONDS) -> 
         when the cancel actually reached something.
     """
     targets = loading_tasks.active_task_ids()
-    if dataset_progress.get()["status"] != "idle":
-        targets.append(LEGACY_PROGRESS_TARGET)
-
     loading_tasks.cancel_all()
-    dataset_progress.cancel()
-
     return _cancel_report(targets, grace_seconds)
 
 
@@ -1033,11 +1044,6 @@ def cancel_dataset_task(task_id: str, grace_seconds: float = CANCEL_ACK_GRACE_SE
     targets = [task_id] if tracker.get()["status"] != "idle" else []
     tracker.cancel()
     return _cancel_report(targets, grace_seconds)
-
-
-def check_dataset_cancelled() -> None:
-    """Raise :class:`CancelledError` if the dataset operation was cancelled."""
-    dataset_progress.check_cancelled()
 
 
 def update_sort_progress(

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -13,14 +13,13 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
+from vtscore.concurrency.progress import ProgressCallback, resolve_progress_callback
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
 from vtscore.utils.hashing import content_md5
 
 logger = logging.getLogger(__name__)
-
-ProgressCallback = Callable[[str, str, int, int], None]
 
 
 def _normalise_converter_specs(
@@ -54,17 +53,6 @@ def _normalise_converter_specs(
             continue
         result.append((c, params))
     return result
-
-
-def _default_progress() -> ProgressCallback:
-    from vtscore.concurrency.progress import get_thread_progress
-
-    cb = get_thread_progress()
-    if cb is not None:
-        return cb
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
 
 
 _OPTIONAL_OUTPUT_FIELDS = ("media_bytes", "media_string", "width", "height", "word_count", "character_count")
@@ -329,7 +317,7 @@ def run_converters_on_folder(
         return
 
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     from vtscore.media import get as media_get, get_by_folder_name  # noqa: PLC0415
 
@@ -424,7 +412,7 @@ def apply_converter_to_demo(
         raise ValueError(f"Unknown converter: {converter_name}")
 
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     source_items = list(medias.items())
     converted: dict[int, dict[str, Any]] = {}

--- a/vtscore/datasets/archive.py
+++ b/vtscore/datasets/archive.py
@@ -42,9 +42,10 @@ import tarfile
 import threading
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Iterator, Optional
 from uuid import uuid4
 
+from vtscore.concurrency.progress import ProgressCallback, resolve_progress_callback
 from vtscore.config import DATA_DIR
 from vtscore.security.archive import safe_tar_extract
 from vtscore.security.path_validation import glob_top_level, rglob_follow_symlinks
@@ -64,8 +65,6 @@ __all__ = [
     "iter_archive_chunks",
     "load_archive_into",
 ]
-
-ProgressCallback = Callable[[str, str, int, int], None]
 
 #: File suffixes recognised as archives.  Compound tar suffixes are listed
 #: explicitly so :func:`is_archive_path` matches e.g. ``foo.tar.gz``.
@@ -90,13 +89,6 @@ _ARCHIVE_GLOBS: tuple[str, ...] = tuple(f"*{suffix}" for suffix in ARCHIVE_SUFFI
 LOCAL_ARCHIVE_IMPORTER = "local_archive"
 
 _cache_lock = threading.Lock()
-
-
-def _default_progress() -> ProgressCallback:
-    from vtscore.concurrency.progress import get_thread_progress, update_progress  # noqa: PLC0415
-
-    cb = get_thread_progress()
-    return cb if cb is not None else update_progress
 
 
 def is_archive_path(path: str | Path) -> bool:
@@ -161,7 +153,7 @@ def extract_archive(
     before it is written to disk.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     name = archive_path.name.lower()
     extract_dir_resolved = extract_dir.resolve()

--- a/vtscore/datasets/downloader/__init__.py
+++ b/vtscore/datasets/downloader/__init__.py
@@ -130,7 +130,6 @@ from vtscore.datasets.downloader.core import (
     VISUAL_GENOME_OBJECTS_URL,
     ProgressCallback,
     RemoteUnreachableError,
-    _default_progress,
     _download_and_extract,
     _move_tree_contents,
     _validate_archive,
@@ -210,7 +209,6 @@ __all__ = [
     "text",
     "video",
     # Core (private helpers re-exported for tests)
-    "_default_progress",
     "_download_and_extract",
     "_move_tree_contents",
     "_validate_archive",

--- a/vtscore/datasets/downloader/audio.py
+++ b/vtscore/datasets/downloader/audio.py
@@ -8,6 +8,7 @@ from typing import Optional
 import requests
 
 from vtscore.datasets.downloader import core as _core
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.datasets.downloader.core import ProgressCallback
 
 
@@ -20,14 +21,14 @@ def download_esc50(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``audio/`` subdirectory inside the extracted ``ESC-50-master``
         directory (e.g. ``data/ESC-50-master/audio``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "ESC-50-master"
     _core._download_and_extract(
@@ -54,14 +55,14 @@ def download_gtzan(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``genres/`` directory containing genre subdirectories
         with ``.wav`` files (e.g. ``data/gtzan/genres``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     genres_dir = _core.DATA_DIR / "gtzan" / "genres"
     _core._download_and_extract(
@@ -88,7 +89,7 @@ def download_speech_commands_v2(on_progress: Optional[ProgressCallback] = None) 
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``speech_commands_v2/`` directory containing keyword
@@ -96,7 +97,7 @@ def download_speech_commands_v2(on_progress: Optional[ProgressCallback] = None) 
         ``data/speech_commands_v2``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "speech_commands_v2"
     _core._download_and_extract(
@@ -123,14 +124,14 @@ def download_urbansound8k(on_progress: Optional[ProgressCallback] = None) -> Pat
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``UrbanSound8K/`` directory containing ``audio/`` and
         ``metadata/`` subdirectories (e.g. ``data/UrbanSound8K``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "UrbanSound8K"
     _core._download_and_extract(
@@ -160,14 +161,14 @@ def download_clotho(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``clotho/`` directory holding the extracted ``.wav`` files
         (e.g. ``data/clotho``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "clotho"
     _core._download_and_extract(
@@ -197,14 +198,14 @@ def download_tut_sound_events_2017(on_progress: Optional[ProgressCallback] = Non
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``tut_sound_events_2017/`` directory whose subdirectories
         hold the extracted ``.wav`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     base = _core.DATA_DIR / "tut_sound_events_2017"
     archives = _core.TUT_SOUND_EVENTS_2017_ARCHIVES
@@ -406,13 +407,13 @@ def download_apollo11_audio(
             :func:`apollo11_audio_manifest`.  ``None`` fetches every track
             (~10.1 GB).
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``apollo11_audio/`` directory holding the ``.mp3`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
     if tracks is None:
         tracks = apollo11_audio_manifest()
 
@@ -475,14 +476,14 @@ def download_birdvox_full_night(
             :func:`birdvox_full_night_manifest`.  ``None`` fetches all six
             (~5.65 GB).
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``birdvox_full_night/`` directory whose per-unit
         subdirectories hold the segmented ``.flac`` chunks.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
     if units is None:
         units = birdvox_full_night_manifest()
 
@@ -553,14 +554,14 @@ def download_nixon_tapes(
             :func:`nixon_tape_manifest`.  ``None`` fetches all twelve
             (~10.2 GB).
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``nixon_tapes/`` directory whose per-tape subdirectories
         hold the conversation ``.mp3`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
     if tapes is None:
         tapes = nixon_tape_manifest()
 

--- a/vtscore/datasets/downloader/core.py
+++ b/vtscore/datasets/downloader/core.py
@@ -2,9 +2,11 @@
 
 All public functions accept an optional ``on_progress`` callback with the
 signature ``(status: str, message: str, current: int, total: int) -> None``.
-When omitted the functions fall back to the application-wide
-:func:`~vtscore.concurrency.progress.update_progress` reporter; pass an explicit callback
-to use these functions outside the Flask app (scripts, notebooks, tests).
+When omitted the functions resolve one with
+:func:`~vtscore.concurrency.progress.resolve_progress_callback`: the callback
+the calling thread bound, or a no-op when it bound none.  Pass an explicit
+callback to use these functions outside the Flask app (scripts, notebooks,
+tests).
 """
 
 import os
@@ -19,6 +21,7 @@ from urllib.parse import urlparse
 
 import requests
 
+from vtscore.concurrency.progress import ProgressCallback, resolve_progress_callback
 from vtscore.config import DATA_DIR
 from vtscore.security.archive import safe_tar_extract
 from vtscore.security.hf_auth import GatedResourceError, auth_header_for_url
@@ -368,20 +371,6 @@ HMDB51_DOWNLOAD_SIZE_MB = 2000
 UCF101_FULL_DOWNLOAD_SIZE_MB = 6960
 KTH_DOWNLOAD_SIZE_MB = 1150
 
-ProgressCallback = Callable[[str, str, int, int], None]
-
-
-def _default_progress() -> ProgressCallback:
-    """Lazily resolve the progress callback for the current thread."""
-    from vtscore.concurrency.progress import get_thread_progress
-
-    cb = get_thread_progress()
-    if cb is not None:
-        return cb
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
-
 
 def _request_headers(url: str, headers: Optional[dict]) -> dict:
     """Merge caller *headers* with a HuggingFace bearer token when *url* is a Hub
@@ -595,7 +584,7 @@ def download_file_with_progress(  # noqa: C901
             server does not supply a ``Content-Length`` header. Pass 0 (default)
             if the size is unknown.
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Raises:
         requests.HTTPError: If the server returns a non-retryable error status.
@@ -605,7 +594,7 @@ def download_file_with_progress(  # noqa: C901
             its ``__cause__``.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     session = guarded_session()
     downloaded = 0  # bytes already on disk at dest_path
@@ -693,7 +682,7 @@ def fetch_text_with_retry(url: str, label: str = "", on_progress: Optional[Progr
         label: Short human-readable name for the fetch, used in the retry
             progress message.  Defaults to the URL's last path segment.
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Raises:
         requests.HTTPError: If the server returns a non-retryable error status.
@@ -701,7 +690,7 @@ def fetch_text_with_retry(url: str, label: str = "", on_progress: Optional[Progr
             keeps returning a retryable status, after the final retry attempt.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
     label = label or urlparse(url).path.rsplit("/", 1)[-1] or url
 
     session = guarded_session()

--- a/vtscore/datasets/downloader/documents.py
+++ b/vtscore/datasets/downloader/documents.py
@@ -6,6 +6,7 @@ from typing import Optional
 import requests
 
 from vtscore.datasets.downloader import core as _core
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.datasets.downloader.core import ProgressCallback
 
 
@@ -30,14 +31,14 @@ def download_ucsf_documents(  # noqa: C901
             (e.g. ``["Tobacco", "Food", "Drug"]``).
         docs_per_category: Maximum number of PDFs to download per category.
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``ucsf_documents/`` directory containing category
         subdirectories with ``.pdf`` files (e.g. ``data/ucsf_documents``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "ucsf_documents"
     _core.DATA_DIR.mkdir(exist_ok=True)

--- a/vtscore/datasets/downloader/images.py
+++ b/vtscore/datasets/downloader/images.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from vtscore.datasets.downloader import core as _core
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.datasets.downloader.core import ProgressCallback
 from vtscore.security.archive import safe_tar_extract
 
@@ -24,14 +25,14 @@ def download_cifar10(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``cifar-10-batches-py/`` directory containing the raw pickle
         batch files (e.g. ``data/cifar-10-batches-py``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "cifar-10-batches-py"
     _core._download_and_extract(
@@ -58,14 +59,14 @@ def download_vggface2(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``test/`` directory holding the per-identity subfolders
         (e.g. ``data/vggface2/test``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "vggface2"
     test_dir = extract_dir / "test"
@@ -113,7 +114,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``101_ObjectCategories/`` directory containing category
@@ -121,7 +122,7 @@ def download_caltech101(on_progress: Optional[ProgressCallback] = None) -> Path:
         ``data/caltech-101/101_ObjectCategories``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "caltech-101"
     categories_dir = extract_dir / "101_ObjectCategories"
@@ -202,7 +203,7 @@ def download_caltech256(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``256_ObjectCategories/`` directory containing category
@@ -210,7 +211,7 @@ def download_caltech256(on_progress: Optional[ProgressCallback] = None) -> Path:
         ``data/caltech-256/256_ObjectCategories``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -240,14 +241,14 @@ def download_oxford_flowers(on_progress: Optional[ProgressCallback] = None) -> P
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``oxford_flowers/`` directory containing ``jpg/`` and
         ``imagelabels.mat`` (e.g. ``data/oxford_flowers``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -285,14 +286,14 @@ def download_food101(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``food-101/images/`` directory containing category
         subdirectories with JPEG images (e.g. ``data/food-101/images``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -321,14 +322,14 @@ def download_eurosat(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``EuroSAT_RGB/`` directory containing class
         subdirectories with JPEG images (e.g. ``data/EuroSAT_RGB``).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -361,14 +362,14 @@ def download_roxford5k(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``roxford5k/`` directory containing ``jpg/`` (the flat image
         folder) and ``gnd_roxford5k.pkl`` (the ground-truth file).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -415,14 +416,14 @@ def download_openlogo(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``openlogo/`` directory containing ``data/`` (the flat image
         folder) and ``samples.json`` (the per-image detection annotations).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -543,13 +544,13 @@ def download_rico_icons_manifest(on_progress: Optional[ProgressCallback] = None)
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``rico_icons/`` directory containing ``samples.json``.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
     extract_dir = _core.DATA_DIR / "rico_icons"
@@ -573,13 +574,13 @@ def download_rico_icons_shards(
     Args:
         shard_dirs: Repo-relative shard folder paths.
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``rico_icons/`` directory containing the ``data/`` tree.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "rico_icons"
     # A shard folder is "present" only if it holds at least one decoded JPEG; an
@@ -610,14 +611,14 @@ def download_enrico(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``enrico/`` directory containing the extracted screenshots
         and ``design_topics.csv``.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
     extract_dir = _core.DATA_DIR / "enrico"
@@ -669,7 +670,7 @@ def download_rico_screen2words(on_progress: Optional[ProgressCallback] = None) -
         Path to the ``screenshots/`` directory (the folder-per-category root).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     from vtscore.datasets.downloader._hf_parquet import (  # noqa: PLC0415
         download_parquet_shards,
@@ -739,7 +740,7 @@ def download_rvl_cdip(on_progress: Optional[ProgressCallback] = None) -> Path:
         Path to the ``images/`` directory (the folder-per-class root).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     from vtscore.datasets.downloader._hf_parquet import (  # noqa: PLC0415
         download_parquet_shards,
@@ -811,7 +812,7 @@ def download_places365(on_progress: Optional[ProgressCallback] = None) -> Path:
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``places365/`` directory containing ``val_256/`` (the
@@ -819,7 +820,7 @@ def download_places365(on_progress: Optional[ProgressCallback] = None) -> Path:
         file).
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
 
@@ -891,14 +892,14 @@ def download_visual_genome(on_progress: Optional[ProgressCallback] = None) -> Pa
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``visual_genome/`` directory containing ``VG_100K/`` and
         ``VG_100K_2/`` (the flat image folders) plus ``objects.json``.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     _core.IMAGE_DIR.mkdir(exist_ok=True, parents=True)
     vg_dir = _core.DATA_DIR / "visual_genome"

--- a/vtscore/datasets/downloader/text.py
+++ b/vtscore/datasets/downloader/text.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode
 import requests
 
 from vtscore.datasets.downloader import core as _core
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.datasets.downloader.core import ProgressCallback
 
 
@@ -85,7 +86,7 @@ def download_20newsgroups(
             Any category not in the mapping is passed through unchanged as the
             full newsgroup name.
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A 3-tuple ``(texts, labels, category_names)`` where:
@@ -98,7 +99,7 @@ def download_20newsgroups(
           ordered to correspond with label index values.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     from sklearn.datasets import fetch_20newsgroups
 
@@ -234,14 +235,14 @@ def download_bbc_news(
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A dict mapping category name to a list of article text strings, e.g.
         ``{"business": ["Article text...", ...], "sport": [...], ...}``.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "bbc-fulltext"
     _core.DATA_DIR.mkdir(exist_ok=True)
@@ -282,7 +283,7 @@ def download_ag_news(
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A dict mapping category name to a list of article text strings, e.g.
@@ -291,7 +292,7 @@ def download_ag_news(
     import csv  # noqa: PLC0415
 
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     csv_path = _core.DATA_DIR / "ag_news_train.csv"
     _core.DATA_DIR.mkdir(exist_ok=True)
@@ -356,14 +357,14 @@ def download_imdb(
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A dict mapping category name to a list of review text strings, e.g.
         ``{"pos": ["Great film...", ...], "neg": ["Terrible...", ...]}``.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "aclImdb"
     _core._download_and_extract(
@@ -439,7 +440,7 @@ def download_dbpedia(
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A dict mapping ontology class name (e.g. ``"Company"``,
@@ -448,7 +449,7 @@ def download_dbpedia(
     import csv  # noqa: PLC0415
 
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "dbpedia_csv"
     _core._download_and_extract(
@@ -571,14 +572,14 @@ def download_arxiv_abstracts(  # noqa: C901
             per category.  The API may return fewer if a category has less
             content; this just bounds the work.
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A dict mapping category name to a list of ``title + abstract``
         strings, e.g. ``{"cs.AI": ["Deep Learning...", ...], ...}``.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     cats = list(categories) if categories else list(ARXIV_DEFAULT_CATEGORIES)
 
@@ -687,14 +688,14 @@ def download_reuters21578(
 
     Args:
         on_progress: Optional progress callback.  Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         A dict mapping TOPIC name (e.g. ``"earn"``, ``"acq"``) to a list of
         ``title + body`` strings.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     extract_dir = _core.DATA_DIR / "reuters21578"
     _core._download_and_extract(

--- a/vtscore/datasets/downloader/video.py
+++ b/vtscore/datasets/downloader/video.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from vtscore.datasets.downloader import core as _core
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.datasets.downloader.core import ProgressCallback
 
 
@@ -23,7 +24,7 @@ def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Pa
 
     Args:
         on_progress: Optional progress callback. Falls back to the
-            application-wide ``update_progress`` when ``None``.
+            the calling thread's progress sink when ``None``.
 
     Returns:
         Path to the ``ucf101/`` directory inside ``VIDEO_DIR`` (e.g.
@@ -31,7 +32,7 @@ def download_ucf101_subset(on_progress: Optional[ProgressCallback] = None) -> Pa
         ``.avi`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     video_dir = _core.VIDEO_DIR / "ucf101"
     _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
@@ -97,7 +98,7 @@ def download_hmdb51(on_progress: Optional[ProgressCallback] = None) -> Path:
         one subdirectory per action category with ``.avi`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     video_dir = _core.VIDEO_DIR / "hmdb51"
     _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
@@ -141,7 +142,7 @@ def download_ucf101_full(on_progress: Optional[ProgressCallback] = None) -> Path
         containing 101 category subdirectories with ``.avi`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     video_dir = _core.VIDEO_DIR / "ucf101_full"
     _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)
@@ -185,7 +186,7 @@ def download_kth(on_progress: Optional[ProgressCallback] = None) -> Path:
         jogging, running, walking) with ``.avi`` files.
     """
     if on_progress is None:
-        on_progress = _core._default_progress()
+        on_progress = resolve_progress_callback()
 
     video_dir = _core.VIDEO_DIR / "kth"
     _core.VIDEO_DIR.mkdir(exist_ok=True, parents=True)

--- a/vtscore/datasets/importers/combine_datasets/__init__.py
+++ b/vtscore/datasets/importers/combine_datasets/__init__.py
@@ -10,13 +10,8 @@ import gc
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.datasets.importers.base import ImporterBase, PluginField
-
-
-def _get_progress():
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
 
 
 def _load_clips_from_pickle(file_path: Path, thin: bool = False) -> dict[int, dict[str, Any]]:
@@ -223,7 +218,7 @@ class CombineDatasetsImporter(ImporterBase):
         """
         paths = _parse_dataset_paths(field_values.get("datasets", ""))
         keep_embedders = _parse_keep_embedders(field_values.get("keep_embedders"))
-        progress = _get_progress()
+        progress = resolve_progress_callback()
 
         all_clips: list[dict[str, Any]] = []
         seen_md5s: set[str] = set()
@@ -272,7 +267,7 @@ class CombineDatasetsImporter(ImporterBase):
         msg = f"Combined {len(medias)} medias from {len(paths)} datasets"
         if total_dupes:
             msg += f" ({total_dupes} duplicate(s) skipped)"
-        progress("idle", msg)
+        progress("idle", msg, 0, 0)
 
     def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
         """CLI entry point -- *datasets* is a comma-separated path string."""
@@ -302,7 +297,7 @@ class CombineDatasetsImporter(ImporterBase):
             from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
 
             _, kept_patch, kept_structural = derive_binding_from_names(keep_embedders)
-        progress = _get_progress()
+        progress = resolve_progress_callback()
         seen_md5s: set[str] = set()
         mtype_state: list[str | None] = [None]
 

--- a/vtscore/datasets/importers/http_archive/__init__.py
+++ b/vtscore/datasets/importers/http_archive/__init__.py
@@ -23,27 +23,15 @@ from __future__ import annotations
 import json
 import shutil
 from pathlib import Path
-from typing import Any, Callable, Iterator
+from typing import Any, Iterator
 from uuid import uuid4
 
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.config import DATA_DIR
 from vtscore.datasets.archive import extract_archive, is_archive_path, load_archive_into
 from vtscore.datasets.downloader import download_file_with_progress
 from vtscore.datasets.importers.base import DatasetImporter, PluginField, SourceSpec
 from vtscore.datasets.loader import load_dataset_from_folder
-
-ProgressCallback = Callable[[str, str, int, int], None]
-
-
-def _default_progress() -> ProgressCallback:
-    from vtscore.concurrency.progress import get_thread_progress
-
-    cb = get_thread_progress()
-    if cb is not None:
-        return cb
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
 
 
 def _is_url(value: str) -> bool:
@@ -174,7 +162,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
 
         DATA_DIR.mkdir(exist_ok=True)
 
-        progress = _default_progress()
+        progress = resolve_progress_callback()
 
         # Derive a local filename from the URL so we preserve the extension
         url_path = url.split("?")[0].rstrip("/")
@@ -230,7 +218,7 @@ class HttpArchiveDatasetImporter(DatasetImporter):
         url = field_values["url"]
 
         DATA_DIR.mkdir(exist_ok=True)
-        progress = _default_progress()
+        progress = resolve_progress_callback()
 
         url_path = url.split("?")[0].rstrip("/")
         url_filename = url_path.split("/")[-1] or "archive"

--- a/vtscore/datasets/importers/pickle/__init__.py
+++ b/vtscore/datasets/importers/pickle/__init__.py
@@ -10,25 +10,10 @@ import tempfile
 from pathlib import Path
 from typing import Any, Iterator
 
+from vtscore.concurrency.progress import resolve_progress_callback
 from vtscore.config import DATA_DIR
 from vtscore.datasets.importers.base import ImporterBase, PluginField
 from vtscore.datasets.loader import load_dataset_from_pickle, load_dataset_from_pickle_chunked
-
-
-def _get_progress():
-    """Resolve the progress sink, preferring the per-task thread callback.
-
-    ``_run_importer`` installs the load's own stepped tracker as the thread
-    progress before calling ``run()``, so preferring it routes this importer's
-    messages to the dashboard row for *this* import.  Reporting straight to the
-    global ``update_progress`` singleton (the previous behaviour) published on
-    the ``dataset`` channel instead, where the row never reads it.  Mirrors
-    ``vtscore.datasets.loader_common._default_progress``.
-    """
-    from vtscore.concurrency.progress import get_thread_progress, update_progress
-
-    cb = get_thread_progress()
-    return cb if cb is not None else update_progress
 
 
 class PickleDatasetImporter(ImporterBase):
@@ -57,7 +42,7 @@ class PickleDatasetImporter(ImporterBase):
 
     def run(self, field_values: dict, medias: dict, thin: bool = False) -> None:
         file_obj = field_values["file"]  # UploadedFile (FileStorage / CliUploadedFile / BytesIOUploadedFile)
-        progress = _get_progress()
+        progress = resolve_progress_callback()
         progress("loading", "Loading dataset from file...", 0, 0)
         DATA_DIR.mkdir(exist_ok=True)
         fd, tmp_name = tempfile.mkstemp(suffix=".pkl", dir=DATA_DIR)
@@ -75,7 +60,7 @@ class PickleDatasetImporter(ImporterBase):
             load_dataset_from_pickle(temp_path, medias, thin=thin, on_progress=progress)
         finally:
             temp_path.unlink(missing_ok=True)
-        progress("idle", f"Loaded {len(medias)} medias from file")
+        progress("idle", f"Loaded {len(medias)} medias from file", 0, 0)
 
     @property
     def supports_chunked(self) -> bool:

--- a/vtscore/datasets/ingest.py
+++ b/vtscore/datasets/ingest.py
@@ -17,26 +17,14 @@ full importer - this is much faster when only a few medias are missing.
 from __future__ import annotations
 
 import json
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
+from vtscore.concurrency.progress import ProgressCallback, resolve_progress_callback
 from vtscore.state import next_media_id
 from vtscore.embedding.media_vectors import init_embeddings
 from vtscore.embedding.normalize import l2_normalize
 from vtscore.state.core import _state_lock
 from vtscore.utils.hashing import content_md5
-
-ProgressCallback = Callable[[str, str, int, int], None]
-
-
-def _default_progress() -> ProgressCallback:
-    from vtscore.concurrency.progress import get_thread_progress
-
-    cb = get_thread_progress()
-    if cb is not None:
-        return cb
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
 
 
 def _group_by_origin(
@@ -535,7 +523,7 @@ def ingest_missing_medias(
         The number of medias successfully ingested.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     groups = _group_by_origin(missing_entries)
     if not groups:

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -26,7 +26,6 @@ from vtscore.concurrency.gate import ConcurrencyGate
 from vtscore.concurrency.progress import (
     CancelledError,
     clear_thread_progress,
-    dataset_progress,
     loading_tasks,
     set_thread_progress,
 )
@@ -396,24 +395,6 @@ def _park_load_terminal(tracker, n_items: int) -> None:
     )
 
 
-def _park_global_progress_if_orphaned() -> None:
-    """Park the legacy global tracker when nothing is left to keep it moving.
-
-    ``dataset_progress`` is the SSE ``dataset`` channel and is written by any
-    library path that reports progress without a per-thread callback.  Those
-    callers each terminate their own work now, but the channel is the one
-    surface a user reads as "is this server busy?", so the last load out of the
-    door also checks it: a non-idle channel with no loading task behind it is a
-    phantom by definition, and leaving it up is what made a finished import
-    indistinguishable from a wedged one (#3167).
-    """
-    if loading_tasks.has_active_tasks():
-        return
-    if dataset_progress.get().get("status") == "idle":
-        return
-    dataset_progress.update("idle", "", 0, 0)
-
-
 def _run_origin_load_in_background(
     load_fn,
     origin: dict,
@@ -452,13 +433,6 @@ def _run_origin_load_in_background(
 
     Returns the task_id that can be used to poll progress or cancel.
     """
-    # Reset the legacy cancellation flag so a previous cancel does not
-    # immediately abort this new operation; but only when no other parallel
-    # loads are running (otherwise we would clear cancellation that might
-    # still be intended for those in-flight tasks).
-    if not loading_tasks.has_active_tasks():
-        dataset_progress.reset_cancel()
-
     # Remember the user's embedder pick per media type so the next dataset
     # importer modal can pre-select it even when no loaded dataset is
     # around to supply the same hint via ``guessedMediaEmbedder``.
@@ -654,7 +628,6 @@ def _run_origin_load_in_background(
             timing_recorder.finish(n=len(ctx.medias), size_mb=size_mb, ok=not tracker.get().get("error"))
             _park_load_terminal(tracker, len(ctx.medias))
             loading_tasks.mark_finished(task_id)
-            _park_global_progress_if_orphaned()
 
     # Registered before the thread starts so a cancel arriving in the same
     # instant can tell "not started yet" from "nothing here"; see
@@ -845,11 +818,9 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
 
     Each call gets a dedicated :class:`ProgressTracker` (via ``loading_tasks``),
     keyed by the returned ``task_id``, mirroring
-    :func:`_run_origin_load_in_background`.  Previously every staging import
-    reported through the single global ``dataset_progress`` tracker, so two
-    concurrent stagings interleaved one channel and the terminal
-    ``staging_result`` was last-writer-wins - orphaning the loser's staged pkl.
-    With a per-task tracker the results no longer collide.
+    :func:`_run_origin_load_in_background`, so two concurrent stagings never
+    interleave one channel and their terminal ``staging_result``s cannot
+    collide.
 
     Returns the ``task_id`` a caller can poll (via the ``loading-tasks`` SSE
     channel) for progress and the final ``staging_result``.

--- a/vtscore/datasets/loader_common.py
+++ b/vtscore/datasets/loader_common.py
@@ -9,35 +9,22 @@ way to make that work was to push the façade's own imports to the bottom of
 the file behind ``# noqa: E402``.
 
 Nothing here performs I/O or touches the media registry; the module-level
-imports are deliberately limited to numpy so importing it can never pull in a
-cycle.
+imports are deliberately limited to numpy and
+:mod:`vtscore.concurrency.progress` (itself a stdlib-only leaf) so importing it
+can never pull in a cycle.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 
 #: Signature of the progress reporter every public loader accepts:
-#: ``(status, message, current, total) -> None``.
-ProgressCallback = Callable[[str, str, int, int], None]
-
-
-def _default_progress() -> ProgressCallback:
-    """Lazily resolve the progress callback for the current thread.
-
-    Checks for a per-thread callback first (set during parallel dataset
-    loading) and falls back to the global singleton.
-    """
-    from vtscore.concurrency.progress import get_thread_progress
-
-    cb = get_thread_progress()
-    if cb is not None:
-        return cb
-    from vtscore.concurrency.progress import update_progress
-
-    return update_progress
+#: ``(status, message, current, total) -> None``.  Defined once in
+#: :mod:`vtscore.concurrency.progress` and re-exported here so the loaders keep
+#: importing it from their own leaf.
+from vtscore.concurrency.progress import ProgressCallback  # noqa: F401 - re-exported for consumers
 
 
 def _pop_md5_key(d: dict[str, Any]) -> str:

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -20,11 +20,8 @@ import numpy as np
 from vtscore.config import EMBEDDINGS_DIR
 from vtscore.embedding.stack import embedding_stack
 from vtscore.datasets.config import DEMO_DATASETS
-from vtscore.datasets.loader_common import (
-    ProgressCallback,
-    _default_progress,
-    _embeddings_dict_for_pickle,
-)
+from vtscore.concurrency.progress import ProgressCallback, resolve_progress_callback
+from vtscore.datasets.loader_common import _embeddings_dict_for_pickle
 from vtscore.datasets.loader_pickle import load_dataset_from_pickle
 
 
@@ -214,7 +211,9 @@ def load_demo_dataset(
     named converter.  The resulting dataset contains the *target* type and
     is cached under a separate pickle key.
 
-    Progress throughout the operation is reported via :func:`update_progress`.
+    Progress throughout the operation is reported through the calling
+    thread's progress sink (see
+    :func:`~vtscore.concurrency.progress.resolve_progress_callback`).
 
     Args:
         dataset_name: Key into ``DEMO_DATASETS`` identifying which demo dataset
@@ -241,7 +240,7 @@ def load_demo_dataset(
             media type does not support the requested demo source.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     if dataset_name not in DEMO_DATASETS:
         raise ValueError(f"Unknown dataset: {dataset_name}")

--- a/vtscore/datasets/loader_folder.py
+++ b/vtscore/datasets/loader_folder.py
@@ -20,9 +20,8 @@ from contextlib import closing
 from pathlib import Path
 from typing import Any, Callable, Generator, Iterator, Optional
 
+from vtscore.concurrency.progress import ProgressCallback, resolve_progress_callback
 from vtscore.datasets.loader_common import (
-    ProgressCallback,
-    _default_progress,
     _get_embedding_value,
     _get_md5_value,
     _pop_md5_key,
@@ -696,7 +695,7 @@ def load_dataset_from_folder(
             multiple files in the folder.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     on_progress("loading", "Scanning media files...", 0, 0)
 
@@ -804,7 +803,7 @@ def load_dataset_from_folder_chunked(
             has a bare-basename key that would silently fan out.
     """
     if on_progress is None:
-        on_progress = _default_progress()
+        on_progress = resolve_progress_callback()
 
     on_progress("loading", "Scanning media files...", 0, 0)
 

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -13,6 +13,7 @@ import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable
 
+from vtscore.concurrency.progress import noop_progress
 from vtscore.embedding.binding import expected_dim_for_embedder
 from vtscore.embedding.matrix import invalidate_embedding_matrix
 from vtscore.embedding.media_vectors import (
@@ -142,20 +143,15 @@ def _stamp_requested_embedder(medias: dict[int, dict[str, Any]], embedder_name: 
         m["embedder"] = embedder_name
 
 
-def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-    """Progress sink used when no ``on_progress`` callback was supplied."""
-    return None
-
-
 def _ensure_model_loaded(emb, on_progress: Callable[[str, str, int, int], None]) -> None:
     """Load the embedder's models if not already loaded, announcing progress.
 
     The load runs inside :meth:`~vtscore.media.embedder.MediaEmbedder.progress_scope`
     so the model's own "Loading … processor…" ticks land on *this* load's
     tracker, next to every other phase of the import.  Unscoped they fall
-    through to the embedder's process-wide default sink — the global
-    ``dataset_progress`` singleton — which belongs to no particular import and
-    so shows the right message on the wrong channel (#3167).
+    through to the embedder's process-wide default sink, which resolves
+    per-thread — so on a worker that bound no tracker of its own they would be
+    dropped entirely rather than surfacing next to the import they belong to.
     """
     if getattr(emb, "_model", None) is None:
         on_progress("loading", "Loading embedding model…", 0, 0)
@@ -355,7 +351,7 @@ def embed_missing(
         return
 
     if on_progress is None:
-        on_progress = _noop_progress
+        on_progress = noop_progress
 
     _ensure_model_loaded(emb, on_progress)
 

--- a/vtscore/docs/extending/dataset-importers.md
+++ b/vtscore/docs/extending/dataset-importers.md
@@ -221,6 +221,20 @@ update_progress("downloading", "Downloading file 3/10", 3, 10)
 update_progress("embedding", "Embedding 7/10", 7, 10)
 ```
 
+`update_progress()` resolves the progress sink the **calling thread**
+bound, which for an importer's `run()` is the tracker behind this
+import's own dashboard row. If you would rather hold the callback than
+call the free function, `resolve_progress_callback()` from the same
+module returns it; both come from the same per-thread lookup, and both
+are inert when no load is in flight (a unit test calling your importer
+directly, say).
+
+There is no process-wide progress sink to fall back to. Reporting from a
+thread that bound nothing discards the tick rather than publishing it
+somewhere nobody is watching — a channel with no owner cannot say when
+its work ended, which is what made a finished import indistinguishable
+from a wedged one (#3167).
+
 Status strings are conventional, not enforced: `"downloading"`,
 `"embedding"`, `"importing"`. The dataset-loading pipeline keys on the
 first `"embedding"` status to swap between the download

--- a/vtscore/docs/faq.md
+++ b/vtscore/docs/faq.md
@@ -511,10 +511,13 @@ predict this deployment will need.
 Yes, with `vtscore.concurrency.progress.cancel_dataset_progress()`
 (import from the module - `vtscore.concurrency` is an implicit namespace
 package with no `__init__.py`, so there is nothing to import *from* it
-directly). The
-operation polls `check_dataset_cancelled()` at chunk boundaries and
+directly), or `cancel_dataset_task(task_id)` for one operation. Both set
+the cancel event on the loading task's own `ProgressTracker`; the
+operation polls `tracker.check_cancelled()` at chunk boundaries and
 raises `CancelledError` when set. Worker functions that want to be
-cancellable should call `check_dataset_cancelled()` periodically
-themselves (not from inside a bounded loop - use a `while True` loop
-with the cancel check at the top; bounded loops can run to completion
-before the cancel signal arrives in some race conditions).
+cancellable should call it periodically themselves (not from inside a
+bounded loop - use a `while True` loop with the cancel check at the top;
+bounded loops can run to completion before the cancel signal arrives in
+some race conditions). Reporting progress through the thread's own sink
+usually does this for you: the callbacks the load pipeline binds check
+cancellation before recording each tick.

--- a/vtscore/docs/packages/concurrency.md
+++ b/vtscore/docs/packages/concurrency.md
@@ -198,11 +198,10 @@ _PROGRESS_COMMON_EXTRAS = {
 }
 ```
 
-`dataset_progress` still declares `"staging_result"` (retained for the
-legacy free-function API and its test), but the staging flow itself now
-runs through per-task trackers created via
+The staging flow declares one extra of its own, on the staging task's
+tracker rather than anywhere global:
 `LoadingTasksTracker.create_task(..., extra_fields={"staging_result": None})`,
-so two concurrent staging imports no longer collide on one channel.
+so two concurrent staging imports cannot collide on one channel.
 
 **ETA:** when `extra_fields` includes `"eta_seconds"`, every `update()`
 recomputes a smoothed ETA. The tracker keeps a phase key
@@ -255,7 +254,6 @@ the polling frontend can display them. The prune runs lazily inside
 
 ```python
 # vtscore/concurrency/progress.py
-dataset_progress = ProgressTracker(extra_fields={**_PROGRESS_COMMON_EXTRAS, "staging_result": None})
 sort_progress    = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
 eval_progress    = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
 find_progress    = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
@@ -269,30 +267,43 @@ callers don't have to import the tracker itself:
 
 | Tracker | Update | Get | Cancel |
 |---------|--------|-----|--------|
-| `dataset_progress` | `update_progress(...)` | `get_progress()` | `cancel_dataset_progress()` |
 | `sort_progress` | `update_sort_progress(...)` | `get_sort_progress()` | - |
 | `eval_progress` | `update_eval_progress(...)` | `get_eval_progress()` | - |
 | `find_progress` | `update_find_progress(...)` | `get_find_progress()` | - |
 
+**There is deliberately no `dataset_progress` singleton.** Dataset and
+import progress lives entirely in `loading_tasks`, one tracker per
+operation. The global one that used to sit alongside it - reachable as
+`dataset_progress` / `update_progress()` / `get_progress()`, and streamed
+on an SSE `dataset` channel - was removed because a process-wide sink has
+no owner: nothing could say when the work it was narrating had ended, so a
+finished import and a wedged one produced the same output (#3167). Cancel
+it and no worker was reading the flag; leave it and it sat on its last
+message forever. `cancel_dataset_progress()` survives the removal and now
+cancels exactly the active tasks in `loading_tasks` (staging imports
+included).
+
+`update_progress()` also survives, with a new meaning: it is the free-
+function spelling of `resolve_progress_callback()` (below), for plugin
+authors who would rather report progress with a call than by accepting an
+`on_progress` argument. It reports into whatever tracker the calling
+thread bound and is a no-op when nothing is bound.
+
 ```python
-from vtscore.concurrency.progress import update_progress, get_progress, check_dataset_cancelled
+from vtscore.concurrency.progress import update_progress
 
+# Inside an importer's run(): lands on *this* import's dashboard row.
 update_progress("loading", "Starting", 0, 100, step=1, total_steps=3)
-check_dataset_cancelled()   # raises CancelledError if cancel was requested
-update_progress("loading", "Halfway", 50, 100)
-update_progress("done", "Finished", 100, 100)
+update_progress("embedding", "Halfway", 50, 100)
 ```
-
-`get_progress()` is asymmetric: it checks the per-task `loading_tasks`
-first (used by parallel dataset loading) and only falls back to
-`dataset_progress` when no per-task entry is active. A caller that wants
-progress shown on the dashboard should prefer `loading_tasks.create_task()`
-over the singleton when parallel loads are possible.
 
 The free functions honour a sentinel default (`_UNSET = object()`) for
 optional extras: only fields explicitly supplied by the caller are
 forwarded, so omitted fields are left unchanged - true update/merge
-semantics rather than "every call clobbers every field".
+semantics rather than "every call clobbers every field". `update_progress()`
+forwards its extras only when the bound sink's signature accepts them; the
+plain four-argument callbacks the load pipeline installs get the four
+positional arguments alone.
 
 ---
 
@@ -300,15 +311,33 @@ semantics rather than "every call clobbers every field".
 
 Background loading threads inside `vtscore.datasets` and
 `vtscore.embedding.loader` write progress through a per-thread callback,
-not directly to a tracker. Module-level helpers check the thread-local
-first and fall back to a global default when nothing is set.
+not directly to a tracker. This is the **only** resolution there is: a
+thread that bound nothing reports into a no-op, not into a shared sink.
 
 ```python
 # vtscore/concurrency/progress.py
+ProgressCallback = Callable[[str, str, int, int], None]
+
 def set_thread_progress(callback) -> None: ...
 def get_thread_progress(): ...
 def clear_thread_progress() -> None: ...
+def noop_progress(status, message="", current=0, total=0) -> None: ...
+def resolve_progress_callback() -> ProgressCallback: ...
 ```
+
+`resolve_progress_callback()` returns the thread's callback, or
+`noop_progress` when there isn't one. Every library module that takes an
+optional `on_progress` uses it to fill in the `None` case:
+
+```python
+def load_something(path, on_progress=None):
+    if on_progress is None:
+        on_progress = resolve_progress_callback()
+```
+
+`ProgressCallback` and `noop_progress` are defined here and imported
+everywhere else (`vtscore.media.base` re-exports them); `progress.py`
+imports nothing from `vtscore`, so there is no cycle to work around.
 
 This mirrors `vtscore.media.set_thread_progress_callback` (a separate
 channel for the media-registry's callback). Both exist so multi-threaded
@@ -338,25 +367,33 @@ running thread; the thread must check periodically and return early.
 `CancelledError`. The canonical pattern inside a loop:
 
 ```python
-from vtscore.concurrency.progress import check_dataset_cancelled, update_progress
+from vtscore.concurrency.progress import loading_tasks
 
+tracker = loading_tasks.get_tracker(task_id)
 for i, item in enumerate(items):
-    check_dataset_cancelled()           # raises CancelledError if cancelled
-    update_progress("loading", f"item {i}", i, len(items))
+    tracker.check_cancelled()           # raises CancelledError if cancelled
+    tracker.update("loading", f"item {i}", i, len(items))
     # ... do work ...
 ```
+
+Library code that only has the thread's sink gets the same effect for
+free: the callbacks the load pipeline binds call `check_cancelled()` on
+their own tracker before recording the tick, so reporting progress *is*
+the cancellation check.
 
 `AsyncJob` cancellation is the analogous pattern but uses the job's own
 event: the target function checks `job.is_cancelled` and returns.
 
-**Cancellation is one-shot per operation.** Call `reset_cancel()` at the
-start of each new operation so a previous cancellation doesn't
-immediately abort the next run.
+**Cancellation is one-shot per operation.** A tracker that outlives one
+operation needs `reset_cancel()` before the next, so a previous
+cancellation doesn't immediately abort the next run. Dataset loads don't
+need it: each load creates its own tracker, so its flag starts clear and
+a cancel aimed at an earlier load stays with that load.
 
-`cancel_dataset_progress()` is a convenience that cancels every active
-task in `loading_tasks` (which now includes staging imports) **and** the
-legacy `dataset_progress` singleton, so a clean abort touches both
-surfaces regardless of which one a given operation reports through.
+`cancel_dataset_progress()` cancels every active task in `loading_tasks`
+(staging imports included) and reports what each one did - see
+`_cancel_report` for the acknowledged / pending / unresponsive
+classification.
 
 ---
 

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -561,7 +561,7 @@ in place, non-matching files are embedded, inserted with an
 obvious.
 
 - **`vtscore.concurrency.progress`** - long-running-operation
-  progress and cancellation (`ProgressTracker`, `dataset_progress`,
+  progress and cancellation (`ProgressTracker`, `loading_tasks`,
   `sort_progress`, etc.).
 - **`vtscore.detectors.labeling_progress`** - per-step model cache and
   stopping-condition metrics. Used by the labeling-progress UI to

--- a/vtscore/media/audio/_demo_sources.py
+++ b/vtscore/media/audio/_demo_sources.py
@@ -885,9 +885,9 @@ def load_demo_source(
 ):
 
     if on_progress is None:
-        from vtscore.concurrency.progress import update_progress
+        from vtscore.concurrency.progress import resolve_progress_callback
 
-        on_progress = update_progress
+        on_progress = resolve_progress_callback()
 
     if embedder is None:
         from vtscore.media import embedders_for_type

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -24,16 +24,19 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import numpy as np
 
 from vtscore.security.path_validation import resolve_media_file_path
 
-# Type alias for progress callbacks.  Modules that accept an ``on_progress``
-# parameter use this signature so callers can report status without depending
-# on ``vtscore.concurrency.progress``.
-ProgressCallback = Callable[[str, str, int, int], None]
+# Progress callbacks.  Re-exported from ``vtscore.concurrency.progress`` (which
+# imports nothing from vtscore, so there is no cycle) rather than redeclared,
+# so the one signature every sink implements has exactly one definition.
+from vtscore.concurrency.progress import (  # noqa: E402
+    ProgressCallback,
+    noop_progress as _noop_progress,
+)
 
 __all__ = [
     "DemoDataset",
@@ -104,10 +107,6 @@ def _resolve_archive_member_bytes(media: dict) -> bytes | None:
     except (ArchiveMemberError, OSError):
         logging.getLogger(__name__).warning("Failed to read archive member %s::%s", ref[0], ref[1], exc_info=True)
         return None
-
-
-def _noop_progress(status: str, message: str = "", current: int = 0, total: int = 0) -> None:
-    """Default no-op progress callback used when no real reporter is set."""
 
 
 @dataclass

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -872,12 +872,12 @@ class _ThreadLocalProgress:
     ever redirects the progress of embed / model-load calls made *by that
     thread*, which is exactly what every save-and-restore call site wants.  A
     thread that never assigned anything reads the process-wide default
-    (:meth:`MediaEmbedder.set_default_progress_callback`), so background work
-    with no explicit callback still reports into the host application's
-    progress sink.  That fallback narrates work the sink cannot see the end of,
-    so a model load taken through it is terminated explicitly by
-    :meth:`MediaEmbedder._orphan_progress`; background warm-ups that want no
-    progress surface at all should say so with :meth:`MediaEmbedder.silent_progress`.
+    (:meth:`MediaEmbedder.set_default_progress_callback`), which the app wires
+    to :func:`~vtscore.concurrency.progress.update_progress` — itself a
+    per-thread resolution, so an unscoped load on a thread that bound nothing
+    lands in a no-op rather than on a channel nobody can terminate.  Background
+    warm-ups running *inside* a load that did bind a tracker say they want no
+    progress surface with :meth:`MediaEmbedder.silent_progress`.
     """
 
     def __get__(self, obj: "MediaEmbedder | None", objtype: type | None = None) -> Any:
@@ -959,43 +959,11 @@ class MediaEmbedder(ABC):
 
         Sugar over :meth:`progress_scope` for background warm-ups that have no
         progress surface of their own (the smart-preload threads, the
-        post-import embedder warm-up).  Without it those calls fall through to
-        the process-wide default sink, which in the app is the dataset-import
-        channel — see :meth:`_orphan_progress`.
+        post-import embedder warm-up).  Without it a warm-up that runs on a
+        thread which *did* bind a tracker — the tail of an import, say — would
+        narrate itself onto that import's row after the import is over.
         """
         return self.progress_scope(_noop_progress)
-
-    @contextlib.contextmanager
-    def _orphan_progress(self):
-        """Publish a terminal ``idle`` for a model load nobody is watching.
-
-        A thread that installed no :meth:`progress_scope` still reports through
-        the process-wide default sink, which the app wires to the global
-        ``dataset_progress`` tracker — the SSE ``dataset`` channel.  That sink
-        has no idea when the work it is narrating ends, so an unscoped
-        ``load_models`` left the channel parked on its last "Loading … processor…"
-        message forever: an import that had *succeeded* looked exactly like a
-        wedged one, and only a profiler could tell them apart (#3167).
-
-        The load itself is the boundary that knows when the work ends, so it is
-        where the terminal state belongs.  For the duration of an unscoped load
-        this pins the default sink as the thread's own callback (so a nested
-        ``load_models`` doesn't re-arm the same wrapper) and, in a ``finally``,
-        sends one ``idle`` tick to say the phase is over.
-
-        A caller that installed a scope owns its own channel and is left alone;
-        so is a sink that is already the no-op default.
-        """
-        slot = _progress_slot(self)
-        if getattr(slot.local, "cb", None) is not None or slot.default is _noop_progress:
-            yield
-            return
-        sink = slot.default
-        with self.progress_scope(sink):
-            try:
-                yield
-            finally:
-                sink("idle", "", 0, 0)
 
     # ------------------------------------------------------------------
     # Identity
@@ -1179,12 +1147,12 @@ class MediaEmbedder(ABC):
         ``self._model is not None``).
 
         A load whose caller installed no :meth:`progress_scope` reports through
-        the process-wide default sink and is terminated there on the way out;
-        see :meth:`_orphan_progress`.
+        the process-wide default sink, which resolves per-thread and drops the
+        ticks when the thread bound no tracker.
         """
         if getattr(self, "_model", None) is not None:
             return
-        with self._orphan_progress(), self._model_load_lock:
+        with self._model_load_lock:
             try:
                 self._load_models_impl()
             except ImportError as exc:

--- a/vtscore/media/image/_demo_sources.py
+++ b/vtscore/media/image/_demo_sources.py
@@ -1557,9 +1557,9 @@ def load_demo_source(  # noqa: C901 - flat per-source dispatch; one branch per d
     **kwargs,
 ):
     if on_progress is None:
-        from vtscore.concurrency.progress import update_progress
+        from vtscore.concurrency.progress import resolve_progress_callback
 
-        on_progress = update_progress
+        on_progress = resolve_progress_callback()
 
     if embedder is None:
         from vtscore.media import embedders_for_type

--- a/vtscore/media/text/_demo_sources.py
+++ b/vtscore/media/text/_demo_sources.py
@@ -468,9 +468,9 @@ def load_demo_source(
 ):
 
     if on_progress is None:
-        from vtscore.concurrency.progress import update_progress
+        from vtscore.concurrency.progress import resolve_progress_callback
 
-        on_progress = update_progress
+        on_progress = resolve_progress_callback()
 
     if embedder is None:
         from vtscore.media import embedders_for_type

--- a/vtscore/media/video/_demo_sources.py
+++ b/vtscore/media/video/_demo_sources.py
@@ -453,9 +453,9 @@ def load_demo_source(  # noqa: C901 - flat per-item embed/defer branching
 ):
 
     if on_progress is None:
-        from vtscore.concurrency.progress import update_progress
+        from vtscore.concurrency.progress import resolve_progress_callback
 
-        on_progress = update_progress
+        on_progress = resolve_progress_callback()
 
     if embedder is None:
         from vtscore.media import embedders_for_type

--- a/vtscore/projection/umap_projection.py
+++ b/vtscore/projection/umap_projection.py
@@ -32,10 +32,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from vtscore.concurrency.progress import ProgressCallback
 from vtscore.config import PROJECTION_COMPACT_DEFAULT, PROJECTION_MIN_DIST, PROJECTION_N_NEIGHBORS
-
-# Matches the ingest progress-callback shape (status, message, current, total).
-ProgressCallback = Callable[[str, str, int, int], None]
 
 # How often the UMAP fit emits a "still working" heartbeat.  UMAP's
 # ``fit_transform`` is one opaque blocking call (the epoch loop runs inside

--- a/vtscore/utils/synthetic/audio.py
+++ b/vtscore/utils/synthetic/audio.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import math
 import wave
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 import numpy as np
 
-ProgressCallback = Callable[[str, str, int, int], None]
+from vtscore.concurrency.progress import ProgressCallback
 
 SAMPLE_RATE = 48000
 

--- a/vtscore/utils/synthetic/images.py
+++ b/vtscore/utils/synthetic/images.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 import numpy as np
 
-ProgressCallback = Callable[[str, str, int, int], None]
+from vtscore.concurrency.progress import ProgressCallback
 
 CANVAS_SIZE = 256
 

--- a/vtscore/utils/synthetic/video.py
+++ b/vtscore/utils/synthetic/video.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
 import numpy as np
 
-ProgressCallback = Callable[[str, str, int, int], None]
+from vtscore.concurrency.progress import ProgressCallback
 
 CANVAS_SIZE = 224
 FPS = 12

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -797,9 +797,9 @@ def _run_autodetect(args, parser, importer, exporter) -> None:
     """Drive the ``--autodetect`` flow: progress wiring, auth, optional label
     import, then dispatch to the importer/pickle code path."""
     # Wire the CLI progress format (text/json) before any pipeline call
-    # produces output. In JSON mode we also re-route the global media
-    # progress callback from update_progress (which writes to a tracker
-    # nothing reads in CLI mode) to an NDJSON emitter on stdout.
+    # produces output. In JSON mode we also re-route the process-wide media
+    # progress callback from update_progress (which resolves per-thread, so
+    # headless it reaches nothing) to an NDJSON emitter on stdout.
     from vtscore import cli_progress
     from vtscore.concurrency.notifications import notifications
 


### PR DESCRIPTION
Dataset and import progress now lives entirely in the per-task `loading_tasks` registry, one `ProgressTracker` per operation. The global `dataset_progress` singleton beside it is gone, along with `get_progress()`, `check_dataset_cancelled()`, `LEGACY_PROGRESS_TARGET`, and the SSE `dataset` channel it backed.

## Why the premise held

Three things checked in the tree before starting:

- **`get_progress()` had no production caller.** The function whose loading-tasks-then-global fallback justified the whole arrangement is referenced only from `tests/` and `tests_lib/`.
- **The SSE `dataset` channel had no production consumer.** `progressEvents.dataset` / `dataset$` were read only by `progress-events.service.spec.ts`; the dashboard renders from `loading-tasks`. `docs/api/events.md` already labelled it "legacy single-op fallback".
- **Nothing read the global's cancel flag.** `ProgressTracker.update()` never calls `check_cancelled()`, and `check_dataset_cancelled()` — the flag's only reader — had no production caller (it was vulture-whitelisted). So `cancel_dataset_progress()` was adding `"dataset_progress"` to `targets`, cancelling a flag no worker polled, and then classifying it `pending`/`unresponsive` because it could never acknowledge. That is the #3167 phantom, still wired in.

A process-wide sink has no owner: nothing can say when the work it narrates has ended, so a finished import and a wedged one produce identical output. The workarounds it needed were the tell — `_park_global_progress_if_orphaned()` swept by the last load out of the door, a synthetic terminal tick appended to every unscoped `load_models()` (`MediaEmbedder._orphan_progress`), and a `LEGACY_PROGRESS_TARGET` special case threaded through cancellation. All deleted rather than fixed.

## The library break, and why it isn't one for importers

`update_progress` and `dataset_progress` are public in `vtscore.concurrency.progress`, so this was raised before committing to it. `update_progress()` stays public with a new meaning: the free-function spelling of the new `resolve_progress_callback()`, reporting into whatever tracker the calling thread bound and no-opping when nothing is.

That **fixes** third-party importers rather than breaking them. `vtscore/docs/extending/dataset-importers.md` tells plugin authors to report progress by calling `update_progress`, but writing straight to the global meant their ticks landed on a channel the dashboard does not render — so their import's row never moved, and the `"embedding"` status that swaps the download concurrency-gate for the embed gate never reached the pipeline. Both work now with no change to the calling code. Two in-tree importers had the identical bug (`recaller`, and `DatasetImporter`'s default record loop); `combine_datasets` and `pickle` also went through the same dead path.

Two narrower signature changes: `staging_result=` is gone (that field belongs to the staging task's own tracker, via `create_task(..., extra_fields=...)`), and the remaining extras are forwarded only when the bound sink's signature accepts them. Acceptance is decided by inspecting the signature, not by catching `TypeError` from the call, so a `TypeError` raised *inside* a sink still propagates instead of being retried as an arity mismatch.

`cancel_dataset_progress()` keeps its contract and now cancels exactly the active loading tasks; its `targets` list no longer contains the sentinel string `"dataset_progress"`. A new load no longer needs a guarded `reset_cancel()` — a per-task flag starts clear, and a cancel aimed at an earlier load stays with that load.

Recorded as an `[Unreleased]` entry in `vtscore/CHANGELOG.md` (Removed / Added / Changed), naming both symbols and what replaces them.

## Folded-in prerequisite (#3392)

`ProgressCallback`, `noop_progress()` and `resolve_progress_callback()` now have one definition, in `vtscore/concurrency/progress.py`. The type alias had been redeclared in ten modules and the "thread callback, else a default" resolution copied byte-identically into eight (`loader_common`, `downloader/core`, `ingest`, `archive`, `http_archive`, `converters/runner`, and two importer-local variants). `vtscore.media.base` and `vtscore.datasets.loader_common` re-export the alias so existing imports keep working. Done in the same PR because the dedup collapses to a few lines once the fallback becomes a no-op, and splitting it would have meant touching the same call sites twice.

## Tests

Rewritten rather than deleted, so the properties the old ones covered still have a home:

- `test_parallel_loading.py` gains a guard that the removed names stay removed, and that an unbound thread resolves to `noop_progress`.
- `test_load_terminal_state.py`'s channel assertion now walks the whole SSE snapshot: after a load finishes, no channel is still narrating, and no `dataset` frame exists.
- `test_progress_termination.py` covers the new contract — an unscoped load reports verbatim with no synthetic terminal tick, and the app's actual default sink (`update_progress`) drops ticks from an unwatched thread while reaching a bound tracker.
- `test_tqdm_progress.py` covers extras forwarding, the no-op case, extras dropped for a four-argument sink, and a `TypeError` from inside a sink propagating.
- Both conftests now clear the thread-local progress callback between tests — with no global fallback, that binding is the only resolution there is.
- `current_loading_progress()` added to `tests/helpers.py` and `tests_lib/helpers.py` (kept byte-identical) as the replacement for `get_progress()`.

Full `./run-tests.sh` green on the current tree: **9692 passed, 6 skipped**; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all OK.

## Rebase notes

`dev` moved a lot while this was open, and two of its refactors landed on exactly the code this PR deletes. Both resolutions kept `dev`'s new structure and re-applied this change at the code's new home:

- **#3462, the demo-source split** (`Mirror the image demo-source layout for audio, video and text`) moved the `on_progress is None` fallback out of `audio`/`text`/`video` `media_type.py` into new `_demo_sources.py` modules. Took `dev`'s delegated form in the three `media_type.py` files and re-applied `resolve_progress_callback()` at the fallback's new home in all three.
- **#3393, the loader-façade split** (`Break the loader façade's circular bottom imports`) moved `_default_progress()` and the `ProgressCallback` alias into a new `loader_common.py` leaf. Took `dev`'s façade wholesale and deleted the moved copy there instead, with `loader_common` now re-exporting the alias so its three sibling loaders keep importing it from their own leaf. Its docstring's "imports are deliberately limited to numpy" claim was updated, since `vtscore.concurrency.progress` is now imported too — it is a stdlib-only leaf, so the no-cycle guarantee holds.

Also picked up along the way: the shipped pointers for #3376 and #3392 pruned from `docs/plans/codebase-audit-2026-09.md` (which landed on `dev` after this branch was cut), and a passage in `docs/ARCHITECTURE.md` describing `_orphan_progress` that the original sweep missed because it names the channel in prose rather than by symbol. A duplicate `check-extension-docs.py` fix was written here and then dropped once `dev` landed its own (`186a7550`).

Closes #3376, closes #3392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X41iTpywGS76BdyqMYaBpy