### PR TITLE
Split the bin details' member grid out, and signalize the shell

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -538,8 +538,8 @@ and both are correct as written:
   bounds, never `destroy$`.
 - A **re-assigned `Subscription` field** that unsubscribes the previous value
   before storing the next: `text-viewer`'s `sub`, `folder-browser`'s
-  `currentSub`, `browse-bin-popup`'s `scrollSub` (re-keyed to the viewport
-  *instance*), `label-importer-modal`'s `ingestSub`.
+  `currentSub`, `browse-bin-member-grid`'s `scrollSub` (re-keyed to the
+  viewport *instance*), `label-importer-modal`'s `ingestSub`.
 
 A `Subscription` field is only a teardown idiom when it is written once and
 read only by `ngOnDestroy`. If it is re-assigned anywhere, it is cancellation

--- a/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.component.html
+++ b/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.component.html
@@ -1,0 +1,84 @@
+@if (ids().length > 0) {
+  <div class="bin-popup-grid-header">
+    @if (ids().length > 1) {
+      <button
+        type="button"
+        class="bin-popup-select-all"
+        role="checkbox"
+        (click)="toggleAll()"
+        [title]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
+        [attr.aria-label]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
+        [attr.aria-checked]="selectionState === 'all' ? 'true' : selectionState === 'some' ? 'mixed' : 'false'">
+        @switch (selectionState) {
+          @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
+          @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
+          @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
+        }
+      </button>
+    }
+    <span
+      class="bin-popup-count"
+      [title]="'Items in this bin (' + ids().length + ')'">
+      {{ ids().length | number }} item{{ ids().length === 1 ? '' : 's' }}
+    </span>
+    <!-- Thumbnail smaller/larger sits on the select-all row (it controls this
+         grid), rather than in the shell's header beside the detail-image size
+         buttons. -->
+    <vt-view-controls
+      side="popup"
+      [currentMediaType]="mediaType()"
+      [showFocus]="false"
+      class="bin-popup-grid-view-controls" />
+  </div>
+  <cdk-virtual-scroll-viewport
+    [itemSize]="rowSize()"
+    class="bin-popup-scroll"
+    (mouseleave)="gridLeave.emit()">
+    <div
+      *cdkVirtualFor="let row of rows(); trackBy: trackByRow"
+      class="bin-popup-row"
+      [style.height.px]="rowSize()"
+      [style.--popup-cols]="columns()"
+      [style.--popup-cell]="cellWidth() + 'px'">
+      @for (id of row; track trackById($index, id)) {
+        <div
+          class="bin-popup-entry"
+          [attr.data-entry-id]="id"
+          [class.selected]="isSelected(id)"
+          [class.focused]="isFocused(id)"
+          role="button"
+          tabindex="0"
+          [attr.aria-pressed]="isSelected(id)"
+          [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
+          [title]="name(id)"
+          (click)="entryClick.emit(id)"
+          (keydown)="onEntryKeydown($event, id)"
+          (focus)="entryFocus.emit(id)"
+          (mouseenter)="entryEnter.emit(id)">
+          @if (hasThumbnailUrl(id)) {
+            <span class="bin-popup-thumb-wrap">
+              @if (isAudioWaveform()) {
+                <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
+                <span
+                  class="bin-popup-thumb-wave waveform-mask"
+                  [style.-webkit-mask-image]="'url(' + thumbnailUrl(id) + ')'"
+                  [style.mask-image]="'url(' + thumbnailUrl(id) + ')'"></span>
+              } @else {
+                <img
+                  class="bin-popup-thumb"
+                  [src]="thumbnailUrl(id)"
+                  [alt]="name(id)"
+                  loading="lazy"
+                  (error)="onThumbnailError(thumbnailUrl(id))" />
+              }
+            </span>
+          } @else {
+            <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
+          }
+        </div>
+      }
+    </div>
+  </cdk-virtual-scroll-viewport>
+} @else if (docked()) {
+  <p class="bin-popup-empty-hint">Right-click a bin on the canvas to show it here.</p>
+}

--- a/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.component.scss
+++ b/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.component.scss
@@ -1,0 +1,235 @@
+// Styles for the bin details' member grid, lifted wholesale out of
+// `browse-bin-popup.component.scss` when the grid was split into its own
+// component. The class names keep their `bin-popup-` prefix: this is still the
+// bin popup's grid, and the DOM contract (notably the `[data-entry-id]` entry
+// lookup) moved across unchanged.
+//
+// The column that used to be `.bin-popup-grid-col` inside the shell is now this
+// component's own host element, and the shell's `.bin-popup--docked` descendant
+// overrides are `:host(.docked)` rules here — a parent stylesheet cannot reach
+// into a child under emulated view encapsulation, so the docked variants have
+// to live with the elements they style.
+
+// The grid column: a fixed-width stack of the member-count label above the
+// scrolling thumbnail grid, so the shell hugs it plus the preview pane. The
+// count sits at the column's top-left; the grid fills the remaining height.
+:host {
+  display: flex;
+  flex-direction: column;
+  width: 280px;
+  height: 100%;
+  flex-shrink: 0;
+  min-height: 0;
+}
+
+// Top row of the grid column: the select-all control + member-count label on
+// the left, and the thumbnail smaller/larger controls pushed to the right (they
+// resize this grid, so they live on its header row rather than in the window
+// header).
+.bin-popup-grid-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: 0 var(--space-2xs) var(--space-2xs);
+}
+
+// Thumbnail size buttons, pushed to the right end of the grid header row.
+.bin-popup-grid-view-controls {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+// Tri-state master checkbox, mirroring the dashboard's select-all button but
+// tuned to this window: smaller icon and tighter padding for the compact header.
+.bin-popup-select-all {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-2xs);
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--transition-base), background var(--transition-base);
+
+  &:hover {
+    background: var(--btn-icon-hover-bg);
+    color: var(--text-primary);
+  }
+}
+
+// Member-count label, right end of the header row.
+.bin-popup-count {
+  flex-shrink: 0;
+  font-size: var(--font-xs);
+  letter-spacing: var(--tracking-wide);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+}
+
+// The scrolling thumbnail grid fills the column below the count label.
+.bin-popup-scroll {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+}
+
+// --- Rows ------------------------------------------------------------------
+// One virtual item == one grid row: a CSS grid of fixed-size thumbnail cells.
+.bin-popup-row {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(var(--popup-cols, 1), 1fr);
+  align-content: start;
+  justify-items: center;
+  column-gap: var(--space-2xs);
+}
+
+// A grid cell: a single thumbnail (the name that used to sit beneath it is gone).
+.bin-popup-entry {
+  box-sizing: border-box;
+  cursor: pointer;
+  color: var(--text-vote);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2px;
+  // Sharp: one item per cell, so its hover fill and selection ring stay square
+  // (rounded is reserved for multi-item piles — see the thumbnail note below).
+  width: var(--popup-cell, 80px);
+  // Animate the "viewed" enlarge (below) so items grow/settle smoothly rather
+  // than popping as focus walks the grid.
+  transition: transform var(--transition-base);
+
+  &:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+
+  // Two orthogonal per-thumb cues, so a thumbnail can show either or BOTH at
+  // once without them fighting. Selection is a BOUNDARY (a ring); "viewed" is a
+  // SIZE/depth cue (enlarge + lift). Different visual channels means a selected
+  // item you're also viewing reads unmistakably as ringed AND lifted.
+  //
+  // Selection: a solid accent ring at the cell edge (mirrors bin selection on
+  // the canvas) plus an accent-tinted fill.
+  &.selected {
+    background: var(--accent-highlight-bg);
+    color: var(--text-primary);
+    box-shadow: 0 0 0 2px var(--accent);
+  }
+
+  // The viewed item (shown in the preview pane / walked by the arrow keys) is
+  // ENLARGED and lifted, mirroring the canvas hover-enlarge. Done with
+  // ``transform`` (painted, not laid out) so the scale never reflows the grid,
+  // shifts row heights, or resizes the popup — layout stays pixel-stable, and
+  // ``z-index`` lifts the growing thumb above its neighbours. The lift uses
+  // ``filter: drop-shadow`` rather than ``box-shadow`` so the selection ring's
+  // box-shadow survives untouched when an item is both selected and viewed. The
+  // size/depth channel is the only on-grid cue for non-thumbnail media too,
+  // which has no preview.
+  &.focused {
+    position: relative;
+    z-index: 1;
+    transform: scale(1.35);
+    filter: drop-shadow(0 3px 6px var(--shadow-dropdown));
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+}
+
+// Thumbnail/placeholder square, sized to the chosen icon size (``--popup-cell``,
+// bound per row); falls back to a compact square if the variable is ever absent.
+// The real thumbnail's wrapper and the no-thumbnail placeholder are the same
+// fixed cell-sized box, so they share these metrics (and the themed ``--bg-body``
+// surface: hidden under a cover-fit <img>, and the backdrop the tinted audio
+// waveform (issue #2369) sits on).
+.bin-popup-thumb-wrap,
+.bin-popup-placeholder {
+  width: var(--popup-cell, 28px);
+  height: var(--popup-cell, 28px);
+  // Sharp corners: each grid thumbnail is a single item, and in the VTSBrowse
+  // corner symbology rounded corners mean a multi-item pile, so a lone item is
+  // drawn as a crisp square. (The wrap's ``overflow: hidden`` clips the <img>.)
+  flex-shrink: 0;
+  background: var(--bg-body);
+}
+
+.bin-popup-thumb-wrap {
+  display: block;
+  overflow: hidden;
+}
+
+// Audio waveform in the grid: the shared ``.waveform-mask`` supplies the accent
+// fill and mask chrome; here we cover-fit it (matching the <img> it replaces).
+// No ``background`` — that would out-specify the shared accent and blank the wave.
+.bin-popup-thumb-wave {
+  // ``display: block`` is required: the wave is a <span> (a non-replaced inline
+  // element, unlike the <img> it replaced), so without it ``width``/``height``
+  // are ignored and the box collapses to nothing (issue #2369 regression). The
+  // parent ``.bin-popup-thumb-wrap`` is a fixed square, so ``height: 100%`` is
+  // definite here.
+  display: block;
+  width: 100%;
+  height: 100%;
+  mask-size: cover;
+  -webkit-mask-size: cover;
+}
+
+.bin-popup-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: var(--bg-body);
+  display: block;
+}
+
+.bin-popup-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: var(--font-lg);
+}
+
+// Docked empty state: no bin has been opened yet.
+.bin-popup-empty-hint {
+  margin: auto;
+  padding: var(--space-md);
+  font-size: var(--font-sm);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+// --- Docked presentation ----------------------------------------------------
+// Rendered as the Browse view's persistent left panel, the grid fills whatever
+// the panel leaves below the detail row instead of sitting at a fixed width.
+:host(.docked) {
+  width: 100%;
+  height: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+
+  // Resize like the right (selection) panel: fixed-width columns packed to the
+  // left with a constant gap, so widening the panel keeps the thumbnails (and
+  // the gaps between them) the same size and only reveals a new column once
+  // there's room for a whole one — instead of the floating window's ``1fr``
+  // tracks, which stretch each thumbnail's cell as the panel grows. The browse
+  // view then "pops" the divider tight to the column count on release (see
+  // ``snappedPanelWidth``), mirroring the right panel's snap.
+  .bin-popup-row {
+    grid-template-columns: repeat(var(--popup-cols, 1), var(--popup-cell, 80px));
+    justify-content: start;
+    column-gap: var(--space-xs);
+  }
+}

--- a/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.component.ts
+++ b/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.component.ts
@@ -1,0 +1,345 @@
+import { ChangeDetectionStrategy, Component, ElementRef, OnDestroy, computed, effect, inject, input, output, untracked, viewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { Subscription } from 'rxjs';
+import { BrowseSelectionService } from '../../services/browse-selection.service';
+import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
+import { ActiveContextService } from '../../services/active-context.service';
+import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
+import { ViewControlsComponent } from '../view-controls/view-controls.component';
+import { IconComponent } from '../icon/icon.component';
+import { binGridRowSize } from '../../utils/bin-grid-metrics';
+
+/** Extra rows of metadata prefetched beyond the visible window. */
+const PREFETCH_BUFFER = 50;
+/**
+ * Viewport height (px) assumed while the real one is unmeasurable — before the
+ * virtual viewport exists, or under jsdom, where ``clientHeight`` is always 0.
+ * Only ever used to size a prefetch window or centre a scroll, so an
+ * approximation is harmless; it mirrors the popup's own body cap so the guessed
+ * window matches what the floating presentation actually shows.
+ */
+const FALLBACK_VIEWPORT_PX = 400;
+
+/**
+ * The bin's member items as a virtualized thumbnail grid, with the select-all
+ * control, member count and thumbnail-size buttons on a header row above it.
+ *
+ * Split out of ``BrowseBinPopupComponent``, which is now purely the *shell*
+ * around this: the floating window's drag / summon / clamp machinery and the
+ * detail pane + metadata column. Everything to do with laying the members out
+ * and driving the virtual viewport — column chunking, scroll-driven metadata
+ * prefetch, centring a row, moving DOM focus onto a virtualized entry — lives
+ * here, and is reached from the shell through the three imperative methods at
+ * the bottom of this class ({@link prefetchVisible}, {@link centreOn}, {@link
+ * revealAndFocus}).
+ *
+ * Both of the shell's presentations render this same grid; ``docked`` only
+ * changes its cell tracks (fixed-width columns packed left, so widening the
+ * panel reveals a whole new column rather than stretching the existing ones)
+ * and enables the empty hint. The class names keep the ``bin-popup-`` prefix
+ * they had inside the shell: the DOM contract (notably the
+ * ``[data-entry-id]`` entry lookup) and the stylesheet moved across unchanged.
+ *
+ * **Reactivity.** Two of the values this template renders come from services
+ * with no signal of their own per item — selection membership
+ * ({@link BrowseSelectionService.has}) and cached names/thumbnails
+ * ({@link MediaMetadataCacheService.get}). Every method that reads one also
+ * reads that service's *version* signal first, so the read registers as a
+ * dependency of this view and a mutation anywhere repaints the grid without a
+ * ``markForCheck()``. See ``docs/FRONTEND.md`` §5.
+ */
+@Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'vt-browse-bin-member-grid',
+  standalone: true,
+  imports: [CommonModule, ScrollingModule, ViewControlsComponent, IconComponent],
+  templateUrl: './browse-bin-member-grid.component.html',
+  styleUrl: './browse-bin-member-grid.component.scss',
+  host: { '[class.docked]': 'docked()' },
+})
+export class BrowseBinMemberGridComponent implements OnDestroy {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly selection = inject(BrowseSelectionService);
+  private readonly metadataCache = inject(MediaMetadataCacheService);
+  private readonly activeContext = inject(ActiveContextService);
+  private readonly mediaTypeCaps = inject(MediaTypeCapabilityService);
+
+  /** Every member of the bin, in bin order. Drives the count, the select-all
+   *  tri-state and the prefetch window; {@link rows} is what actually renders. */
+  readonly ids = input<number[]>([]);
+  /** {@link ids} chunked into rows of {@link columns} — the virtual list's data.
+   *  The shell chunks rather than this component, because the same chunking
+   *  feeds its clamp math; a docked singleton is passed an empty list so the
+   *  grid area stays allocated but blank. */
+  readonly rows = input<number[][]>([]);
+  /** Cells per row, mirroring how {@link rows} was chunked. */
+  readonly columns = input(1);
+  /** Target width (px) of one thumbnail cell. */
+  readonly cellWidth = input(80);
+  /** Active media type, for the thumbnail-size controls and waveform rendering. */
+  readonly mediaType = input('');
+  /** Docked presentation: fixed-width cell tracks and an empty-state hint. */
+  readonly docked = input(false);
+  /** The viewed item — shown in the shell's detail pane and ringed here. */
+  readonly focusedId = input<number | null>(null);
+
+  /** An entry was activated (click, or Enter/Space on the focused entry). The
+   *  shell owns the selection toggle, since its detail pane shares it. */
+  readonly entryClick = output<number>();
+  /** DOM focus landed on an entry (arrow-walk, Tab, or click). */
+  readonly entryFocus = output<number>();
+  /** The cursor entered an entry (drives the shell's preview + hover audio). */
+  readonly entryEnter = output<number>();
+  /** The cursor left the grid entirely. */
+  readonly gridLeave = output<void>();
+
+  private readonly viewport = viewChild(CdkVirtualScrollViewport);
+  private scrollSub: Subscription | null = null;
+  /** The viewport instance whose ``scrolledIndexChange`` is currently subscribed. */
+  private scrollSubscribedViewport: CdkVirtualScrollViewport | null = null;
+
+  private readonly failedThumbs = new Set<string>();
+
+  /** Pixel stride of one virtual row. */
+  readonly rowSize = computed(() => binGridRowSize(this.cellWidth()));
+
+  /** True when these thumbnails are audio waveforms: theme-agnostic alpha-mask
+   *  PNGs (issue #2369) rendered as a CSS mask over the accent colour rather
+   *  than a plain <img>, so they recolour with the live theme. */
+  readonly isAudioWaveform = computed(() => this.mediaType() === 'audio');
+
+  constructor() {
+    // (Re-)subscribe the scroll-driven prefetch whenever the virtual viewport
+    // instance changes — it lives behind the template's ``@if``, and the shell
+    // is reused across summons while open (right-clicking another bin only
+    // swaps inputs), so an empty→populated transition creates a brand-new
+    // viewport. Tracking the view query re-runs this the moment that instance
+    // appears; a one-shot ``ngAfterViewInit`` wiring would strand it (mirrors
+    // media-list's viewport re-wire pattern).
+    effect(() => {
+      this.viewport();
+      untracked(() => this.ensureScrollSubscription());
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.scrollSub?.unsubscribe();
+  }
+
+  private ensureScrollSubscription(): void {
+    const vp = this.viewport() ?? null;
+    if (!vp || this.scrollSubscribedViewport === vp) return;
+    this.scrollSubscribedViewport = vp;
+    this.scrollSub?.unsubscribe();
+    this.scrollSub = vp.scrolledIndexChange.subscribe(() => this.prefetchVisible());
+    this.prefetchVisible();
+  }
+
+  // --- Selection -----------------------------------------------------------
+
+  /** Whether ``id`` is selected. Reads the selection version signal so this
+   *  view repaints when the selection changes anywhere (here, the canvas, the
+   *  selection panel) — see the reactivity note on the class. */
+  isSelected(id: number): boolean {
+    this.selection.version();
+    return this.selection.has(id);
+  }
+
+  /** True for the viewed item — the one in the shell's detail pane, ringed here
+   *  as the arrow keys walk through the grid. */
+  isFocused(id: number): boolean {
+    const focused = this.focusedId();
+    return focused != null && id === focused;
+  }
+
+  /** Tri-state of the select-all control: how many members are selected, as
+   *  none / some / all — mirroring the dashboard's master-checkbox states. */
+  get selectionState(): 'none' | 'some' | 'all' {
+    this.selection.version();
+    const total = this.ids().length;
+    if (total === 0) return 'none';
+    const sel = this.selection.selectedCountIn(this.ids());
+    if (sel === 0) return 'none';
+    if (sel >= total) return 'all';
+    return 'some';
+  }
+
+  /** Select every member, or — when all are already selected — clear them.
+   *  Matches the dashboard's toggle-all semantics. */
+  toggleAll(): void {
+    if (this.selectionState === 'all') {
+      this.selection.removeAll(this.ids());
+    } else {
+      this.selection.addAll(this.ids());
+    }
+  }
+
+  onEntryKeydown(event: KeyboardEvent, id: number): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      // Stop the bubble so the shell's document-level Space fallback (which acts
+      // on the viewed item) doesn't also fire and double-toggle. The focused
+      // entry owns its own activation; the fallback is only for when nothing in
+      // the grid holds focus.
+      event.stopPropagation();
+      this.entryClick.emit(id);
+    }
+  }
+
+  // --- Names + thumbnails --------------------------------------------------
+  // Each of these reads the metadata cache's version signal before consulting
+  // the cache, so a batch arrival repaints the visible rows on its own.
+
+  name(id: number): string {
+    this.metadataCache.version();
+    return this.metadataCache.get(id)?.filename || `Clip #${id}`;
+  }
+
+  hasThumbnailUrl(id: number): boolean {
+    this.metadataCache.version();
+    const url = this.thumbnailUrl(id);
+    if (this.failedThumbs.has(url)) return false;
+    const media = this.metadataCache.get(id);
+    return !!media && this.mediaTypeCaps.usesThumbnails(media.media_type);
+  }
+
+  thumbnailUrl(id: number): string {
+    return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
+  }
+
+  onThumbnailError(url: string): void {
+    if (url) this.failedThumbs.add(url);
+  }
+
+  placeholderIcon(id: number): string {
+    if (this.hasThumbnailUrl(id)) return '';
+    const media = this.metadataCache.get(id);
+    if (!media) return '□';
+    if (media.media_type === 'audio') return '♫';
+    if (media.media_type === 'text') return '¶';
+    return '□';
+  }
+
+  trackById(_index: number, id: number): number {
+    return id;
+  }
+
+  trackByRow(index: number): number {
+    return index;
+  }
+
+  // --- Imperative surface used by the shell ---------------------------------
+
+  /** Re-read the viewport's own size after the panel or the row stride changed,
+   *  so its virtual window is computed against the new geometry. */
+  remeasure(): void {
+    this.viewport()?.checkViewportSize();
+  }
+
+  /** Prefetch metadata for the items around the visible window. */
+  prefetchVisible(): void {
+    const ids = this.ids();
+    if (ids.length === 0) return;
+    const cols = Math.max(1, this.columns());
+    const rowSize = this.rowSize();
+    const vp = this.viewport();
+    if (!vp) {
+      const window = Math.ceil(FALLBACK_VIEWPORT_PX / rowSize) * cols + PREFETCH_BUFFER;
+      this.metadataCache.ensureLoaded(ids.slice(0, window));
+      return;
+    }
+    const startRow = Math.floor(vp.measureScrollOffset('top') / rowSize);
+    const visibleRows = Math.ceil(this.viewportHeight(vp) / rowSize);
+    const from = Math.max(0, (startRow - Math.ceil(PREFETCH_BUFFER / cols)) * cols);
+    const to = Math.min(ids.length, (startRow + visibleRows) * cols + PREFETCH_BUFFER);
+    this.metadataCache.ensureLoaded(ids.slice(from, to));
+  }
+
+  /**
+   * Remeasure the viewport (the row stride or the panel width changed) and
+   * scroll so the row holding ``index`` sits roughly centred, so a resize keeps
+   * looking at the same item instead of jumping to the top.
+   *
+   * The virtual viewport may not have applied its scrollable content size yet
+   * (on open, or right after a thumbnail-size change re-chunks the rows), so the
+   * browser clamps this scroll back to 0 and a large bin is left sitting at the
+   * top with the target off-screen. When we meant to scroll down but the offset
+   * didn't take, retry on the next frame (bounded) until the viewport is
+   * scrollable and the target sticks.
+   */
+  centreOn(index: number, attempt = 0): void {
+    const vp = this.viewport();
+    if (!vp) return;
+    if (attempt === 0) this.remeasure();
+    const rowSize = this.rowSize();
+    const row = Math.floor(index / Math.max(1, this.columns()));
+    const viewportH = this.viewportHeight(vp);
+    // The most we can scroll: content height (all rows) minus the visible window.
+    const maxOffset = Math.max(0, this.rows().length * rowSize - viewportH);
+    // Centre the row in the visible window, clamped to [0, maxOffset] so we never
+    // scroll past either end.
+    const target = Math.min(
+      maxOffset,
+      Math.max(0, row * rowSize - Math.max(0, viewportH - rowSize) / 2),
+    );
+    vp.scrollToOffset(target);
+    if (target > 0 && vp.measureScrollOffset('top') < target - 1 && attempt < 5) {
+      requestAnimationFrame(() => this.centreOn(index, attempt + 1));
+    }
+  }
+
+  /**
+   * Scroll the entry at ``index`` into view (the minimum amount; a no-op when it
+   * already is) and move DOM focus onto it, so keyboard activation (Enter /
+   * Space) targets the arrow-walked item rather than whatever entry last held
+   * focus.
+   *
+   * The entry may not be in the DOM yet — the row was just scrolled into view
+   * and the virtual viewport renders it on a subsequent frame — so query for it
+   * after a frame and retry (bounded) until it exists. ``preventScroll`` keeps
+   * the native focus scroll from fighting the scroll we just performed.
+   */
+  revealAndFocus(index: number): void {
+    this.scrollRowIntoView(index);
+    this.focusEntry(index);
+  }
+
+  private scrollRowIntoView(index: number): void {
+    const vp = this.viewport();
+    if (!vp) return;
+    const rowSize = this.rowSize();
+    const row = Math.floor(index / Math.max(1, this.columns()));
+    const rowTop = row * rowSize;
+    const rowBottom = rowTop + rowSize;
+    const top = vp.measureScrollOffset('top');
+    const viewportH = this.viewportHeight(vp);
+    if (rowTop < top) {
+      vp.scrollToOffset(rowTop);
+    } else if (rowBottom > top + viewportH) {
+      vp.scrollToOffset(rowBottom - viewportH);
+    }
+  }
+
+  private focusEntry(index: number, attempt = 0): void {
+    const root = this.host.nativeElement;
+    const id = this.ids()[index];
+    if (!root || id == null) return;
+    requestAnimationFrame(() => {
+      const el = root.querySelector<HTMLElement>(`.bin-popup-entry[data-entry-id="${id}"]`);
+      if (el) {
+        el.focus({ preventScroll: true });
+      } else if (attempt < 5) {
+        this.focusEntry(index, attempt + 1);
+      }
+    });
+  }
+
+  /** Rendered height (px) of the virtual viewport, falling back to the content
+   *  height (capped) when it is unmeasurable — before layout, or under jsdom. */
+  private viewportHeight(vp: CdkVirtualScrollViewport): number {
+    const measured = vp.elementRef.nativeElement.clientHeight;
+    if (measured) return measured;
+    return Math.min(this.rows().length * this.rowSize(), FALLBACK_VIEWPORT_PX);
+  }
+}

--- a/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-member-grid/browse-bin-member-grid.zoneless.spec.ts
@@ -1,0 +1,166 @@
+import { Subject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BrowseBinMemberGridComponent } from './browse-bin-member-grid.component';
+
+/**
+ * Contracts the member grid took over from ``BrowseBinPopupComponent`` when it
+ * was split out (issue #3423). Both describe blocks drive the component
+ * directly rather than through a rendered fixture: the grid is virtualized and
+ * does not render individual entries reliably under jsdom, which is exactly why
+ * these were written against the instance in the first place.
+ */
+describe('BrowseBinMemberGridComponent (scroll-prefetch re-wiring)', () => {
+  it('re-subscribes prefetch when the member-grid viewport is recreated', () => {
+    // Regression: the grid subscribed scrolledIndexChange only once, but the
+    // viewport lives behind an `@if` and the bin details are reused across
+    // summons (right-clicking another bin only swaps inputs). An empty→
+    // populated transition created a fresh viewport whose stream was never
+    // subscribed, so scrolling the member grid never hydrated thumbnails beyond
+    // the initially-prefetched window. In production a constructor effect
+    // tracking the `viewport` view-query signal re-runs ensureScrollSubscription
+    // whenever the instance changes; here the query is stubbed as a plain
+    // function and the method driven directly.
+    const component = Object.create(
+      BrowseBinMemberGridComponent.prototype,
+    ) as BrowseBinMemberGridComponent;
+    const state = component as unknown as {
+      viewport: () => unknown;
+      scrollSub: unknown;
+      scrollSubscribedViewport: unknown;
+      prefetchVisible(): void;
+      ensureScrollSubscription(): void;
+    };
+    state.scrollSub = null;
+    state.scrollSubscribedViewport = null;
+    const prefetchSpy = vi.fn();
+    state.prefetchVisible = prefetchSpy;
+
+    const vp1 = { scrolledIndexChange: new Subject<number>() };
+    state.viewport = () => vp1;
+    state.ensureScrollSubscription();
+    vp1.scrolledIndexChange.next(0);
+    const callsAfterFirstScroll = prefetchSpy.mock.calls.length;
+    expect(callsAfterFirstScroll).toBeGreaterThan(0);
+
+    // Viewport destroyed (the bin emptied, or a previewOnly summon) …
+    vp1.scrolledIndexChange.complete();
+    state.viewport = () => undefined;
+    state.ensureScrollSubscription();
+
+    // … then a new multi-member summon creates a fresh instance.
+    const vp2 = { scrolledIndexChange: new Subject<number>() };
+    state.viewport = () => vp2;
+    state.ensureScrollSubscription();
+
+    const callsBeforeSecondScroll = prefetchSpy.mock.calls.length;
+    vp2.scrolledIndexChange.next(2);
+    expect(prefetchSpy.mock.calls.length).toBe(callsBeforeSecondScroll + 1);
+  });
+});
+
+/**
+ * DOM-focus half of the keyboard walk.
+ *
+ * Arrow keys move the shell's viewed item, but before this they left DOM focus
+ * behind on whatever entry the user last tabbed/clicked. Enter is only caught by
+ * the focused entry's own handler, so it toggled the stale DOM-focused entry
+ * rather than the arrow-walked one; Space fired both the shell's document
+ * fallback and the focused entry, double-toggling. The fix keeps DOM focus glued
+ * to the walked entry, and lets the focused entry own its activation without the
+ * fallback double-firing. The shell drives this through `revealAndFocus`.
+ */
+describe('BrowseBinMemberGridComponent (keyboard focus sync)', () => {
+  interface GridState {
+    ids: () => number[];
+    rows: () => number[][];
+    columns: () => number;
+    rowSize: () => number;
+    viewport: () => unknown;
+    host: { nativeElement: { querySelector: (sel: string) => HTMLElement | null } };
+  }
+
+  function makeGrid(): { component: BrowseBinMemberGridComponent; state: GridState } {
+    const component = Object.create(
+      BrowseBinMemberGridComponent.prototype,
+    ) as BrowseBinMemberGridComponent;
+    const state = component as unknown as GridState;
+    state.ids = () => [10, 20, 30, 40];
+    state.rows = () => [
+      [10, 20],
+      [30, 40],
+    ];
+    state.columns = () => 2;
+    state.rowSize = () => 88;
+    // No viewport: `revealAndFocus`'s scroll half is a no-op, leaving the focus
+    // half — the part these tests are about — to run on its own.
+    state.viewport = () => undefined;
+    return { component, state };
+  }
+
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    // Run rAF synchronously so `focusEntry`'s deferred (and retried) focus lands
+    // within the test tick, deterministically.
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+  });
+  afterEach(() => rafSpy.mockRestore());
+
+  it('moves DOM focus to the entry the shell walked to', () => {
+    const { component, state } = makeGrid();
+    const walked = { focus: vi.fn() } as unknown as HTMLElement;
+    state.host = {
+      nativeElement: {
+        // Only the entry for id 20 (index 1) exists.
+        querySelector: (sel: string) => (sel.includes('"20"') ? walked : null),
+      },
+    };
+
+    component.revealAndFocus(1);
+
+    expect(walked.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('retries the focus until the virtualized entry renders, then focuses it', () => {
+    const { component, state } = makeGrid();
+    const walked = { focus: vi.fn() } as unknown as HTMLElement;
+    let calls = 0;
+    state.host = {
+      nativeElement: {
+        // Absent for the first two frames (row still virtualizing in), then in.
+        querySelector: (sel: string) => {
+          if (!sel.includes('"20"')) return null;
+          return ++calls >= 3 ? walked : null;
+        },
+      },
+    };
+
+    component.revealAndFocus(1);
+
+    expect(walked.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the focused entry own its activation, stopping the fallback double-toggle', () => {
+    const { component } = makeGrid();
+    const emitted: number[] = [];
+    (component as unknown as { entryClick: { emit: (id: number) => void } }).entryClick = {
+      emit: (id: number) => emitted.push(id),
+    };
+    const event = {
+      key: 'Enter',
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent;
+
+    component.onEntryKeydown(event, 42);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    // The bubble is stopped so the shell's document-level Space fallback (which
+    // acts on the viewed item) can't also fire and cancel this toggle.
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(emitted).toEqual([42]);
+  });
+});

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -202,92 +202,18 @@
     }
 
     @if (docked() || !previewOnly) {
-      <div class="bin-popup-grid-col">
-        @if (ids.length > 0) {
-          <div class="bin-popup-grid-header">
-            @if (ids.length > 1) {
-              <button
-                type="button"
-                class="bin-popup-select-all"
-                role="checkbox"
-                (click)="toggleAll()"
-                [title]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
-                [attr.aria-label]="selectionState === 'all' ? 'Deselect all' : 'Select all'"
-                [attr.aria-checked]="selectionState === 'all' ? 'true' : selectionState === 'some' ? 'mixed' : 'false'">
-                @switch (selectionState) {
-                  @case ('all') { <vt-icon type="checkbox-checked" [size]="15"></vt-icon> }
-                  @case ('some') { <vt-icon type="checkbox-some" [size]="15"></vt-icon> }
-                  @default { <vt-icon type="checkbox-blank" [size]="15"></vt-icon> }
-                }
-              </button>
-            }
-            <span
-              class="bin-popup-count"
-              [title]="'Items in this bin (' + ids.length + ')'">
-              {{ ids.length | number }} item{{ ids.length === 1 ? '' : 's' }}
-            </span>
-            <!-- Thumbnail smaller/larger sits on the select-all row (it controls
-                 this grid), rather than in the header beside the detail-image
-                 size buttons. -->
-            <vt-view-controls
-              side="popup"
-              [currentMediaType]="mediaType()"
-              [showFocus]="false"
-              class="bin-popup-grid-view-controls" />
-          </div>
-          <cdk-virtual-scroll-viewport
-            [itemSize]="rowSize"
-            class="bin-popup-scroll"
-            (mouseleave)="onGridLeave()">
-          <div
-            *cdkVirtualFor="let row of displayRows; trackBy: trackByRow"
-            class="bin-popup-row"
-            [style.height.px]="rowSize"
-            [style.--popup-cols]="columns"
-            [style.--popup-cell]="gridGoalWidth + 'px'">
-            @for (id of row; track trackById($index, id)) {
-              <div
-                class="bin-popup-entry"
-                [attr.data-entry-id]="id"
-                [class.selected]="isSelected(id)"
-                [class.focused]="isFocused(id)"
-                role="button"
-                tabindex="0"
-                [attr.aria-pressed]="isSelected(id)"
-                [attr.aria-label]="name(id) + (isSelected(id) ? ' (selected; click to deselect)' : ' (click to select)')"
-                [title]="name(id)"
-                (click)="onEntryClick(id)"
-                (keydown)="onEntryKeydown($event, id)"
-                (focus)="onEntryFocus(id)"
-                (mouseenter)="onEntryEnter(id)">
-                @if (hasThumbnailUrl(id)) {
-                  <span class="bin-popup-thumb-wrap">
-                    @if (isAudioWaveform) {
-                      <!-- Audio waveform alpha mask tinted to the accent (issue #2369). -->
-                      <span
-                        class="bin-popup-thumb-wave waveform-mask"
-                        [style.-webkit-mask-image]="'url(' + thumbnailUrl(id) + ')'"
-                        [style.mask-image]="'url(' + thumbnailUrl(id) + ')'"></span>
-                    } @else {
-                      <img
-                        class="bin-popup-thumb"
-                        [src]="thumbnailUrl(id)"
-                        [alt]="name(id)"
-                        loading="lazy"
-                        (error)="onThumbnailError(thumbnailUrl(id))" />
-                    }
-                  </span>
-                } @else {
-                  <span class="bin-popup-placeholder">{{ placeholderIcon(id) }}</span>
-                }
-              </div>
-            }
-          </div>
-          </cdk-virtual-scroll-viewport>
-        } @else if (docked()) {
-          <p class="bin-popup-empty-hint">Right-click a bin on the canvas to show it here.</p>
-        }
-      </div>
+      <vt-browse-bin-member-grid
+        [ids]="ids"
+        [rows]="displayRows"
+        [columns]="columns"
+        [cellWidth]="gridGoalWidth"
+        [mediaType]="mediaType()"
+        [docked]="docked()"
+        [focusedId]="previewId"
+        (entryClick)="onEntryClick($event)"
+        (entryFocus)="onEntryFocus($event)"
+        (entryEnter)="onEntryEnter($event)"
+        (gridLeave)="onGridLeave()" />
     }
   </div>
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.scss
@@ -268,198 +268,6 @@
   -webkit-mask-size: contain;
 }
 
-// The grid column: a fixed-width stack of the member-count label above the
-// scrolling thumbnail grid, so the popup hugs it plus the preview pane. The
-// count sits at the column's top-left; the grid fills the remaining height.
-.bin-popup-grid-col {
-  width: 280px;
-  height: 100%;
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-// Top row of the grid column: the select-all control + member-count label on
-// the left, and the thumbnail smaller/larger controls pushed to the right (they
-// resize this grid, so they live on its header row rather than in the window
-// header).
-.bin-popup-grid-header {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2xs);
-  padding: 0 var(--space-2xs) var(--space-2xs);
-}
-
-// Thumbnail size buttons, pushed to the right end of the grid header row.
-.bin-popup-grid-view-controls {
-  margin-left: auto;
-  flex-shrink: 0;
-}
-
-// Tri-state master checkbox, mirroring the dashboard's select-all button but
-// tuned to this window: smaller icon and tighter padding for the compact header.
-.bin-popup-select-all {
-  flex-shrink: 0;
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  cursor: pointer;
-  padding: var(--space-2xs);
-  border-radius: var(--radius-sm);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: color var(--transition-base), background var(--transition-base);
-
-  &:hover {
-    background: var(--btn-icon-hover-bg);
-    color: var(--text-primary);
-  }
-}
-
-// Member-count label, right end of the header row.
-.bin-popup-count {
-  flex-shrink: 0;
-  font-size: var(--font-xs);
-  letter-spacing: var(--tracking-wide);
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.4;
-}
-
-// The scrolling thumbnail grid fills the column below the count label.
-.bin-popup-scroll {
-  width: 100%;
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-x: hidden;
-}
-
-// --- Rows ------------------------------------------------------------------
-// One virtual item == one grid row: a CSS grid of fixed-size thumbnail cells.
-.bin-popup-row {
-  box-sizing: border-box;
-  display: grid;
-  grid-template-columns: repeat(var(--popup-cols, 1), 1fr);
-  align-content: start;
-  justify-items: center;
-  column-gap: var(--space-2xs);
-}
-
-// A grid cell: a single thumbnail (the name that used to sit beneath it is gone).
-.bin-popup-entry {
-  box-sizing: border-box;
-  cursor: pointer;
-  color: var(--text-vote);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 2px;
-  // Sharp: one item per cell, so its hover fill and selection ring stay square
-  // (rounded is reserved for multi-item piles — see the thumbnail note below).
-  width: var(--popup-cell, 80px);
-  // Animate the "viewed" enlarge (below) so items grow/settle smoothly rather
-  // than popping as focus walks the grid.
-  transition: transform var(--transition-base);
-
-  &:hover {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-  }
-
-  // Two orthogonal per-thumb cues, so a thumbnail can show either or BOTH at
-  // once without them fighting. Selection is a BOUNDARY (a ring); "viewed" is a
-  // SIZE/depth cue (enlarge + lift). Different visual channels means a selected
-  // item you're also viewing reads unmistakably as ringed AND lifted.
-  //
-  // Selection: a solid accent ring at the cell edge (mirrors bin selection on
-  // the canvas) plus an accent-tinted fill.
-  &.selected {
-    background: var(--accent-highlight-bg);
-    color: var(--text-primary);
-    box-shadow: 0 0 0 2px var(--accent);
-  }
-
-  // The viewed item (shown in the preview pane / walked by the arrow keys) is
-  // ENLARGED and lifted, mirroring the canvas hover-enlarge. Done with
-  // ``transform`` (painted, not laid out) so the scale never reflows the grid,
-  // shifts row heights, or resizes the popup — layout stays pixel-stable, and
-  // ``z-index`` lifts the growing thumb above its neighbours. The lift uses
-  // ``filter: drop-shadow`` rather than ``box-shadow`` so the selection ring's
-  // box-shadow survives untouched when an item is both selected and viewed. The
-  // size/depth channel is the only on-grid cue for non-thumbnail media too,
-  // which has no preview.
-  &.focused {
-    position: relative;
-    z-index: 1;
-    transform: scale(1.35);
-    filter: drop-shadow(0 3px 6px var(--shadow-dropdown));
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: -2px;
-  }
-}
-
-// Thumbnail/placeholder square, sized to the chosen icon size (``--popup-cell``,
-// bound per row); falls back to a compact square if the variable is ever absent.
-// The real thumbnail's wrapper and the no-thumbnail placeholder are the same
-// fixed cell-sized box, so they share these metrics (and the themed ``--bg-body``
-// surface: hidden under a cover-fit <img>, and the backdrop the tinted audio
-// waveform (issue #2369) sits on).
-.bin-popup-thumb-wrap,
-.bin-popup-placeholder {
-  width: var(--popup-cell, 28px);
-  height: var(--popup-cell, 28px);
-  // Sharp corners: each grid thumbnail is a single item, and in the VTSBrowse
-  // corner symbology rounded corners mean a multi-item pile, so a lone item is
-  // drawn as a crisp square. (The wrap's ``overflow: hidden`` clips the <img>.)
-  flex-shrink: 0;
-  background: var(--bg-body);
-}
-
-.bin-popup-thumb-wrap {
-  display: block;
-  overflow: hidden;
-}
-
-// Audio waveform in the grid: the shared ``.waveform-mask`` supplies the accent
-// fill and mask chrome; here we cover-fit it (matching the <img> it replaces).
-// No ``background`` — that would out-specify the shared accent and blank the wave.
-.bin-popup-thumb-wave {
-  // ``display: block`` is required: the wave is a <span> (a non-replaced inline
-  // element, unlike the <img> it replaced), so without it ``width``/``height``
-  // are ignored and the box collapses to nothing (issue #2369 regression). The
-  // parent ``.bin-popup-thumb-wrap`` is a fixed square, so ``height: 100%`` is
-  // definite here.
-  display: block;
-  width: 100%;
-  height: 100%;
-  mask-size: cover;
-  -webkit-mask-size: cover;
-}
-
-.bin-popup-thumb {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  background: var(--bg-body);
-  display: block;
-}
-
-.bin-popup-placeholder {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-muted);
-  font-size: var(--font-lg);
-}
-
 // --- Docked presentation ----------------------------------------------------
 // The same component rendered as the Browse view's persistent left panel: the
 // detail pane top-left with the metadata column to its right (wrapping below
@@ -523,13 +331,6 @@
     height: auto;
   }
 
-  .bin-popup-grid-col {
-    width: 100%;
-    height: auto;
-    flex: 1 1 auto;
-    min-height: 0;
-  }
-
   // Horizontal grab bar between the focused-item row and the member grid.
   // Dragging it resizes the whole panel (the browse view maps the vertical drag
   // onto the panel↔canvas width), so it reads as a full-width row-resize bar
@@ -550,19 +351,6 @@
       width: auto;
       height: 4px;
     }
-  }
-
-  // Resize like the right (selection) panel: fixed-width columns packed to the
-  // left with a constant gap, so widening the panel keeps the thumbnails (and
-  // the gaps between them) the same size and only reveals a new column once
-  // there's room for a whole one — instead of the floating window's ``1fr``
-  // tracks, which stretch each thumbnail's cell as the panel grows. The browse
-  // view then "pops" the divider tight to the column count on release (see
-  // ``snappedPanelWidth``), mirroring the right panel's snap.
-  .bin-popup-row {
-    grid-template-columns: repeat(var(--popup-cols, 1), var(--popup-cell, 80px));
-    justify-content: start;
-    column-gap: var(--space-xs);
   }
 }
 
@@ -608,15 +396,6 @@
 .bin-popup-preview-glyph {
   font-size: 48px;
   color: var(--text-muted);
-}
-
-// Docked empty state: no bin has been opened yet.
-.bin-popup-empty-hint {
-  margin: auto;
-  padding: var(--space-md);
-  font-size: var(--font-sm);
-  color: var(--text-muted);
-  text-align: center;
 }
 
 // (The hidden audio element uses the global `.sr-only` from scss/_components.scss.)

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,34 +1,29 @@
 import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, effect, ElementRef, HostListener, inject, Injector, input, OnDestroy, output, untracked, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
-import { Subscription } from 'rxjs';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { MediaTypeCapabilityService } from '../../services/media-type-capability.service';
-import { ViewControlsComponent } from '../view-controls/view-controls.component';
 import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
+import { BrowseBinMemberGridComponent } from '../browse-bin-member-grid/browse-bin-member-grid.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import {
+  COUNT_LABEL_HEIGHT,
+  GRID_COLUMN_WIDTH,
+  GRID_CONTENT_WIDTH,
+  GRID_GAP,
+  binGridColumns,
+  binGridRowSize,
+} from '../../utils/bin-grid-metrics';
 import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
 
-/** Vertical padding (px) inside every grid cell (``.bin-popup-entry`` 2px top +
- *  2px bottom), always present regardless of icon size. Reserved in {@link
- *  rowSize} so the cell's real rendered height never exceeds its virtual slot. */
-const GRID_CELL_PADDING = 4;
-/** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
-const GRID_GAP = 4;
-/** Width (px) available to lay out cells inside the popup's scroll column (≈ its
- *  width minus padding and the scrollbar). Columns are derived from this. */
-const GRID_CONTENT_WIDTH = 256;
-/** Width (px) of the scrolling grid column; mirrors the historic popup width. */
-const GRID_COLUMN_WIDTH = 280;
 /** Width (px) of the optional metadata column shown left of the preview pane. */
 const METADATA_COLUMN_WIDTH = 200;
 /** Tallest the scrolling body grows before it caps and scrolls internally. */
@@ -36,8 +31,6 @@ const MAX_BODY_PX = 400;
 /** Shortest the scrolling body is ever squeezed to when the visible region is
  *  too short to fit the full popup; below this it just scrolls internally. */
 const MIN_BODY_PX = 80;
-/** Extra rows of metadata prefetched beyond the visible window. */
-const PREFETCH_BUFFER = 50;
 /** Gap (px) kept between the popup and the visible edge when clamping. */
 const EDGE_MARGIN = 8;
 /** Gap (px) between the body's columns (metadata / preview / grid). Mirrors the
@@ -77,8 +70,6 @@ const PREVIEW_OVERSIZE = 2.0;
  * {@link PREVIEW_OVERSIZE}.
  */
 const HOVER_EXTENT_PER_RADIUS = 3;
-/** Vertical room (px) the member-count label takes above the scrolling grid. */
-const COUNT_LABEL_HEIGHT = 22;
 /** Vertical padding (px) inside ``.bin-popup-body`` ({@link BODY_PADDING} on the
  *  top + bottom). The body's bound ``height`` is a *border-box* height (the app
  *  sets ``box-sizing: border-box`` globally), so this padding must be added on
@@ -144,10 +135,18 @@ const DOCKED_MAIN_MIN = 60;
  *   document-level keyboard shortcuts) is disabled; the canvas keeps its own
  *   shortcuts.
  *
- * The members render as a virtualized thumbnail grid (always grid; there is no
- * list mode). Hovering a grid thumbnail paints that item's *full-resolution*
- * original (not its grid thumbnail) into the preview pane, so the user can pull
- * detail out of any pile member in turn. The pane opens showing the bin's
+ * The members themselves render in {@link BrowseBinMemberGridComponent}, which
+ * owns everything below the detail row: the virtualized thumbnail grid (always
+ * grid; there is no list mode), its select-all header, and all of the virtual
+ * viewport's mechanics — scroll-driven metadata prefetch, centring a row,
+ * moving DOM focus onto an entry that has not virtualized in yet. This shell
+ * keeps only what the grid can't own: what to show (it chunks {@link ids} into
+ * {@link rows} because the same chunking feeds its clamp) and what is being
+ * viewed ({@link previewId}), reaching into the grid through the three methods
+ * on that component when the keyboard or a resize needs to move it. Hovering a
+ * grid thumbnail paints that item's *full-resolution* original (not its grid
+ * thumbnail) into the preview pane, so the user can pull detail out of any pile
+ * member in turn. The pane opens showing the bin's
  * representative, so even a singleton bin lands on a large high-res view without
  * any hover. The pane is sized to {@link PREVIEW_OVERSIZE} (50%) larger than the
  * item's on-canvas mouse-over break-out at the current main-canvas thumbnail
@@ -156,9 +155,10 @@ const DOCKED_MAIN_MIN = 60;
  * The thumbnail size of the grid is remembered per media type under the
  * ``grid_icon_size_popup`` setting (independent of the left/right panels), so
  * tuning the popup while browsing one bin becomes the default for every future
- * popup of that media type. The top-right {@link ViewControlsComponent} writes
+ * popup of that media type. The view controls on the grid's header row write
  * that setting and this component re-reads it from {@link SettingsStateService},
- * keyed by the active dataset's media type.
+ * keyed by the active dataset's media type — it needs the size itself, since the
+ * column chunking and the popup's clamped height both derive from it.
  *
  * A second, top-left pair of size buttons controls the *detail canvas* (the
  * large preview pane) rather than the grid thumbnails. Because the popup's
@@ -180,7 +180,7 @@ const DOCKED_MAIN_MIN = 60;
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-browse-bin-popup',
   standalone: true,
-  imports: [CommonModule, ScrollingModule, ViewControlsComponent, IconComponent, CopyDetailButtonComponent],
+  imports: [CommonModule, IconComponent, CopyDetailButtonComponent, BrowseBinMemberGridComponent],
   templateUrl: './browse-bin-popup.component.html',
   styleUrl: './browse-bin-popup.component.scss',
 })
@@ -254,7 +254,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   private readonly panelRef = viewChild<ElementRef<HTMLElement>>('panel');
   private readonly headerRef = viewChild<ElementRef<HTMLElement>>('header');
-  private readonly viewport = viewChild(CdkVirtualScrollViewport);
+  private readonly grid = viewChild(BrowseBinMemberGridComponent);
   private readonly audioRef = viewChild<ElementRef<HTMLAudioElement>>('audioEl');
 
   /** Clamped on-screen position; starts at the anchor and is nudged inward. */
@@ -326,13 +326,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** Whether the one-shot buffering listeners are wired onto the audio element. */
   private audioListenersAttached = false;
 
-  private readonly failedThumbs = new Set<string>();
   /** Ids whose full-res ``/image`` failed; the preview falls back to the
    *  thumbnail for these so it still shows something. */
   private readonly failedPreviews = new Set<number>();
-  private scrollSub: Subscription | null = null;
-  /** The viewport instance whose ``scrolledIndexChange`` is currently subscribed. */
-  private scrollSubscribedViewport: CdkVirtualScrollViewport | null = null;
 
   constructor() {
     // Keep the hover-to-hear preview element in step with the Browse toolbar's
@@ -385,8 +381,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         // the window around it. Deferred so the virtual viewport has the new rows
         // (and, on first open, exists at all — it's created after this effect).
         setTimeout(() => {
-          this.scrollToRep();
-          this.prefetchVisible();
+          this.grid()?.centreOn(this.repIndex());
+          this.prefetchMembers();
         });
       });
     });
@@ -435,8 +431,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         if (!this.docked() || width <= 0) return;
         this.rebuildRows();
         setTimeout(() => {
-          this.viewport()?.checkViewportSize();
-          this.prefetchVisible();
+          this.grid()?.remeasure();
+          this.prefetchMembers();
         });
         this.cdr.markForCheck();
       });
@@ -449,18 +445,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         if (!this.docked() || !np) return;
         this.metadataCache.ensureLoaded([np.mediaId]);
       });
-    });
-    // (Re-)subscribe the member grid's scroll-driven prefetch whenever the
-    // virtual viewport instance changes — it lives behind the template's
-    // ``@if (!previewOnly)``, and the popup is reused across summons while
-    // open (right-clicking another bin only swaps inputs), so a singleton→
-    // multi transition creates a brand-new viewport. Tracking the view query
-    // re-runs this the moment that instance appears; a one-shot
-    // ``ngAfterViewInit`` wiring would strand it (mirrors media-list's
-    // viewport re-wire pattern).
-    effect(() => {
-      this.viewport();
-      untracked(() => this.ensureScrollSubscription());
     });
     // Re-read the popup's thumbnail size whenever settings change (this is how
     // the in-header size buttons take effect, and how a change on one popup
@@ -510,34 +494,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    // Names/thumbnails arrive asynchronously; repaint the visible rows.
+    // Names/thumbnails arrive asynchronously; repaint the metadata column and
+    // the preview pane's labels. (The grid child repaints its own rows.)
     this.metadataCache.version$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.cdr.markForCheck());
     this.settingsState.load();
-    this.prefetchVisible();
+    this.prefetchMembers();
     setTimeout(() => this.place());
   }
 
-  /**
-   * (Re-)subscribe the member grid's scroll-driven thumbnail prefetch, keyed
-   * to the viewport *instance*. Driven by the constructor effect tracking the
-   * ``viewport`` view query, so a singleton→multi transition (which creates a
-   * brand-new viewport behind ``@if (!previewOnly)``) re-wires immediately —
-   * a one-shot subscription would leave everything beyond the
-   * initially-prefetched window as ``□`` placeholders with no recovery.
-   */
-  private ensureScrollSubscription(): void {
-    const vp = this.viewport() ?? null;
-    if (!vp || this.scrollSubscribedViewport === vp) return;
-    this.scrollSubscribedViewport = vp;
-    this.scrollSub?.unsubscribe();
-    this.scrollSub = vp.scrolledIndexChange.subscribe(() => this.prefetchVisible());
-    this.prefetchVisible();
-  }
-
   ngOnDestroy(): void {
-    this.scrollSub?.unsubscribe();
     // Drop any in-flight metadata-divider drag listeners (destroyed mid-drag).
     document.removeEventListener('pointermove', this.boundMetaMove);
     document.removeEventListener('pointerup', this.boundMetaUp);
@@ -687,8 +654,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       // being viewed (the representative until the user hovers/arrows elsewhere)
       // so it stays in view across the size change, then clamp.
       setTimeout(() => {
-        this.viewport()?.checkViewportSize();
-        this.centreRowFor(this.focusIndex());
+        this.grid()?.centreOn(this.focusIndex());
         this.place();
       });
     }
@@ -726,41 +692,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return idx >= 0 ? idx : 0;
   }
 
-  /** Scroll the member grid so the representative's row sits roughly centred, so
-   *  the popup opens looking at the same item whose pile thumbnail was clicked
-   *  rather than the 1-D list's first item. */
-  private scrollToRep(): void {
-    this.centreRowFor(this.repIndex());
-  }
-
-  /** Scroll the member grid so the row holding ``index`` sits roughly centred.
-   *  No-op for a singleton bin (no grid) or before the viewport exists.
-   *
-   *  The virtual viewport may not have applied its scrollable content size yet
-   *  (on open, or right after a thumbnail-size change re-chunks the rows), so the
-   *  browser clamps this scroll back to 0 and a large bin is left sitting at the
-   *  top with the target off-screen. When we meant to scroll down but the offset
-   *  didn't take, retry on the next frame (bounded) until the viewport is
-   *  scrollable and the target sticks. */
-  private centreRowFor(index: number, attempt = 0): void {
-    const vp = this.viewport();
-    if (!vp) return;
-    const row = Math.floor(index / Math.max(1, this.columns));
-    const viewportH = vp.elementRef.nativeElement.clientHeight || this.gridHeight;
-    // The most we can scroll: content height (all rows) minus the visible window.
-    const maxOffset = Math.max(0, this.rows.length * this.rowSize - viewportH);
-    // Centre the row in the visible window, clamped to [0, maxOffset] so we never
-    // scroll past either end.
-    const target = Math.min(
-      maxOffset,
-      Math.max(0, row * this.rowSize - Math.max(0, viewportH - this.rowSize) / 2),
-    );
-    vp.scrollToOffset(target);
-    if (target > 0 && vp.measureScrollOffset('top') < target - 1 && attempt < 5) {
-      requestAnimationFrame(() => this.centreRowFor(index, attempt + 1));
-    }
-  }
-
   /** Width (px) the member grid lays its cells out in: the historic fixed
    *  column width when floating, or the live panel width (minus the body
    *  padding + scrollbar chrome) when docked, so the docked grid re-chunks as
@@ -790,10 +721,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   /** Recompute the column count + row chunking for the current thumbnail size. */
   private rebuildRows(): void {
-    this.columns = Math.max(
-      1,
-      Math.floor((this.gridContentWidth() + GRID_GAP) / (this.gridGoalWidth + GRID_GAP)),
-    );
+    this.columns = binGridColumns(this.gridContentWidth(), this.gridGoalWidth);
     const cols = this.columns;
     const rows: number[][] = [];
     for (let i = 0; i < this.ids.length; i += cols) {
@@ -802,14 +730,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.rows = rows;
   }
 
-  /** Pixel stride of one virtual grid row: the thumbnail plus its always-present
-   *  vertical cell padding and an inter-row gap. The grid no longer prints a name
-   *  under each thumbnail, so only the thumbnail and padding contribute; accounting
-   *  for the cell padding keeps the row's rendered content from overflowing its
-   *  virtual slot by a sub-pixel, which would otherwise force a stray scrollbar on
-   *  even a single row. */
+  /** Pixel stride of one virtual grid row. Shared with the grid component that
+   *  actually renders the rows, so this clamp can't model a row height the grid
+   *  doesn't use — see ``utils/bin-grid-metrics``. */
   get rowSize(): number {
-    return this.gridGoalWidth + GRID_CELL_PADDING + GRID_GAP;
+    return binGridRowSize(this.gridGoalWidth);
   }
 
   /** Height (px) the grid takes: just enough for its rows, capped (to the room
@@ -1167,31 +1092,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     const next = Math.max(0, Math.min(this.ids.length - 1, cur + dCol + dRow * this.columns));
     if (next === cur) return;
     this.previewId = this.ids[next];
-    this.scrollRowIntoView(next);
-    this.focusEntry(next);
+    this.grid()?.revealAndFocus(next);
     this.cdr.markForCheck();
-  }
-
-  /**
-   * Move DOM focus onto the grid entry at ``index`` so keyboard activation
-   * (Enter / Space) targets the arrow-walked item. The entry may not be in the
-   * DOM yet — the row was just scrolled into view and the virtual viewport
-   * renders it on a subsequent frame — so query for it after a frame and retry
-   * (bounded) until it exists. ``preventScroll`` keeps the native focus scroll
-   * from fighting {@link scrollRowIntoView}, which already positioned the row.
-   */
-  private focusEntry(index: number, attempt = 0): void {
-    const panel = this.panelRef()?.nativeElement;
-    const id = this.ids[index];
-    if (!panel || id == null) return;
-    requestAnimationFrame(() => {
-      const el = panel.querySelector<HTMLElement>(`.bin-popup-entry[data-entry-id="${id}"]`);
-      if (el) {
-        el.focus({ preventScroll: true });
-      } else if (attempt < 5) {
-        this.focusEntry(index, attempt + 1);
-      }
-    });
   }
 
   /** Index of the viewed item within {@link ids}, falling back to the
@@ -1199,29 +1101,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private focusIndex(): number {
     const idx = this.previewId == null ? -1 : this.ids.indexOf(this.previewId);
     return idx >= 0 ? idx : this.repIndex();
-  }
-
-  /** True for the viewed item — the one shown in the preview pane and ringed in
-   *  the grid as arrow keys walk through it. */
-  isFocused(id: number): boolean {
-    return this.previewId != null && id === this.previewId;
-  }
-
-  /** Scroll the grid the minimum amount so the row holding ``index`` is fully
-   *  visible (no-op when it already is). */
-  private scrollRowIntoView(index: number): void {
-    const vp = this.viewport();
-    if (!vp) return;
-    const row = Math.floor(index / Math.max(1, this.columns));
-    const rowTop = row * this.rowSize;
-    const rowBottom = rowTop + this.rowSize;
-    const top = vp.measureScrollOffset('top');
-    const viewportH = vp.elementRef.nativeElement.clientHeight || this.gridHeight;
-    if (rowTop < top) {
-      vp.scrollToOffset(rowTop);
-    } else if (rowBottom > top + viewportH) {
-      vp.scrollToOffset(rowBottom - viewportH);
-    }
   }
 
   // --- Dragging (move the popup by its header) ------------------------------
@@ -1256,48 +1135,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   // --- Selection (click stays open so the user can scroll + multi-select) ---
 
-  isSelected(id: number): boolean {
-    return this.selection.has(id);
-  }
-
-  /** Tri-state of the select-all control: how many members are selected, as
-   *  none / some / all — mirroring the dashboard's master-checkbox states. */
-  get selectionState(): 'none' | 'some' | 'all' {
-    const total = this.ids.length;
-    if (total === 0) return 'none';
-    const sel = this.selection.selectedCountIn(this.ids);
-    if (sel === 0) return 'none';
-    if (sel >= total) return 'all';
-    return 'some';
-  }
-
-  /** Select every member, or — when all are already selected — clear them.
-   *  Matches the dashboard's toggle-all semantics. */
-  toggleAll(): void {
-    if (this.selectionState === 'all') {
-      this.selection.removeAll(this.ids);
-    } else {
-      this.selection.addAll(this.ids);
-    }
-  }
-
   onEntryClick(id: number): void {
     if (this.selection.has(id)) {
       this.selection.remove(id);
     } else {
       this.selection.addAll([id]);
-    }
-  }
-
-  onEntryKeydown(event: KeyboardEvent, id: number): void {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      // Stop the bubble so the document-level handler's Space fallback (which
-      // acts on {@link previewId}) doesn't also fire and double-toggle. The
-      // focused entry owns its own activation; the fallback is only for when
-      // nothing in the grid holds focus.
-      event.stopPropagation();
-      this.onEntryClick(id);
     }
   }
 
@@ -1463,19 +1305,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return this.metadataCache.get(id)?.filename || `Clip #${id}`;
   }
 
-  hasThumbnailUrl(id: number): boolean {
-    const url = this.thumbnailUrl(id);
-    if (this.failedThumbs.has(url)) return false;
-    const media = this.metadataCache.get(id);
-    return !!media && this.mediaTypeCaps.usesThumbnails(media.media_type);
-  }
-
   thumbnailUrl(id: number): string {
     return this.activeContext.mediaUrl(`/api/medias/${id}/thumbnail`);
-  }
-
-  onThumbnailError(url: string): void {
-    if (url) this.failedThumbs.add(url);
   }
 
   /** Full-res source for the preview pane: the original ``/image`` unless it has
@@ -1494,23 +1325,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       this.failedPreviews.add(id);
       this.cdr.markForCheck();
     }
-  }
-
-  placeholderIcon(id: number): string {
-    if (this.hasThumbnailUrl(id)) return '';
-    const media = this.metadataCache.get(id);
-    if (!media) return '□';
-    if (media.media_type === 'audio') return '♫';
-    if (media.media_type === 'text') return '¶';
-    return '□';
-  }
-
-  trackById(_index: number, id: number): number {
-    return id;
-  }
-
-  trackByRow(index: number): number {
-    return index;
   }
 
   // --- Positioning ---------------------------------------------------------
@@ -1705,22 +1519,22 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
-  /** Prefetch metadata for the items around the visible window of the grid. */
-  private prefetchVisible(): void {
-    if (this.ids.length === 0) return;
-    const cols = this.columns;
-    const vp = this.viewport();
-    if (!vp) {
-      const window = Math.ceil(MAX_BODY_PX / this.rowSize) * cols + PREFETCH_BUFFER;
-      this.metadataCache.ensureLoaded(this.ids.slice(0, window));
+  /**
+   * Keep metadata loading for whatever is on show.
+   *
+   * The member grid prefetches its own visible window (and re-prefetches as it
+   * scrolls), so normally this just nudges it. When no grid is rendered at all —
+   * a floating singleton bin, which drops the grid column for the detail pane
+   * alone — there is exactly one item on show, and the pane plus the metadata
+   * column both read it, so load that one directly.
+   */
+  private prefetchMembers(): void {
+    const grid = this.grid();
+    if (grid) {
+      grid.prefetchVisible();
       return;
     }
-    const startRow = Math.floor(vp.measureScrollOffset('top') / this.rowSize);
-    const visibleRows = Math.ceil(
-      (vp.elementRef.nativeElement.clientHeight || this.gridHeight) / this.rowSize,
-    );
-    const from = Math.max(0, (startRow - Math.ceil(PREFETCH_BUFFER / cols)) * cols);
-    const to = Math.min(this.ids.length, (startRow + visibleRows) * cols + PREFETCH_BUFFER);
-    this.metadataCache.ensureLoaded(this.ids.slice(from, to));
+    const id = this.displayedId;
+    if (id != null) this.metadataCache.ensureLoaded([id]);
   }
 }

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -1,6 +1,5 @@
-import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, effect, ElementRef, HostListener, inject, Injector, input, OnDestroy, output, untracked, viewChild } from '@angular/core';
+import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, HostListener, inject, Injector, input, OnDestroy, output, signal, untracked, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -191,9 +190,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private activeContext = inject(ActiveContextService);
   private settingsState = inject(SettingsStateService);
   private mediaTypeCaps = inject(MediaTypeCapabilityService);
-  private cdr = inject(ChangeDetectorRef);
   private injector = inject(Injector);
-  private destroyRef = inject(DestroyRef);
 
   /** Member media ids of the bin the popup was summoned over. */
   readonly memberIds = input<number[]>([]);
@@ -257,9 +254,26 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private readonly grid = viewChild(BrowseBinMemberGridComponent);
   private readonly audioRef = viewChild<ElementRef<HTMLAudioElement>>('audioEl');
 
-  /** Clamped on-screen position; starts at the anchor and is nudged inward. */
-  left = 0;
-  top = 0;
+  /**
+   * Clamped on-screen position; starts at the anchor and is nudged inward.
+   *
+   * Signal-backed, read through a plain getter — the shape ``docs/FRONTEND.md``
+   * §5 sanctions for exactly this case. Every write happens outside change
+   * detection (a bare ``setTimeout`` in {@link place}, the ``afterNextRender``
+   * in {@link nudgeOnScreen}, a document-level pointer move), so a plain field
+   * notified nobody and each write site had to remember its own
+   * ``markForCheck()``. Writing the signal schedules the render itself, and a
+   * read inside a template expression registers as that view's dependency, so
+   * the bindings can't go stale however the value was set.
+   */
+  private readonly _left = signal(0);
+  private readonly _top = signal(0);
+  get left(): number {
+    return this._left();
+  }
+  get top(): number {
+    return this._top();
+  }
   /** False until the popup has been clamped *and* measured at its on-screen spot;
    *  the panel is kept ``visibility: hidden`` until then so the user never sees it
    *  flash at the raw summon point (which may be half off-screen) or at a computed
@@ -268,15 +282,24 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  has been measured and any residual overflow removed, and only once settings
    *  have loaded so the size is final. Reset on every genuine re-summon so the
    *  move to a new bin also stays hidden until re-placed. */
-  placed = false;
+  private readonly _placed = signal(false);
+  get placed(): boolean {
+    return this._placed();
+  }
   /** Max width (px) the popup may take; shrunk to fit a narrow visible region. */
-  maxWidthPx = GRID_COLUMN_WIDTH;
+  private readonly _maxWidthPx = signal(GRID_COLUMN_WIDTH);
+  get maxWidthPx(): number {
+    return this._maxWidthPx();
+  }
   /** True once the user has dragged the popup by its header. While set, the
    *  popup keeps the user's chosen spot (re-clamped to stay on-screen) instead
    *  of re-anchoring to the summon point on content changes. Reset per bin. */
   dragged = false;
   /** True only mid-drag (pointer down on the header, not yet released). */
-  dragging = false;
+  private readonly _dragging = signal(false);
+  get dragging(): boolean {
+    return this._dragging();
+  }
   private dragStart = { x: 0, y: 0, left: 0, top: 0 };
   /** Bounded re-measure counter for {@link nudgeOnScreen}: when a correction
    *  actually moves the popup the pre-measurement clamp had under-modelled the
@@ -286,34 +309,58 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   /** Body height cap (px) for the current visible region; the body never grows
    *  past this, so a short region can't push the popup off the bottom edge. */
-  bodyCapPx = MAX_BODY_PX;
+  private readonly _bodyCapPx = signal(MAX_BODY_PX);
+  get bodyCapPx(): number {
+    return this._bodyCapPx();
+  }
 
   /** Preview-pane height cap (px) for the current visible region. The preview is
    *  allowed to grow taller than {@link bodyCapPx} (which only governs the
    *  scrolling grid), so a large zoom-in view isn't truncated to the grid's cap;
    *  it is still kept within the visible region so the popup stays on-screen. */
-  previewCapPx = MAX_PREVIEW_PX;
+  private readonly _previewCapPx = signal(MAX_PREVIEW_PX);
+  get previewCapPx(): number {
+    return this._previewCapPx();
+  }
 
   /** The bin's member ids, in bin order — a locality-preserving 1-D (Hilbert)
    *  traversal of the layout, so spatially/semantically similar items sit
    *  together in the list (the server orders them; see ``tile_member_ids``). */
-  ids: number[] = [];
+  private readonly _ids = signal<number[]>([]);
+  get ids(): number[] {
+    return this._ids();
+  }
 
   /** Grid thumbnail target width (px), mirrored from settings per media type. */
-  gridGoalWidth = 80;
+  private readonly _gridGoalWidth = signal(80);
+  get gridGoalWidth(): number {
+    return this._gridGoalWidth();
+  }
 
   /** Number of columns the grid lays out. */
-  columns = 1;
+  private readonly _columns = signal(1);
+  get columns(): number {
+    return this._columns();
+  }
   /** Member ids chunked into rows of {@link columns}; the virtual list's data. */
-  rows: number[][] = [];
+  private readonly _rows = signal<number[][]>([]);
+  get rows(): number[][] {
+    return this._rows();
+  }
 
   /** Id whose full-res original is painted into the preview pane. Defaults to
    *  the bin's representative (first member) so the pane is never blank, and
    *  follows the grid thumbnail under the cursor while hovering. */
-  previewId: number | null = null;
+  private readonly _previewId = signal<number | null>(null);
+  get previewId(): number | null {
+    return this._previewId();
+  }
 
   /** Currently-playing hover audio source, so re-entering the same row is a no-op. */
-  audioSrc = '';
+  private readonly _audioSrc = signal('');
+  get audioSrc(): string {
+    return this._audioSrc();
+  }
   /** Media id of the clip currently auditioning, so the buffering listeners can
    *  re-emit its now-playing state; ``null`` when silent. */
   private nowPlayingId: number | null = null;
@@ -327,8 +374,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private audioListenersAttached = false;
 
   /** Ids whose full-res ``/image`` failed; the preview falls back to the
-   *  thumbnail for these so it still shows something. */
+   *  thumbnail for these so it still shows something. Paired with a version
+   *  signal because the set is mutated in place: {@link previewUrl} reads the
+   *  version first, so adding an id repaints the pane onto the fallback. */
   private readonly failedPreviews = new Set<number>();
+  private readonly failedPreviewsVersion = signal(0);
 
   constructor() {
     // Keep the hover-to-hear preview element in step with the Browse toolbar's
@@ -357,17 +407,16 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         // repaint doesn't restart the audition, throw away the viewed item, or
         // scroll the grid back to the representative.
         if (this.isInPlaceCull(next)) {
-          this.ids = next;
+          this._ids.set(next);
           this.rebuildRows();
-          this.cdr.markForCheck();
           return;
         }
-        this.ids = next;
+        this._ids.set(next);
         this.stopAudio();
         // Open on the bin's representative (the centroid whose thumbnail the user
         // right-clicked) so the pane is never blank and the detail view starts on
         // the same image — not the 1-D list's first item, which differs.
-        this.previewId = this.representativeId();
+        this._previewId.set(this.representativeId());
         // Auto-play the representative's clip on open (audio) so the detail window
         // is an "intense hover": opening it hears the rep, just like resting on the
         // bin on the canvas. This is the only way to hear a singleton audio bin,
@@ -407,11 +456,11 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       this.memberIds();
       untracked(() => {
         if (!this.dragged) {
-          this.left = x;
-          this.top = y;
+          this._left.set(x);
+          this._top.set(y);
           // Hide the popup until it's re-clamped at the new anchor, so it doesn't
           // flash at the raw summon point (which may be half off-screen) first.
-          this.placed = false;
+          this._placed.set(false);
         }
         // Measure + clamp after the new content lays out.
         setTimeout(() => this.place());
@@ -434,7 +483,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
           this.grid()?.remeasure();
           this.prefetchMembers();
         });
-        this.cdr.markForCheck();
       });
     });
     // Docked audio: the detail pane + metadata column track the auditioning
@@ -451,54 +499,50 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     // becomes the default for every future popup of this media type).
     effect(() => {
       const settings = this.settingsState.settingsSignal();
-      if (!settings) return;
-      this.gridSizeDict = (settings.grid_icon_size_popup as Record<string, string>) ?? {};
-      this.previewSizeDict = (settings.popup_preview_size as Record<string, number>) ?? {};
-      this.metadataShownDict = (settings.popup_metadata_shown as Record<string, boolean>) ?? {};
-      // Mirror the docked metadata-column width (global). Skip mid-drag so a
-      // settings round-trip can't reset the column while the user is dragging it.
-      if (!this.draggingMeta && typeof settings.browse_details_metadata_width === 'number') {
-        this.metadataWidthPx = settings.browse_details_metadata_width;
-      }
-      this.applyViewPrefs();
-      // A detail-canvas size change (the top-left buttons) resizes the preview
-      // pane, hence the whole popup, so re-clamp it back fully on-screen. Showing
-      // or hiding the metadata column likewise changes the popup's width, so it
-      // re-clamps too.
-      const override = this.previewOverride;
-      const metaShown = this.showMetadataColumn;
-      // Re-place when the settings-driven size actually changed, OR when the popup
-      // has mounted but not yet revealed (`placed` still false). The `!this.placed`
-      // clause fixes the "first right-click shows nothing, second opens it" bug:
-      // {@link ngAfterViewInit} calls `settingsState.load()`, which bumps the
-      // settings resource's request and so momentarily resets `settingsSignal()` to
-      // null while it refetches. If `nudgeOnScreen`'s reveal gate (`settingsReady`)
-      // runs during that null window it holds `placed` false, and nothing else
-      // re-runs `place()` when settings land (the size didn't change) — so the popup
-      // strands hidden until the next summon. Re-placing on settings-arrival reveals
-      // it then, keeping the "wait for the real sizes" behaviour (no default-size
-      // flash) while dropping the spurious second click.
-      if (override !== this.lastPreviewOverride || metaShown !== this.lastMetadataShown || !this.placed) {
-        this.lastPreviewOverride = override;
-        this.lastMetadataShown = metaShown;
-        setTimeout(() => this.place());
-      }
-    });
-    // A selection change anywhere (here, the canvas, the panel) re-highlights.
-    // An effect on the signal (rather than a `changed$` subscription) schedules
-    // the repaint under zoneless from any mutation context.
-    effect(() => {
-      this.selection.version();
-      this.cdr.markForCheck();
+      // Track the two genuine triggers explicitly, then run the body untracked.
+      // The body now both reads and writes the view-pref signals (and `placed`),
+      // so a tracked body would re-arm itself on its own writes and spin; naming
+      // the triggers keeps the media-type re-place that the old implicit
+      // `mediaType()` read through `previewOverride` used to give us.
+      this.mediaType();
+      untracked(() => {
+        if (!settings) return;
+        this.gridSizeDict.set((settings.grid_icon_size_popup as Record<string, string>) ?? {});
+        this.previewSizeDict.set((settings.popup_preview_size as Record<string, number>) ?? {});
+        this.metadataShownDict.set((settings.popup_metadata_shown as Record<string, boolean>) ?? {});
+        // Mirror the docked metadata-column width (global). Skip mid-drag so a
+        // settings round-trip can't reset the column while the user is dragging it.
+        if (!this.draggingMeta && typeof settings.browse_details_metadata_width === 'number') {
+          this.metadataWidthPx.set(settings.browse_details_metadata_width);
+        }
+        this.applyViewPrefs();
+        // A detail-canvas size change (the top-left buttons) resizes the preview
+        // pane, hence the whole popup, so re-clamp it back fully on-screen. Showing
+        // or hiding the metadata column likewise changes the popup's width, so it
+        // re-clamps too.
+        const override = this.previewOverride;
+        const metaShown = this.showMetadataColumn;
+        // Re-place when the settings-driven size actually changed, OR when the popup
+        // has mounted but not yet revealed (`placed` still false). The `!this.placed`
+        // clause fixes the "first right-click shows nothing, second opens it" bug:
+        // {@link ngAfterViewInit} calls `settingsState.load()`, which bumps the
+        // settings resource's request and so momentarily resets `settingsSignal()` to
+        // null while it refetches. If `nudgeOnScreen`'s reveal gate (`settingsReady`)
+        // runs during that null window it holds `placed` false, and nothing else
+        // re-runs `place()` when settings land (the size didn't change) — so the popup
+        // strands hidden until the next summon. Re-placing on settings-arrival reveals
+        // it then, keeping the "wait for the real sizes" behaviour (no default-size
+        // flash) while dropping the spurious second click.
+        if (override !== this.lastPreviewOverride || metaShown !== this.lastMetadataShown || !this.placed) {
+          this.lastPreviewOverride = override;
+          this.lastMetadataShown = metaShown;
+          setTimeout(() => this.place());
+        }
+      });
     });
   }
 
   ngAfterViewInit(): void {
-    // Names/thumbnails arrive asynchronously; repaint the metadata column and
-    // the preview pane's labels. (The grid child repaints its own rows.)
-    this.metadataCache.version$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.cdr.markForCheck());
     this.settingsState.load();
     this.prefetchMembers();
     setTimeout(() => this.place());
@@ -511,17 +555,17 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.stopAudio();
   }
 
-  private gridSizeDict: Record<string, string> = {};
+  private readonly gridSizeDict = signal<Record<string, string>>({});
   /** Per-media-type detail-canvas size (px) the user has chosen via the popup's
    *  top-left buttons; absent entries fall back to the radius-derived default. */
-  private previewSizeDict: Record<string, number> = {};
+  private readonly previewSizeDict = signal<Record<string, number>>({});
   /** Last applied preview override, so the settings effect only re-clamps the
    *  popup when the detail-canvas size actually changed. */
   private lastPreviewOverride: number | null = null;
   /** Per-media-type memory of whether the metadata column is shown, mirrored
    *  from the ``popup_metadata_shown`` setting. Absent entries default to hidden
    *  (mirroring the Train/Find center panel's metadata default). */
-  private metadataShownDict: Record<string, boolean> = {};
+  private readonly metadataShownDict = signal<Record<string, boolean>>({});
   /** Last applied column visibility, so the settings effect only re-clamps the
    *  popup when it actually toggled. */
   private lastMetadataShown: boolean | null = null;
@@ -529,7 +573,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  ``browse_details_metadata_width`` setting and driven by the divider between
    *  the metadata column and the large item. Read through {@link
    *  dockedMetadataWidth}, which clamps it against the live panel width. */
-  private metadataWidthPx = 150;
+  private readonly metadataWidthPx = signal(150);
 
   /** True for media types that carry real visual thumbnails (image / video):
    *  the ones that magnify on the main canvas and are worth a large preview. */
@@ -566,7 +610,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  rather than its notes. */
   get metadataShown(): boolean {
     const mediaType = this.mediaType();
-    const value = mediaType ? this.metadataShownDict[mediaType] : undefined;
+    const value = mediaType ? this.metadataShownDict()[mediaType] : undefined;
     return value === true;
   }
 
@@ -588,7 +632,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   toggleMetadata(): void {
     const mediaType = this.mediaType();
     if (!mediaType) return;
-    const dict = { ...this.metadataShownDict, [mediaType]: !this.metadataShown };
+    const dict = { ...this.metadataShownDict(), [mediaType]: !this.metadataShown };
     this.settingsState.update({ popup_metadata_shown: dict } as SettingsUpdate).subscribe();
   }
 
@@ -596,6 +640,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  it has loaded. Everything the column shows reads through this. In docked
    *  audio mode the displayed item follows the auditioning clip. */
   private focusedMedia(): MediaBatchResponse | undefined {
+    // Track the cache version so a batch arrival repaints the metadata column;
+    // the cache itself has no per-item signal. See ``docs/FRONTEND.md`` §5.
+    this.metadataCache.version();
     const id = this.displayedId;
     return id == null ? undefined : this.metadataCache.get(id);
   }
@@ -644,9 +691,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private applyViewPrefs(): void {
     const prevGoal = this.gridGoalWidth;
     const mediaType = this.mediaType();
-    this.gridGoalWidth = iconSizeToGoalWidth(
-      (mediaType && this.gridSizeDict[mediaType]) || 'M',
-    );
+    this._gridGoalWidth.set(iconSizeToGoalWidth(
+      (mediaType && this.gridSizeDict()[mediaType]) || 'M',
+    ));
     if (this.gridGoalWidth !== prevGoal) {
       this.rebuildRows();
       // The row stride changed, so the old scroll offset now points at a
@@ -658,7 +705,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         this.place();
       });
     }
-    this.cdr.markForCheck();
   }
 
   /**
@@ -721,13 +767,13 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   /** Recompute the column count + row chunking for the current thumbnail size. */
   private rebuildRows(): void {
-    this.columns = binGridColumns(this.gridContentWidth(), this.gridGoalWidth);
+    this._columns.set(binGridColumns(this.gridContentWidth(), this.gridGoalWidth));
     const cols = this.columns;
     const rows: number[][] = [];
     for (let i = 0; i < this.ids.length; i += cols) {
       rows.push(this.ids.slice(i, i + cols));
     }
-    this.rows = rows;
+    this._rows.set(rows);
   }
 
   /** Pixel stride of one virtual grid row. Shared with the grid component that
@@ -747,7 +793,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  ``null`` when they haven't set one (and the radius-derived default is used). */
   get previewOverride(): number | null {
     const mediaType = this.mediaType();
-    const value = mediaType ? this.previewSizeDict[mediaType] : undefined;
+    const value = mediaType ? this.previewSizeDict()[mediaType] : undefined;
     return typeof value === 'number' ? value : null;
   }
 
@@ -786,7 +832,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         ? (PREVIEW_SIZE_STEPS.find((s) => s > current) ?? PREVIEW_SIZE_STEPS[PREVIEW_SIZE_STEPS.length - 1])
         : ([...PREVIEW_SIZE_STEPS].reverse().find((s) => s < current) ?? PREVIEW_SIZE_STEPS[0]);
     if (next === this.previewOverride) return;
-    const dict = { ...this.previewSizeDict, [mediaType]: next };
+    const dict = { ...this.previewSizeDict(), [mediaType]: next };
     this.settingsState.update({ popup_preview_size: dict } as SettingsUpdate).subscribe();
   }
 
@@ -886,7 +932,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   get dockedMetadataWidth(): number {
     const content = this.dockedContentWidth();
     const maxWidth = Math.max(DOCKED_META_MIN, content - META_DIVIDER_WIDTH - DOCKED_MAIN_MIN);
-    return Math.round(Math.max(DOCKED_META_MIN, Math.min(this.metadataWidthPx, maxWidth)));
+    return Math.round(Math.max(DOCKED_META_MIN, Math.min(this.metadataWidthPx(), maxWidth)));
   }
 
   /** Side (px) of the square docked detail pane. The large item takes whatever
@@ -907,7 +953,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   // ``browse_details_metadata_width`` (metadata fields are media-agnostic).
 
   /** True only mid-drag of the metadata/item divider (template drag cue). */
-  draggingMeta = false;
+  private readonly _draggingMeta = signal(false);
+  get draggingMeta(): boolean {
+    return this._draggingMeta();
+  }
   private metaDragStartX = 0;
   private metaDragStartWidth = 0;
   private readonly boundMetaMove = this.onMetaDividerMove.bind(this);
@@ -917,7 +966,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   onMetaDividerPointerDown(event: PointerEvent): void {
     if (!this.docked() || event.button !== 0) return;
     event.preventDefault();
-    this.draggingMeta = true;
+    this._draggingMeta.set(true);
     this.metaDragStartX = event.clientX;
     this.metaDragStartWidth = this.dockedMetadataWidth;
     document.addEventListener('pointermove', this.boundMetaMove);
@@ -931,15 +980,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     const dx = event.clientX - this.metaDragStartX;
     const content = this.dockedContentWidth();
     const maxWidth = Math.max(DOCKED_META_MIN, content - META_DIVIDER_WIDTH - DOCKED_MAIN_MIN);
-    this.metadataWidthPx = Math.round(
-      Math.max(DOCKED_META_MIN, Math.min(this.metaDragStartWidth - dx, maxWidth)),
+    this.metadataWidthPx.set(
+      Math.round(Math.max(DOCKED_META_MIN, Math.min(this.metaDragStartWidth - dx, maxWidth))),
     );
-    this.cdr.markForCheck();
   }
 
   private onMetaDividerUp(): void {
     if (!this.draggingMeta) return;
-    this.draggingMeta = false;
+    this._draggingMeta.set(false);
     document.removeEventListener('pointermove', this.boundMetaMove);
     document.removeEventListener('pointerup', this.boundMetaUp);
     // Persist the settled (clamped) width; the settings round-trip returns the
@@ -1091,9 +1139,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     const cur = this.focusIndex();
     const next = Math.max(0, Math.min(this.ids.length - 1, cur + dCol + dRow * this.columns));
     if (next === cur) return;
-    this.previewId = this.ids[next];
+    this._previewId.set(this.ids[next]);
     this.grid()?.revealAndFocus(next);
-    this.cdr.markForCheck();
   }
 
   /** Index of the viewed item within {@link ids}, falling back to the
@@ -1112,7 +1159,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     if (event.button !== 0) return;
     if ((event.target as HTMLElement).closest('button, vt-view-controls')) return;
     event.preventDefault();
-    this.dragging = true;
+    this._dragging.set(true);
     this.dragged = true;
     this.dragStart = { x: event.clientX, y: event.clientY, left: this.left, top: this.top };
     // Keep receiving moves even if the pointer outruns the header.
@@ -1130,7 +1177,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   @HostListener('document:pointerup')
   onPointerUp(): void {
-    this.dragging = false;
+    this._dragging.set(false);
   }
 
   // --- Selection (click stays open so the user can scroll + multi-select) ---
@@ -1149,13 +1196,15 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  Space will act on, regardless of how focus arrived. */
   onEntryFocus(id: number): void {
     if (this.previewId === id) return;
-    this.previewId = id;
-    this.cdr.markForCheck();
+    this._previewId.set(id);
   }
 
   /** True when the item currently shown in the preview pane is selected, so the
    *  large detail image can render the same highlight ring as a grid entry. */
   isPreviewSelected(): boolean {
+    // Track the selection version, so a selection change anywhere (here, the
+    // canvas, the selection panel) re-rings the pane. See ``docs/FRONTEND.md`` §5.
+    this.selection.version();
     const id = this.displayedId;
     return id != null && this.selection.has(id);
   }
@@ -1188,7 +1237,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     // (thumbnail media) and drive the metadata column + focus ring to it (every
     // media type, so audio/text/document read metadata for the item under the
     // cursor even without a preview pane).
-    this.previewId = id;
+    this._previewId.set(id);
     this.playAudio(id);
   }
 
@@ -1202,7 +1251,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     if (this.mediaType() !== 'audio') return;
     const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
     if (this.audioSrc === src) return;
-    this.audioSrc = src;
+    this._audioSrc.set(src);
     this.nowPlayingId = id;
     // The autoplay-on-open path may fire before prefetchVisible has hydrated the
     // representative's metadata, so make sure its clip extents are loading (the
@@ -1281,8 +1330,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.stopAudio();
     // Fall the focus back to the bin's representative so the pane and metadata
     // column stay populated (every media type, matching the hover-follow above).
-    this.previewId = this.representativeId();
-    this.cdr.markForCheck();
+    this._previewId.set(this.representativeId());
   }
 
   private stopAudio(): void {
@@ -1294,7 +1342,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       el.pause();
       el.currentTime = 0;
     }
-    this.audioSrc = '';
+    this._audioSrc.set('');
     this.nowPlayingId = null;
     if (wasPlaying) this.nowPlaying.emit(null);
   }
@@ -1302,6 +1350,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   // --- Names + thumbnails (mirrors the selection panel's treatment) ---------
 
   name(id: number): string {
+    this.metadataCache.version();
     return this.metadataCache.get(id)?.filename || `Clip #${id}`;
   }
 
@@ -1313,6 +1362,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  failed for this id, in which case fall back to the thumbnail. Empty when
    *  there is nothing to preview. */
   previewUrl(): string {
+    // Track the in-place-mutated failure set, so a failed load repaints onto
+    // the thumbnail fallback (see the field's note).
+    this.failedPreviewsVersion();
     const id = this.previewId;
     if (id == null) return '';
     if (this.failedPreviews.has(id)) return this.thumbnailUrl(id);
@@ -1323,7 +1375,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     const id = this.previewId;
     if (id != null && !this.failedPreviews.has(id)) {
       this.failedPreviews.add(id);
-      this.cdr.markForCheck();
+      this.failedPreviewsVersion.update((v) => v + 1);
     }
   }
 
@@ -1347,18 +1399,15 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     // call (e.g. from ngAfterViewInit) will run once it's in the DOM. Staying
     // unplaced keeps the popup hidden until then rather than showing it unclamped.
     if (!this.panelRef()?.nativeElement) return;
-    this.clampInto(this.left, this.top);
-    // Flush the freshly-clamped position and the size caps clampInto just set
-    // (bodyCapPx/previewCapPx/maxWidthPx) to the DOM. This runs in a bare
-    // setTimeout, so under zoneless change detection nothing else schedules a
-    // render; without this markForCheck the clamp would never reach the DOM
-    // until some unrelated event happened to tick CD. The popup stays hidden
+    // The clamp writes signals (position + the bodyCapPx/previewCapPx/maxWidthPx
+    // size caps), so it schedules its own render even though this runs from a
+    // bare setTimeout with no change detection attached. The popup stays hidden
     // (``placed`` is still false) — the actual reveal happens in nudgeOnScreen,
     // on the next frame, once the *rendered* panel has been measured and any
     // residual overflow corrected. Revealing here, before that measurement, was
     // what let the popup flash at the computed clamp and then jump to the
     // corrected spot.
-    this.cdr.markForCheck();
+    this.clampInto(this.left, this.top);
     this.nudgeSettleAttempts = 0;
     this.scheduleNudge();
   }
@@ -1411,8 +1460,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     l = Math.max(regionLeft + EDGE_MARGIN, l);
     t = Math.max(regionTop + EDGE_MARGIN, t);
     const moved = l !== this.left || t !== this.top;
-    this.left = l;
-    this.top = t;
+    this._left.set(l);
+    this._top.set(t);
     // Reveal now that the panel is measured and corrected, so the first painted
     // frame is already at the final on-screen spot. Gate the first reveal on the
     // settings being loaded: the popup's size (grid thumbnail size, whether the
@@ -1422,14 +1471,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     // once settings resolve, which reveals then. Browse only ever mounts with
     // settings present, so this never strands the popup permanently hidden.
     const settingsReady = this.settingsState.settingsSignal() != null;
-    if (!this.placed) {
-      if (settingsReady) {
-        this.placed = true;
-        this.cdr.markForCheck();
-      }
-    } else if (moved) {
-      this.cdr.markForCheck();
-    }
+    if (!this.placed && settingsReady) this._placed.set(true);
     // A correction that actually moved the popup means this pass measured a
     // panel larger than the pre-measurement clamp modelled (e.g. the header or
     // the view-controls settled a hair taller a frame after layout). Moving
@@ -1479,12 +1521,12 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     // The grid column also carries the member-count label above the scroll, so
     // its cap leaves that label room; the scroll then fills what's left.
     const gridRoom = regionRoom - COUNT_LABEL_HEIGHT;
-    this.bodyCapPx = Math.max(MIN_BODY_PX, Math.min(MAX_BODY_PX, gridRoom));
+    this._bodyCapPx.set(Math.max(MIN_BODY_PX, Math.min(MAX_BODY_PX, gridRoom)));
     // The preview gets its own, larger cap: it may grow past the grid's body cap,
     // bounded only by the visible region and the absolute MAX_PREVIEW_PX.
-    this.previewCapPx = Math.max(MIN_PREVIEW_PX, Math.min(MAX_PREVIEW_PX, regionRoom));
+    this._previewCapPx.set(Math.max(MIN_PREVIEW_PX, Math.min(MAX_PREVIEW_PX, regionRoom)));
     // Likewise shrink the overall width to fit a narrow region.
-    this.maxWidthPx = Math.max(0, regionRight - regionLeft - 2 * EDGE_MARGIN);
+    this._maxWidthPx.set(Math.max(0, regionRight - regionLeft - 2 * EDGE_MARGIN));
     // A singleton bin drops the grid column and shows only the preview pane.
     const gridW = this.previewOnly ? 0 : GRID_COLUMN_WIDTH;
     const paneW = this.previewPaneSize;
@@ -1514,9 +1556,8 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
       t = regionBottom - height - EDGE_MARGIN;
     }
     // Never push the top-left off the opposite edge (popup larger than region).
-    this.left = Math.max(regionLeft + EDGE_MARGIN, l);
-    this.top = Math.max(regionTop + EDGE_MARGIN, t);
-    this.cdr.markForCheck();
+    this._left.set(Math.max(regionLeft + EDGE_MARGIN, l));
+    this._top.set(Math.max(regionTop + EDGE_MARGIN, t));
   }
 
   /**

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { signal } from '@angular/core';
-import { of, Subject } from 'rxjs';
+import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BrowseBinPopupComponent } from './browse-bin-popup.component';
@@ -53,6 +53,7 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     };
     const metadataStub: Partial<MediaMetadataCacheService> = {
       version$: of(0),
+      version: signal(0),
       get: () => undefined,
       ensureLoaded: () => {},
     };
@@ -351,6 +352,7 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
     };
     const metadataStub: Partial<MediaMetadataCacheService> = {
       version$: of(0),
+      version: signal(0),
       get: () => undefined,
       ensureLoaded: () => {},
     };
@@ -457,7 +459,7 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
     const cmp = fixture.componentInstance;
     // The grid column is present (not dropped like the floating previewOnly path)…
     const root = fixture.nativeElement as HTMLElement;
-    expect(root.querySelector('.bin-popup-grid-col')).not.toBeNull();
+    expect(root.querySelector('vt-browse-bin-member-grid')).not.toBeNull();
     // …but renders no rows: the lone item lives in the detail pane above.
     expect(cmp.displayRows.length).toBe(0);
 
@@ -655,70 +657,16 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
   });
 });
 
-describe('BrowseBinPopupComponent (scroll-prefetch re-wiring)', () => {
-  it('re-subscribes prefetch when the member-grid viewport is recreated', () => {
-    // Regression: the popup subscribed scrolledIndexChange only once, but the
-    // viewport lives behind @if (!previewOnly) and the popup is reused across
-    // summons (right-clicking another bin only swaps inputs). A singleton→multi
-    // transition created a fresh viewport whose stream was never subscribed, so
-    // scrolling the member grid never hydrated thumbnails beyond the
-    // initially-prefetched window. In production a constructor effect tracking
-    // the `viewport` view-query signal re-runs ensureScrollSubscription
-    // whenever the instance changes; here the query is stubbed as a plain
-    // function and the method driven directly, since the virtualized grid
-    // doesn't render reliably under jsdom.
-    const component = Object.create(
-      BrowseBinPopupComponent.prototype,
-    ) as BrowseBinPopupComponent;
-    const state = component as unknown as {
-      viewport: () => unknown;
-      scrollSub: unknown;
-      scrollSubscribedViewport: unknown;
-      prefetchVisible(): void;
-      ensureScrollSubscription(): void;
-    };
-    state.scrollSub = null;
-    state.scrollSubscribedViewport = null;
-    const prefetchSpy = vi.fn();
-    state.prefetchVisible = prefetchSpy;
-
-    const vp1 = { scrolledIndexChange: new Subject<number>() };
-    state.viewport = () => vp1;
-    state.ensureScrollSubscription();
-    vp1.scrolledIndexChange.next(0);
-    const callsAfterFirstScroll = prefetchSpy.mock.calls.length;
-    expect(callsAfterFirstScroll).toBeGreaterThan(0);
-
-    // Viewport destroyed (previewOnly summon) …
-    vp1.scrolledIndexChange.complete();
-    state.viewport = () => undefined;
-    state.ensureScrollSubscription();
-
-    // … then a new multi-member summon creates a fresh instance.
-    const vp2 = { scrolledIndexChange: new Subject<number>() };
-    state.viewport = () => vp2;
-    state.ensureScrollSubscription();
-
-    const callsBeforeSecondScroll = prefetchSpy.mock.calls.length;
-    vp2.scrolledIndexChange.next(2);
-    expect(prefetchSpy.mock.calls.length).toBe(callsBeforeSecondScroll + 1);
-  });
-});
-
 /**
- * Keyboard focus sync for the member grid.
+ * Keyboard walk of the viewed item.
  *
- * Arrow keys walk the highlighted item (``previewId``), but before this they
- * left DOM focus behind on whatever entry the user last tabbed/clicked. Enter is
- * only caught by the focused entry's own handler, so it toggled the stale
- * DOM-focused entry rather than the arrow-walked one; Space fired both the
- * document fallback and the focused entry, double-toggling. The fix keeps DOM
- * focus glued to the walked entry (and ``previewId`` glued to DOM focus), and
- * lets the focused entry own its activation without the fallback double-firing.
- *
- * The member grid is virtualized and doesn't render individual entries reliably
- * under jsdom, so these drive the sync contract directly on the component rather
- * than through a rendered ArrowRight → ``document.activeElement`` round-trip.
+ * Arrow keys move `previewId` through the bin, and the grid child is told to
+ * scroll that entry into view and take DOM focus, so Enter/Space act on the
+ * highlighted item rather than on whatever entry last held focus. The focus
+ * mechanics themselves live in (and are tested by) the grid component; what this
+ * pins is that the shell walks the right index and hands it over. The grid is
+ * virtualized and does not render under jsdom, so the contract is driven on the
+ * instance rather than through a rendered ArrowRight round-trip.
  */
 describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
   interface GridState {
@@ -726,98 +674,63 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
     columns: number;
     previewId: number | null;
     cdr: { markForCheck: () => void };
-    // The `panelRef` view query is a signal; stub it as a plain function.
-    panelRef?: () => { nativeElement: { querySelector: (sel: string) => HTMLElement | null } };
+    grid: () => { revealAndFocus: (index: number) => void } | undefined;
     mediaType: () => string;
     mediaTypeCaps: { usesThumbnails: (t: string) => boolean };
-    scrollRowIntoView: (index: number) => void;
     selection: { has: (id: number) => boolean; addAll: (ids: number[]) => void; remove: (id: number) => void };
     moveFocus(dCol: number, dRow: number): void;
   }
 
-  function makeGridComponent(): { component: BrowseBinPopupComponent; state: GridState } {
+  function makeGridComponent(): { component: BrowseBinPopupComponent; state: GridState; revealed: number[] } {
     const component = Object.create(BrowseBinPopupComponent.prototype) as BrowseBinPopupComponent;
     const state = component as unknown as GridState;
+    const revealed: number[] = [];
     state.ids = [10, 20, 30, 40];
     state.columns = 2;
     state.previewId = 10;
     state.cdr = { markForCheck: vi.fn() };
+    state.grid = () => ({ revealAndFocus: (index: number) => revealed.push(index) });
     // Non-thumbnail media so `previewOnly` is false and the grid path is live.
     state.mediaType = () => 'text';
     state.mediaTypeCaps = { usesThumbnails: (t: string) => t !== 'text' };
-    state.scrollRowIntoView = vi.fn();
     state.selection = { has: () => false, addAll: vi.fn(), remove: vi.fn() };
-    return { component, state };
+    return { component, state, revealed };
   }
 
-  let rafSpy: ReturnType<typeof vi.spyOn>;
-  beforeEach(() => {
-    // Run rAF synchronously so `focusEntry`'s deferred (and retried) focus lands
-    // within the test tick, deterministically.
-    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
-      cb(0);
-      return 0;
-    });
-  });
-  afterEach(() => rafSpy.mockRestore());
-
-  it('moves DOM focus to the arrow-walked entry', () => {
-    const { component, state } = makeGridComponent();
-    const walked = { focus: vi.fn() } as unknown as HTMLElement;
-    state.panelRef = () => ({
-      nativeElement: {
-        // Only the entry for id 20 (the ArrowRight target from index 0) exists.
-        querySelector: (sel: string) => (sel.includes('"20"') ? walked : null),
-      },
-    });
+  it('walks the viewed item and hands the entry to the grid to reveal + focus', () => {
+    const { state, revealed } = makeGridComponent();
 
     state.moveFocus(1, 0);
 
     // The highlight advanced to id 20 …
     expect(state.previewId).toBe(20);
-    // … and DOM focus followed it, so Enter/Space now act on the highlighted item.
-    expect(walked.focus).toHaveBeenCalledWith({ preventScroll: true });
+    // … and the grid was told to scroll it in and take DOM focus, so Enter/Space
+    // now act on the highlighted item.
+    expect(revealed).toEqual([1]);
   });
 
-  it('retries the focus until the virtualized entry renders, then focuses it', () => {
-    const { state } = makeGridComponent();
-    const walked = { focus: vi.fn() } as unknown as HTMLElement;
-    let calls = 0;
-    state.panelRef = () => ({
-      nativeElement: {
-        // Absent for the first two frames (row still virtualizing in), then in.
-        querySelector: (sel: string) => {
-          if (!sel.includes('"20"')) return null;
-          return ++calls >= 3 ? walked : null;
-        },
-      },
-    });
+  it('walks a whole row at a time for vertical steps', () => {
+    const { state, revealed } = makeGridComponent();
 
-    state.moveFocus(1, 0);
+    state.moveFocus(0, 1);
 
-    expect(walked.focus).toHaveBeenCalledTimes(1);
+    expect(state.previewId).toBe(30);
+    expect(revealed).toEqual([2]);
+  });
+
+  it('clamps at the ends of the bin rather than walking off it', () => {
+    const { state, revealed } = makeGridComponent();
+
+    state.moveFocus(-1, 0);
+
+    // Already on the first member: nothing moved, and the grid was not disturbed.
+    expect(state.previewId).toBe(10);
+    expect(revealed).toEqual([]);
   });
 
   it('syncs the highlight to DOM focus that arrives by Tab or click', () => {
     const { component, state } = makeGridComponent();
     component.onEntryFocus(30);
     expect(state.previewId).toBe(30);
-  });
-
-  it('lets the focused entry own its activation, stopping the fallback double-toggle', () => {
-    const { component, state } = makeGridComponent();
-    const event = {
-      key: 'Enter',
-      preventDefault: vi.fn(),
-      stopPropagation: vi.fn(),
-    } as unknown as KeyboardEvent;
-
-    component.onEntryKeydown(event, 42);
-
-    expect(event.preventDefault).toHaveBeenCalled();
-    // The bubble is stopped so the document-level Space fallback (which acts on
-    // previewId) can't also fire and cancel this toggle.
-    expect(event.stopPropagation).toHaveBeenCalled();
-    expect(state.selection.addAll).toHaveBeenCalledWith([42]);
   });
 });

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import { signal, type WritableSignal } from '@angular/core';
 import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -669,15 +669,15 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
  * instance rather than through a rendered ArrowRight round-trip.
  */
 describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
+  // The rendered state is signal-backed behind read-only getters, so the stub
+  // seeds the backing signals and asserts through the public getters.
   interface GridState {
-    ids: number[];
-    columns: number;
-    previewId: number | null;
-    cdr: { markForCheck: () => void };
+    _ids: WritableSignal<number[]>;
+    _columns: WritableSignal<number>;
+    _previewId: WritableSignal<number | null>;
     grid: () => { revealAndFocus: (index: number) => void } | undefined;
     mediaType: () => string;
     mediaTypeCaps: { usesThumbnails: (t: string) => boolean };
-    selection: { has: (id: number) => boolean; addAll: (ids: number[]) => void; remove: (id: number) => void };
     moveFocus(dCol: number, dRow: number): void;
   }
 
@@ -685,52 +685,50 @@ describe('BrowseBinPopupComponent (keyboard focus sync)', () => {
     const component = Object.create(BrowseBinPopupComponent.prototype) as BrowseBinPopupComponent;
     const state = component as unknown as GridState;
     const revealed: number[] = [];
-    state.ids = [10, 20, 30, 40];
-    state.columns = 2;
-    state.previewId = 10;
-    state.cdr = { markForCheck: vi.fn() };
+    state._ids = signal([10, 20, 30, 40]);
+    state._columns = signal(2);
+    state._previewId = signal<number | null>(10);
     state.grid = () => ({ revealAndFocus: (index: number) => revealed.push(index) });
     // Non-thumbnail media so `previewOnly` is false and the grid path is live.
     state.mediaType = () => 'text';
     state.mediaTypeCaps = { usesThumbnails: (t: string) => t !== 'text' };
-    state.selection = { has: () => false, addAll: vi.fn(), remove: vi.fn() };
     return { component, state, revealed };
   }
 
   it('walks the viewed item and hands the entry to the grid to reveal + focus', () => {
-    const { state, revealed } = makeGridComponent();
+    const { component, state, revealed } = makeGridComponent();
 
     state.moveFocus(1, 0);
 
     // The highlight advanced to id 20 …
-    expect(state.previewId).toBe(20);
+    expect(component.previewId).toBe(20);
     // … and the grid was told to scroll it in and take DOM focus, so Enter/Space
     // now act on the highlighted item.
     expect(revealed).toEqual([1]);
   });
 
   it('walks a whole row at a time for vertical steps', () => {
-    const { state, revealed } = makeGridComponent();
+    const { component, state, revealed } = makeGridComponent();
 
     state.moveFocus(0, 1);
 
-    expect(state.previewId).toBe(30);
+    expect(component.previewId).toBe(30);
     expect(revealed).toEqual([2]);
   });
 
   it('clamps at the ends of the bin rather than walking off it', () => {
-    const { state, revealed } = makeGridComponent();
+    const { component, state, revealed } = makeGridComponent();
 
     state.moveFocus(-1, 0);
 
     // Already on the first member: nothing moved, and the grid was not disturbed.
-    expect(state.previewId).toBe(10);
+    expect(component.previewId).toBe(10);
     expect(revealed).toEqual([]);
   });
 
   it('syncs the highlight to DOM focus that arrives by Tab or click', () => {
-    const { component, state } = makeGridComponent();
+    const { component } = makeGridComponent();
     component.onEntryFocus(30);
-    expect(state.previewId).toBe(30);
+    expect(component.previewId).toBe(30);
   });
 });

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy, inject } from '@angular/core';
+import { Injectable, OnDestroy, inject, signal } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
@@ -46,6 +46,20 @@ export class MediaMetadataCacheService implements OnDestroy {
   private readonly versionSubject = new BehaviorSubject<number>(0);
   readonly version$ = this.versionSubject.asObservable();
 
+  /**
+   * The same cache version as a signal.
+   *
+   * A component that renders cached values reads this inside the expression
+   * that reads the cache (``version(); return get(id)?.filename``), which makes
+   * the batch arrival a tracked dependency of that view — so it repaints itself
+   * under zoneless change detection with no ``markForCheck()`` bridge. Prefer it
+   * over subscribing to {@link version$}, which notifies nobody on its own; see
+   * ``docs/FRONTEND.md`` §5. The observable stays for the consumers that still
+   * bridge it manually.
+   */
+  private readonly versionSignal = signal(0);
+  readonly version = this.versionSignal.asReadonly();
+
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
@@ -71,7 +85,7 @@ export class MediaMetadataCacheService implements OnDestroy {
   clear(): void {
     this.cache.clear();
     this.pendingByDataset.clear();
-    this.versionSubject.next(0);
+    this.bumpVersion(0);
   }
 
   /**
@@ -108,6 +122,13 @@ export class MediaMetadataCacheService implements OnDestroy {
   // ---------------------------------------------------------------------------
   // Internal
   // ---------------------------------------------------------------------------
+
+  /** Publish a new cache version on both channels, so the observable bridges
+   *  and the signal readers stay in lockstep. */
+  private bumpVersion(next: number): void {
+    this.versionSubject.next(next);
+    this.versionSignal.set(next);
+  }
 
   private keyFor(datasetId: string, id: number): string {
     return `${datasetId}:${id}`;
@@ -157,7 +178,7 @@ export class MediaMetadataCacheService implements OnDestroy {
             for (const item of items) {
               this.cache.set(this.keyFor(datasetId, item.id), item);
             }
-            this.versionSubject.next(this.versionSubject.value + 1);
+            this.bumpVersion(this.versionSubject.value + 1);
           },
           error: () => {
             // Re-queue failed IDs under the dataset that issued the

--- a/frontend/src/app/utils/bin-grid-metrics.ts
+++ b/frontend/src/app/utils/bin-grid-metrics.ts
@@ -1,0 +1,52 @@
+/**
+ * Geometry shared by the bin details' member grid and the floating popup shell
+ * that positions itself around it.
+ *
+ * These live outside both components because each needs the same numbers for a
+ * different reason: {@link BrowseBinMemberGridComponent} lays the grid out and
+ * drives its virtual viewport with them, while ``BrowseBinPopupComponent``
+ * models the rendered popup's height/width from them when it clamps itself onto
+ * the visible canvas. A private copy in either place would let the clamp drift
+ * from what the grid actually renders — which shows up as a popup whose floor
+ * sits just off-screen, the exact class of bug the clamp exists to prevent.
+ */
+
+/** Vertical padding (px) inside every grid cell (``.bin-popup-entry`` 2px top +
+ *  2px bottom), always present regardless of icon size. Reserved in {@link
+ *  binGridRowSize} so the cell's real rendered height never exceeds its virtual
+ *  slot. */
+export const GRID_CELL_PADDING = 4;
+
+/** Gap (px) between grid cells (and grid rows); matches ``--space-2xs``-ish. */
+export const GRID_GAP = 4;
+
+/** Width (px) available to lay out cells inside the popup's scroll column (≈ its
+ *  width minus padding and the scrollbar). Columns are derived from this. */
+export const GRID_CONTENT_WIDTH = 256;
+
+/** Width (px) of the scrolling grid column; mirrors the historic popup width. */
+export const GRID_COLUMN_WIDTH = 280;
+
+/** Vertical room (px) the member-count label takes above the scrolling grid. */
+export const COUNT_LABEL_HEIGHT = 22;
+
+/**
+ * Pixel stride of one virtual grid row: the thumbnail plus its always-present
+ * vertical cell padding and an inter-row gap. The grid prints no name under each
+ * thumbnail, so only the thumbnail and padding contribute; accounting for the
+ * cell padding keeps the row's rendered content from overflowing its virtual
+ * slot by a sub-pixel, which would otherwise force a stray scrollbar on even a
+ * single row.
+ */
+export function binGridRowSize(cellWidth: number): number {
+  return cellWidth + GRID_CELL_PADDING + GRID_GAP;
+}
+
+/**
+ * How many fixed-width cells fit across ``contentWidth``. At least one, so a
+ * panel narrower than a single thumbnail still chunks into one-item rows rather
+ * than dividing by zero.
+ */
+export function binGridColumns(contentWidth: number, cellWidth: number): number {
+  return Math.max(1, Math.floor((contentWidth + GRID_GAP) / (cellWidth + GRID_GAP)));
+}


### PR DESCRIPTION
Closes #3423

`browse-bin-popup` carried the app's largest component stylesheet by 39% — **7,688 bytes against the 8 kB `anyComponentStyle` budget** that `run-tests.sh` treats as a hard failure. That is 504 bytes of headroom, not the ~800 the issue estimated, and there was no cheap way under it: every selector in the sheet is live, and moving the chrome rules to global SCSS would spend a scarcer budget (`styles.css` counts toward the initial total, which sits at 517 kB against a 520 kB limit).

It was also the only large component with **zero internal reactive state** — 0 `signal()`/`computed()` against 32 in `browse-view` and 16 in `dashboard` — with 14 `markForCheck()` calls standing in for the notifications its plain fields didn't send.

## (a) The member grid becomes its own component

`BrowseBinMemberGridComponent` takes the virtualized thumbnail grid, its select-all header, and all of the virtual viewport's mechanics: scroll-driven metadata prefetch, centring a row, moving DOM focus onto an entry that hasn't virtualized in yet. The shell keeps what the grid can't own — what to show, what's being viewed, and the floating window's summon/drag/clamp machinery — and reaches in through `prefetchVisible` / `centreOn` / `revealAndFocus`.

The stylesheet splits **5,040 / 2,607** bytes. That is 41 bytes *fewer* in total, so nothing was duplicated to get there, and the shell now has 3,152 bytes of headroom. The docked descendant overrides become `:host(.docked)` rules in the child, since a parent sheet can't reach into a child under emulated view encapsulation.

Row geometry both halves need moved to `utils/bin-grid-metrics`, so the shell's clamp can no longer model a row height the grid doesn't use — the drift that shows up as a popup whose floor sits just off-screen.

## (b) Signalizing, and all 14 CD calls

Each rendered field is now a signal read through a plain getter — the shape `docs/FRONTEND.md` §5 sanctions — so every read site and the whole template stay byte-identical while the writes schedule their own render. Most of those writes happen *outside* change detection (a bare `setTimeout` in `place()`, the `afterNextRender` in `nudgeOnScreen()`, a document-level pointer move), which is why each site previously needed its own bridge, and why a forgotten one is a silent stale view. That accounts for 11 of the calls.

The other three were bridges from services with no per-item signal, and deleting them outright would have broken selection highlighting and async thumbnail arrival. Instead the expressions that read those services now read their version signal first — `selection.version()` in `isPreviewSelected()`, `metadataCache.version()` in `focusedMedia()`/`name()` — which makes the read a tracked dependency of the view and *retires* the bridge rather than removing it. `MediaMetadataCacheService` grows a `version` signal beside its existing `version$` (additive; the four other components that bridge the observable are untouched).

The settings effect now names its two triggers and runs its body `untracked`: it both reads and writes the view-pref signals, so a tracked body would re-arm on its own writes. Naming `mediaType()` explicitly preserves the media-type re-place that used to arrive implicitly through `previewOverride`.

## Rebased onto #3462; how the overlap with `dev` was resolved

`dev` landed "Converge subscription teardown on `takeUntilDestroyed()`" (99d365f) on this same file while the PR was open. Its change here is **subsumed**: it converted the `metadataCache.version$` subscription from a `subs[]` array onto `takeUntilDestroyed()`, and (b) deletes that subscription outright in favour of the in-expression `version()` read. Its intent is satisfied more strongly — there is nothing left to tear down, and the popup now holds no `Subscription` at all.

That commit also documents `browse-bin-popup`'s `scrollSub` as *cancellation, not teardown* — deliberately left on manual unsubscribe because `takeUntilDestroyed()` cannot express cancel-the-previous. That field moved into the grid child here, still re-assigned and still unsubscribing the previous value, so it continues to follow the rule; the last commit repoints the `docs/FRONTEND.md` example at the component that now holds it.

## Verification

`./run-tests.sh` **after the rebase**: **RUN PASSED** — 9668 passed, 6 skipped; pyright, pip-audit, `vulture` whitelist, npm audit and the Vitest suite all green. `build:prod` emits no budget warning.

Because the reactivity claims are exactly the kind jsdom cannot check, the rendered behaviour was also driven in **real chromium** against the `syn-imgs` fixture — 20 assertions, all passing (re-run after the rebase, identical numbers), each about what actually painted after a write outside change detection:

- the docked panel mounts the extracted grid, empty hint and all; right-click fills it
- clicking an entry rings it, and the detail pane tracks the same selection (the `selection.version()` read, with the old effect gone)
- select-all rings and clears all five members
- **the metadata column resizes *during* a divider drag** (150 → 214px) and the width survives the settings round-trip on release — this one is the load-bearing test, since `onMetaDividerMove` runs from a document-level `pointermove` with no template event and no CD attached
- a thumbnail-size change re-lays the grid through the now-`untracked` settings effect
- the floating window reveals itself (`visibility: visible`, i.e. the `placed` signal reached the DOM), clamps fully on-screen, and **moves under a header drag** (y 271 → 391) and stays put on release
- ArrowRight walks the focus ring and DOM focus follows it (`previewId` signal → `grid.revealAndFocus`)

The verification script is deliberately not committed: `run-tests.sh` stays browser-free by design.

## Notes on the issue's framing

Three corrections, none of which change the conclusion that the work was worth doing:

- **"Zero signals" was wrong as written** — the component had 12 signal `input()`s and 4 `viewChild()` signals. The accurate claim is zero *internal* reactive state.
- **"This halves the SCSS per component" is the wrong argument**, and the wrong number (it's 65/35). `anyComponentStyle` is a *per-stylesheet* budget, so a split ships identical CSS; if clearing the budget were the only merit this would be a budget bump in disguise. It's justified on decomposition merits, with the budget relief as a consequence.
- **"Delete the manual CD calls" is unsafe taken literally** — three of the fourteen were load-bearing bridges. They're retired here by a different mechanism, not deleted.

The shell is 1726 → 1581 lines; with the 345-line child that is ~200 lines more overall, since the signal getters and the child's documented API cost more than the moved code saved. What actually shrank is the stylesheet pressure and the manual-CD surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JY2B4c4y9F7G4bYsPSm9ei