### PR TITLE
Move the projection lifecycle into a vtscore service; leave the private slots alone

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -317,11 +317,14 @@ VTSearch/
 │   │   ├── pyramid.py              Stage 2: hex/square-tile zoom pyramid
 │   │   ├── params.py               Projection knobs (n_neighbors, min_dist, …) + their identity
 │   │   ├── persistence.py          Projection (de)serialization (npz <-> meta)
+│   │   ├── store.py                Where a layout lives on disk + the params-freshness guard
+│   │   ├── service.py              The layout lifecycle: build / re-bin / reset / subset, and the meta + tile payloads
 │   │   ├── labels.py               Signposts — RegionLabelSet + the labeler signature a stale set is checked on
 │   │   ├── signpost_prep.py        Signposts — region selection + sampling ahead of captioning
 │   │   ├── signpost_captioners.py  Signposts — pluggable captioners (zero-shot tags, toponymy, …)
 │   │   ├── signpost_texts.py       Signposts — per-media-type tag vocabularies (browse_signpost_vocab override)
 │   │   ├── signpost_build.py       Signposts — builds the RegionLabelSet for a frozen layout
+│   │   ├── signpost_serve.py       Signposts — resolving which set to serve over a layout (and self-healing a stale one)
 │   │   └── demo_signposts.py       Signposts — pre-baked signposts shipped with the demo datasets
 │   │
 │   ├── concurrency/                Async jobs, memory budgeting, progress tracking
@@ -423,7 +426,7 @@ VTSearch/
 │       ├── jobs.py                 Job management (/api/jobs/*)
 │       ├── sessions.py             Session management (/api/sessions/*)
 │       ├── achievements.py         Achievement routes (/api/achievements/*)
-│       ├── projection.py           VTSBrowse projection routes (/api/projection/*)
+│       ├── projection.py           VTSBrowse projection routes (/api/projection/*); the lifecycle is vtscore/projection/service.py
 │       ├── datasets/               Dataset routes; listings, load, staging, registry, status, ui
 │       ├── detectors/              Detector routes; crud, labels, registry, scoring, find, export
 │       ├── processors/             Processor routes; crud, scoring (extractors/localizers)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -15510,7 +15510,7 @@
     },
     "/api/projection/build": {
       "post": {
-        "description": "Body: ``{\"ids\": [...]?, \"force\": bool?}``.  The bin shape is not a request\nparameter \u2014 it is derived from the dataset's media type (see\n:func:`_shape_for`).\n\nReturns immediately.  If the pyramid is already cached or persisted, returns\n``\"ready\"``.  Only the first build of a dataset, where no layout exists yet,\nruns UMAP in the background and returns a ``job_id`` for polling via\n``GET /api/projection/meta``.\n\n``force`` overrides every short-circuit: it discards the existing layout\n(cached + persisted for a full build, or the in-memory subset layout for an\n``ids`` build) and runs a fresh UMAP fit over the current items, returning a\nnew ``projection_id``.  This is the Browser's \"Re-project\" action.",
+        "description": "Body: ``{\"ids\": [...]?, \"force\": bool?}``.  The bin shape is not a request\nparameter \u2014 it is derived from the dataset's media type.\n\nReturns immediately.  If the pyramid is already cached or persisted, returns\n``\"ready\"``.  Only the first build of a dataset, where no layout exists yet,\nruns UMAP in the background and returns a ``job_id`` for polling via\n``GET /api/projection/meta``.\n\n``ids`` projects only the supplied media (e.g. the positive results of a\nFind run), fitting UMAP on just their high-d vectors into an ephemeral\nsubset layout held alongside the full-dataset one.\n\n``force`` overrides every short-circuit: it discards the existing layout\n(cached + persisted for a full build, or the in-memory subset layout for an\n``ids`` build) and runs a fresh UMAP fit over the current items, returning a\nnew ``projection_id``.  This is the Browser's \"Re-project\" action.",
         "operationId": "build_projection",
         "responses": {
           "200": {
@@ -15563,7 +15563,7 @@
     },
     "/api/projection/meta": {
       "get": {
-        "description": "The bin shape is derived from the dataset's media type (see\n:func:`_shape_for`), not a query parameter.  When the pyramid is ready,\nincludes bounds, zoom levels, cell sizing, point count, the dataset's media\ntype, and the ``bin_shape`` the canvas should render.",
+        "description": "The bin shape is derived from the dataset's media type, not a query\nparameter.  When the pyramid is ready, includes bounds, zoom levels, cell\nsizing, point count, the dataset's media type, and the ``bin_shape`` the\ncanvas should render.",
         "operationId": "projection_meta",
         "responses": {
           "200": {
@@ -15588,7 +15588,7 @@
     },
     "/api/projection/subset/remove": {
       "post": {
-        "description": "Re-bins the frozen subset layout onto its existing grid minus the removed\npoints: the remaining points keep their exact 2-D positions and bins, only\ncounts/representatives change.  The ``projection_id`` (layout identity) is\npreserved and a bumped ``content_version`` busts the otherwise-immutable\ntile cache.  The served ``bounds`` shrink to the survivors' extent so the\nclient re-frames to what's left (zoom-to-fit, minimap) instead of keeping\ndead space where the culled points were \u2014 safe because bin assignment is\norigin-independent; bounds only drive client framing.  Returns the updated\nsubset meta for the dataset's shape.\n\nPowers the Browser's \"Remove from Good\" cull, which marks the items Bad via\n``/api/medias/vote-bulk`` and then calls this to make them disappear.",
+        "description": "The remaining points keep their exact 2-D positions and bins; only counts\nand representatives change.  The ``projection_id`` (layout identity) is\npreserved and a bumped ``content_version`` busts the otherwise-immutable\ntile cache.  The served ``bounds`` shrink to the survivors' extent so the\nclient re-frames to what's left (zoom-to-fit, minimap) instead of keeping\ndead space where the culled points were.  Returns the updated subset meta\nfor the dataset's shape.\n\nPowers the Browser's \"Remove from Good\" cull, which marks the items Bad via\n``/api/medias/vote-bulk`` and then calls this to make them disappear.",
         "operationId": "remove_from_subset",
         "requestBody": {
           "content": {
@@ -15629,7 +15629,7 @@
     },
     "/api/projection/tiles/{level}/{tx}/{ty}": {
       "get": {
-        "description": "The bin shape is derived from the dataset's media type (see\n:func:`_shape_for`).  Because the projection is frozen at ingest, tiles are\nimmutable for the life of the dataset and can be cached aggressively by the\nclient.",
+        "description": "The bin shape is derived from the dataset's media type.  Because the\nprojection is frozen at ingest, tiles are immutable for the life of the\ndataset and can be cached aggressively by the client.",
         "operationId": "get_tile",
         "responses": {
           "200": {

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -32,10 +32,10 @@ def _default_hex_media_type():
     fixtures are audio, which now tiles as squares (waveform thumbnails), so
     resolve to ``text`` — the canonical hex type — by default, keeping the many
     lattice-agnostic tests below on the hex path. Tests that exercise a specific
-    media type (image → square, audio → square) patch ``_media_type_for``
+    media type (image → square, audio → square) patch ``service.media_type_for``
     themselves, which overrides this.
     """
-    with patch("vtsearch.routes.projection._media_type_for", return_value="text"):
+    with patch("vtscore.projection.service.media_type_for", return_value="text"):
         yield
 
 
@@ -274,7 +274,7 @@ class TestProjectionPersistence:
         append_projection(fake_pkl, proj, pyr)
 
         with patch(
-            "vtsearch.routes.projection._pkl_path_for",
+            "vtscore.projection.store.pkl_path_for",
             return_value=str(fake_pkl),
         ):
             resp = client.post("/api/projection/build")
@@ -306,7 +306,7 @@ class TestProjectionPersistence:
 
         with (
             patch(
-                "vtsearch.routes.projection._pkl_path_for",
+                "vtscore.projection.store.pkl_path_for",
                 return_value=str(fake_pkl),
             ),
             patch(
@@ -335,7 +335,7 @@ class TestProjectionPersistence:
         write_container(fake_pkl, pkl_bytes, {"format_version": 1})
 
         with patch(
-            "vtsearch.routes.projection._pkl_path_for",
+            "vtscore.projection.store.pkl_path_for",
             return_value=str(fake_pkl),
         ):
             resp = client.post("/api/projection/build")
@@ -458,7 +458,7 @@ class TestBinShapeByMediaType:
     routes derive it from the active dataset via ``MediaType.has_thumbnail``.
     """
 
-    @patch("vtsearch.routes.projection._media_type_for", return_value="audio")
+    @patch("vtscore.projection.service.media_type_for", return_value="audio")
     def test_audio_dataset_reports_square(self, _mock_mt, client):
         """Audio resolves to the square lattice (its waveform thumbnails tile
         as squares like image/video)."""
@@ -473,7 +473,7 @@ class TestBinShapeByMediaType:
         meta = client.get("/api/projection/meta").get_json()
         assert meta["bin_shape"] == "square"
 
-    @patch("vtsearch.routes.projection._media_type_for", return_value="image")
+    @patch("vtscore.projection.service.media_type_for", return_value="image")
     @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
     def test_image_dataset_builds_and_serves_square(self, _mock_fit, _mock_mt, client):
         """An image dataset is tiled with squares end to end (build, meta, tiles)."""
@@ -501,7 +501,7 @@ class TestBinShapeByMediaType:
             assert tile_resp.get_json()["level"] == level
             break
 
-    @patch("vtsearch.routes.projection._media_type_for", return_value="image")
+    @patch("vtscore.projection.service.media_type_for", return_value="image")
     @patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection)
     def test_square_persisted_for_image_dataset(self, _mock_fit, _mock_mt, client, tmp_path):
         """An image dataset's build persists its square pyramid into the container."""
@@ -514,7 +514,7 @@ class TestBinShapeByMediaType:
         write_container(fake_pkl, pkl_bytes, {"format_version": 1})
 
         with patch(
-            "vtsearch.routes.projection._pkl_path_for",
+            "vtscore.projection.store.pkl_path_for",
             return_value=str(fake_pkl),
         ):
             client.post("/api/projection/build")
@@ -733,7 +733,7 @@ class TestForceReproject:
         fake_pkl = tmp_path / "reproject_persist.pkl"
         write_container(fake_pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
 
-        with patch("vtsearch.routes.projection._pkl_path_for", return_value=str(fake_pkl)):
+        with patch("vtscore.projection.store.pkl_path_for", return_value=str(fake_pkl)):
             client.post("/api/projection/build")
             _wait_projection()
             first = read_projection(fake_pkl, "hex")
@@ -772,7 +772,7 @@ class TestForceReproject:
         append_projection(fake_pkl, legacy, build_pyramid(legacy, bin_shape="square", n_levels=2))
         assert read_projection(fake_pkl, "square") is not None
 
-        with patch("vtsearch.routes.projection._pkl_path_for", return_value=str(fake_pkl)):
+        with patch("vtscore.projection.store.pkl_path_for", return_value=str(fake_pkl)):
             # Force-rebuild the (audio → hex) dataset: the stale square entry is
             # dropped, and the fresh hex layout replaces the legacy one.
             client.post("/api/projection/build", json={"force": True})
@@ -836,70 +836,6 @@ class TestBrowseCompactDefault:
             client.post("/api/projection/build", json={"ids": ids})
             _wait_projection()
         assert captured["compact"] is False
-
-
-def test_projection_params_match(monkeypatch):
-    """The persisted-projection guard invalidates a layout when UMAP params change."""
-    import numpy as np
-
-    from vtsearch.routes import projection as proj_route
-    from vtscore.projection.params import ProjectionParams
-    from vtscore.projection.umap_projection import Projection
-
-    coords = np.zeros((3, 2), dtype=np.float32)
-    ids = [0, 1, 2]
-    umap_default = Projection("p", ids, coords, "umap", 15, 0.1, False)
-    umap_changed = Projection("p", ids, coords, "umap", 30, 0.1, False)
-    pca = Projection("p", ids, coords, "pca", None, None, None)
-    legacy = Projection("p", ids, coords, "umap", None, None, None)
-
-    # Active settings at the config defaults.
-    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(15, 0.1, False))
-    assert proj_route._projection_params_match(umap_default) is True
-    assert proj_route._projection_params_match(umap_changed) is False
-    assert proj_route._projection_params_match(pca) is True
-    # Legacy None UMAP knobs are assumed to be the config defaults — but an
-    # unstamped ``compact`` means "compacted", which today's default is not.
-    assert proj_route._projection_params_match(legacy) is False
-
-    # Operator tuned the setting away from the default -> stale layouts recompute.
-    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(30, 0.1, False))
-    assert proj_route._projection_params_match(legacy) is False
-    assert proj_route._projection_params_match(umap_changed) is True
-    assert proj_route._projection_params_match(pca) is True
-
-
-def test_projection_params_match_detects_compaction_mismatch(monkeypatch):
-    """A layout compacted under the old default is refit, not silently served.
-
-    ``compact`` used not to be stamped at all, so a compacted layout was
-    indistinguishable from an uncompacted one and the mismatch could never
-    force a recompute (issue #3056).
-    """
-    import numpy as np
-
-    from vtsearch.routes import projection as proj_route
-    from vtscore.projection.params import ProjectionParams
-    from vtscore.projection.umap_projection import Projection
-
-    coords = np.zeros((3, 2), dtype=np.float32)
-    ids = [0, 1, 2]
-    compacted = Projection("p", ids, coords, "umap", 15, 0.1, True)
-    uncompacted = Projection("p", ids, coords, "umap", 15, 0.1, False)
-    unstamped = Projection("p", ids, coords, "umap", 15, 0.1, None)
-
-    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(15, 0.1, False))
-    assert proj_route._projection_params_match(uncompacted) is True
-    assert proj_route._projection_params_match(compacted) is False
-    # Unstamped reads as compacted — what it was when nothing recorded it.
-    assert proj_route._projection_params_match(unstamped) is False
-
-    # ...and the guard is symmetric: with compaction back on, the uncompacted
-    # layout is the stale one.
-    monkeypatch.setattr(proj_route, "_projection_params", lambda ctx=None: ProjectionParams(15, 0.1, True))
-    assert proj_route._projection_params_match(compacted) is True
-    assert proj_route._projection_params_match(unstamped) is True
-    assert proj_route._projection_params_match(uncompacted) is False
 
 
 class TestProjectionLabels:
@@ -1011,7 +947,7 @@ class TestProjectionLabels:
         assert client.get("/api/projection/meta?subset=1").get_json()["has_labels"] is True
 
     def test_reset_full_projection_drops_labels(self, client):
-        from vtsearch.routes.projection import _reset_full_projection
+        from vtscore.projection.service import reset_full_projection
 
         ctx = get_active_context()
         proj, pyr = self._build_hex_pyramid()
@@ -1019,7 +955,7 @@ class TestProjectionLabels:
         ctx._pyramids = {"hex": pyr}
         ctx._region_labels = self._label_set(pyr.projection_id)
 
-        _reset_full_projection(ctx)
+        reset_full_projection(ctx)
         assert ctx._region_labels is None
 
 
@@ -1053,7 +989,7 @@ class TestPersistedLabelRestore:
         ctx._projection = proj
         ctx._pyramids = {"hex": pyr}
         pkl = self._persist(tmp_path, stored_id, stored_sig)
-        monkeypatch.setattr("vtsearch.routes.projection._pkl_path_for", lambda dataset_id: str(pkl))
+        monkeypatch.setattr("vtscore.projection.store.pkl_path_for", lambda dataset_id: str(pkl))
         if active_sig != "__unset__":
             monkeypatch.setattr("vtscore.projection.signpost_prep.labeler_signature", lambda ctx: active_sig)
         return client.get("/api/projection/labels").get_json()
@@ -1143,7 +1079,7 @@ class TestPersistedLabelRestore:
 
         ctx = get_active_context()
         pkl = self._persist(tmp_path, "live-layout", "sig-old")
-        monkeypatch.setattr("vtsearch.routes.projection._pkl_path_for", lambda dataset_id: str(pkl))
+        monkeypatch.setattr("vtscore.projection.store.pkl_path_for", lambda dataset_id: str(pkl))
         monkeypatch.setattr("vtscore.projection.signpost_prep.labeler_signature", lambda ctx: "sig-new")
 
         proj, pyr = TestProjectionLabels._build_hex_pyramid("live-layout")

--- a/tests/datasets/test_load_projection_stage.py
+++ b/tests/datasets/test_load_projection_stage.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from vtscore.concurrency.progress import LoadingTasksTracker
 from vtscore.datasets.load_pipeline import _parse_bool
-from vtscore.datasets.stages.projection import _build_projection_stage, _persist_projection_to_container
+from vtscore.datasets.stages.projection import _build_projection_stage
 from vtscore.projection import Projection
 from vtscore.state.core import DatasetContext
 
@@ -73,9 +73,9 @@ class TestBuildProjectionStage:
         ctx = self._ctx_with_embeddings("proj_stage_ok")
         with (
             patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection),
-            patch("vtscore.datasets.stages.projection._persist_projection_to_container") as mock_persist,
+            patch("vtscore.projection.store.persist_projection") as mock_persist,
         ):
-            _build_projection_stage(ctx, _make_tracker(), "ds-123")
+            _build_projection_stage(ctx, _make_tracker())
 
         assert ctx._projection is not None
         assert ctx._projection.projection_id == "fake-pid"
@@ -83,9 +83,9 @@ class TestBuildProjectionStage:
         assert ctx._pyramids.get("square") is not None
         assert ctx._pyramids["square"].projection_id == "fake-pid"
         mock_persist.assert_called_once()
-        # dataset_id and the freshly-built artifacts are forwarded for persistence.
+        # The context's own id and the freshly-built artifacts go to the store.
         args = mock_persist.call_args.args
-        assert args[0] == "ds-123"
+        assert args[0] == "proj_stage_ok"
         assert args[1] is ctx._projection
         assert args[2] is ctx._pyramids["square"]
 
@@ -106,9 +106,9 @@ class TestBuildProjectionStage:
 
         with (
             patch("vtscore.projection.fit_projection", side_effect=_capturing),
-            patch("vtscore.datasets.stages.projection._persist_projection_to_container"),
+            patch("vtscore.projection.store.persist_projection"),
         ):
-            _build_projection_stage(ctx, _make_tracker(), "ds-params")
+            _build_projection_stage(ctx, _make_tracker())
 
         # The fixtures are CLAP-embedded, whose swept defaults are (15, 0.10).
         assert captured["n_neighbors"] == 15
@@ -136,9 +136,9 @@ class TestBuildProjectionStage:
 
         with (
             patch("vtscore.projection.fit_projection", side_effect=_capturing),
-            patch("vtscore.datasets.stages.projection._persist_projection_to_container"),
+            patch("vtscore.projection.store.persist_projection"),
         ):
-            _build_projection_stage(ctx, _make_tracker(), "ds-siglip")
+            _build_projection_stage(ctx, _make_tracker())
 
         assert (captured["n_neighbors"], captured["min_dist"]) == (10, 0.05)
 
@@ -152,7 +152,7 @@ class TestBuildProjectionStage:
         the user silently got the compacted arrangement the sweep measured as
         worse.
         """
-        from vtsearch.routes.projection import _projection_params_match
+        from vtscore.projection.store import projection_params_match
 
         ctx = DatasetContext("proj_stage_untuned")
         rng = np.random.default_rng(11)
@@ -179,60 +179,22 @@ class TestBuildProjectionStage:
 
         with (
             patch("vtscore.projection.fit_projection", side_effect=_stamping),
-            patch("vtscore.datasets.stages.projection._persist_projection_to_container"),
+            patch("vtscore.projection.store.persist_projection"),
         ):
-            _build_projection_stage(ctx, _make_tracker(), "ds-untuned")
+            _build_projection_stage(ctx, _make_tracker())
 
         assert ctx._projection.compact is False
-        assert _projection_params_match(ctx._projection, ctx) is True
+        assert projection_params_match(ctx._projection, ctx) is True
 
     def test_empty_dataset_is_noop(self):
         ctx = DatasetContext("proj_stage_empty")
         with (
             patch("vtscore.projection.fit_projection", side_effect=_fake_fit_projection) as mock_fit,
-            patch("vtscore.datasets.stages.projection._persist_projection_to_container") as mock_persist,
+            patch("vtscore.projection.store.persist_projection") as mock_persist,
         ):
-            _build_projection_stage(ctx, _make_tracker(), "ds-empty")
+            _build_projection_stage(ctx, _make_tracker())
 
         assert ctx._projection is None
         assert ctx._pyramids == {}
         mock_fit.assert_not_called()
         mock_persist.assert_not_called()
-
-
-class TestPersistProjectionToContainer:
-    def test_appends_to_registered_container(self, tmp_path):
-        import pickle as _pickle
-
-        from vtscore.datasets.container import read_projection, write_container
-
-        ids = [1, 2, 3]
-        rng = np.random.default_rng(7)
-        coords = rng.standard_normal((3, 2)).astype(np.float32)
-        proj = Projection("persist-pid", ids, coords, "pca")
-        from vtscore.projection import build_pyramid
-
-        pyr = build_pyramid(proj, n_levels=1)
-
-        pkl = tmp_path / "ds.pkl"
-        write_container(pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
-
-        with patch(
-            "vtscore.datasets.registry.get_dataset",
-            return_value={"pkl_path": str(pkl)},
-        ):
-            _persist_projection_to_container("ds-xyz", proj, pyr)
-
-        loaded = read_projection(str(pkl))
-        assert loaded is not None
-        loaded_proj, _loaded_pyr = loaded
-        assert loaded_proj.projection_id == "persist-pid"
-
-    def test_missing_registry_entry_is_noop(self):
-        proj = Projection("x", [1], np.zeros((1, 2), dtype=np.float32), "pca")
-        from vtscore.projection import build_pyramid
-
-        pyr = build_pyramid(proj, n_levels=1)
-        with patch("vtscore.datasets.registry.get_dataset", return_value=None):
-            # Must not raise even though there is no container to write to.
-            _persist_projection_to_container("nonexistent", proj, pyr)

--- a/tests_lib/projection/test_service.py
+++ b/tests_lib/projection/test_service.py
@@ -1,0 +1,390 @@
+"""The Browse layout lifecycle, driven directly (``vtscore.projection.service``).
+
+Every case here used to need a Flask test client: the build/re-bin/reset/
+subset state machine lived inside ``vtsearch/routes/projection.py`` and could
+only be reached through an HTTP request.  It is library code now, so these
+exercise it as what it is — functions over an explicit ``DatasetContext``.
+
+The UMAP fit is faked throughout (a seeded random layout): what is under test
+is *which* of the four sources answers a build and what it leaves on the
+context, not the arrangement itself.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vtscore.concurrency.async_jobs import projection_jobs
+from vtscore.projection import Projection, build_pyramid
+from vtscore.projection import service as svc
+from vtscore.state.core import DatasetContext
+
+
+def _fake_fit(matrix, ids, **kwargs):
+    """Cheap stand-in for UMAP: a seeded random 2-D layout with a fresh id."""
+    rng = np.random.default_rng(len(ids))
+    coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+    return Projection(uuid.uuid4().hex, list(ids), coords, "fake")
+
+
+def _faked_fit():
+    return patch("vtscore.projection.fit_projection", side_effect=_fake_fit)
+
+
+def _ctx(name: str = "svc", n: int = 6, media_type: str = "text") -> DatasetContext:
+    ctx = DatasetContext(name)
+    rng = np.random.default_rng(0)
+    for cid in range(1, n + 1):
+        ctx.medias[cid] = {
+            "id": cid,
+            "media_type": media_type,
+            "embedder": "clap",
+            "embeddings": {"clap": rng.standard_normal(8).astype(np.float32)},
+        }
+    return ctx
+
+
+def _layout(ctx: DatasetContext, bin_shape: str = "hex", pid: str = "pid"):
+    """A projection + pyramid over *ctx*'s ids, built without any fit."""
+    ids = sorted(ctx.medias.keys())
+    rng = np.random.default_rng(1)
+    coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+    proj = Projection(pid, ids, coords, "fake")
+    return proj, build_pyramid(proj, bin_shape=bin_shape, n_levels=2)
+
+
+def _await_build(timeout: float = 30.0) -> None:
+    """Block until the projection runner is idle."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        job = projection_jobs.current()
+        if job is None:
+            return
+        if job.status in ("running", "pending"):
+            job.done_event.wait(timeout=0.05)
+            continue
+        return
+    raise TimeoutError("projection job did not finish")
+
+
+class TestShapeFor:
+    """The bin shape is read off the dataset, never off a request."""
+
+    def test_text_tiles_as_hexes_and_audio_as_squares(self):
+        assert svc.shape_for(_ctx(media_type="text")) == "hex"
+        # Audio has a browsable waveform thumbnail, so it packs as squares.
+        assert svc.shape_for(_ctx(media_type="audio")) == "square"
+
+    def test_empty_dataset_falls_back_to_hex(self):
+        assert svc.media_type_for(DatasetContext("empty")) == ""
+        assert svc.shape_for(DatasetContext("empty")) == "hex"
+
+    def test_a_media_without_a_declared_type_reads_as_audio(self):
+        """Which is what the ingest pre-build must agree with.
+
+        The stage used to read a bare ``.get("media_type")`` (``None`` → hex)
+        while the serve path defaulted to audio (→ square), so such a dataset
+        was pre-built under a shape the serve path would never ask for.
+        """
+        ctx = DatasetContext("untyped")
+        ctx.medias[1] = {"id": 1}
+        assert svc.media_type_for(ctx) == "audio"
+
+
+class TestBuildLayoutShortCircuits:
+    def test_a_cached_pyramid_answers_without_a_fit(self):
+        ctx = _ctx()
+        proj, pyr = _layout(ctx)
+        svc.install_layout(ctx, proj, pyr)
+
+        with _faked_fit() as fit:
+            assert svc.build_layout(ctx) == {"status": "ready", "projection_id": "pid"}
+        fit.assert_not_called()
+
+    def test_an_empty_dataset_has_nothing_to_project(self):
+        with pytest.raises(svc.NothingToProject, match="Dataset is empty"):
+            svc.build_layout(DatasetContext("empty"))
+
+    def test_a_dataset_without_embeddings_has_nothing_to_project(self):
+        ctx = DatasetContext("no-vectors")
+        ctx.medias[1] = {"id": 1, "media_type": "text"}
+        with pytest.raises(ValueError):
+            svc.build_layout(ctx)
+
+    def test_nothing_to_project_is_a_value_error(self):
+        """So one ``except ValueError`` at the HTTP edge covers both it and the
+        embedding-matrix builder's own signal."""
+        assert issubclass(svc.NothingToProject, ValueError)
+
+
+class TestBuildLayoutFits:
+    def test_first_build_starts_a_job_and_installs_the_result(self):
+        ctx = _ctx("svc-first")
+        with _faked_fit():
+            started = svc.build_layout(ctx)
+            assert started["status"] == "building"
+            assert ctx._full_job_id == started["job_id"]
+            _await_build()
+
+        assert ctx._projection is not None
+        assert ctx._pyramids.get("hex") is not None
+        assert svc.layout_meta(ctx, "hex", subset=False)["status"] == "ready"
+
+    def test_the_other_shape_re_bins_the_frozen_layout_without_re_fitting(self):
+        """The hex/square toggle costs a re-bin, never a second UMAP fit."""
+        ctx = _ctx("svc-rebin")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr)
+
+        with _faked_fit() as fit:
+            ready = svc.rebin_from_existing_layout(ctx, sorted(ctx.medias), "square")
+        fit.assert_not_called()
+        assert ready == {"status": "ready", "projection_id": "pid"}
+        # Same coordinates, both binnings cached side by side.
+        assert ctx._pyramids["square"].projection_id == "pid"
+        assert ctx._pyramids["hex"] is pyr
+
+    def test_a_stale_id_set_is_not_re_binned(self):
+        """A layout fit over different items can't be re-tiled for these ones."""
+        ctx = _ctx("svc-stale")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr)
+        assert svc.rebin_from_existing_layout(ctx, [*sorted(ctx.medias), 999], "square") is None
+
+    def test_force_drops_the_frozen_layout_and_re_fits(self):
+        ctx = _ctx("svc-force")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr)
+
+        with _faked_fit() as fit:
+            assert svc.build_layout(ctx, force=True)["status"] == "building"
+            _await_build()
+        assert fit.call_count == 1
+        assert ctx._projection.projection_id != "pid"
+
+    def test_reset_drops_the_layout_its_pyramids_and_its_signs(self):
+        ctx = _ctx("svc-reset")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr)
+        ctx._region_labels = object()
+        ctx._full_job_id = "stale-job"
+
+        svc.reset_full_projection(ctx)
+
+        assert ctx._projection is None
+        assert ctx._pyramids == {}
+        assert ctx._region_labels is None
+        assert ctx._full_job_id is None
+
+    def test_reset_leaves_the_subset_layout_standing(self):
+        """It is an independent fit the user may still be browsing."""
+        ctx = _ctx("svc-reset-subset")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr, subset=True)
+
+        svc.reset_full_projection(ctx)
+        assert ctx._subset_projection is proj
+        assert ctx._subset_pyramids["hex"] is pyr
+
+
+class TestSubsetLayout:
+    def test_an_empty_selection_has_nothing_to_project(self):
+        with pytest.raises(svc.NothingToProject, match="No items selected"):
+            svc.build_layout(_ctx(), ids=[])
+
+    def test_a_selection_against_an_empty_dataset_has_nothing_to_project(self):
+        with pytest.raises(svc.NothingToProject, match="Dataset is empty"):
+            svc.build_layout(DatasetContext("empty"), ids=[1, 2])
+
+    def test_the_subset_fit_lands_in_the_subset_slots_only(self):
+        ctx = _ctx("svc-sub")
+        with _faked_fit():
+            assert svc.build_layout(ctx, ids=[1, 2, 3])["status"] == "building"
+            _await_build()
+
+        assert ctx._subset_projection is not None
+        assert sorted(ctx._subset_projection.ids) == [1, 2, 3]
+        assert ctx._subset_pyramids.get("hex") is not None
+        # The full-dataset layout is untouched by a subset browse.
+        assert ctx._projection is None
+        assert ctx._pyramids == {}
+
+    def test_the_same_subset_re_bins_instead_of_re_fitting(self):
+        ctx = _ctx("svc-sub-same")
+        proj, pyr = _layout(ctx, "hex", pid="sub-pid")
+        ctx._subset_projection = proj
+        ctx._subset_pyramids = {"hex": pyr}
+        ctx._subset_ids = list(proj.ids)
+
+        with _faked_fit() as fit:
+            same = svc.build_layout(ctx, ids=list(reversed(proj.ids)))
+            other = svc.build_subset_layout(ctx, list(proj.ids), "square")
+        fit.assert_not_called()
+        assert same == {"status": "ready", "projection_id": "sub-pid"}
+        assert other == {"status": "ready", "projection_id": "sub-pid"}
+
+    def test_a_different_subset_drops_the_stale_layout_before_fitting(self):
+        ctx = _ctx("svc-sub-diff")
+        proj, pyr = _layout(ctx, "hex", pid="sub-pid")
+        ctx._subset_projection = proj
+        ctx._subset_pyramids = {"hex": pyr}
+        ctx._subset_ids = list(proj.ids)
+        ctx._subset_content_version = 4
+        ctx._subset_region_labels = object()
+
+        with _faked_fit():
+            assert svc.build_layout(ctx, ids=[1, 2])["status"] == "building"
+            # The old layout is gone the moment the new fit is dispatched — the
+            # tile token resets and the signs anchored in it are dropped.
+            assert ctx._subset_content_version == 0
+            assert ctx._subset_region_labels is None
+            _await_build()
+
+        assert sorted(ctx._subset_projection.ids) == [1, 2]
+
+
+class TestRemoveFromSubset:
+    def _built_subset(self, ctx, shapes=("hex",)):
+        ids = sorted(ctx.medias.keys())
+        rng = np.random.default_rng(2)
+        coords = rng.standard_normal((len(ids), 2)).astype(np.float32)
+        proj = Projection("cull-pid", ids, coords, "fake")
+        ctx._subset_projection = proj
+        ctx._subset_ids = list(ids)
+        ctx._subset_pyramids = {s: build_pyramid(proj, bin_shape=s, n_levels=2) for s in shapes}
+        return proj
+
+    def test_the_cull_preserves_layout_identity_and_busts_the_tile_cache(self):
+        ctx = _ctx("svc-cull")
+        self._built_subset(ctx)
+
+        svc.remove_subset_ids(ctx, [1, 2])
+
+        assert ctx._subset_ids == [3, 4, 5, 6]
+        # Same layout — the canvas keeps its viewport — but a new tile token.
+        assert ctx._subset_pyramids["hex"].projection_id == "cull-pid"
+        assert ctx._subset_content_version == 1
+        assert svc.layout_meta(ctx, "hex", subset=True)["content_version"] == 1
+
+    def test_every_built_shape_is_re_binned(self):
+        ctx = _ctx("svc-cull-shapes")
+        self._built_subset(ctx, shapes=("hex", "square"))
+        svc.remove_subset_ids(ctx, [1])
+        for shape, pyr in ctx._subset_pyramids.items():
+            assert pyr.bin_shape == shape
+            assert pyr.point_count == 5
+
+    def test_the_bounds_shrink_to_the_survivors(self):
+        """So the canvas re-frames to what is left instead of keeping dead space."""
+        ctx = _ctx("svc-cull-bounds")
+        self._built_subset(ctx)
+        svc.remove_subset_ids(ctx, [1, 2, 3])
+        assert ctx._subset_pyramids["hex"].bounds == ctx._subset_projection.bounds
+
+    def test_a_cull_without_a_subset_is_a_refusal(self):
+        with pytest.raises(svc.NothingToProject, match="build it first"):
+            svc.remove_subset_ids(_ctx("svc-cull-none"), [1])
+
+
+class TestLayoutMeta:
+    def test_idle_without_a_layout_or_a_job(self):
+        ctx = _ctx("svc-meta-idle")
+        assert svc.layout_meta(ctx, "hex", subset=False) == {"status": "idle"}
+        assert svc.layout_meta(ctx, "hex", subset=True) == {"status": "idle"}
+
+    def test_ready_reports_the_shape_the_media_type_resolved_to(self):
+        ctx = _ctx("svc-meta-ready", media_type="audio")
+        proj, pyr = _layout(ctx, "square")
+        svc.install_layout(ctx, proj, pyr)
+
+        meta = svc.layout_meta(ctx, "square", subset=False)
+        assert meta["status"] == "ready"
+        assert meta["bin_shape"] == "square"
+        assert meta["media_type"] == "audio"
+        assert meta["method"] == "fake"
+        # Full-dataset layouts are never edited in place.
+        assert meta["content_version"] == 0
+
+    def test_an_errored_job_is_reported_rather_than_read_as_idle(self):
+        ctx = _ctx("svc-meta-err")
+
+        def _boom(job):
+            raise RuntimeError("umap exploded")
+
+        job = projection_jobs.start(("svc-meta-err", "hex"), _boom, dataset_id=ctx.dataset_id)
+        ctx._full_job_id = job.job_id
+        job.done_event.wait(timeout=10)
+
+        meta = svc.layout_meta(ctx, "hex", subset=False)
+        assert meta["status"] == "error"
+        assert "umap exploded" in meta["error"]
+
+    def test_a_job_id_pointing_at_nothing_reads_as_idle(self):
+        """The runner is app-wide and its history is bounded, so a stale id is
+        expected rather than exceptional."""
+        ctx = _ctx("svc-meta-stale")
+        ctx._full_job_id = "no-such-job"
+        assert svc.layout_meta(ctx, "hex", subset=False) == {"status": "idle"}
+
+
+class TestBuildProgress:
+    class _Job:
+        job_id = "j"
+        message = "arranging items"
+        error = None
+        status = "running"
+
+        def __init__(self, step, total_steps, current, total):
+            self.step, self.total_steps = step, total_steps
+            self.current, self.total = current, total
+
+    def test_stitches_within_phase_counts_into_a_whole_job_fraction(self):
+        body = svc.build_progress(self._Job(2, 3, 1, 4))
+        # Phase 2 of 3, a quarter of the way in: (2 - 1 + 0.25) / 3.
+        assert body["overall"] == pytest.approx(1.25 / 3)
+        assert body["overall_step_end"] == pytest.approx(2 / 3)
+
+    def test_an_uncountable_phase_parks_at_its_slice_start(self):
+        """The UMAP fit reports no fraction, so the bar must not invent one."""
+        body = svc.build_progress(self._Job(1, 3, 0, 0))
+        assert body["overall"] == pytest.approx(0.0)
+        assert body["overall_step_end"] == pytest.approx(1 / 3)
+
+    def test_a_phaseless_job_reports_no_overall(self):
+        body = svc.build_progress(self._Job(0, 0, 3, 10))
+        assert body["overall"] is None
+        assert body["overall_step_end"] is None
+        assert (body["step"], body["total_steps"]) == (None, None)
+
+
+class TestTilePayload:
+    def test_an_unbuilt_layout_has_no_tile(self):
+        assert svc.tile_payload(_ctx("svc-tile-none"), "hex", 0, 0, 0, subset=False) is None
+
+    def test_a_tile_off_the_grid_is_empty_rather_than_missing(self):
+        ctx = _ctx("svc-tile-off")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr)
+        payload = svc.tile_payload(ctx, "hex", 0, 9999, 9999, subset=False)
+        assert payload == {"level": 0, "tx": 9999, "ty": 9999, "cells": []}
+
+    def test_cells_carry_their_member_ids(self):
+        """Re-derived from the frozen layout; the pyramid stores only counts."""
+        ctx = _ctx("svc-tile-members")
+        proj, pyr = _layout(ctx, "hex")
+        svc.install_layout(ctx, proj, pyr)
+
+        seen: list[int] = []
+        for level, tx, ty in pyr.tiles:
+            payload = svc.tile_payload(ctx, "hex", level, tx, ty, subset=False)
+            if level == 0:
+                for cell in payload["cells"]:
+                    assert "member_ids" in cell
+                    assert len(cell["member_ids"]) == cell["count"]
+                    seen.extend(cell["member_ids"])
+        assert sorted(seen) == sorted(ctx.medias)

--- a/tests_lib/projection/test_service.py
+++ b/tests_lib/projection/test_service.py
@@ -382,6 +382,7 @@ class TestTilePayload:
         seen: list[int] = []
         for level, tx, ty in pyr.tiles:
             payload = svc.tile_payload(ctx, "hex", level, tx, ty, subset=False)
+            assert payload is not None
             if level == 0:
                 for cell in payload["cells"]:
                     assert "member_ids" in cell

--- a/tests_lib/projection/test_store.py
+++ b/tests_lib/projection/test_store.py
@@ -1,0 +1,218 @@
+"""Layout persistence and the freshness guard (``vtscore.projection.store``).
+
+These used to live in the app-tier route tests because the code did: the
+persisted-projection guard and the container path resolution were private
+helpers of ``vtsearch/routes/projection.py``, so exercising them meant
+importing a Flask blueprint.  They are library code now, and this is a
+library test.
+"""
+
+from __future__ import annotations
+
+import pickle as _pickle
+from unittest.mock import patch
+
+import numpy as np
+
+from vtscore.datasets.container import read_projection, write_container
+from vtscore.projection import Projection, build_pyramid
+from vtscore.projection.params import ProjectionParams
+from vtscore.projection.store import (
+    load_any_persisted_layout,
+    load_persisted_layout,
+    persist_projection,
+    pkl_path_for,
+    projection_params_match,
+    remove_persisted_projections,
+)
+from vtscore.state.core import DatasetContext
+
+
+def _params(n_neighbors: int, min_dist: float, compact: bool):
+    """Patch what the active configuration would resolve for any dataset."""
+    return patch(
+        "vtscore.projection.params.resolve_projection_params",
+        lambda ctx=None: ProjectionParams(n_neighbors, min_dist, compact),
+    )
+
+
+def _projection(pid: str, ids: list[int], method: str = "pca", *knobs) -> Projection:
+    coords = np.zeros((len(ids), 2), dtype=np.float32)
+    return Projection(pid, ids, coords, method, *knobs)
+
+
+class TestProjectionParamsMatch:
+    def test_invalidates_a_layout_whose_umap_params_changed(self):
+        ids = [0, 1, 2]
+        umap_default = _projection("p", ids, "umap", 15, 0.1, False)
+        umap_changed = _projection("p", ids, "umap", 30, 0.1, False)
+        pca = _projection("p", ids, "pca", None, None, None)
+        legacy = _projection("p", ids, "umap", None, None, None)
+
+        # Active settings at the config defaults.
+        with _params(15, 0.1, False):
+            assert projection_params_match(umap_default) is True
+            assert projection_params_match(umap_changed) is False
+            assert projection_params_match(pca) is True
+            # Legacy None UMAP knobs are assumed to be the config defaults — but
+            # an unstamped ``compact`` means "compacted", which today's default
+            # is not.
+            assert projection_params_match(legacy) is False
+
+        # Operator tuned the setting away from the default -> stale layouts
+        # recompute.
+        with _params(30, 0.1, False):
+            assert projection_params_match(legacy) is False
+            assert projection_params_match(umap_changed) is True
+            assert projection_params_match(pca) is True
+
+    def test_detects_compaction_mismatch(self):
+        """A layout compacted under the old default is refit, not silently served.
+
+        ``compact`` used not to be stamped at all, so a compacted layout was
+        indistinguishable from an uncompacted one and the mismatch could never
+        force a recompute (issue #3056).
+        """
+        ids = [0, 1, 2]
+        compacted = _projection("p", ids, "umap", 15, 0.1, True)
+        uncompacted = _projection("p", ids, "umap", 15, 0.1, False)
+        unstamped = _projection("p", ids, "umap", 15, 0.1, None)
+
+        with _params(15, 0.1, False):
+            assert projection_params_match(uncompacted) is True
+            assert projection_params_match(compacted) is False
+            # Unstamped reads as compacted — what it was when nothing recorded it.
+            assert projection_params_match(unstamped) is False
+
+        # ...and the guard is symmetric: with compaction back on, the
+        # uncompacted layout is the stale one.
+        with _params(15, 0.1, True):
+            assert projection_params_match(compacted) is True
+            assert projection_params_match(unstamped) is True
+            assert projection_params_match(uncompacted) is False
+
+
+class TestPklPathFor:
+    def test_reads_the_registry_entry(self):
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": "/tmp/x.pkl"}):
+            assert pkl_path_for("ds") == "/tmp/x.pkl"
+
+    def test_unregistered_or_pathless_entries_read_as_absent(self):
+        with patch("vtscore.datasets.registry.get_dataset", return_value=None):
+            assert pkl_path_for("nope") is None
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": ""}):
+            assert pkl_path_for("pathless") is None
+
+
+class TestPersistProjection:
+    def _container(self, tmp_path):
+        pkl = tmp_path / "ds.pkl"
+        write_container(pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
+        return pkl
+
+    def test_appends_to_registered_container(self, tmp_path):
+        pkl = self._container(tmp_path)
+        proj = _projection("persist-pid", [1, 2, 3])
+        pyr = build_pyramid(proj, n_levels=1)
+
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            persist_projection("ds-xyz", proj, pyr)
+
+        loaded = read_projection(str(pkl))
+        assert loaded is not None
+        assert loaded[0].projection_id == "persist-pid"
+
+    def test_missing_registry_entry_is_noop(self):
+        proj = _projection("x", [1])
+        pyr = build_pyramid(proj, n_levels=1)
+        with patch("vtscore.datasets.registry.get_dataset", return_value=None):
+            # Must not raise even though there is no container to write to.
+            persist_projection("nonexistent", proj, pyr)
+            remove_persisted_projections("nonexistent")
+
+    def test_removal_clears_every_stored_shape(self, tmp_path):
+        """A forced re-projection must not leave the other shape behind.
+
+        The coordinates are shared across bin shapes, so a surviving square
+        pyramid would resurrect exactly the arrangement the user asked to
+        replace the next time the hex map was opened.
+        """
+        pkl = self._container(tmp_path)
+        proj = _projection("shared-pid", [1, 2, 3])
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            persist_projection("ds", proj, build_pyramid(proj, bin_shape="hex", n_levels=1))
+            persist_projection("ds", proj, build_pyramid(proj, bin_shape="square", n_levels=1))
+            assert read_projection(str(pkl), "hex") is not None
+            assert read_projection(str(pkl), "square") is not None
+
+            remove_persisted_projections("ds")
+            assert read_projection(str(pkl), "hex") is None
+            assert read_projection(str(pkl), "square") is None
+
+
+class TestLoadPersistedLayout:
+    def _stored(self, tmp_path, ids, shapes=("hex",), method="pca", knobs=()):
+        pkl = tmp_path / "ds.pkl"
+        write_container(pkl, _pickle.dumps({"medias": {}}), {"format_version": 1})
+        proj = _projection("stored-pid", list(ids), method, *knobs)
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            for shape in shapes:
+                persist_projection("ds", proj, build_pyramid(proj, bin_shape=shape, n_levels=1))
+        return pkl
+
+    def test_round_trips_a_matching_layout(self, tmp_path):
+        pkl = self._stored(tmp_path, [1, 2, 3])
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            loaded = load_persisted_layout(ctx, [1, 2, 3], "hex")
+        assert loaded is not None
+        assert loaded[0].projection_id == "stored-pid"
+        assert loaded[1].bin_shape == "hex"
+
+    def test_id_set_mismatch_reads_as_absent(self, tmp_path):
+        """A dataset that gained or lost items must be re-fit, not re-served."""
+        pkl = self._stored(tmp_path, [1, 2, 3])
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            assert load_persisted_layout(ctx, [1, 2, 3, 4], "hex") is None
+
+    def test_stale_params_read_as_absent(self, tmp_path):
+        pkl = self._stored(tmp_path, [1, 2, 3], method="umap", knobs=(15, 0.1, False))
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            with _params(15, 0.1, False):
+                assert load_persisted_layout(ctx, [1, 2, 3], "hex") is not None
+            with _params(30, 0.1, False):
+                assert load_persisted_layout(ctx, [1, 2, 3], "hex") is None
+
+    def test_unstored_shape_reads_as_absent(self, tmp_path):
+        pkl = self._stored(tmp_path, [1, 2, 3], shapes=("hex",))
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            assert load_persisted_layout(ctx, [1, 2, 3], "square") is None
+
+    def test_any_shape_yields_the_shared_coordinates(self, tmp_path):
+        """Only hex is stored, but a square request still gets the layout back.
+
+        The 2-D coordinates are shared across bin shapes, so the caller can
+        re-bin them instead of paying for a second UMAP fit.
+        """
+        pkl = self._stored(tmp_path, [1, 2, 3], shapes=("hex",))
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            loaded = load_any_persisted_layout(ctx, [1, 2, 3], prefer="square")
+        assert loaded is not None
+        assert loaded[1].bin_shape == "hex"
+
+    def test_prefer_wins_when_both_shapes_are_stored(self, tmp_path):
+        pkl = self._stored(tmp_path, [1, 2, 3], shapes=("hex", "square"))
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
+            assert load_any_persisted_layout(ctx, [1, 2, 3], prefer="square")[1].bin_shape == "square"
+            assert load_any_persisted_layout(ctx, [1, 2, 3], prefer="hex")[1].bin_shape == "hex"
+
+    def test_unregistered_dataset_reads_as_absent(self):
+        ctx = DatasetContext("ds")
+        with patch("vtscore.datasets.registry.get_dataset", return_value=None):
+            assert load_persisted_layout(ctx, [1], "hex") is None
+            assert load_any_persisted_layout(ctx, [1]) is None

--- a/tests_lib/projection/test_store.py
+++ b/tests_lib/projection/test_store.py
@@ -208,8 +208,10 @@ class TestLoadPersistedLayout:
         pkl = self._stored(tmp_path, [1, 2, 3], shapes=("hex", "square"))
         ctx = DatasetContext("ds")
         with patch("vtscore.datasets.registry.get_dataset", return_value={"pkl_path": str(pkl)}):
-            assert load_any_persisted_layout(ctx, [1, 2, 3], prefer="square")[1].bin_shape == "square"
-            assert load_any_persisted_layout(ctx, [1, 2, 3], prefer="hex")[1].bin_shape == "hex"
+            square = load_any_persisted_layout(ctx, [1, 2, 3], prefer="square")
+            hexed = load_any_persisted_layout(ctx, [1, 2, 3], prefer="hex")
+        assert square is not None and square[1].bin_shape == "square"
+        assert hexed is not None and hexed[1].bin_shape == "hex"
 
     def test_unregistered_dataset_reads_as_absent(self):
         ctx = DatasetContext("ds")

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -613,7 +613,7 @@ def _run_origin_load_in_background(
                     if build_projection:
                         fin.begin("projection")
                         try:
-                            _build_projection_stage(ctx, fin, context_id)
+                            _build_projection_stage(ctx, fin)
                         except Exception:
                             traceback.print_exc()
                     # Embedder warm-up is fire-and-forget so the dashboard row goes

--- a/vtscore/datasets/stages/projection.py
+++ b/vtscore/datasets/stages/projection.py
@@ -1,10 +1,19 @@
 """Projection stage: compute + persist the 2-D Browse projection at ingest.
 
 Opt-in stage that fits UMAP on the cached embedding matrix, builds the
-hex-tile pyramid, caches both on the context, and persists them into the
-dataset container so the Browse canvas opens instantly instead of paying for
-the fit lazily on first visit. Best-effort by contract: the dataset is
-already registered and usable before this runs.
+tile pyramid, letters it with signposts, caches everything on the context,
+and persists it into the dataset container so the Browse canvas opens
+instantly instead of paying for the fit lazily on first visit. Best-effort by
+contract: the dataset is already registered and usable before this runs.
+
+The fit itself is not implemented here — it is
+:func:`vtscore.projection.service.fit_and_install_layout`, the same call the
+lazy Browse-time build makes. That sharing is load-bearing rather than tidy:
+a layout pre-built under different knobs (or a different bin shape) than the
+serve path resolves is *worse* than no pre-build at all, because the first
+Browse open either throws it away and re-fits or serves an arrangement nobody
+configured. What is left in this module is the load-pipeline wiring: progress
+reporting through the loading tracker, and the best-effort contract.
 """
 
 from __future__ import annotations
@@ -17,30 +26,14 @@ from vtscore.datasets.stages._common import _TOTAL_LOAD_STEPS
 if TYPE_CHECKING:
     from vtscore.state import DatasetContext
 
-
-def _persist_projection_to_container(dataset_id: str, proj, pyr) -> None:
-    """Best-effort save of the freshly-built projection into the dataset container.
-
-    Mirrors ``vtsearch.routes.projection._persist_projection`` but resolves
-    the container path through the dataset registry from inside the load
-    pipeline.  Failures are swallowed (logged): the in-memory projection is
-    already cached on the context, and a missing on-disk copy just means the
-    next Browse open recomputes it.
-    """
-    from vtscore.datasets.registry import get_dataset  # noqa: PLC0415
-
-    entry = get_dataset(dataset_id)
-    if entry is None:
-        return
-    pkl_path = entry.get("pkl_path")
-    if not pkl_path:
-        return
-    try:
-        from vtscore.datasets.container import append_projection  # noqa: PLC0415
-
-        append_projection(pkl_path, proj, pyr)
-    except Exception:
-        traceback.print_exc()
+#: What the loading bar says during each of the build's three phases (see
+#: :data:`vtscore.projection.service.BUILD_STEPS`), in the load pipeline's own
+#: voice rather than the job runner's.
+_PHASE_MESSAGES = {
+    1: "Building 2-D projection…",
+    2: "Building tile pyramid…",
+    3: "Naming regions…",
+}
 
 
 def _signpost_texts_stage(ctx: DatasetContext, tracker) -> None:
@@ -87,24 +80,16 @@ def _maybe_signpost_texts_stage(ctx: DatasetContext, fin, enabled: bool) -> None
         traceback.print_exc()
 
 
-def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> None:
-    """Compute + persist the 2-D UMAP projection and its signposts at ingest (opt-in).
+def _build_projection_stage(ctx: DatasetContext, tracker) -> None:
+    """Compute + persist the 2-D UMAP projection and its signposts at ingest.
 
     Runs inline as a load stage (after the dataset is registered) so the
     Browse canvas opens instantly instead of paying for the UMAP fit lazily
-    on first visit.  This mirrors the on-demand
-    ``POST /api/projection/build`` path: fit UMAP on the cached embedding
-    matrix, build the hex-tile pyramid, run the signpost labeling over the
-    frozen layout (see ``vtscore.projection.signpost_prep``), cache
-    everything on the context, and persist it into the dataset container.
-
-    "Mirrors" includes the knobs: the fit goes through the same
-    :func:`~vtscore.projection.params.resolve_projection_params` the route
-    uses, never ``fit_projection``'s signature defaults.  A layout fit under
-    different params than the route would resolve is worse than no pre-build
-    at all — the first Browse open either throws it away (params mismatch, so
-    UMAP re-runs and the opt-in bought nothing) or keeps a layout nobody
-    configured.
+    on first visit.  Delegates the whole build to
+    :func:`~vtscore.projection.service.fit_and_install_layout`, which is what
+    ``POST /api/projection/build`` runs in the background — same knobs, same
+    bin shape, same signpost pass, same persistence — so the layout this
+    leaves behind is exactly the one the serve path would have produced.
 
     Best-effort by contract: the dataset is already registered and usable
     before this runs, so any failure here (including a cancellation during
@@ -113,12 +98,7 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
     reason.
     """
     from vtscore.embedding.matrix import get_embedding_matrix  # noqa: PLC0415
-    from vtscore.projection import (  # noqa: PLC0415
-        bin_shape_for_media_type,
-        build_pyramid,
-        fit_projection,
-        resolve_projection_params,
-    )
+    from vtscore.projection import service  # noqa: PLC0415
 
     def _progress(current: int, total: int, message: str) -> None:
         tracker.check_cancelled()
@@ -131,6 +111,11 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
             total_steps=_TOTAL_LOAD_STEPS,
         )
 
+    def _on_phase(step: int, message: str) -> None:
+        # Also the cancellation checkpoint between phases: ``_progress``
+        # raises through the tracker, so a cancel lands before the next one.
+        _progress(0, 0 if step == 1 else 1, _PHASE_MESSAGES.get(step, message))
+
     try:
         # Cluster in the score embedder's space (patch-else-text; v3 routing).
         sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
@@ -139,41 +124,12 @@ def _build_projection_stage(ctx: DatasetContext, tracker, dataset_id: str) -> No
     if matrix.size == 0:
         return
 
-    _progress(0, 0, "Building 2-D projection…")
-
-    def _on_fit_progress(status: str, message: str, current: int, total: int) -> None:
-        _progress(current, total, message or "Building 2-D projection…")
-
-    params = resolve_projection_params(ctx)
-    proj = fit_projection(
-        matrix,
+    service.fit_and_install_layout(
+        ctx,
         list(sorted_ids),
-        n_neighbors=params.n_neighbors,
-        min_dist=params.min_dist,
-        compact=params.compact,
-        on_progress=_on_fit_progress,
+        matrix,
+        service.shape_for(ctx),
+        on_phase=_on_phase,
+        on_progress=_progress,
     )
-    _progress(0, 1, "Building tile pyramid…")
-    # The bin shape is a fixed property of the dataset's media type — squares
-    # for browsable-thumbnail media (image/video/document), hexes otherwise —
-    # so build exactly the one shape this dataset will ever use.
-    media_type = next(iter(ctx.medias.values())).get("media_type") if ctx.medias else None
-    pyr = build_pyramid(proj, bin_shape=bin_shape_for_media_type(media_type))
-
-    # Letter the frozen layout before it's cached/persisted, so the first
-    # Browse open finds the signs together with the map (the canvas fetches
-    # labels once per projection_id).  Reuses the texts the pre-registry
-    # stage cached into the pickle; itself best-effort — a labeling failure
-    # must not cost the user the projection they just paid for.
-    try:
-        from vtscore.projection.signpost_prep import prep_signposts  # noqa: PLC0415
-
-        prep_signposts(ctx, proj, subset=False, on_progress=_progress)
-    except Exception:
-        traceback.print_exc()
     _progress(1, 1, "Projection ready")
-
-    ctx._projection = proj
-    ctx._pyramids[pyr.bin_shape] = pyr
-
-    _persist_projection_to_container(dataset_id, proj, pyr)

--- a/vtscore/detectors/positives_browse.py
+++ b/vtscore/detectors/positives_browse.py
@@ -147,6 +147,7 @@ def build_positives_browse_context(
         fit_projection,
         resolve_projection_params,
     )
+    from vtscore.projection.service import install_layout
 
     if on_progress is not None:
         on_progress(total, total, "Building projection…")
@@ -163,6 +164,5 @@ def build_positives_browse_context(
         compact=params.compact,
     )
     pyr = build_pyramid(proj, bin_shape=bin_shape_for_media_type(media_type))
-    ctx._projection = proj
-    ctx._pyramids[pyr.bin_shape] = pyr
+    install_layout(ctx, proj, pyr)
     return ctx

--- a/vtscore/docs/packages/projection.md
+++ b/vtscore/docs/packages/projection.md
@@ -28,6 +28,13 @@ for the background-job runner the builds ride on.
 | `vtscore/projection/squarebin.py` | Vectorised square-grid binning |
 | `vtscore/projection/persistence.py` | Serialisation helpers shared with the ZIP container |
 
+**The lifecycle** - what turns those stages into a browsable map.
+
+| Module | Concern |
+|--------|---------|
+| `vtscore/projection/store.py` | Where a layout lives on disk: `pkl_path_for`, `persist_projection`, `load_persisted_layout`, and the `projection_params_match` freshness guard |
+| `vtscore/projection/service.py` | The state machine: `build_layout`, `fit_and_install_layout`, the subset fit and cull, and the meta / labels / tile payloads |
+
 **Signposts** - the "street sign" naming layer.
 
 | Module | Concern |
@@ -38,6 +45,7 @@ for the background-job runner the builds ride on.
 | `vtscore/projection/signpost_captioners.py` | The generative text tier (image VLM, audio captioner) |
 | `vtscore/projection/signpost_build.py` | Fit Toponymy over a frozen layout and flatten its topic tree into labels |
 | `vtscore/projection/demo_signposts.py` | Ground-truth signposts read from a dataset's hierarchical `category` |
+| `vtscore/projection/signpost_serve.py` | The read side: which set to letter a layout with, and the background self-heal of a stale one |
 
 ---
 
@@ -244,8 +252,10 @@ lights up the moment it is browsed.
 ## Persistence
 
 `persistence.py` holds the serialisation helpers only; the ZIP container
-module (`vtscore.datasets.container`) does the actual writing, and the
-Browse routes own the HTTP surface.
+module (`vtscore.datasets.container`) does the actual writing; `store.py`
+resolves which container a dataset writes to and judges whether what is
+already stored is still fresh; and the Browse routes own nothing but the
+HTTP surface.
 
 Storing a projection and its pyramid **is** a carve-out from the
 No-Persisted-Vectors rule, and a narrow one: what gets written is the
@@ -262,6 +272,7 @@ it.
 - [`embedding.md`](embedding.md) - `get_embedding_matrix` produces the
   input, and `l2_normalize` is why the euclidean metric is correct.
 - [`state.md`](state.md) - `DatasetContext._projection` / `_pyramids` /
-  `_region_labels` and their subset twins.
+  `_region_labels` and their subset twins, which `service.py` is the one
+  place that drives.
 - [`datasets.md`](datasets.md) - the ingest projection stage, and the
   container format that persists the result.

--- a/vtscore/projection/__init__.py
+++ b/vtscore/projection/__init__.py
@@ -13,9 +13,14 @@ The Flask-free core of the VTSBrowse browse canvas (see
   :func:`bin_shape_for_media_type` returns squares for browsable-thumbnail
   media (image/video/document) and hexes for the rest (audio/text).
 
-Persistence of the projection + pyramid (the carve-out from the
-"No Persisted Vectors or MLPs" rule) and the HTTP endpoints live in the
-VTSearch Browse routes, not here.
+Two more modules sit on top of those stages: :mod:`vtscore.projection.store`
+persists a layout beside its dataset (the carve-out from the "No Persisted
+Vectors or MLPs" rule) and judges whether a stored one is still fresh, and
+:mod:`vtscore.projection.service` drives the whole lifecycle the Browse
+canvas sees.  Neither is imported here: they pull the dataset registry and
+the job runners, which the pure-NumPy stages above deliberately do not.
+Only the HTTP endpoints live outside this package, in the VTSearch Browse
+routes.
 """
 
 from __future__ import annotations

--- a/vtscore/projection/service.py
+++ b/vtscore/projection/service.py
@@ -1,0 +1,646 @@
+"""The VTSBrowse layout lifecycle: build it, restore it, report on it, serve it.
+
+The state machine behind ``/api/projection/*``, with no HTTP in it.  Every
+function takes an explicit :class:`~vtscore.state.DatasetContext` and returns
+plain data, so the whole lifecycle — first fit, restore-from-container,
+re-bin to the other shape, forced re-projection, ephemeral subset fits, and
+in-place subset culls — is exercisable without a Flask client.
+
+**Where a layout comes from.**  A dataset's 2-D arrangement is fit once and
+then frozen.  A build request is answered by the cheapest source that can
+honestly serve it:
+
+1. the pyramid already cached on the context for this bin shape,
+2. the layout persisted in the dataset container (:mod:`.store`), if its ids
+   and fit parameters still match,
+3. a re-bin of the frozen coordinates that some *other* shape persisted — the
+   coordinates are shared across shapes, so a hex/square toggle costs a
+   re-bin, never a re-fit, and
+4. only then a background UMAP fit.
+
+``force`` (the Browser's "Re-project") skips all four and starts over.
+
+**Full vs subset.**  A dataset carries two independent layouts: the
+full-dataset one, which is persisted, and an ephemeral *subset* fit over just
+some ids (the positives of a Find run), which lives in memory and is never
+written to disk.  Every entry point here takes the same shape for both, and
+the ``subset`` flag picks which set of context slots it reads and writes.
+
+**The bin shape is not a choice.**  It is a fixed property of the dataset's
+media type — squares for browsable-thumbnail media (image/video/document),
+hexes for the rest — resolved by :func:`shape_for`.  Callers never pass one in
+from a request.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from vtscore.projection import store
+from vtscore.projection.signpost_serve import label_set_for, prep_signposts_best_effort
+
+if TYPE_CHECKING:
+    from vtscore.projection.pyramid import Pyramid
+    from vtscore.projection.umap_projection import Projection
+    from vtscore.state import DatasetContext
+
+logger = logging.getLogger(__name__)
+
+#: The coarse phases every projection build walks through, in order:
+#: 1. arranging the items (the UMAP fit), 2. tiling the layout into the pyramid,
+#: 3. naming the regions (signposts).  Reported as ``step``/``total_steps`` on
+#: the build meta so the client draws **one** whole-job bar that fills across the
+#: build instead of three bars that each restart at zero.  The UMAP fit itself is
+#: a single opaque call with no fraction to report (see
+#: :mod:`vtscore.projection.umap_projection`), so phase position is the only
+#: honest "how far along" signal for the longest part of the build.
+BUILD_STEPS = 3
+
+#: ``(step, message)`` sink for the coarse build phases above.
+PhaseFn = Callable[[int, str], None]
+
+#: ``(current, total, message)`` sink for within-phase progress.
+ProgressFn = Callable[[int, int, str], None]
+
+
+class NothingToProject(ValueError):
+    """There is nothing to lay out: no items, no selection, or no embeddings.
+
+    A ``ValueError`` subclass because the embedding-matrix builders already
+    signal the same class of "this dataset can't be projected" with a plain
+    ``ValueError``, and every caller wants to treat the two identically (the
+    HTTP layer answers both with a 409 carrying the message).
+    """
+
+
+# ----------------------------------------------------------------------
+# Context probes
+# ----------------------------------------------------------------------
+
+
+def media_type_for(ctx: DatasetContext) -> str:
+    """Return the media type of the first item in the dataset, or ``""``."""
+    if not ctx.medias:
+        return ""
+    first = next(iter(ctx.medias.values()))
+    return first.get("media_type", "audio")
+
+
+def shape_for(ctx: DatasetContext) -> str:
+    """The bin shape this dataset is tiled with, fixed by its media type.
+
+    Squares for browsable-thumbnail media (image/video/document), hexes for the
+    rest (audio/text).  Not a user choice — see
+    :func:`vtscore.projection.bin_shape_for_media_type`.
+    """
+    from vtscore.projection import bin_shape_for_media_type  # noqa: PLC0415
+
+    return bin_shape_for_media_type(media_type_for(ctx))
+
+
+# ----------------------------------------------------------------------
+# Status reporting
+# ----------------------------------------------------------------------
+
+
+def build_progress(job) -> dict:
+    """The ``status: building`` meta payload for an in-flight build *job*.
+
+    Carries the within-phase counts **and** the whole-job structure: which of
+    the :data:`BUILD_STEPS` phases is running, plus an ``overall`` completion
+    fraction stitched from the two so the client's bar advances monotonically
+    across the whole build.  A phase with no countable total (the UMAP fit)
+    contributes its slice only when it ends — the bar parks inside it rather
+    than pretending to a fraction the fit cannot report.  ``overall_step_end``
+    (the fraction at which the running phase's slice ends) is published
+    alongside so the client can shade the parked-to-slice-end span as a bounded
+    indeterminate zone: "somewhere in here" is all the fit can honestly say.
+    """
+    total_steps = job.total_steps or 0
+    step = job.step or 0
+    within = job.current / job.total if job.total > 0 else 0.0
+    overall = None
+    overall_step_end = None
+    if total_steps > 0 and step > 0:
+        overall = min(1.0, max(0.0, (step - 1 + within) / total_steps))
+        overall_step_end = max(min(1.0, step / total_steps), overall)
+    return {
+        "status": "building",
+        "job_id": job.job_id,
+        "current": job.current,
+        "total": job.total,
+        "message": job.message,
+        "step": step or None,
+        "total_steps": total_steps or None,
+        "overall": overall,
+        "overall_step_end": overall_step_end,
+    }
+
+
+def layout_meta(ctx: DatasetContext, bin_shape: str, *, subset: bool) -> dict:
+    """Projection/pyramid metadata + build status for one of the two layouts.
+
+    ``ready`` carries the pyramid's own meta (bounds, zoom levels, cell
+    sizing, point count) plus what the canvas needs to draw over it.  With no
+    pyramid, the layout's in-flight job — if any — decides between
+    ``building``, ``error``, and ``idle``.
+
+    ``content_version`` busts the otherwise-immutable tile cache.  Full-dataset
+    layouts are never edited in place, so theirs is a constant ``0``; the
+    subset's advances on every cull.
+    """
+    from vtscore.concurrency.async_jobs import projection_jobs  # noqa: PLC0415
+
+    pyr = (ctx._subset_pyramids if subset else ctx._pyramids).get(bin_shape)
+    if pyr is not None:
+        proj = ctx._subset_projection if subset else ctx._projection
+        meta = pyr.meta()
+        meta["status"] = "ready"
+        meta["media_type"] = media_type_for(ctx)
+        meta["method"] = proj.method if proj else None
+        meta["content_version"] = ctx._subset_content_version if subset else 0
+        label_set = label_set_for(ctx, pyr, subset=subset)
+        meta["has_labels"] = bool(label_set and label_set.labels)
+        return meta
+
+    job_id = ctx._subset_job_id if subset else ctx._full_job_id
+    if job_id:
+        job = projection_jobs.get(job_id)
+        if job is not None:
+            if job.status in ("running", "pending"):
+                return build_progress(job)
+            if job.status == "error":
+                return {"status": "error", "error": job.error or "projection build failed"}
+
+    return {"status": "idle"}
+
+
+def labels_payload(ctx: DatasetContext, bin_shape: str, *, subset: bool) -> dict:
+    """The region signpost labels to letter over one of the two layouts.
+
+    Labels are optional decoration: a layout whose labeling pipeline hasn't
+    run (or that predates it) answers an empty list, not an error, and
+    ``status`` is ``"idle"`` only when no layout is built at all.
+    """
+    pyr = (ctx._subset_pyramids if subset else ctx._pyramids).get(bin_shape)
+    if pyr is None:
+        return {"status": "idle", "labels": []}
+
+    label_set = label_set_for(ctx, pyr, subset=subset)
+    return {
+        "status": "ready",
+        "projection_id": pyr.projection_id,
+        "labels": label_set.payload() if label_set is not None else [],
+    }
+
+
+def tile_payload(
+    ctx: DatasetContext,
+    bin_shape: str,
+    level: int,
+    tx: int,
+    ty: int,
+    *,
+    subset: bool,
+) -> dict | None:
+    """One tile of a layout's pyramid, or ``None`` when it isn't built yet.
+
+    A tile outside the pyramid is not an error — it answers an empty cell
+    list, which is how the canvas learns that corner of the map is empty.
+    Only a missing *pyramid* returns ``None`` (the caller's 404).
+
+    Each cell carries its full member id list so the canvas can render
+    per-cell selection state and toggle a whole bin.  The pyramid keeps only
+    counts + representatives, so the members are re-derived on demand from the
+    frozen layout.
+    """
+    if subset:
+        pyr = ctx._subset_pyramids.get(bin_shape)
+        proj = ctx._subset_projection
+    else:
+        pyr = ctx._pyramids.get(bin_shape)
+        proj = ctx._projection
+    if pyr is None:
+        return None
+
+    tile = pyr.get_tile(level, tx, ty)
+    if tile is None:
+        return {"level": level, "tx": tx, "ty": ty, "cells": []}
+
+    payload = tile.to_payload()
+    if proj is not None and payload["cells"]:
+        from vtscore.projection import tile_member_ids  # noqa: PLC0415
+
+        members = tile_member_ids(pyr, proj, level, tx, ty)
+        for cell in payload["cells"]:
+            cell["member_ids"] = members.get((cell["q"], cell["r"]), [])
+
+    return payload
+
+
+# ----------------------------------------------------------------------
+# Fitting a layout
+# ----------------------------------------------------------------------
+
+
+def fit_and_install_layout(
+    ctx: DatasetContext,
+    sorted_ids: list[int],
+    matrix,
+    bin_shape: str,
+    *,
+    subset: bool = False,
+    on_phase: PhaseFn | None = None,
+    on_progress: ProgressFn | None = None,
+) -> tuple[Projection, Pyramid]:
+    """Fit UMAP over *matrix*, tile it, letter it, and cache it on *ctx*.
+
+    The one implementation of "make a layout", shared by the lazy Browse
+    build, the opt-in ingest pre-build stage, and the subset fit.  Keeping it
+    single-sourced is what stops the ingest stage from drifting away from the
+    on-demand path: a layout fit under different knobs than the serve path
+    resolves is worse than no pre-build at all, because the first Browse open
+    throws it away and the pre-build bought nothing.
+
+    Walks the three :data:`BUILD_STEPS` phases, reporting each through
+    *on_phase* and within-phase counts through *on_progress*.  Signposting is
+    best-effort and runs before the layout is cached, so the canvas finds the
+    signs together with the map.  Full-dataset layouts are persisted into the
+    dataset container; subset layouts are ephemeral and never written.
+    """
+    from vtscore.projection import build_pyramid, fit_projection  # noqa: PLC0415
+    from vtscore.projection.params import resolve_projection_params  # noqa: PLC0415
+
+    def _phase(step: int, message: str) -> None:
+        if on_phase is not None:
+            on_phase(step, message)
+
+    def _on_fit_progress(status: str, message: str, current: int, total: int) -> None:
+        if on_progress is not None:
+            on_progress(current, total, message)
+
+    params = resolve_projection_params(ctx)
+    _phase(1, "arranging items")
+    proj = fit_projection(
+        matrix,
+        list(sorted_ids),
+        n_neighbors=params.n_neighbors,
+        min_dist=params.min_dist,
+        compact=params.compact,
+        on_progress=_on_fit_progress,
+    )
+    _phase(2, "building pyramid")
+    pyr = build_pyramid(proj, bin_shape=bin_shape)
+    # Fresh signs over exactly these items: for a subset the contrastive
+    # keyphrases recompute against the subset's own siblings (better than any
+    # filtered dataset-level signs), and the per-media texts were cached at
+    # ingest, so this is the cheap half of the pipeline.
+    _phase(3, "naming regions")
+    prep_signposts_best_effort(ctx, proj, subset=subset, on_progress=on_progress)
+
+    install_layout(ctx, proj, pyr, subset=subset)
+    if not subset:
+        store.persist_projection(ctx.dataset_id, proj, pyr)
+    return proj, pyr
+
+
+def install_layout(ctx: DatasetContext, proj: Projection, pyr: Pyramid, *, subset: bool = False) -> None:
+    """Cache *proj* + *pyr* on *ctx* as the layout for ``pyr``'s bin shape."""
+    if subset:
+        ctx._subset_projection = proj
+        ctx._subset_pyramids[pyr.bin_shape] = pyr
+    else:
+        ctx._projection = proj
+        ctx._pyramids[pyr.bin_shape] = pyr
+
+
+def reset_full_projection(ctx: DatasetContext) -> None:
+    """Discard the cached + persisted full-dataset layout for a forced rebuild.
+
+    A re-projection must not be short-circuited by the frozen layout, so clear
+    the in-memory projection and every shape's cached pyramid, and drop the
+    persisted entries from the container — otherwise a later load, or the
+    not-yet-rebuilt other bin shape, would resurrect the stale coordinates
+    (which are shared across shapes).  The subset layout is deliberately left
+    standing: it is an independent fit the user may still be browsing.
+    """
+    ctx.reset_derived_caches(matrices=False, lookups=False, projection=True, subset=False)
+    store.remove_persisted_projections(ctx.dataset_id)
+
+
+# ----------------------------------------------------------------------
+# The build entry point
+# ----------------------------------------------------------------------
+
+
+def build_layout(
+    ctx: DatasetContext,
+    *,
+    ids: list[int] | None = None,
+    force: bool = False,
+) -> dict:
+    """Ensure a layout exists for *ctx*, and report where that left things.
+
+    Answers ``{"status": "ready", "projection_id": ...}`` when a layout was
+    already available (or could be re-binned from frozen coordinates without a
+    fit), or ``{"status": "building", "job_id": ...}`` when a background UMAP
+    fit had to be started.  Returns immediately either way.
+
+    With *ids*, projects only those media — an ephemeral subset layout held
+    separately from the full-dataset one.  With *force*, discards whichever
+    layout the request targets and re-fits from scratch.
+
+    Raises :class:`NothingToProject` (or a plain ``ValueError`` from the
+    embedding-matrix builder) when there is nothing to lay out.
+    """
+    bin_shape = shape_for(ctx)
+
+    if ids is not None:
+        return build_subset_layout(ctx, ids, bin_shape, force=force)
+
+    if not force:
+        cached = ctx._pyramids.get(bin_shape)
+        if cached is not None:
+            return {"status": "ready", "projection_id": cached.projection_id}
+
+    if not ctx.medias:
+        raise NothingToProject("Dataset is empty — nothing to project.")
+
+    from vtscore.embedding.matrix import get_embedding_matrix  # noqa: PLC0415
+
+    # The coverage atlas / projection clusters in the score embedder's space
+    # (patch-else-text; the v3 routing table).
+    sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
+    if matrix.size == 0:
+        raise NothingToProject("Dataset has no embeddings — nothing to project.")
+
+    if force:
+        reset_full_projection(ctx)
+    else:
+        ready = rebin_from_existing_layout(ctx, sorted_ids, bin_shape)
+        if ready is not None:
+            return ready
+
+    return start_full_build(ctx, sorted_ids, matrix, bin_shape, force=force)
+
+
+def rebin_from_existing_layout(ctx: DatasetContext, sorted_ids: list[int], bin_shape: str) -> dict | None:
+    """Serve *bin_shape* without a UMAP fit, if at all possible.
+
+    Tries, in order: this shape's persisted pyramid, then re-binning the shared
+    frozen layout (already in memory or persisted under another shape).  Returns
+    a ready-response dict, or ``None`` when no layout exists yet and UMAP must
+    run.
+    """
+    from vtscore.projection import build_pyramid  # noqa: PLC0415
+
+    proj = ctx._projection
+    if proj is None or set(proj.ids) != set(sorted_ids):
+        # Nothing usable in memory: probe the container, preferring this
+        # shape's own pyramid so a stored one is served rather than re-binned.
+        loaded = store.load_any_persisted_layout(ctx, sorted_ids, prefer=bin_shape)
+        if loaded is None:
+            return None
+        proj, pyr = loaded
+        install_layout(ctx, proj, pyr)
+        if pyr.bin_shape == bin_shape:
+            return {"status": "ready", "projection_id": pyr.projection_id}
+    else:
+        # The coordinates are in memory but this shape has no pyramid; a
+        # stored one for it beats re-binning, since it was built already.
+        loaded = store.load_persisted_layout(ctx, sorted_ids, bin_shape)
+        if loaded is not None:
+            stored_proj, stored_pyr = loaded
+            install_layout(ctx, stored_proj, stored_pyr)
+            return {"status": "ready", "projection_id": stored_pyr.projection_id}
+
+    pyr = build_pyramid(proj, bin_shape=bin_shape)
+    ctx._pyramids[bin_shape] = pyr
+    store.persist_projection(ctx.dataset_id, proj, pyr)
+    return {"status": "ready", "projection_id": pyr.projection_id}
+
+
+def start_full_build(
+    ctx: DatasetContext,
+    sorted_ids: list[int],
+    matrix,
+    bin_shape: str,
+    *,
+    force: bool = False,
+) -> dict:
+    """Start (or reuse) the background UMAP fit + pyramid build for *bin_shape*.
+
+    With *force*, run a brand-new fit even when the ids are unchanged: the job
+    signature is namespaced with a nonce so the result cache can't hand back the
+    old frozen layout, yielding a fresh (differently-seeded) arrangement.
+    """
+    from vtscore.concurrency.async_jobs import projection_jobs  # noqa: PLC0415
+
+    sig: tuple = (ctx.dataset_id, bin_shape, tuple(sorted_ids))
+    if force:
+        sig = (*sig, uuid.uuid4().hex)
+    else:
+        reused = _reuse_existing_build(ctx, sig, subset=False)
+        if reused is not None:
+            return reused
+
+    run = _build_runner(ctx, sorted_ids, matrix, bin_shape, subset=False)
+    job = projection_jobs.start(sig, run, dataset_id=ctx.dataset_id)
+    ctx._full_job_id = job.job_id
+    return {"status": "building", "job_id": job.job_id}
+
+
+def build_subset_layout(
+    ctx: DatasetContext,
+    requested_ids: list[int],
+    bin_shape: str,
+    *,
+    force: bool = False,
+) -> dict:
+    """Build (or reuse) an ephemeral UMAP projection over just *requested_ids*.
+
+    Unlike the full-dataset path, the subset projection is computed from only
+    the high-dimensional vectors of the requested ids (e.g. the positives of a
+    Find run), held in dedicated ``_subset_*`` slots on the context, and never
+    persisted.  The shared 2-D layout is reused across bin shapes, so a shape
+    toggle re-bins in milliseconds instead of re-fitting UMAP.
+    """
+    from vtscore.embedding.matrix import get_embedding_submatrix  # noqa: PLC0415
+    from vtscore.projection import build_pyramid  # noqa: PLC0415
+
+    if not requested_ids:
+        raise NothingToProject("No items selected — nothing to project.")
+    if not ctx.medias:
+        raise NothingToProject("Dataset is empty — nothing to project.")
+
+    sorted_ids, matrix = get_embedding_submatrix(ctx, requested_ids, ctx.routed_embedder("score"))
+    if matrix.size == 0:
+        raise NothingToProject("None of the selected items have embeddings — nothing to project.")
+
+    if not force and ctx._subset_ids == sorted_ids:
+        # Same subset: serve the cached pyramid, or re-bin the shared layout.
+        pyr = ctx._subset_pyramids.get(bin_shape)
+        if pyr is not None:
+            return {"status": "ready", "projection_id": pyr.projection_id}
+        proj = ctx._subset_projection
+        if proj is not None:
+            pyr = build_pyramid(proj, bin_shape=bin_shape)
+            ctx._subset_pyramids[bin_shape] = pyr
+            return {"status": "ready", "projection_id": pyr.projection_id}
+    else:
+        # A different subset — or a forced re-projection — drops the stale layout
+        # before fitting.  ``force`` re-fits even when the ids are unchanged, so
+        # the survivors of a cull re-spread instead of keeping their old slots.
+        # Drops the layout, its pyramids, the in-flight job id, the tile-cache
+        # token, and the signposts anchored in the dropped layout.
+        ctx.reset_derived_caches(matrices=False, lookups=False, projection=False, subset=True)
+        ctx._subset_ids = sorted_ids
+
+    return start_subset_build(ctx, sorted_ids, matrix, bin_shape, force=force)
+
+
+def start_subset_build(
+    ctx: DatasetContext,
+    sorted_ids: list[int],
+    matrix,
+    bin_shape: str,
+    *,
+    force: bool = False,
+) -> dict:
+    """Start (or reuse) the background subset UMAP fit + pyramid build.
+
+    With *force*, run a brand-new fit even for an unchanged id set (see
+    :func:`start_full_build`): the signature carries a nonce so neither the
+    result cache nor an in-flight job is reused.
+    """
+    from vtscore.concurrency.async_jobs import projection_jobs  # noqa: PLC0415
+
+    sig: tuple = (ctx.dataset_id, "subset", bin_shape, tuple(sorted_ids))
+    if force:
+        sig = (*sig, uuid.uuid4().hex)
+    else:
+        reused = _reuse_existing_build(ctx, sig, subset=True)
+        if reused is not None:
+            return reused
+
+    run = _build_runner(ctx, sorted_ids, matrix, bin_shape, subset=True)
+    job = projection_jobs.start(sig, run, dataset_id=ctx.dataset_id)
+    ctx._subset_job_id = job.job_id
+    return {"status": "building", "job_id": job.job_id}
+
+
+def remove_subset_ids(ctx: DatasetContext, ids: list[int]) -> None:
+    """Drop *ids* from the current subset layout **without re-fitting UMAP**.
+
+    Re-bins the frozen subset layout onto its existing grid minus the removed
+    points: the remaining points keep their exact 2-D positions and bins, only
+    counts/representatives change.  The ``projection_id`` (layout identity) is
+    preserved and a bumped ``content_version`` busts the otherwise-immutable
+    tile cache.  The served ``bounds`` shrink to the survivors' extent so the
+    client re-frames to what's left (zoom-to-fit, minimap) instead of keeping
+    dead space where the culled points were — safe because bin assignment is
+    origin-independent; bounds only drive client framing.
+
+    Raises :class:`NothingToProject` when no subset layout is built.
+    """
+    from dataclasses import replace  # noqa: PLC0415
+
+    from vtscore.projection import rebin_like  # noqa: PLC0415
+    from vtscore.projection import remove_ids as _remove_ids  # noqa: PLC0415
+
+    proj = ctx._subset_projection
+    if proj is None:
+        raise NothingToProject("No subset projection to update — build it first.")
+
+    new_proj = _remove_ids(proj, ids)
+    ctx._subset_projection = new_proj
+    ctx._subset_ids = list(new_proj.ids)
+    ctx._subset_job_id = None
+    ctx._subset_content_version += 1
+    # Re-bin every shape that was already built, each on its own preserved grid,
+    # then stamp the survivors' extent over rebin_like's kept template bounds.
+    ctx._subset_pyramids = {
+        s: replace(rebin_like(new_proj, pyr), bounds=new_proj.bounds) for s, pyr in ctx._subset_pyramids.items()
+    }
+
+
+# ----------------------------------------------------------------------
+# Background-job plumbing
+# ----------------------------------------------------------------------
+
+
+def _reuse_existing_build(ctx: DatasetContext, sig: tuple, *, subset: bool) -> dict | None:
+    """Answer *sig* from a finished or in-flight job, or ``None`` to start one.
+
+    Two short-circuits, in order: the runner's result cache still holds the
+    layout this exact signature produced (install it and report ready), or a
+    job for this exact dataset + shape + id set is already running (report its
+    id instead of queueing a duplicate fit behind it).
+    """
+    from vtscore.concurrency.async_jobs import projection_jobs  # noqa: PLC0415
+
+    job_cached = projection_jobs.cached_for(sig)
+    if job_cached is not None and job_cached.result is not None:
+        proj, pyr = job_cached.result
+        install_layout(ctx, proj, pyr, subset=subset)
+        return {"status": "ready", "projection_id": pyr.projection_id}
+
+    job_id = ctx._subset_job_id if subset else ctx._full_job_id
+    if job_id:
+        existing = projection_jobs.get(job_id)
+        if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
+            return {"status": "building", "job_id": existing.job_id}
+    return None
+
+
+def _build_runner(ctx: DatasetContext, sorted_ids: list[int], matrix, bin_shape: str, *, subset: bool):
+    """The worker-thread body for a background fit of *sorted_ids*.
+
+    Snapshots the matrix and id list so the job is independent of any later
+    mutation of the dataset, and re-binds the worker thread to *ctx* (the
+    runner is a single app-wide slot shared with every other dataset's build).
+    """
+    mat_copy = matrix.copy()
+    ids_copy = list(sorted_ids)
+
+    def _run(job):
+        from vtscore.state.core import thread_dataset_context  # noqa: PLC0415
+
+        with thread_dataset_context(ctx):
+            proj, pyr = fit_and_install_layout(
+                ctx,
+                ids_copy,
+                mat_copy,
+                bin_shape,
+                subset=subset,
+                on_phase=lambda step, message: job.set_phase(step, BUILD_STEPS, message),
+                on_progress=job.update_progress,
+            )
+            job.update_progress(1, 1, "done")
+            job.result = (proj, pyr)
+
+    return _run
+
+
+__all__ = [
+    "BUILD_STEPS",
+    "NothingToProject",
+    "build_layout",
+    "build_progress",
+    "build_subset_layout",
+    "fit_and_install_layout",
+    "install_layout",
+    "labels_payload",
+    "layout_meta",
+    "media_type_for",
+    "rebin_from_existing_layout",
+    "remove_subset_ids",
+    "reset_full_projection",
+    "shape_for",
+    "start_full_build",
+    "start_subset_build",
+    "tile_payload",
+]

--- a/vtscore/projection/signpost_prep.py
+++ b/vtscore/projection/signpost_prep.py
@@ -6,9 +6,9 @@ hand (see ``docs/plans/vtsbrowse-toponymy.md``):
 * the **ingest** projection stage (``vtscore.datasets.stages.projection``) —
   the user is already watching a progress bar, so prep rides along and the
   first Browse opens lettered;
-* the **lazy Browse build** (``vtsearch.routes.projection._start_umap_build``)
+* the **lazy Browse build** (``vtscore.projection.service.start_full_build``)
   — datasets ingested before/without prep get signs on their first Browse;
-* the **Find→Browse subset build** (``_start_subset_umap_build``) — signs are
+* the **Find→Browse subset build** (``service.start_subset_build``) — signs are
   re-fit over just the subset (contrastive keyphrases recompute against the
   subset's own siblings, which the image study showed beats filtering
   dataset-level signs), reusing the per-media texts cached at ingest so the
@@ -195,7 +195,7 @@ def prep_signposts(
         # Nothing worth lettering (tiny corpus, degenerate tree).  Leave the
         # context slot alone rather than pinning an empty set — an empty set
         # would suppress the lazy ground-truth fallback for datasets that
-        # ship a category hierarchy (see the routes' ``_label_set_for``).
+        # ship a category hierarchy (see ``signpost_serve.label_set_for``).
         return None
 
     if subset:

--- a/vtscore/projection/signpost_serve.py
+++ b/vtscore/projection/signpost_serve.py
@@ -1,0 +1,210 @@
+"""Resolving the region signposts to serve over a frozen Browse layout.
+
+The read side of the "street sign" name layer (see
+``docs/plans/vtsbrowse-toponymy.md``); :mod:`vtscore.projection.signpost_prep`
+is the write side.  Given a layout the canvas is about to draw, this module
+answers *which* label set belongs on it, in resolution order:
+
+1. a set already cached on the context for exactly this layout,
+2. the set the labeling pipeline **persisted** beside the dataset (full
+   layouts only), provided its labeler signature still matches what the
+   active pipeline would produce,
+3. lazily-derived **ground-truth signposts** from the dataset's category
+   annotations (the demo datasets), and
+4. nothing -- an unlettered map.
+
+Every step is best-effort.  Signs are decoration: a missing labeler, an
+uninstallable dependency, or a failed fit leaves the map unlettered, never
+broken.  Labels are pinned to the ``projection_id`` they were fit against and
+are treated as absent over any other layout, so a stale set is inert rather
+than wrong -- anchors are meaningless off their own layout.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from vtscore.projection import store
+
+if TYPE_CHECKING:
+    from vtscore.projection.labels import RegionLabelSet
+    from vtscore.projection.pyramid import Pyramid
+    from vtscore.projection.umap_projection import Projection
+    from vtscore.state import DatasetContext
+
+logger = logging.getLogger(__name__)
+
+#: ``(current, total, message)`` progress sink, matching
+#: :data:`vtscore.projection.signpost_prep.ProgressFn`.
+ProgressFn = Callable[[int, int, str], None]
+
+
+def label_set_for(ctx: DatasetContext, pyr: Pyramid, *, subset: bool) -> RegionLabelSet | None:
+    """The context's :class:`RegionLabelSet` for ``pyr``'s layout, or ``None``.
+
+    Labels are pinned to the frozen layout they were computed from: a set
+    whose ``projection_id`` doesn't match the active pyramid's is stale (the
+    layout was re-fit underneath it) and is treated as absent rather than
+    served over the wrong coordinates.
+
+    When no set is cached for this layout, resolution falls through the order
+    in the module docstring.  The result -- including an empty set, so a
+    dataset with no signs isn't re-probed on every poll -- is cached on the
+    context.  A set left behind by the live labeling pipeline wins: it
+    already matches the layout, so this never overwrites it.
+    """
+    label_set = ctx._subset_region_labels if subset else ctx._region_labels
+    if label_set is not None and label_set.projection_id == pyr.projection_id:
+        return label_set
+
+    built = None if subset else _maybe_load_persisted_labels(ctx, pyr)
+    if built is None:
+        proj = ctx._subset_projection if subset else ctx._projection
+        built = _maybe_build_demo_signposts(proj, pyr, ctx.medias)
+    if subset:
+        ctx._subset_region_labels = built
+    else:
+        # A background relabel (issue #2404) or build job may have installed a
+        # matching set on ``_region_labels`` while we were resolving the
+        # fallback; don't clobber it with a derived/empty stand-in — the
+        # freshly-built signs already match this layout and are strictly better.
+        current = ctx._region_labels
+        if current is not None and current.projection_id == pyr.projection_id:
+            return current
+        ctx._region_labels = built
+    if built is None or built.projection_id != pyr.projection_id:
+        return None
+    return built
+
+
+def prep_signposts_best_effort(
+    ctx: DatasetContext,
+    proj: Projection,
+    *,
+    subset: bool,
+    on_progress: ProgressFn | None = None,
+) -> None:
+    """Run the signpost labeling pipeline over *proj*, best-effort.
+
+    Called between the pyramid build and the moment the layout is cached on
+    the context: the canvas fetches labels once per ``projection_id`` when the
+    meta first reports ready, so the signs must exist by then.  Any failure
+    (or an environment without toponymy) leaves the map unlettered, never
+    broken — signs are optional decoration.
+
+    *on_progress* takes ``(current, total, message)``; a background job passes
+    its own ``update_progress`` straight in.
+    """
+    try:
+        from vtscore.projection.signpost_prep import prep_signposts  # noqa: PLC0415
+
+        prep_signposts(ctx, proj, subset=subset, on_progress=on_progress)
+    except Exception:
+        logger.warning("Signpost labeling failed for %s", ctx.dataset_id, exc_info=True)
+
+
+def _maybe_load_persisted_labels(ctx: DatasetContext, pyr: Pyramid) -> RegionLabelSet | None:
+    """Restore the signpost labels persisted next to the full-dataset layout.
+
+    Served only over the exact layout they were computed from
+    (``projection_id`` match), and only while their labeler signature still
+    matches what the active pipeline would produce — a changed provider,
+    embedder, or toponymy version makes them stale.  On a stale set we kick a
+    background rebuild (:func:`_kick_relabel_if_idle`) so the signs self-heal
+    to the active pipeline without a forced Re-project (issue #2404), and treat
+    the stale set as absent meanwhile — the map goes briefly unlettered rather
+    than serving signs the active labeler would no longer produce.
+
+    When the active pipeline can't label this dataset at all (e.g. toponymy
+    isn't installed here), a persisted set is still served: it's derived text
+    pinned to the right layout, strictly better than nothing.
+    """
+    pkl_path = store.pkl_path_for(ctx.dataset_id)
+    if pkl_path is None:
+        return None
+    from vtscore.datasets.container import read_region_labels  # noqa: PLC0415
+
+    loaded = read_region_labels(pkl_path)
+    if loaded is None:
+        return None
+    label_set, stored_signature = loaded
+    if label_set.projection_id != pyr.projection_id:
+        return None
+    from vtscore.projection.signpost_prep import labeler_signature  # noqa: PLC0415
+
+    active = labeler_signature(ctx)
+    if active is not None and active != stored_signature:
+        _kick_relabel_if_idle(ctx, pyr)
+        return None
+    return label_set
+
+
+def _kick_relabel_if_idle(ctx: DatasetContext, pyr: Pyramid) -> None:
+    """Rebuild a stale persisted label set in the background (issue #2404).
+
+    A persisted set whose ``labeler_signature`` no longer matches the active
+    pipeline is served as absent, but nothing re-runs the labeler while the
+    layout stays cached/persisted — only a forced Re-project re-letters the
+    map.  This kicks a best-effort background job that re-fits the signs over
+    the frozen full-dataset layout and re-persists them under the current
+    signature, so the stale signs self-heal on an ordinary Browse.
+
+    Coalescing: repeated meta/labels polls all land here until the rebuild
+    lands, so a job already in flight for this context short-circuits — one
+    rebuild per stale layout, not one per poll.  Best-effort throughout: a
+    missing projection or a labeling failure just leaves the map unlettered.
+    """
+    proj = ctx._projection
+    if proj is None or proj.projection_id != pyr.projection_id:
+        return
+
+    from vtscore.concurrency.async_jobs import signpost_relabel_jobs  # noqa: PLC0415
+
+    job_id = ctx._relabel_job_id
+    if job_id:
+        existing = signpost_relabel_jobs.get(job_id)
+        if existing is not None and existing.status in ("running", "pending"):
+            return
+
+    def _run(job):
+        # Runs on the relabel runner's worker thread, which the JobManager has
+        # already bound to this dataset's context.  ``prep_signposts`` (inside
+        # the best-effort wrapper) re-fits the signs, caches them on
+        # ``ctx._region_labels``, and re-persists them under the active
+        # signature — overwriting the empty interim the serve path cached.
+        prep_signposts_best_effort(ctx, proj, subset=False, on_progress=job.update_progress)
+
+    job = signpost_relabel_jobs.start(
+        (ctx.dataset_id, "relabel", proj.projection_id),
+        _run,
+        dataset_id=ctx.dataset_id,
+    )
+    ctx._relabel_job_id = job.job_id
+
+
+def _maybe_build_demo_signposts(proj: Any, pyr: Pyramid, medias) -> RegionLabelSet | None:
+    """Derive ground-truth signposts for ``pyr``'s layout, or ``None``.
+
+    Cheap-probes the medias for a hierarchical (``/``-separated) ``category``
+    first, so non-demo datasets never pay for a build.  Returns an id-pinned
+    :class:`RegionLabelSet` (possibly empty) when the layout is usable, else
+    ``None``.
+    """
+    if proj is None or proj.projection_id != pyr.projection_id:
+        return None
+    from vtscore.projection.demo_signposts import has_hierarchical_categories  # noqa: PLC0415
+
+    if not has_hierarchical_categories(medias):
+        # Cache an empty, id-pinned set so we don't re-probe every poll.
+        from vtscore.projection.labels import make_label_set  # noqa: PLC0415
+
+        return make_label_set(pyr.projection_id, [])
+
+    from vtscore.projection.demo_signposts import build_category_signposts  # noqa: PLC0415
+
+    return build_category_signposts(proj, medias)
+
+
+__all__ = ["label_set_for", "prep_signposts_best_effort"]

--- a/vtscore/projection/store.py
+++ b/vtscore/projection/store.py
@@ -1,0 +1,187 @@
+"""Where a dataset's Browse layout lives on disk, and whether it is still fresh.
+
+The persistence half of the projection lifecycle: resolving a dataset id to
+its container path, saving a freshly-fit layout into it, restoring one back
+out, and deciding whether a restored layout was fit under the knobs the
+active configuration would use today.
+
+This is the carve-out from the "No Persisted Vectors or MLPs" rule (see
+CLAUDE.md): a projection is 2-D coordinates derived from the pickle's own
+medias, written beside them in the same container, and rebuilt from scratch
+when the id set or the fit parameters no longer match.
+
+Everything here is best-effort by contract.  A missing container, an
+unwritable pickle, or a layout fit under stale parameters costs only the time
+of a re-fit, never correctness -- so failures are logged and reported as
+"nothing stored", never raised at the caller.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vtscore.projection.pyramid import Pyramid
+    from vtscore.projection.umap_projection import Projection
+    from vtscore.state import DatasetContext
+
+logger = logging.getLogger(__name__)
+
+#: Bin shapes a dataset can be tiled with.  Mirrors
+#: :data:`vtscore.projection.pyramid.BIN_SHAPES`, kept as a local literal so
+#: probing the container for persisted coordinates does not import the
+#: (numba-pulling) binning modules.
+_VALID_SHAPES = ("hex", "square")
+
+
+def pkl_path_for(dataset_id: str) -> str | None:
+    """Return the container path registered for *dataset_id*, or ``None``.
+
+    The single seam every projection-persistence path resolves its container
+    through -- the lazy Browse build, the ingest pre-build stage, and the
+    signpost writer all used to inline their own copy of this registry
+    lookup.  Being one function also makes it one monkeypatch target for
+    tests that want to point persistence at a temp file.
+    """
+    from vtscore.datasets.registry import get_dataset  # noqa: PLC0415
+
+    entry = get_dataset(dataset_id)
+    if entry is None:
+        return None
+    return entry.get("pkl_path") or None
+
+
+def persist_projection(dataset_id: str, proj: Projection, pyr: Pyramid) -> None:
+    """Best-effort save of *proj* (for ``pyr``'s bin shape) into the container.
+
+    Failures are swallowed and logged: the layout is already cached on the
+    context, so a missing on-disk copy costs the next process a re-fit and
+    nothing else.
+    """
+    pkl_path = pkl_path_for(dataset_id)
+    if pkl_path is None:
+        return
+    try:
+        from vtscore.datasets.container import append_projection  # noqa: PLC0415
+
+        append_projection(pkl_path, proj, pyr)
+    except Exception:
+        logger.warning("Failed to persist projection for %s", dataset_id, exc_info=True)
+
+
+def remove_persisted_projections(dataset_id: str) -> None:
+    """Best-effort drop of every persisted layout for *dataset_id*.
+
+    Called by a forced re-projection: the coordinates are shared across bin
+    shapes, so leaving any stored shape behind would let a later load (or the
+    not-yet-rebuilt other shape) resurrect the arrangement the user just
+    asked to replace.
+    """
+    pkl_path = pkl_path_for(dataset_id)
+    if pkl_path is None:
+        return
+    try:
+        from vtscore.datasets.container import remove_projections  # noqa: PLC0415
+
+        remove_projections(pkl_path)
+    except Exception:
+        logger.warning("Failed to clear persisted projection for %s", dataset_id, exc_info=True)
+
+
+def projection_params_match(proj: Any, ctx: DatasetContext | None = None) -> bool:
+    """Whether a persisted projection was fit under the active params.
+
+    Non-UMAP layouts (the PCA / trivial fallbacks for tiny datasets) ignore
+    these knobs, so they always match.  A legacy projection with no stamped
+    UMAP params is assumed to have used the config defaults, so it only
+    mismatches once an operator has changed a setting away from the default --
+    exactly when its layout must be recomputed.  An unstamped ``compact``
+    reads as ``True``: compaction was on by default for every layout written
+    before it was recorded, so those layouts correctly fail against today's
+    ``compact=False`` and get refit.
+    """
+    if getattr(proj, "method", None) != "umap":
+        return True
+    from vtscore.config import PROJECTION_MIN_DIST, PROJECTION_N_NEIGHBORS  # noqa: PLC0415
+    from vtscore.projection.params import resolve_projection_params  # noqa: PLC0415
+
+    stored_n = proj.n_neighbors if proj.n_neighbors is not None else PROJECTION_N_NEIGHBORS
+    stored_d = proj.min_dist if proj.min_dist is not None else PROJECTION_MIN_DIST
+    stored_c = getattr(proj, "compact", None)
+    stored_c = True if stored_c is None else bool(stored_c)
+    want = resolve_projection_params(ctx)
+    return (
+        stored_n == want.n_neighbors
+        and math.isclose(stored_d, want.min_dist, abs_tol=1e-9)
+        and stored_c == want.compact
+    )
+
+
+def load_persisted_layout(
+    ctx: DatasetContext,
+    sorted_ids: list[int],
+    bin_shape: str,
+) -> tuple[Any, Any] | None:
+    """Restore the *bin_shape* layout from the container, or ``None``.
+
+    Returns the ``(projection, pyramid)`` pair only when it is genuinely
+    usable for *ctx* right now: the stored id set must match *sorted_ids*
+    (the dataset has not gained or lost items) and the stored fit parameters
+    must match what :func:`projection_params_match` would resolve today.
+    Does **not** install anything on the context -- that is the caller's
+    decision.
+    """
+    pkl_path = pkl_path_for(ctx.dataset_id)
+    if pkl_path is None:
+        return None
+    from vtscore.datasets.container import read_projection  # noqa: PLC0415
+
+    loaded = read_projection(pkl_path, bin_shape)
+    if loaded is None:
+        return None
+    proj, pyr = loaded
+    if set(proj.ids) != set(sorted_ids):
+        logger.info("Persisted %s projection ids mismatch; will recompute.", bin_shape)
+        return None
+    if not projection_params_match(proj, ctx):
+        logger.info("Persisted %s projection UMAP params changed; will recompute.", bin_shape)
+        return None
+    return proj, pyr
+
+
+def load_any_persisted_layout(
+    ctx: DatasetContext,
+    sorted_ids: list[int],
+    *,
+    prefer: str | None = None,
+) -> tuple[Any, Any] | None:
+    """Restore a usable layout from *any* persisted bin shape, or ``None``.
+
+    The 2-D coordinates are shared across bin shapes, so any stored pyramid
+    yields them -- letting a shape that was never persisted be re-binned from
+    the frozen layout instead of re-fitting UMAP.  The pyramid that supplied
+    the coordinates is returned alongside, since it was deserialized anyway,
+    and *prefer* is probed first so a caller that wants one particular shape
+    gets its own pyramid back rather than a re-bin of the other one.
+
+    Each shape is probed at most once, so a caller that wants "this shape,
+    else any" makes one pass and logs one line per genuinely stale shape.
+    """
+    shapes = _VALID_SHAPES if prefer is None else (prefer, *(s for s in _VALID_SHAPES if s != prefer))
+    for shape in shapes:
+        loaded = load_persisted_layout(ctx, sorted_ids, shape)
+        if loaded is not None:
+            return loaded
+    return None
+
+
+__all__ = [
+    "load_any_persisted_layout",
+    "load_persisted_layout",
+    "persist_projection",
+    "pkl_path_for",
+    "projection_params_match",
+    "remove_persisted_projections",
+]

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -120,7 +120,10 @@ def remove_from_subset(body: dict):
     The remaining points keep their exact 2-D positions and bins; only counts
     and representatives change.  The ``projection_id`` (layout identity) is
     preserved and a bumped ``content_version`` busts the otherwise-immutable
-    tile cache.  Returns the updated subset meta for the dataset's shape.
+    tile cache.  The served ``bounds`` shrink to the survivors' extent so the
+    client re-frames to what's left (zoom-to-fit, minimap) instead of keeping
+    dead space where the culled points were.  Returns the updated subset meta
+    for the dataset's shape.
 
     Powers the Browser's "Remove from Good" cull, which marks the items Bad via
     ``/api/medias/vote-bulk`` and then calls this to make them disappear.

--- a/vtsearch/routes/projection.py
+++ b/vtsearch/routes/projection.py
@@ -3,18 +3,30 @@
 Kick off a background UMAP + tile pyramid build for the active dataset,
 query its status/metadata, and stream tiles to the browse canvas.
 
+HTTP only.  The lifecycle these endpoints drive — first fit, restore from the
+dataset container, re-bin to the other shape, forced re-projection, ephemeral
+subset fits, and in-place subset culls — lives in
+:mod:`vtscore.projection.service`, which is Flask-free and takes an explicit
+context.  What is left here is request parsing, error-code mapping, and cache
+headers.
+
 The pyramid tiles the projection as hexagons or squares, but the shape is a
 fixed property of the dataset's **media type** — squares for browsable-thumbnail
 media (image/video/document), hexes for the rest (audio/text) — not a per-request
 choice.  Every endpoint derives the shape from the active dataset
-(:func:`_shape_for`); the client never sends it.  The meta response reports the
-resolved ``bin_shape`` so the canvas knows which lattice to draw.
+(:func:`vtscore.projection.service.shape_for`); the client never sends it.  The
+meta response reports the resolved ``bin_shape`` so the canvas knows which
+lattice to draw.
+
+Every ``vtscore.projection`` import here is function-local on purpose: the
+package pulls numba/UMAP, and this module is imported at app startup by
+``vtsearch.routes``.  That import cost belongs on the first Browse request,
+not on every boot.
 """
 
 from __future__ import annotations
 
 import logging
-import uuid
 
 from flask import after_this_request, request
 from flask_smorest import Blueprint, abort
@@ -35,617 +47,27 @@ projection_bp = Blueprint(
     description="VTSBrowse projection: UMAP layout + hex/square tile pyramid.",
 )
 
-#: Bin shapes a dataset can be tiled with.  Mirrors
-#: ``vtscore.projection.BIN_SHAPES``; kept as a local literal so probing the
-#: container for persisted coordinates does not import the (numba-pulling)
-#: projection package on the request path.
-_VALID_SHAPES = ("hex", "square")
-
-#: The coarse phases every projection build walks through, in order:
-#: 1. arranging the items (the UMAP fit), 2. tiling the layout into the pyramid,
-#: 3. naming the regions (signposts).  Reported as ``step``/``total_steps`` on
-#: the build meta so the client draws **one** whole-job bar that fills across the
-#: build instead of three bars that each restart at zero.  The UMAP fit itself is
-#: a single opaque call with no fraction to report (see
-#: :mod:`vtscore.projection.umap_projection`), so phase position is the only
-#: honest "how far along" signal for the longest part of the build.
-_BUILD_STEPS = 3
-
-
-def _build_progress(job) -> dict:
-    """The ``status: building`` meta payload for an in-flight build *job*.
-
-    Carries the within-phase counts **and** the whole-job structure: which of
-    the :data:`_BUILD_STEPS` phases is running, plus an ``overall`` completion
-    fraction stitched from the two so the client's bar advances monotonically
-    across the whole build.  A phase with no countable total (the UMAP fit)
-    contributes its slice only when it ends — the bar parks inside it rather
-    than pretending to a fraction the fit cannot report.  ``overall_step_end``
-    (the fraction at which the running phase's slice ends) is published
-    alongside so the client can shade the parked-to-slice-end span as a bounded
-    indeterminate zone: "somewhere in here" is all the fit can honestly say.
-    """
-    total_steps = job.total_steps or 0
-    step = job.step or 0
-    within = job.current / job.total if job.total > 0 else 0.0
-    overall = None
-    overall_step_end = None
-    if total_steps > 0 and step > 0:
-        overall = min(1.0, max(0.0, (step - 1 + within) / total_steps))
-        overall_step_end = max(min(1.0, step / total_steps), overall)
-    return {
-        "status": "building",
-        "job_id": job.job_id,
-        "current": job.current,
-        "total": job.total,
-        "message": job.message,
-        "step": step or None,
-        "total_steps": total_steps or None,
-        "overall": overall,
-        "overall_step_end": overall_step_end,
-    }
-
-
-def _shape_for(ctx) -> str:
-    """The bin shape this dataset is tiled with, fixed by its media type.
-
-    Squares for browsable-thumbnail media (image/video/document), hexes for the
-    rest (audio/text).  Not a user choice — see
-    :func:`vtscore.projection.bin_shape_for_media_type`.
-    """
-    from vtscore.projection import bin_shape_for_media_type
-
-    return bin_shape_for_media_type(_media_type_for(ctx))
-
 
 def _is_subset(value: str | None) -> bool:
     """Whether a request targets the ephemeral subset projection."""
     return str(value).lower() in ("1", "true", "yes")
 
 
-def _subset_meta(ctx, bin_shape: str) -> dict:
-    """Return projection/pyramid metadata + build status for the subset layout."""
-    from vtscore.concurrency.async_jobs import projection_jobs
+def _requested_ids(raw) -> list[int]:
+    """Validate a request body's ``ids`` into a list of media ids.
 
-    pyr = ctx._subset_pyramids.get(bin_shape)
-    if pyr is not None:
-        meta = pyr.meta()
-        meta["status"] = "ready"
-        meta["media_type"] = _media_type_for(ctx)
-        meta["method"] = ctx._subset_projection.method if ctx._subset_projection else None
-        meta["content_version"] = ctx._subset_content_version
-        label_set = _label_set_for(ctx, pyr, subset=True)
-        meta["has_labels"] = bool(label_set and label_set.labels)
-        return meta
-
-    if ctx._subset_job_id:
-        job = projection_jobs.get(ctx._subset_job_id)
-        if job is not None:
-            if job.status in ("running", "pending"):
-                return _build_progress(job)
-            if job.status == "error":
-                return {"status": "error", "error": job.error or "projection build failed"}
-
-    return {"status": "idle"}
-
-
-def _label_set_for(ctx, pyr, *, subset: bool):
-    """The context's :class:`RegionLabelSet` for ``pyr``'s layout, or ``None``.
-
-    Labels are pinned to the frozen layout they were computed from: a set whose
-    ``projection_id`` doesn't match the active pyramid's is stale (the layout
-    was re-fit underneath it) and is treated as absent rather than served over
-    the wrong coordinates.
-
-    When no set is cached for this layout, resolution order is: the set the
-    labeling pipeline **persisted** into the dataset container (full layouts
-    only — see :func:`_maybe_load_persisted_labels`), then lazily-derived
-    **ground-truth signposts** from the dataset's category annotations (see
-    :func:`_maybe_build_demo_signposts`).  The result — including an empty
-    set, so a dataset with no signs isn't re-probed on every poll — is cached
-    on the context.  A set left behind by the live labeling pipeline wins: it
-    already matches the layout, so this never overwrites it.
+    A malformed body is a 400 — the client sent the wrong shape.  An *empty*
+    selection is not: the request is well-formed and there is simply nothing
+    to project, which the service reports as a 409 like every other
+    nothing-to-project case.
     """
-    label_set = ctx._subset_region_labels if subset else ctx._region_labels
-    if label_set is not None and label_set.projection_id == pyr.projection_id:
-        return label_set
-
-    built = None if subset else _maybe_load_persisted_labels(ctx, pyr)
-    if built is None:
-        proj = ctx._subset_projection if subset else ctx._projection
-        built = _maybe_build_demo_signposts(proj, pyr, ctx.medias)
-    if subset:
-        ctx._subset_region_labels = built
-    else:
-        # A background relabel (issue #2404) or build job may have installed a
-        # matching set on ``_region_labels`` while we were resolving the
-        # fallback; don't clobber it with a derived/empty stand-in — the
-        # freshly-built signs already match this layout and are strictly better.
-        current = ctx._region_labels
-        if current is not None and current.projection_id == pyr.projection_id:
-            return current
-        ctx._region_labels = built
-    if built is None or built.projection_id != pyr.projection_id:
-        return None
-    return built
-
-
-def _maybe_load_persisted_labels(ctx, pyr):
-    """Restore the signpost labels persisted next to the full-dataset layout.
-
-    Served only over the exact layout they were computed from
-    (``projection_id`` match), and only while their labeler signature still
-    matches what the active pipeline would produce — a changed provider,
-    embedder, or toponymy version makes them stale.  On a stale set we kick a
-    background rebuild (:func:`_kick_relabel_if_idle`) so the signs self-heal
-    to the active pipeline without a forced Re-project (issue #2404), and treat
-    the stale set as absent meanwhile — the map goes briefly unlettered rather
-    than serving signs the active labeler would no longer produce.
-
-    When the active pipeline can't label this dataset at all (e.g. toponymy
-    isn't installed here), a persisted set is still served: it's derived text
-    pinned to the right layout, strictly better than nothing.
-    """
-    pkl_path = _pkl_path_for(ctx.dataset_id)
-    if pkl_path is None:
-        return None
-    from vtscore.datasets.container import read_region_labels
-
-    loaded = read_region_labels(pkl_path)
-    if loaded is None:
-        return None
-    label_set, stored_signature = loaded
-    if label_set.projection_id != pyr.projection_id:
-        return None
-    from vtscore.projection.signpost_prep import labeler_signature
-
-    active = labeler_signature(ctx)
-    if active is not None and active != stored_signature:
-        _kick_relabel_if_idle(ctx, pyr)
-        return None
-    return label_set
-
-
-def _kick_relabel_if_idle(ctx, pyr) -> None:
-    """Rebuild a stale persisted label set in the background (issue #2404).
-
-    A persisted set whose ``labeler_signature`` no longer matches the active
-    pipeline is served as absent, but nothing re-runs the labeler while the
-    layout stays cached/persisted — only a forced Re-project re-letters the
-    map.  This kicks a best-effort background job that re-fits the signs over
-    the frozen full-dataset layout and re-persists them under the current
-    signature, so the stale signs self-heal on an ordinary Browse.
-
-    Coalescing: repeated meta/labels polls all land here until the rebuild
-    lands, so a job already in flight for this context short-circuits — one
-    rebuild per stale layout, not one per poll.  Best-effort throughout: a
-    missing projection or a labeling failure just leaves the map unlettered.
-    """
-    proj = ctx._projection
-    if proj is None or proj.projection_id != pyr.projection_id:
-        return
-
-    from vtscore.concurrency.async_jobs import signpost_relabel_jobs
-
-    job_id = ctx._relabel_job_id
-    if job_id:
-        existing = signpost_relabel_jobs.get(job_id)
-        if existing is not None and existing.status in ("running", "pending"):
-            return
-
-    def _run(job):
-        # Runs on the relabel runner's worker thread, which the JobManager has
-        # already bound to this dataset's context.  ``prep_signposts`` (inside
-        # the best-effort wrapper) re-fits the signs, caches them on
-        # ``ctx._region_labels``, and re-persists them under the active
-        # signature — overwriting the empty interim the serve path cached.
-        _prep_signposts_best_effort(ctx, proj, job, subset=False)
-
-    job = signpost_relabel_jobs.start(
-        (ctx.dataset_id, "relabel", proj.projection_id),
-        _run,
-        dataset_id=ctx.dataset_id,
-    )
-    ctx._relabel_job_id = job.job_id
-
-
-def _maybe_build_demo_signposts(proj, pyr, medias):
-    """Derive ground-truth signposts for ``pyr``'s layout, or ``None``.
-
-    Cheap-probes the medias for a hierarchical (``/``-separated) ``category``
-    first, so non-demo datasets never pull the projection package on the
-    request path or pay for a build.  Returns an id-pinned
-    :class:`RegionLabelSet` (possibly empty) when the layout is usable, else
-    ``None``.
-    """
-    if proj is None or proj.projection_id != pyr.projection_id:
-        return None
-    from vtscore.projection.demo_signposts import has_hierarchical_categories
-
-    if not has_hierarchical_categories(medias):
-        # Cache an empty, id-pinned set so we don't re-probe every poll.
-        from vtscore.projection.labels import make_label_set
-
-        return make_label_set(pyr.projection_id, [])
-
-    from vtscore.projection.demo_signposts import build_category_signposts
-
-    return build_category_signposts(proj, medias)
-
-
-def _media_type_for(ctx) -> str:
-    """Return the media type of the first item in the dataset, or ``""``."""
-    if not ctx.medias:
-        return ""
-    first = next(iter(ctx.medias.values()))
-    return first.get("media_type", "audio")
-
-
-def _pkl_path_for(dataset_id: str) -> str | None:
-    """Return the pkl_path from the dataset registry, or ``None``."""
-    from vtscore.datasets.registry import get_dataset
-
-    entry = get_dataset(dataset_id)
-    if entry is None:
-        return None
-    return entry.get("pkl_path") or None
-
-
-def _projection_params(ctx=None):
-    """The knobs a projection for *ctx* should be fit under.
-
-    A thin pass-through to the shared resolver
-    (:func:`vtscore.projection.params.resolve_projection_params`), which the
-    ingest-time pre-build stage calls too — the two paths must agree or the
-    pre-built layout is discarded (or silently served) on the first Browse
-    open.  Kept as a named seam here so the freshness check and the build
-    entry points read the same way, and so tests can substitute it.
-    """
-    from vtscore.projection.params import resolve_projection_params
-
-    return resolve_projection_params(ctx)
-
-
-def _projection_params_match(proj, ctx=None) -> bool:
-    """Whether a persisted projection was fit under the active params.
-
-    Non-UMAP layouts (the PCA / trivial fallbacks for tiny datasets) ignore
-    these knobs, so they always match.  A legacy projection with no stamped
-    UMAP params is assumed to have used the config defaults, so it only
-    mismatches once an operator has changed a setting away from the default —
-    exactly when its layout must be recomputed.  An unstamped ``compact``
-    reads as ``True``: compaction was on by default for every layout written
-    before it was recorded, so those layouts correctly fail against today's
-    ``compact=False`` and get refit.
-    """
-    import math
-
-    if getattr(proj, "method", None) != "umap":
-        return True
-    from vtscore.config import PROJECTION_MIN_DIST, PROJECTION_N_NEIGHBORS
-
-    stored_n = proj.n_neighbors if proj.n_neighbors is not None else PROJECTION_N_NEIGHBORS
-    stored_d = proj.min_dist if proj.min_dist is not None else PROJECTION_MIN_DIST
-    stored_c = getattr(proj, "compact", None)
-    stored_c = True if stored_c is None else bool(stored_c)
-    want = _projection_params(ctx)
-    return (
-        stored_n == want.n_neighbors
-        and math.isclose(stored_d, want.min_dist, abs_tol=1e-9)
-        and stored_c == want.compact
-    )
-
-
-def _try_load_persisted(ctx, sorted_ids: list[int], bin_shape: str) -> dict | None:
-    """Try to restore the *bin_shape* pyramid from the dataset container.
-
-    Returns a ready-response dict on success, or ``None`` if no valid
-    persisted pyramid for that shape is available.
-    """
-    pkl_path = _pkl_path_for(ctx.dataset_id)
-    if pkl_path is None:
-        return None
-    from vtscore.datasets.container import read_projection
-
-    loaded = read_projection(pkl_path, bin_shape)
-    if loaded is None:
-        return None
-    proj, pyr = loaded
-    if set(proj.ids) != set(sorted_ids):
-        logger.info("Persisted %s projection ids mismatch; will recompute.", bin_shape)
-        return None
-    if not _projection_params_match(proj, ctx):
-        logger.info("Persisted %s projection UMAP params changed; will recompute.", bin_shape)
-        return None
-    ctx._projection = proj
-    ctx._pyramids[bin_shape] = pyr
-    return {"status": "ready", "projection_id": pyr.projection_id}
-
-
-def _load_projection_coords(ctx, sorted_ids: list[int]):
-    """Populate ``ctx._projection`` from any persisted bin shape, or return ``None``.
-
-    The 2-D coordinates are shared across bin shapes, so any stored pyramid
-    yields them — letting a shape that was never persisted be re-binned from
-    the frozen layout instead of re-fitting UMAP.  The pyramid that supplied
-    the coordinates is cached too, since it was deserialized anyway.
-    """
-    pkl_path = _pkl_path_for(ctx.dataset_id)
-    if pkl_path is None:
-        return None
-    from vtscore.datasets.container import read_projection
-
-    for shape in _VALID_SHAPES:
-        loaded = read_projection(pkl_path, shape)
-        if loaded is None:
-            continue
-        proj, pyr = loaded
-        if set(proj.ids) != set(sorted_ids):
-            continue
-        if not _projection_params_match(proj, ctx):
-            continue
-        ctx._projection = proj
-        ctx._pyramids.setdefault(pyr.bin_shape, pyr)
-        return proj
-    return None
-
-
-def _rebin_from_existing_layout(ctx, sorted_ids: list[int], bin_shape: str) -> dict | None:
-    """Serve *bin_shape* without a UMAP fit, if at all possible.
-
-    Tries, in order: this shape's persisted pyramid, then re-binning the shared
-    frozen layout (already in memory or persisted under another shape).  Returns
-    a ready-response dict, or ``None`` when no layout exists yet and UMAP must
-    run.
-    """
-    from vtscore.projection import build_pyramid
-
-    persisted = _try_load_persisted(ctx, sorted_ids, bin_shape)
-    if persisted is not None:
-        return persisted
-
-    proj = ctx._projection
-    if proj is None or set(proj.ids) != set(sorted_ids):
-        proj = _load_projection_coords(ctx, sorted_ids)
-    if proj is None:
-        return None
-
-    pyr = build_pyramid(proj, bin_shape=bin_shape)
-    ctx._pyramids[bin_shape] = pyr
-    _persist_projection(ctx.dataset_id, proj, pyr)
-    return {"status": "ready", "projection_id": pyr.projection_id}
-
-
-def _reset_full_projection(ctx) -> None:
-    """Discard the cached + persisted full-dataset layout for a forced rebuild.
-
-    A re-projection must not be short-circuited by the frozen layout, so clear
-    the in-memory projection and every shape's cached pyramid, and drop the
-    persisted entries from the container — otherwise a later load, or the
-    not-yet-rebuilt other bin shape, would resurrect the stale coordinates
-    (which are shared across shapes).  The subset layout is deliberately left
-    standing: it is an independent fit the user may still be browsing.
-    """
-    ctx.reset_derived_caches(matrices=False, lookups=False, projection=True, subset=False)
-    pkl_path = _pkl_path_for(ctx.dataset_id)
-    if pkl_path is None:
-        return
-    try:
-        from vtscore.datasets.container import remove_projections
-
-        remove_projections(pkl_path)
-    except Exception:
-        logger.warning("Failed to clear persisted projection for %s", ctx.dataset_id, exc_info=True)
-
-
-def _prep_signposts_best_effort(ctx, proj, job, *, subset: bool) -> None:
-    """Run the signpost labeling pipeline inside a build job, best-effort.
-
-    Called between the pyramid build and the moment the layout is cached on
-    the context: the canvas fetches labels once per ``projection_id`` when the
-    meta first reports ready, so the signs must exist by then.  Any failure
-    (or an environment without toponymy) leaves the map unlettered, never
-    broken — signs are optional decoration.
-    """
-    try:
-        from vtscore.projection.signpost_prep import prep_signposts
-
-        def _on_progress(current: int, total: int, message: str) -> None:
-            job.update_progress(current, total, message)
-
-        prep_signposts(ctx, proj, subset=subset, on_progress=_on_progress)
-    except Exception:
-        logger.warning("Signpost labeling failed for %s", ctx.dataset_id, exc_info=True)
-
-
-def _start_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, force: bool = False) -> dict:
-    """Start (or reuse) the background UMAP fit + pyramid build for *bin_shape*.
-
-    With *force*, run a brand-new fit even when the ids are unchanged: the job
-    signature is namespaced with a nonce so the result cache can't hand back the
-    old frozen layout, yielding a fresh (differently-seeded) arrangement.
-    """
-    from vtscore.concurrency.async_jobs import projection_jobs
-    from vtscore.projection import build_pyramid, fit_projection
-    from vtscore.state.core import thread_dataset_context
-
-    sig = (ctx.dataset_id, bin_shape, tuple(sorted_ids))
-    if force:
-        sig = (*sig, uuid.uuid4().hex)
-    else:
-        job_cached = projection_jobs.cached_for(sig)
-        if job_cached is not None and job_cached.result is not None:
-            proj, pyr = job_cached.result
-            ctx._projection = proj
-            ctx._pyramids[bin_shape] = pyr
-            return {"status": "ready", "projection_id": pyr.projection_id}
-
-        # Already building this exact dataset + shape?  Reuse the in-flight job
-        # instead of queueing a duplicate fit behind it.
-        if ctx._full_job_id:
-            existing = projection_jobs.get(ctx._full_job_id)
-            if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
-                return {"status": "building", "job_id": existing.job_id}
-
-    mat_copy = matrix.copy()
-    ids_copy = list(sorted_ids)
-    dataset_id = ctx.dataset_id
-    params = _projection_params(ctx)
-
-    def _run(job):
-        with thread_dataset_context(ctx):
-
-            def _on_progress(status, message, current, total):
-                job.update_progress(current, total, message)
-
-            job.set_phase(1, _BUILD_STEPS, "arranging items")
-            proj = fit_projection(
-                mat_copy,
-                ids_copy,
-                n_neighbors=params.n_neighbors,
-                min_dist=params.min_dist,
-                compact=params.compact,
-                on_progress=_on_progress,
-            )
-            job.set_phase(2, _BUILD_STEPS, "building pyramid")
-            pyr = build_pyramid(proj, bin_shape=bin_shape)
-            job.set_phase(3, _BUILD_STEPS, "naming regions")
-            _prep_signposts_best_effort(ctx, proj, job, subset=False)
-            job.update_progress(1, 1, "done")
-
-            ctx._projection = proj
-            ctx._pyramids[bin_shape] = pyr
-            job.result = (proj, pyr)
-
-            _persist_projection(dataset_id, proj, pyr)
-
-    job = projection_jobs.start(sig, _run, dataset_id=ctx.dataset_id)
-    ctx._full_job_id = job.job_id
-    return {"status": "building", "job_id": job.job_id}
-
-
-def _dispatch_subset_build(ctx, ids_raw, bin_shape: str, *, force: bool = False) -> dict:
-    """Validate the request body's ``ids`` and route to the subset build."""
-    if not isinstance(ids_raw, list):
+    if not isinstance(raw, list):
         abort(400, message="`ids` must be a list of media ids.")
     try:
-        requested = [int(c) for c in ids_raw]
+        requested = [int(c) for c in raw]
     except (TypeError, ValueError):
         abort(400, message="`ids` must be a list of integer media ids.")
-    if not requested:
-        abort(409, message="No items selected — nothing to project.")
-    if not ctx.medias:
-        abort(409, message="Dataset is empty — nothing to project.")
-    try:
-        return _build_subset(ctx, requested, bin_shape, force=force)
-    except ValueError as exc:
-        abort(409, message=str(exc))
-
-
-def _build_subset(ctx, requested_ids: list[int], bin_shape: str, *, force: bool = False) -> dict:
-    """Build (or reuse) an ephemeral UMAP projection over just *requested_ids*.
-
-    Unlike the full-dataset path, the subset projection is computed from only
-    the high-dimensional vectors of the requested ids (e.g. the positives of a
-    Find run), held in dedicated ``_subset_*`` slots on the context, and never
-    persisted.  The shared 2-D layout is reused across bin shapes, so a shape
-    toggle re-bins in milliseconds instead of re-fitting UMAP.
-    """
-    from vtscore.embedding.matrix import get_embedding_submatrix
-    from vtscore.projection import build_pyramid
-
-    sorted_ids, matrix = get_embedding_submatrix(ctx, requested_ids, ctx.routed_embedder("score"))
-    if matrix.size == 0:
-        abort(409, message="None of the selected items have embeddings — nothing to project.")
-
-    if not force and ctx._subset_ids == sorted_ids:
-        # Same subset: serve the cached pyramid, or re-bin the shared layout.
-        pyr = ctx._subset_pyramids.get(bin_shape)
-        if pyr is not None:
-            return {"status": "ready", "projection_id": pyr.projection_id}
-        proj = ctx._subset_projection
-        if proj is not None:
-            pyr = build_pyramid(proj, bin_shape=bin_shape)
-            ctx._subset_pyramids[bin_shape] = pyr
-            return {"status": "ready", "projection_id": pyr.projection_id}
-    else:
-        # A different subset — or a forced re-projection — drops the stale layout
-        # before fitting.  ``force`` re-fits even when the ids are unchanged, so
-        # the survivors of a cull re-spread instead of keeping their old slots.
-        # Drops the layout, its pyramids, the in-flight job id, the tile-cache
-        # token, and the signposts anchored in the dropped layout.
-        ctx.reset_derived_caches(matrices=False, lookups=False, projection=False, subset=True)
-        ctx._subset_ids = sorted_ids
-
-    return _start_subset_umap_build(ctx, sorted_ids, matrix, bin_shape, force=force)
-
-
-def _start_subset_umap_build(ctx, sorted_ids: list[int], matrix, bin_shape: str, *, force: bool = False) -> dict:
-    """Start (or reuse) the background subset UMAP fit + pyramid build.
-
-    With *force*, run a brand-new fit even for an unchanged id set (see
-    :func:`_start_umap_build`): the signature carries a nonce so neither the
-    result cache nor an in-flight job is reused.
-    """
-    from vtscore.concurrency.async_jobs import projection_jobs
-    from vtscore.projection import build_pyramid, fit_projection
-    from vtscore.state.core import thread_dataset_context
-
-    sig = (ctx.dataset_id, "subset", bin_shape, tuple(sorted_ids))
-    if force:
-        sig = (*sig, uuid.uuid4().hex)
-    else:
-        job_cached = projection_jobs.cached_for(sig)
-        if job_cached is not None and job_cached.result is not None:
-            proj, pyr = job_cached.result
-            ctx._subset_projection = proj
-            ctx._subset_pyramids[bin_shape] = pyr
-            return {"status": "ready", "projection_id": pyr.projection_id}
-
-        # Already building this exact subset + shape?  Reuse the in-flight job
-        # instead of queueing a duplicate fit.
-        if ctx._subset_job_id:
-            existing = projection_jobs.get(ctx._subset_job_id)
-            if existing is not None and existing.signature == sig and existing.status in ("running", "pending"):
-                return {"status": "building", "job_id": existing.job_id}
-
-    mat_copy = matrix.copy()
-    ids_copy = list(sorted_ids)
-    params = _projection_params(ctx)
-
-    def _run(job):
-        with thread_dataset_context(ctx):
-
-            def _on_progress(status, message, current, total):
-                job.update_progress(current, total, message)
-
-            job.set_phase(1, _BUILD_STEPS, "arranging items")
-            proj = fit_projection(
-                mat_copy,
-                ids_copy,
-                n_neighbors=params.n_neighbors,
-                min_dist=params.min_dist,
-                compact=params.compact,
-                on_progress=_on_progress,
-            )
-            job.set_phase(2, _BUILD_STEPS, "building pyramid")
-            pyr = build_pyramid(proj, bin_shape=bin_shape)
-            # Fresh signs over just this subset: the contrastive keyphrases
-            # recompute against the subset's own siblings (better than any
-            # filtered dataset-level signs), and the per-media texts were
-            # cached at ingest, so this is the cheap half of the pipeline.
-            job.set_phase(3, _BUILD_STEPS, "naming regions")
-            _prep_signposts_best_effort(ctx, proj, job, subset=True)
-            job.update_progress(1, 1, "done")
-
-            ctx._subset_projection = proj
-            ctx._subset_pyramids[bin_shape] = pyr
-            job.result = (proj, pyr)
-            # Subset projections are ephemeral — never persisted (labels included).
-
-    job = projection_jobs.start(sig, _run, dataset_id=ctx.dataset_id)
-    ctx._subset_job_id = job.job_id
-    return {"status": "building", "job_id": job.job_id}
+    return requested
 
 
 @projection_bp.route("/api/projection/build", methods=["POST"])
@@ -655,62 +77,37 @@ def build_projection():
     """Kick off (or short-circuit) a build of the dataset's projection.
 
     Body: ``{"ids": [...]?, "force": bool?}``.  The bin shape is not a request
-    parameter — it is derived from the dataset's media type (see
-    :func:`_shape_for`).
+    parameter — it is derived from the dataset's media type.
 
     Returns immediately.  If the pyramid is already cached or persisted, returns
     ``"ready"``.  Only the first build of a dataset, where no layout exists yet,
     runs UMAP in the background and returns a ``job_id`` for polling via
     ``GET /api/projection/meta``.
 
+    ``ids`` projects only the supplied media (e.g. the positive results of a
+    Find run), fitting UMAP on just their high-d vectors into an ephemeral
+    subset layout held alongside the full-dataset one.
+
     ``force`` overrides every short-circuit: it discards the existing layout
     (cached + persisted for a full build, or the in-memory subset layout for an
     ``ids`` build) and runs a fresh UMAP fit over the current items, returning a
     new ``projection_id``.  This is the Browser's "Re-project" action.
     """
-    from vtscore.embedding.matrix import get_embedding_matrix
+    from vtscore.projection import service
     from vtscore.state.core import get_active_context
 
     ctx = get_active_context()
     body = request.get_json(silent=True) or {}
-    shape = _shape_for(ctx)
-    # ``force`` re-fits UMAP over the currently displayed items even when a
-    # layout already exists, replacing it with a fresh arrangement.  Powers the
-    # Browser's "Re-project" button (e.g. to re-spread the survivors after a
-    # cull, or just to reshuffle).
-    force = bool(body.get("force"))
-
-    # Subset build: project only the supplied media ids (e.g. the positive
-    # results of a Find run), fitting UMAP on just their high-d vectors.
-    if body.get("ids") is not None:
-        return _dispatch_subset_build(ctx, body["ids"], shape, force=force)
-
-    if not force:
-        cached = ctx._pyramids.get(shape)
-        if cached is not None:
-            return {"status": "ready", "projection_id": cached.projection_id}
-
-    if not ctx.medias:
-        abort(409, message="Dataset is empty — nothing to project.")
+    raw_ids = body.get("ids")
+    ids = None if raw_ids is None else _requested_ids(raw_ids)
 
     try:
-        # The coverage atlas / projection clusters in the score embedder's
-        # space (patch-else-text; the v3 routing table).
-        sorted_ids, matrix = get_embedding_matrix(ctx, ctx.routed_embedder("score"))
+        return service.build_layout(ctx, ids=ids, force=bool(body.get("force")))
     except ValueError as exc:
+        # The service's own "nothing to project" signals and the
+        # embedding-matrix builder's ValueErrors mean the same thing to a
+        # client: the dataset can't be laid out as it currently stands.
         abort(409, message=str(exc))
-
-    if matrix.size == 0:
-        abort(409, message="Dataset has no embeddings — nothing to project.")
-
-    if force:
-        _reset_full_projection(ctx)
-    else:
-        ready = _rebin_from_existing_layout(ctx, sorted_ids, shape)
-        if ready is not None:
-            return ready
-
-    return _start_umap_build(ctx, sorted_ids, matrix, shape, force=force)
 
 
 @projection_bp.route("/api/projection/subset/remove", methods=["POST"])
@@ -720,45 +117,24 @@ def build_projection():
 def remove_from_subset(body: dict):
     """Drop ids from the current subset browse **without re-fitting UMAP**.
 
-    Re-bins the frozen subset layout onto its existing grid minus the removed
-    points: the remaining points keep their exact 2-D positions and bins, only
-    counts/representatives change.  The ``projection_id`` (layout identity) is
+    The remaining points keep their exact 2-D positions and bins; only counts
+    and representatives change.  The ``projection_id`` (layout identity) is
     preserved and a bumped ``content_version`` busts the otherwise-immutable
-    tile cache.  The served ``bounds`` shrink to the survivors' extent so the
-    client re-frames to what's left (zoom-to-fit, minimap) instead of keeping
-    dead space where the culled points were — safe because bin assignment is
-    origin-independent; bounds only drive client framing.  Returns the updated
-    subset meta for the dataset's shape.
+    tile cache.  Returns the updated subset meta for the dataset's shape.
 
     Powers the Browser's "Remove from Good" cull, which marks the items Bad via
     ``/api/medias/vote-bulk`` and then calls this to make them disappear.
     """
-    from dataclasses import replace
-
-    from vtscore.projection import rebin_like
-    from vtscore.projection import remove_ids as _remove_ids
+    from vtscore.projection import service
     from vtscore.state.core import get_active_context
 
     ctx = get_active_context()
-    shape = _shape_for(ctx)
-    ids = body["ids"]
+    try:
+        service.remove_subset_ids(ctx, body["ids"])
+    except ValueError as exc:
+        abort(409, message=str(exc))
 
-    proj = ctx._subset_projection
-    if proj is None:
-        abort(409, message="No subset projection to update — build it first.")
-
-    new_proj = _remove_ids(proj, ids)
-    ctx._subset_projection = new_proj
-    ctx._subset_ids = list(new_proj.ids)
-    ctx._subset_job_id = None
-    ctx._subset_content_version += 1
-    # Re-bin every shape that was already built, each on its own preserved grid,
-    # then stamp the survivors' extent over rebin_like's kept template bounds.
-    ctx._subset_pyramids = {
-        s: replace(rebin_like(new_proj, pyr), bounds=new_proj.bounds) for s, pyr in ctx._subset_pyramids.items()
-    }
-
-    return _subset_meta(ctx, shape)
+    return service.layout_meta(ctx, service.shape_for(ctx), subset=True)
 
 
 @projection_bp.route("/api/projection/meta", methods=["GET"])
@@ -766,40 +142,20 @@ def remove_from_subset(body: dict):
 def projection_meta():
     """Return projection/pyramid metadata and build status for the dataset.
 
-    The bin shape is derived from the dataset's media type (see
-    :func:`_shape_for`), not a query parameter.  When the pyramid is ready,
-    includes bounds, zoom levels, cell sizing, point count, the dataset's media
-    type, and the ``bin_shape`` the canvas should render.
+    The bin shape is derived from the dataset's media type, not a query
+    parameter.  When the pyramid is ready, includes bounds, zoom levels, cell
+    sizing, point count, the dataset's media type, and the ``bin_shape`` the
+    canvas should render.
     """
-    from vtscore.concurrency.async_jobs import projection_jobs
+    from vtscore.projection import service
     from vtscore.state.core import get_active_context
 
     ctx = get_active_context()
-    shape = _shape_for(ctx)
-
-    if _is_subset(request.args.get("subset")):
-        return _subset_meta(ctx, shape)
-
-    pyr = ctx._pyramids.get(shape)
-    if pyr is not None:
-        meta = pyr.meta()
-        meta["status"] = "ready"
-        meta["media_type"] = _media_type_for(ctx)
-        meta["method"] = ctx._projection.method if ctx._projection else None
-        meta["content_version"] = 0  # full-dataset layouts are never edited in place
-        label_set = _label_set_for(ctx, pyr, subset=False)
-        meta["has_labels"] = bool(label_set and label_set.labels)
-        return meta
-
-    if ctx._full_job_id:
-        job = projection_jobs.get(ctx._full_job_id)
-        if job is not None:
-            if job.status in ("running", "pending"):
-                return _build_progress(job)
-            if job.status == "error":
-                return {"status": "error", "error": job.error or "projection build failed"}
-
-    return {"status": "idle"}
+    return service.layout_meta(
+        ctx,
+        service.shape_for(ctx),
+        subset=_is_subset(request.args.get("subset")),
+    )
 
 
 @projection_bp.route("/api/projection/labels", methods=["GET"])
@@ -819,21 +175,15 @@ def projection_labels():
     set computed for a *different* layout than the active pyramid's is treated
     as absent — anchors are meaningless off their own layout.
     """
+    from vtscore.projection import service
     from vtscore.state.core import get_active_context
 
     ctx = get_active_context()
-    shape = _shape_for(ctx)
-    subset = _is_subset(request.args.get("subset"))
-    pyr = (ctx._subset_pyramids if subset else ctx._pyramids).get(shape)
-    if pyr is None:
-        return {"status": "idle", "labels": []}
-
-    label_set = _label_set_for(ctx, pyr, subset=subset)
-    return {
-        "status": "ready",
-        "projection_id": pyr.projection_id,
-        "labels": label_set.payload() if label_set is not None else [],
-    }
+    return service.labels_payload(
+        ctx,
+        service.shape_for(ctx),
+        subset=_is_subset(request.args.get("subset")),
+    )
 
 
 @projection_bp.route(
@@ -845,23 +195,23 @@ def projection_labels():
 def get_tile(level: int, tx: int, ty: int):
     """Return the cells for one tile of the dataset's pyramid at ``(level, tx, ty)``.
 
-    The bin shape is derived from the dataset's media type (see
-    :func:`_shape_for`).  Because the projection is frozen at ingest, tiles are
-    immutable for the life of the dataset and can be cached aggressively by the
-    client.
+    The bin shape is derived from the dataset's media type.  Because the
+    projection is frozen at ingest, tiles are immutable for the life of the
+    dataset and can be cached aggressively by the client.
     """
+    from vtscore.projection import service
     from vtscore.state.core import get_active_context
 
     ctx = get_active_context()
-    shape = _shape_for(ctx)
-    subset = _is_subset(request.args.get("subset"))
-    if subset:
-        pyr = ctx._subset_pyramids.get(shape)
-        proj = ctx._subset_projection
-    else:
-        pyr = ctx._pyramids.get(shape)
-        proj = ctx._projection
-    if pyr is None:
+    payload = service.tile_payload(
+        ctx,
+        service.shape_for(ctx),
+        level,
+        tx,
+        ty,
+        subset=_is_subset(request.args.get("subset")),
+    )
+    if payload is None:
         abort(404, message="Projection not built yet — call POST /api/projection/build first.")
 
     # Tiles are frozen at ingest, so let the browser serve repeat visits from its
@@ -869,45 +219,16 @@ def get_tile(level: int, tx: int, ty: int):
     # blanking when you pan/zoom back over ground you've already seen. The tile
     # URL omits the dataset id (it rides on the X-Dataset-Id header), so we must
     # Vary on it or the cache could hand one dataset's tiles to another. Scoped
-    # to this response only, and registered after the 404 check so a not-yet-built
-    # projection is never cached. ``?subset`` is already part of the URL.
+    # to this response only, and registered after the not-built check so a
+    # not-yet-built projection is never cached. ``?subset`` is already part of
+    # the URL.
     @after_this_request
     def _cache_tile(response):  # type: ignore[unused-ignore]
         response.headers["Cache-Control"] = "private, max-age=3600, immutable"
         response.vary.add("X-Dataset-Id")
         return response
 
-    tile = pyr.get_tile(level, tx, ty)
-    if tile is None:
-        return {"level": level, "tx": tx, "ty": ty, "cells": []}
-
-    payload = tile.to_payload()
-    # Attach each cell its full member id list so the canvas can render
-    # per-cell selection state and toggle a whole bin. The pyramid keeps only
-    # counts + representatives, so this is re-derived on demand from the frozen
-    # layout (see ``tile_member_ids``); it rides along on the immutable,
-    # HTTP-cached tile response.
-    if proj is not None and payload["cells"]:
-        from vtscore.projection import tile_member_ids
-
-        members = tile_member_ids(pyr, proj, level, tx, ty)
-        for cell in payload["cells"]:
-            cell["member_ids"] = members.get((cell["q"], cell["r"]), [])
-
     return payload
-
-
-def _persist_projection(dataset_id: str, proj, pyr) -> None:
-    """Best-effort save of the projection (for ``pyr``'s bin shape) into the container."""
-    pkl_path = _pkl_path_for(dataset_id)
-    if pkl_path is None:
-        return
-    try:
-        from vtscore.datasets.container import append_projection
-
-        append_projection(pkl_path, proj, pyr)
-    except Exception:
-        logger.warning("Failed to persist projection for %s", dataset_id, exc_info=True)
 
 
 __all__ = ["projection_bp"]

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -293,7 +293,7 @@ class ServerSettings(BaseModel):
     # Browse UMAP projection knobs (Stage 1).  They change the map layout, so
     # a per-deployment operator may want to tune them.  The persisted
     # projection is keyed on these values (see
-    # ``vtsearch.routes.projection._projection_params_match``), so a change
+    # ``vtscore.projection.store.projection_params_match``), so a change
     # forces a recompute instead of serving a layout fit under the old params.
     projection_n_neighbors: Annotated[int, _clamp(2, 200)] = PROJECTION_N_NEIGHBORS
     projection_min_dist: Annotated[float, _clamp(0.0, 0.99)] = PROJECTION_MIN_DIST


### PR DESCRIPTION
`routes/projection.py` was a state machine wearing a route module. The first route decorator sat at line 654; the 598 lines above it were 21 orchestration helpers driving UMAP fits, pyramid builds, signposts and persistence through exactly 70 private-attribute accesses on `DatasetContext`. None of that lifecycle was reachable without a Flask test client.

## What changed

Three new Flask-free modules under `vtscore/projection/`:

| Module | Concern |
|---|---|
| `store.py` | Container path resolution, save/restore/remove of a layout, and the `projection_params_match` freshness guard |
| `signpost_serve.py` | The read side of the signpost layer — which set to letter a layout with, and the background self-heal of a stale one — beside the `signpost_prep` write side |
| `service.py` | The lifecycle itself: `build_layout`, `fit_and_install_layout`, re-bin, reset, the subset fit and cull, plus the meta / labels / tile payloads |

`vtsearch/routes/projection.py` drops **916 → 234 lines** of request parsing, error-code mapping and cache headers. The route's `vtscore.projection` imports stay function-local: the package pulls numba/UMAP, and this module is imported at app startup.

## It collapses three self-declared mirrors

This is the part that makes the move more than relocation. The ingest pre-build stage carried a `_persist_projection_to_container` whose own docstring said it *"Mirrors `vtsearch.routes.projection._persist_projection`"*, and re-implemented the whole fit → pyramid → signposts → install → persist sequence a second time. It now calls `service.fit_and_install_layout` — the same function the lazy Browse build runs, which is what stops the two from drifting (a layout pre-built under different knobs than the serve path resolves is worse than no pre-build at all). `store.pkl_path_for` replaces three inlined copies of the same registry lookup, and `positives_browse` installs through `install_layout` instead of writing the private slots itself.

## Two behaviour fixes fall out of the dedup

- **The ingest stage and the serve path disagreed on bin shape.** The stage read a bare `.get("media_type")` (`None` → hex) while the route defaulted a missing key to audio (→ square). A media without the key was pre-built under a shape the route would never ask for, so the pre-build was silently wasted. Both now go through `service.shape_for`.
- **`rebin_from_existing_layout` probed the requested shape's stored pyramid twice** on the fallback path (once directly, once inside the all-shapes scan). It now probes each shape at most once, and *installs* the loaded pyramid rather than `setdefault`-ing it behind a stale one belonging to the projection being replaced.

`_build_projection_stage`'s `dataset_id` parameter is gone: `_migrate_context_id` sets `ctx.dataset_id` to the same value the pipeline was passing it, so the two could only ever disagree by accident.

## Scope deliberately not taken

The issue's Direction had a second half — *"promote the projection slots into a public state object with real methods (pairs with the `BrowseState` grouping in the `state/core.py` item)"*. **That companion item no longer exists.** #3377 was rescoped earlier the same day and #3455 merged with the `BrowseState` grouping explicitly dropped, for a reason that applies verbatim here: `_freeze_into` substitutes a frozen container only for `dict` and `list` values, so a sub-object slot would land on the request-missing sentinel as a *live mutable object*. `sentinel.browse.projection = x` would then succeed — reopening the silent-mistarget failure mode (H13/H16) the sentinel exists to close, and defeating `tests_lib/core/test_request_missing_sentinel_slots.py`'s freeze guarantees.

So the slots keep their names. What the service does instead is make them **one module's business**: `install_layout` / `reset_full_projection` / the subset helpers are now the only writers outside `state/core.py` itself, where before three modules across two tiers wrote them by hand.

## Testing

The extraction's whole point is that the lifecycle is now testable without HTTP, so:

- `tests_lib/projection/test_service.py` (new) drives build / re-bin / reset / subset / cull directly, including cases the HTTP tests could not reach: that the empty-selection and empty-dataset refusals are distinguishable, that a reset spares the subset layout, that the cull re-bins every built shape, and the build-progress fraction arithmetic.
- `tests_lib/projection/test_store.py` (new) takes over the params-match and persistence tests, which lived in the app tier only because the code did.

Full `./run-tests.sh`: **9570 passed**, 6 skipped, 2 xpassed. All gates green — every stage-1 check, plus pyright, pip-audit, npm audit and the Vitest suite. The OpenAPI snapshot is regenerated (endpoint descriptions only).

Closes #3418


---
_Generated by [Claude Code](https://claude.ai/code/session_0117skNHycQ1HXRQK2JNum9T)_