### PR TITLE
Extract browse-canvas's thumbnail store and prefetch geometry

### DIFF
--- a/docs/plans/codebase-audit-2026-08.md
+++ b/docs/plans/codebase-audit-2026-08.md
@@ -236,26 +236,6 @@ ship on its own.
 
 <!-- item-sep -->
 
-### Frontend — browse surface
-
-<!-- item-sep -->
-
-- **Idle thumbnail preloader fetches full-resolution originals once the full-res tier engages, unbounded in bytes** — `frontend/src/app/components/browse-canvas/browse-canvas.component.ts:1950` (medium impact)
-
-  `useFullResThumbs` (line 668) flips `startThumbLoad` to the uncapped `/image` endpoint (line 1950), justified by the comment "Only a handful of such giant cells fit on screen at once, so the LRU still bounds memory". But the idle preloader (`runThumbPrefetch` → `warmThumbsForTiles` → `startThumbLoad(cell.rep_id, true)`, line 2165) shares the same tier and the same 2048-entry `MAX_THUMBS` cap: at a large thumbnail size (4XL/5XL crosses the 384px threshold at dpr 1), every idle pass warms up to 64 OFF-SCREEN cells — the pan ring plus the finer level's cells — with full-resolution originals, up to 2048 of them. For a photo dataset that is potentially gigabytes of image data fetched and retained for cells the user may never see; the cache bound is a count, not bytes, so the stated memory reasoning doesn't hold for the preload path. The benefit of fixing this is bounded memory/network at high zoom, where the app is otherwise most responsive.
-
-  *Direction:* Have preload (`preload === true`) always fetch the capped `/thumbnail` regardless of tier (a later on-screen paint upgrades it), or shrink the LRU cap sharply while `thumbsAreFullRes` is active.
-
-<!-- item-sep -->
-
-- **A transient thumbnail load failure permanently blanks that cell until the projection changes** — `frontend/src/app/components/browse-canvas/browse-canvas.component.ts:1939` (low impact)
-
-  `img.onerror` (line 1939-1942) adds the rep id to `thumbFailed`, and every subsequent `getThumb`/preload skips it forever — `thumbFailed` is only cleared on a projection switch or a resolution-tier crossing. A single transient failure (server restart, brief network blip, one 502 during a burst of 64 preload fetches) therefore leaves that bin rendered as flat density shading among thumbnails for the rest of the session, with no retry path and no user-visible way to recover short of leaving the view. The `onerror` also fires no redraw, relying on the 12s first-view backstop timer for the opening view.
-
-  *Direction:* Treat failures as retryable: store a failure timestamp and retry after a backoff (or cap retries per id), and/or clear `thumbFailed` on `zoomToFit`/manual refresh actions.
-
-<!-- item-sep -->
-
 ### Frontend — dashboard & modals
 
 <!-- item-sep -->

--- a/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
+++ b/frontend/src/app/components/browse-canvas/browse-canvas.component.ts
@@ -48,6 +48,15 @@ import {
   type BrowseGraphicsMode,
 } from './render-perf';
 import { onDevicePixelRatioChange } from '../../utils/device-pixel-ratio';
+import { MAX_THUMBS, THUMB_NATIVE_MAX_DIM, ThumbStore } from './thumb-store';
+import {
+  finerTilesForZoom,
+  offViewRing,
+  smoothPanDirection,
+  tilesAtLevel,
+  type PanDirection,
+  type TileCoord,
+} from './prefetch-geometry';
 import type {
   HexCellPayload,
   ProjectionMeta,
@@ -115,11 +124,10 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
   /** On-screen bin radius (CSS px) the "M" thumbnail size targets, and the
    * default before any saved size is applied. See {@link targetRadius}. */
   static readonly DEFAULT_TARGET_RADIUS = 28;
-  /** Longest side (px) the ``/thumbnail`` route caps images at (mirrors
-   * ``vtscore`` ``DEFAULT_MAX_DIM``). Once a cell is drawn wider than this the
-   * capped thumbnail would upscale, so at those zoom levels the canvas fetches
-   * the full-res ``/image`` instead. See {@link useFullResThumbs}. */
-  static readonly THUMB_NATIVE_MAX_DIM = 384;
+  /** Longest side (px) the ``/thumbnail`` route caps images at. Re-exported
+   * from `thumb-store.ts` (which owns the tier the constant defines) so the
+   * browse toolbar's size pulldown can keep reading it off the component. */
+  static readonly THUMB_NATIVE_MAX_DIM = THUMB_NATIVE_MAX_DIM;
   /**
    * Target on-screen bin radius in CSS px: the size each bin/thumbnail aims to
    * render at. Level selection picks the pyramid level whose bins land closest
@@ -214,22 +222,17 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
    */
   readonly firstViewReady = output<void>();
 
-  /** Loaded representative thumbnails, keyed by media id (insertion-ordered LRU). */
-  private thumbCache = new Map<number, HTMLImageElement>();
-  /** Media ids whose thumbnail failed to load, so we don't retry every frame. */
-  private thumbFailed = new Set<number>();
-  private readonly MAX_THUMBS = 2048;
-  /** Audio waveform thumbnails are theme-agnostic alpha masks (issue #2369);
-   *  this caches each one tinted to the current theme's accent colour so the
-   *  {@link ImageBitmap}-style ``source-in`` fill runs once per (clip, theme),
-   *  not per frame. Cleared whenever the raw {@link thumbCache} is (dataset /
-   *  level switch) and — via {@link retintWaveforms} — on a theme flip. */
-  private tintedThumbCache = new Map<number, HTMLCanvasElement>();
-  /** Resolution tier the {@link thumbCache} is currently filled at. Flips to
-   * ``true`` once the zoom is large enough that {@link getThumb} fetches the
-   * full-res ``/image`` instead of the capped ``/thumbnail``; crossing the
-   * threshold drops the cache so cells reload at the matching resolution. */
-  private thumbsAreFullRes = false;
+  /**
+   * Representative-thumbnail cache: the LRU of decoded images, the tinted
+   * waveform masks, the resolution tier, and the retry backoff for failed
+   * loads. See `thumb-store.ts`; the canvas only decides *which* ids to ask
+   * for, never how they are fetched or retained.
+   */
+  private readonly thumbs = new ThumbStore({
+    mediaUrl: (path) => this.activeContext.mediaUrl(path),
+    onLoaded: () => this.requestRedraw(),
+    accent: () => this.waveAccent,
+  });
   /** Cap on new thumbnail fetches kicked off per idle preload pass, so a fast
    * pan can warm the just-revealed ring without flooding the network or filling
    * the thumbnail cache in a single burst. */
@@ -249,9 +252,9 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
    * centre it was last measured from. Biases which off-view tiles warm first:
    * the preload ring extends one tile further on the leading edges so a sustained
    * pan stays ahead of the motion. Decays toward zero when the view holds still,
-   * so a stationary view warms its ring symmetrically. */
-  private panDirX = 0;
-  private panDirY = 0;
+   * so a stationary view warms its ring symmetrically. See
+   * {@link smoothPanDirection}. */
+  private panDir: PanDirection = { x: 0, y: 0 };
   private lastDrawCenterX = Number.NaN;
   private lastDrawCenterY = Number.NaN;
 
@@ -616,9 +619,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
         // A brand-new projection opens auto-fit: clear the user-framed flag so a
         // saved cell size applied right after load re-fits to keep it all in view.
         this.framedByUser = false;
-        this.thumbCache.clear();
-        this.thumbFailed.clear();
-        this.tintedThumbCache.clear();
+        this.thumbs.clear();
         // A new projection (media-type switch / rebuild) re-lays-out every item,
         // so the old selection no longer maps to what's on screen — drop it. A
         // bin-shape toggle keeps the same projection id and selection, since the
@@ -674,24 +675,12 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     return this.mediaTypeCaps.usesThumbnails(this.mediaType());
   }
 
-  /** At the largest zoom levels a cell is drawn wider (in device px) than the
-   * thumbnail's native longest side, so painting the capped ``/thumbnail`` would
-   * just upscale a blurry bitmap. Past that point fetch the full-res ``/image``
-   * instead. Only a handful of such giant cells fit on screen at once, so the
-   * LRU still bounds memory. */
-  private get useFullResThumbs(): boolean {
-    return 2 * this.targetRadius * this.dpr > BrowseCanvasComponent.THUMB_NATIVE_MAX_DIM;
-  }
-
-  /** Drop the thumbnail cache when the zoom crosses the full-res threshold so
-   * cells reload at the resolution matching the new tier. Cheap no-op while the
-   * tier is unchanged. */
+  /** Push the current cell size / pixel density at the thumb store, which drops
+   * its cache when the zoom crosses the full-res threshold so cells reload at
+   * the resolution matching the new tier. Cheap no-op while the tier is
+   * unchanged. See {@link ThumbStore.wantsFullRes}. */
   private syncThumbResolutionTier(): void {
-    if (this.useFullResThumbs === this.thumbsAreFullRes) return;
-    this.thumbsAreFullRes = this.useFullResThumbs;
-    this.thumbCache.clear();
-    this.thumbFailed.clear();
-    this.tintedThumbCache.clear();
+    this.thumbs.setFullRes(ThumbStore.wantsFullRes(this.targetRadius, this.dpr));
   }
 
   /** Geometry (hex or square) for the active projection's bin shape. */
@@ -747,7 +736,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
       // drop the tinted cache (issue #2369); each visible wave re-tints on the
       // redraw below. The raw mask cache is untouched — the masks are
       // theme-agnostic, so nothing needs re-fetching.
-      this.tintedThumbCache.clear();
+      this.thumbs.clearTinted();
       this.requestRedraw();
     });
     this.themeObserver.observe(document.documentElement, {
@@ -798,9 +787,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     }
     document.removeEventListener('mousemove', this.boundMouseMove);
     document.removeEventListener('mouseup', this.boundMouseUp);
-    this.thumbCache.clear();
-    this.thumbFailed.clear();
-    this.tintedThumbCache.clear();
+    this.thumbs.clear();
   }
 
   private resize(): void {
@@ -1106,7 +1093,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
    * sit just outside the frozen viewport. `sctx` is the snapshot context with a
    * CSS-px (dpr) transform already applied and the buffer centred on
    * {@link animFrom}'s centre. Only cells whose tile is already cached are drawn
-   * (and `getThumb` paints whatever the prefetch warmed), so the fill reaches as
+   * (and the thumb store paints whatever the prefetch warmed), so the fill reaches as
    * far as the cache does and falls off to background past it — never a network
    * wait. The centre is left for the frozen viewport copy to overwrite.
    */
@@ -1532,11 +1519,11 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
         const [sx, sy] = this.projToScreen(cell.cx, cell.cy);
         if (sx < -screenRadius * 2 || sx > this.width + screenRadius * 2) continue;
         if (sy < -screenRadius * 2 || sy > this.height + screenRadius * 2) continue;
-        if (this.thumbFailed.has(cell.rep_id)) continue;
+        if (this.thumbs.failed(cell.rep_id)) continue;
         // draw() already kicked off the load for every drawn cell; here we only
         // read whether it has decoded. A missing / still-decoding image holds
         // the reveal (its onload fires a redraw that re-checks).
-        const img = this.thumbCache.get(cell.rep_id);
+        const img = this.thumbs.peek(cell.rep_id);
         if (!img || !img.complete || img.naturalWidth === 0) return;
       }
     }
@@ -1701,7 +1688,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // inside the bin's border. The hovered cell (either type) instead draws the
     // whole thumbnail to fill `trim`, whose rectangle already carries the
     // image's aspect ratio, so it shows undistorted and uncropped.
-    const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
+    const thumb = this.thumbnailMode ? this.thumbs.get(cell.rep_id) : null;
     if (thumb) {
       ctx.save();
       ctx.clip();
@@ -1712,7 +1699,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
         // recolours on a theme flip instead of showing baked-in pixels.
         ctx.fillStyle = this.waveSurface;
         ctx.fill();
-        const tinted = this.getTintedThumb(cell.rep_id, thumb);
+        const tinted = this.thumbs.tinted(cell.rep_id, thumb);
         if (trim) {
           ctx.drawImage(tinted, cx - trim.hw, cy - trim.hh, trim.hw * 2, trim.hh * 2);
         } else {
@@ -1815,7 +1802,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // singleton (`traceTrimRect`). A non-thumbnail (flat density) cell has no
     // such rectangle, so it keeps its silhouette and simply lifts off with a
     // fixed size bump.
-    const thumb = this.thumbnailMode ? this.getThumb(cell.rep_id) : null;
+    const thumb = this.thumbnailMode ? this.thumbs.get(cell.rep_id) : null;
     const trim = thumb ? this.hoverThumbRect(thumb, radius) : null;
     const bumped = radius * HOVER_RADIUS_SCALE;
 
@@ -1917,109 +1904,6 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     return hoverThumbHalfExtents(aspect, radius, this.geom.neighborOffsets());
   }
 
-  /**
-   * Return the loaded thumbnail for a representative media id, or null while it
-   * loads / if it failed. Kicks off the fetch on first request and redraws when
-   * the image arrives.
-   */
-  private getThumb(representativeId: number): HTMLImageElement | null {
-    const cached = this.thumbCache.get(representativeId);
-    if (cached) {
-      // Bump recency: re-insert so a thumbnail painted this frame becomes the
-      // newest entry. The cache is insertion-ordered (see {@link evictThumbs}),
-      // so this keeps currently-visible thumbnails last in line for eviction —
-      // off-view preloads (which never bump) are dropped first, so warming the
-      // ring can never evict something that's on screen.
-      this.thumbCache.delete(representativeId);
-      this.thumbCache.set(representativeId, cached);
-      return cached.complete && cached.naturalWidth > 0 ? cached : null;
-    }
-    this.startThumbLoad(representativeId, false);
-    return null;
-  }
-
-  /**
-   * Kick off the thumbnail fetch for a representative id and stash the pending
-   * image in the cache. ``preload`` marks an off-view warm-up: it loads at low
-   * network priority and does not repaint when it lands (the cell isn't on
-   * screen), so it never competes with visible thumbnails. A no-op when the id
-   * is already cached or known-failed.
-   */
-  private startThumbLoad(representativeId: number, preload: boolean): void {
-    if (this.thumbCache.has(representativeId) || this.thumbFailed.has(representativeId)) return;
-
-    if (this.thumbCache.size >= this.MAX_THUMBS) this.evictThumbs();
-
-    const img = new Image();
-    img.decoding = 'async';
-    if (preload) {
-      // Idle warm-up: let the browser schedule it behind visible-thumbnail and
-      // tile requests, and skip the repaint — the cell is off-screen, so a later
-      // draw picks it up from the cache once the user pans to it.
-      img.setAttribute('fetchpriority', 'low');
-    } else {
-      img.onload = () => this.requestRedraw();
-    }
-    img.onerror = () => {
-      this.thumbCache.delete(representativeId);
-      this.thumbFailed.add(representativeId);
-    };
-    // Downscaled /thumbnail by default: a browse projection can hold thousands
-    // of points, so painting full-size bitmaps onto every hex would exhaust
-    // memory. The /thumbnail route serves the frame for video via the same
-    // image_response hook, then downscales it. At the largest zoom levels,
-    // though, a cell is drawn wider than the thumbnail's native resolution, so
-    // we fetch the full-res /image instead (only a few such giant cells fit on
-    // screen, so memory stays bounded). See {@link useFullResThumbs}.
-    const endpoint = this.thumbsAreFullRes ? 'image' : 'thumbnail';
-    img.src = this.activeContext.mediaUrl(`/api/medias/${representativeId}/${endpoint}`);
-    this.thumbCache.set(representativeId, img);
-  }
-
-  /** Drop the oldest quarter of cached thumbnails (insertion-ordered LRU). */
-  private evictThumbs(): void {
-    const target = Math.floor(this.MAX_THUMBS * 0.75);
-    const toRemove = this.thumbCache.size - target;
-    let i = 0;
-    for (const key of this.thumbCache.keys()) {
-      if (i++ >= toRemove) break;
-      this.thumbCache.delete(key);
-      // Drop the matching tinted mask (issue #2369) so it can't outlive its
-      // raw source and leak; it re-tints on demand if the clip is revisited.
-      this.tintedThumbCache.delete(key);
-    }
-  }
-
-  /**
-   * Return the audio waveform thumbnail tinted to the live theme's accent
-   * colour, built once per (clip, theme) and cached (issue #2369).
-   *
-   * The raw thumbnail is a theme-agnostic alpha mask — a transparent PNG whose
-   * only opaque pixels are the wave. Painting it to an offscreen canvas and
-   * compositing the accent through ``source-in`` recolours just the wave,
-   * leaving the background transparent so the tile's themed surface (filled by
-   * the caller) shows through. The tinted cache is cleared on a theme flip and
-   * whenever the raw {@link thumbCache} is, so it never serves a stale colour.
-   */
-  private getTintedThumb(representativeId: number, src: HTMLImageElement): HTMLCanvasElement {
-    const cached = this.tintedThumbCache.get(representativeId);
-    if (cached) return cached;
-
-    const w = src.naturalWidth || 1;
-    const h = src.naturalHeight || 1;
-    const off = document.createElement('canvas');
-    off.width = w;
-    off.height = h;
-    const octx = off.getContext('2d');
-    if (octx) {
-      octx.drawImage(src, 0, 0);
-      octx.globalCompositeOperation = 'source-in';
-      octx.fillStyle = this.waveAccent;
-      octx.fillRect(0, 0, w, h);
-    }
-    this.tintedThumbCache.set(representativeId, off);
-    return off;
-  }
 
   private themeColor(varName: string): string {
     return getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
@@ -2038,7 +1922,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     // Warm the geometry of the ring just beyond the drawn tiles (8-connected, so
     // diagonals are covered, plus an extra tile in the direction of travel) so a
     // pan into it never blanks while the tile fetch is in flight.
-    for (const { tx, ty } of this.offViewRing(visibleTiles)) {
+    for (const { tx, ty } of offViewRing(visibleTiles, this.panDir)) {
       this.tileCache.prefetch(level, tx, ty);
     }
     if (level > 0) {
@@ -2058,44 +1942,6 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     if (this.thumbnailMode) this.scheduleThumbPrefetch();
   }
 
-  /**
-   * The ring of tiles just outside the drawn set: the bounding box of
-   * ``visibleTiles`` grown by one tile on every side (8-connected, so diagonals
-   * are included), minus the box itself. The growth is extended by a second tile
-   * on whichever sides the view is panning toward ({@link panDirX} /
-   * {@link panDirY}), so a sustained pan warms further ahead in the direction of
-   * travel. ``visibleTiles`` already carries a one-tile margin (see
-   * {@link getVisibleTiles}), so this ring sits one to two tiles beyond what's
-   * actually painted.
-   */
-  private offViewRing(visibleTiles: { tx: number; ty: number }[]): { tx: number; ty: number }[] {
-    if (visibleTiles.length === 0) return [];
-    let txMin = Infinity;
-    let txMax = -Infinity;
-    let tyMin = Infinity;
-    let tyMax = -Infinity;
-    for (const { tx, ty } of visibleTiles) {
-      if (tx < txMin) txMin = tx;
-      if (tx > txMax) txMax = tx;
-      if (ty < tyMin) tyMin = ty;
-      if (ty > tyMax) tyMax = ty;
-    }
-    // One ring on every side, plus a directional extra tile on the leading edges.
-    const DIR = 0.3;
-    const outTxMin = txMin - (this.panDirX < -DIR ? 2 : 1);
-    const outTxMax = txMax + (this.panDirX > DIR ? 2 : 1);
-    const outTyMin = tyMin - (this.panDirY < -DIR ? 2 : 1);
-    const outTyMax = tyMax + (this.panDirY > DIR ? 2 : 1);
-    const ring: { tx: number; ty: number }[] = [];
-    for (let tx = outTxMin; tx <= outTxMax; tx++) {
-      for (let ty = outTyMin; ty <= outTyMax; ty++) {
-        // Keep only the new border; the interior is the already-drawn box.
-        if (tx >= txMin && tx <= txMax && ty >= tyMin && ty <= tyMax) continue;
-        ring.push({ tx, ty });
-      }
-    }
-    return ring;
-  }
 
   /**
    * Queue a single low-priority pass that warms off-view thumbnails when the main
@@ -2146,7 +1992,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     if (!this.thumbnailMode || !meta) return;
     const level = this.activeLevel;
     const total = BrowseCanvasComponent.PRELOAD_MAX_PER_PASS;
-    const panRing = this.offViewRing(this.getVisibleTiles());
+    const panRing = offViewRing(this.getVisibleTiles(), this.panDir);
     // Only reserve for zoom when there's a finer level to zoom into; otherwise
     // pan gets the whole budget on the first sweep.
     const canZoomIn = meta.levels.length > level + 1;
@@ -2157,7 +2003,7 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
     let remaining = total - this.warmThumbsForTiles(level, panRing, total - zoomReserve);
     // Zoom-in: the finer tiles centred under the view, newest-revealed first.
     if (canZoomIn && remaining > 0) {
-      remaining -= this.warmThumbsForTiles(level + 1, this.finerTilesForZoom(), remaining);
+      remaining -= this.warmThumbsForTiles(level + 1, this.finerZoomTiles(), remaining);
     }
     // Hand any unspent budget back to the pan ring.
     if (remaining > 0) this.warmThumbsForTiles(level, panRing, remaining);
@@ -2182,11 +2028,14 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
       if (!tile) continue;
       for (const cell of tile.cells) {
         if (spent >= budget) break;
-        if (this.thumbCache.has(cell.rep_id) || this.thumbFailed.has(cell.rep_id)) continue;
+        if (this.thumbs.known(cell.rep_id)) continue;
         // Stop before the cache fills so a preload never forces an eviction; the
-        // free slots come from visible getThumb()s bumping past stale warms.
-        if (this.thumbCache.size >= this.MAX_THUMBS) return spent;
-        this.startThumbLoad(cell.rep_id, true);
+        // free slots come from visible ThumbStore.get()s bumping past stale warms.
+        if (this.thumbs.full) return spent;
+        // Refused outright in the full-res tier, where a speculative fetch costs
+        // a multi-megabyte original rather than a capped thumbnail; the whole
+        // pass is abandoned rather than spun through — see {@link ThumbStore.warm}.
+        if (!this.thumbs.warm(cell.rep_id)) return spent;
         spent++;
       }
     }
@@ -2195,88 +2044,60 @@ export class BrowseCanvasComponent implements AfterViewInit, OnDestroy {
 
   /**
    * The tiles of the next finer level ({@link activeLevel} + 1) that cover the
-   * current viewport: what a zoom-in would render. A finer level halves the bin
-   * radius, so each visible tile maps to a 2×2 block of finer tiles; the union is
-   * returned sorted by distance from the view centre, since a zoom-in anchors
-   * near the centre (or cursor) and so reveals the central tiles first. Mirrors
-   * the geometry warmed by {@link prefetchLevel} for ``level + 1``, so the tiles
-   * walked here are the ones already being fetched.
+   * current viewport: what a zoom-in would render. Derives the finer level's
+   * tile pitch and the view centre in those tile units, then hands the ranking
+   * to {@link finerTilesForZoom}. Mirrors the geometry warmed by
+   * {@link prefetchLevel} for ``level + 1``, so the tiles walked here are the
+   * ones already being fetched.
    */
-  private finerTilesForZoom(): { tx: number; ty: number }[] {
+  private finerZoomTiles(): TileCoord[] {
     const meta = this.meta();
     if (!meta) return [];
-    const finerLevel = this.activeLevel + 1;
-    const radius = meta.base_radius / Math.pow(2, finerLevel);
+    const radius = meta.base_radius / Math.pow(2, this.activeLevel + 1);
     const tileW = meta.tile_span * this.geom.dx(radius);
     const tileH = meta.tile_span * this.geom.dy(radius);
     const [vxmin, vymin, vxmax, vymax] = this.getVisibleBounds();
-    // View centre in finer-tile coordinates, to rank tiles centre-out.
-    const ccx = (vxmin + vxmax) / 2 / tileW;
-    const ccy = (vymin + vymax) / 2 / tileH;
-    const seen = new Set<string>();
-    const tiles: { tx: number; ty: number; d2: number }[] = [];
-    for (const { tx, ty } of this.getVisibleTiles()) {
-      // Each current-level tile spans a 2×2 block at the finer level.
-      for (let dx = 0; dx <= 1; dx++) {
-        for (let dy = 0; dy <= 1; dy++) {
-          const ftx = tx * 2 + dx;
-          const fty = ty * 2 + dy;
-          const key = `${ftx}:${fty}`;
-          if (seen.has(key)) continue;
-          seen.add(key);
-          const ex = ftx + 0.5 - ccx;
-          const ey = fty + 0.5 - ccy;
-          tiles.push({ tx: ftx, ty: fty, d2: ex * ex + ey * ey });
-        }
-      }
-    }
-    tiles.sort((a, b) => a.d2 - b.d2);
-    return tiles.map(({ tx, ty }) => ({ tx, ty }));
+    return finerTilesForZoom(
+      this.getVisibleTiles(),
+      (vxmin + vxmax) / 2 / tileW,
+      (vymin + vymax) / 2 / tileH,
+    );
   }
 
   /**
    * Track a smoothed pan direction from the frame-to-frame change in the view
-   * centre, used to bias which off-view tiles to warm first. The exponential
-   * smoothing keeps a single jittery frame from flipping the bias and lets the
-   * direction decay toward zero when the view holds still (so a stationary view
-   * warms its ring symmetrically).
+   * centre, used to bias which off-view tiles to warm first. The smoothing
+   * itself is {@link smoothPanDirection}; this only supplies consecutive
+   * centres and holds the result. The first frame has no predecessor, so it
+   * seeds the reference centre without moving the direction.
    */
   private updatePanDirection(): void {
     const cx = this.transform.centerX;
     const cy = this.transform.centerY;
-    const SMOOTH = 0.4;
     if (!Number.isNaN(this.lastDrawCenterX)) {
-      const dx = cx - this.lastDrawCenterX;
-      const dy = cy - this.lastDrawCenterY;
-      const mag = Math.hypot(dx, dy);
-      const ux = mag > 1e-6 ? dx / mag : 0;
-      const uy = mag > 1e-6 ? dy / mag : 0;
-      this.panDirX += (ux - this.panDirX) * SMOOTH;
-      this.panDirY += (uy - this.panDirY) * SMOOTH;
+      this.panDir = smoothPanDirection(
+        this.panDir,
+        { x: this.lastDrawCenterX, y: this.lastDrawCenterY },
+        { x: cx, y: cy },
+      );
     }
     this.lastDrawCenterX = cx;
     this.lastDrawCenterY = cy;
   }
 
-  private prefetchLevel(targetLevel: number, sourceTiles: { tx: number; ty: number }[]): void {
+  /**
+   * Warm the geometry of ``sourceTiles``' region at an adjacent pyramid level,
+   * so a zoom in either direction finds its tiles already fetched. The tile-set
+   * maths is {@link tilesAtLevel}; this only resolves the two levels' radius
+   * ratio and issues the prefetches.
+   */
+  private prefetchLevel(targetLevel: number, sourceTiles: TileCoord[]): void {
     const meta = this.meta();
     if (!meta) return;
     const sourceRadius = meta.base_radius / Math.pow(2, this.activeLevel);
     const targetRadius = meta.base_radius / Math.pow(2, targetLevel);
-    const ratio = sourceRadius / targetRadius;
-    const seen = new Set<string>();
-    for (const { tx, ty } of sourceTiles) {
-      const ttx = Math.floor(tx * ratio);
-      const tty = Math.floor(ty * ratio);
-      for (let dx = -1; dx <= 1; dx++) {
-        for (let dy = -1; dy <= 1; dy++) {
-          const key = `${ttx + dx}:${tty + dy}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            this.tileCache.prefetch(targetLevel, ttx + dx, tty + dy);
-          }
-        }
-      }
+    for (const { tx, ty } of tilesAtLevel(sourceTiles, sourceRadius / targetRadius)) {
+      this.tileCache.prefetch(targetLevel, tx, ty);
     }
   }
 

--- a/frontend/src/app/components/browse-canvas/prefetch-geometry.spec.ts
+++ b/frontend/src/app/components/browse-canvas/prefetch-geometry.spec.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  finerTilesForZoom,
+  offViewRing,
+  PAN_DIR_BIAS_THRESHOLD,
+  smoothPanDirection,
+  tilesAtLevel,
+  type TileCoord,
+} from './prefetch-geometry';
+
+/**
+ * Unit coverage for the browse canvas's prefetch tile-set geometry: which tiles
+ * a pan is about to scroll in, which a zoom-in is about to reveal, how a region
+ * re-expresses at an adjacent pyramid level, and the smoothed direction estimate
+ * that biases the pan ring.
+ */
+
+/** Stable key for set comparisons, since the functions don't promise an order
+ *  (except {@link finerTilesForZoom}, whose ranking is asserted directly). */
+const key = ({ tx, ty }: TileCoord) => `${tx}:${ty}`;
+const keys = (tiles: TileCoord[]) => tiles.map(key).sort();
+
+/** The tiles of the inclusive box [x0,x1]×[y0,y1]. */
+function box(x0: number, x1: number, y0: number, y1: number): TileCoord[] {
+  const out: TileCoord[] = [];
+  for (let tx = x0; tx <= x1; tx++) for (let ty = y0; ty <= y1; ty++) out.push({ tx, ty });
+  return out;
+}
+
+const STILL = { x: 0, y: 0 };
+
+describe('offViewRing', () => {
+  it('returns nothing for an empty visible set', () => {
+    expect(offViewRing([], STILL)).toEqual([]);
+  });
+
+  it('rings a single tile with its 8 neighbours', () => {
+    const ring = offViewRing([{ tx: 4, ty: 7 }], STILL);
+    expect(keys(ring)).toEqual(keys(box(3, 5, 6, 8).filter((t) => key(t) !== '4:7')));
+  });
+
+  it('excludes the visible box itself', () => {
+    const visible = box(0, 2, 0, 2);
+    const ring = offViewRing(visible, STILL);
+    for (const tile of visible) expect(keys(ring)).not.toContain(key(tile));
+  });
+
+  it('rings the bounding box, not each tile, for a ragged visible set', () => {
+    // A sparse L-shape: the ring is still the box's border, so interior holes
+    // are not re-warmed as if they were outside.
+    const ragged: TileCoord[] = [
+      { tx: 0, ty: 0 },
+      { tx: 2, ty: 0 },
+      { tx: 0, ty: 2 },
+    ];
+    const ring = offViewRing(ragged, STILL);
+    expect(keys(ring)).toEqual(
+      keys(box(-1, 3, -1, 3).filter((t) => !(t.tx >= 0 && t.tx <= 2 && t.ty >= 0 && t.ty <= 2))),
+    );
+  });
+
+  it('extends two tiles on the leading edge when panning right', () => {
+    const ring = offViewRing(box(0, 1, 0, 1), { x: 1, y: 0 });
+    const txs = ring.map((t) => t.tx);
+    // Leading (+x) edge reaches 3; trailing edge stays at the single ring.
+    expect(Math.max(...txs)).toBe(3);
+    expect(Math.min(...txs)).toBe(-1);
+    // The cross-axis is unbiased.
+    const tys = ring.map((t) => t.ty);
+    expect(Math.max(...tys)).toBe(2);
+    expect(Math.min(...tys)).toBe(-1);
+  });
+
+  it('extends the negative edge when panning left/up', () => {
+    const ring = offViewRing(box(0, 1, 0, 1), { x: -1, y: -1 });
+    expect(Math.min(...ring.map((t) => t.tx))).toBe(-2);
+    expect(Math.min(...ring.map((t) => t.ty))).toBe(-2);
+    expect(Math.max(...ring.map((t) => t.tx))).toBe(2);
+    expect(Math.max(...ring.map((t) => t.ty))).toBe(2);
+  });
+
+  it('stays symmetric for a drift below the bias threshold', () => {
+    const drift = PAN_DIR_BIAS_THRESHOLD * 0.9;
+    expect(keys(offViewRing(box(0, 1, 0, 1), { x: drift, y: drift }))).toEqual(
+      keys(offViewRing(box(0, 1, 0, 1), STILL)),
+    );
+  });
+
+  it('never repeats a tile', () => {
+    const ring = offViewRing(box(0, 3, 0, 3), { x: 1, y: 1 });
+    expect(new Set(ring.map(key)).size).toBe(ring.length);
+  });
+});
+
+describe('finerTilesForZoom', () => {
+  it('maps each visible tile to its 2x2 finer block', () => {
+    const finer = finerTilesForZoom([{ tx: 3, ty: 5 }], 7, 11);
+    expect(keys(finer)).toEqual(['6:10', '6:11', '7:10', '7:11']);
+  });
+
+  it('de-duplicates the union across adjacent visible tiles', () => {
+    const finer = finerTilesForZoom(box(0, 1, 0, 1), 2, 2);
+    // Four source tiles × 4 = 16 finer tiles, all distinct.
+    expect(finer).toHaveLength(16);
+    expect(new Set(finer.map(key)).size).toBe(16);
+  });
+
+  it('ranks tiles centre-out, since a zoom-in reveals the centre first', () => {
+    const finer = finerTilesForZoom(box(0, 2, 0, 2), 3, 3);
+    // Centre (3,3) in finer-tile units sits on the corner of tiles 2..3; the
+    // nearest tile centres (x.5) are the four touching it.
+    expect(keys(finer.slice(0, 4))).toEqual(['2:2', '2:3', '3:2', '3:3']);
+    // ...and the ranking is monotone in distance from the centre.
+    const d2 = finer.map(({ tx, ty }) => (tx + 0.5 - 3) ** 2 + (ty + 0.5 - 3) ** 2);
+    for (let i = 1; i < d2.length; i++) expect(d2[i]).toBeGreaterThanOrEqual(d2[i - 1]);
+  });
+
+  it('returns nothing for an empty visible set', () => {
+    expect(finerTilesForZoom([], 0, 0)).toEqual([]);
+  });
+});
+
+describe('tilesAtLevel', () => {
+  it('pads a mapped tile with its 8-connected neighbourhood', () => {
+    // ratio 1: the same grid, so the result is the 3x3 around the source.
+    expect(keys(tilesAtLevel([{ tx: 5, ty: 5 }], 1))).toEqual(keys(box(4, 6, 4, 6)));
+  });
+
+  it('halves coordinates toward a coarser level', () => {
+    // A coarser level has bins twice as wide, so ratio = 1/2 and tile 6 maps to 3.
+    const out = tilesAtLevel([{ tx: 6, ty: 8 }], 0.5);
+    expect(keys(out)).toEqual(keys(box(2, 4, 3, 5)));
+  });
+
+  it('doubles coordinates toward a finer level', () => {
+    expect(keys(tilesAtLevel([{ tx: 3, ty: 4 }], 2))).toEqual(keys(box(5, 7, 7, 9)));
+  });
+
+  it('floors rather than truncates toward zero for negative tiles', () => {
+    // Math.floor(-3 * 0.5) is -2, not -1: a tile left of the origin must map to
+    // the coarser tile that actually contains it.
+    const out = tilesAtLevel([{ tx: -3, ty: -3 }], 0.5);
+    expect(keys(out)).toEqual(keys(box(-3, -1, -3, -1)));
+  });
+
+  it('de-duplicates where neighbourhoods overlap', () => {
+    const out = tilesAtLevel(box(0, 1, 0, 1), 0.5);
+    // All four source tiles map to (0,0), so the union is one 3x3 block.
+    expect(out).toHaveLength(9);
+    expect(new Set(out.map(key)).size).toBe(9);
+  });
+
+  it('returns nothing for an empty source set', () => {
+    expect(tilesAtLevel([], 2)).toEqual([]);
+  });
+});
+
+describe('smoothPanDirection', () => {
+  it('eases toward the unit direction of travel', () => {
+    const next = smoothPanDirection({ x: 0, y: 0 }, { x: 0, y: 0 }, { x: 10, y: 0 }, 0.4);
+    expect(next.x).toBeCloseTo(0.4);
+    expect(next.y).toBeCloseTo(0);
+  });
+
+  it('normalizes, so a fast and a slow pan agree on direction', () => {
+    const slow = smoothPanDirection(STILL, { x: 0, y: 0 }, { x: 0.01, y: 0 }, 0.4);
+    const fast = smoothPanDirection(STILL, { x: 0, y: 0 }, { x: 1000, y: 0 }, 0.4);
+    expect(slow.x).toBeCloseTo(fast.x);
+  });
+
+  it('converges toward the direction under sustained motion', () => {
+    let dir = { x: 0, y: 0 };
+    for (let i = 0; i < 20; i++) {
+      dir = smoothPanDirection(dir, { x: i, y: 0 }, { x: i + 1, y: 0 }, 0.4);
+    }
+    expect(dir.x).toBeCloseTo(1, 3);
+    // ...and crosses the bias threshold, so the ring actually leads the pan.
+    expect(dir.x).toBeGreaterThan(PAN_DIR_BIAS_THRESHOLD);
+  });
+
+  it('decays toward zero when the view holds still', () => {
+    let dir = { x: 1, y: 1 };
+    for (let i = 0; i < 20; i++) {
+      dir = smoothPanDirection(dir, { x: 5, y: 5 }, { x: 5, y: 5 }, 0.4);
+    }
+    expect(dir.x).toBeCloseTo(0, 3);
+    expect(dir.y).toBeCloseTo(0, 3);
+    expect(Math.abs(dir.x)).toBeLessThan(PAN_DIR_BIAS_THRESHOLD);
+  });
+
+  it('does not let one jittery frame flip an established bias', () => {
+    const established = { x: 1, y: 0 };
+    const jittered = smoothPanDirection(established, { x: 5, y: 0 }, { x: 4, y: 0 }, 0.4);
+    // One reversed frame pulls the estimate back toward neutral — at most the
+    // ring goes symmetric for a frame — but it must never swing far enough to
+    // start leading the *opposite* way off a single sample.
+    expect(jittered.x).toBeLessThan(established.x);
+    expect(jittered.x).toBeGreaterThan(-PAN_DIR_BIAS_THRESHOLD);
+  });
+
+  it('needs several consistent frames to reverse an established bias', () => {
+    let dir = { x: 1, y: 0 };
+    dir = smoothPanDirection(dir, { x: 5, y: 0 }, { x: 4, y: 0 }, 0.4);
+    expect(dir.x).toBeGreaterThan(-PAN_DIR_BIAS_THRESHOLD);
+    for (let i = 0; i < 5; i++) {
+      dir = smoothPanDirection(dir, { x: 5 - i, y: 0 }, { x: 4 - i, y: 0 }, 0.4);
+    }
+    // A sustained reversal does eventually lead the other way.
+    expect(dir.x).toBeLessThan(-PAN_DIR_BIAS_THRESHOLD);
+  });
+
+  it('treats a sub-epsilon move as stationary rather than amplifying noise', () => {
+    const next = smoothPanDirection({ x: 0.5, y: 0 }, { x: 0, y: 0 }, { x: 1e-9, y: 0 }, 0.4);
+    // Decays (toward zero), never jumps to a full unit vector.
+    expect(next.x).toBeCloseTo(0.3);
+  });
+
+  it('is pure — it does not mutate the previous direction', () => {
+    const previous = { x: 0.2, y: 0.2 };
+    smoothPanDirection(previous, { x: 0, y: 0 }, { x: 1, y: 1 }, 0.4);
+    expect(previous).toEqual({ x: 0.2, y: 0.2 });
+  });
+});

--- a/frontend/src/app/components/browse-canvas/prefetch-geometry.ts
+++ b/frontend/src/app/components/browse-canvas/prefetch-geometry.ts
@@ -1,0 +1,174 @@
+/**
+ * Tile-set geometry for the browse canvas's prefetch paths.
+ *
+ * The canvas warms two things ahead of the user: tile *geometry* (from the tile
+ * cache) and representative *thumbnails* (from the thumb store). Both need the
+ * same question answered first — which tiles is the view about to need? — and
+ * that question is pure geometry over the pyramid:
+ *
+ * - {@link offViewRing} — the tiles a **pan** is about to scroll in.
+ * - {@link finerTilesForZoom} — the tiles a **zoom-in** is about to reveal.
+ * - {@link tilesAtLevel} — the same region re-expressed at an adjacent level.
+ * - {@link smoothPanDirection} — the direction estimate that biases the ring.
+ *
+ * Everything here is a pure function of numbers and tile coordinates: no tile
+ * cache, no thumbnails, no canvas, no Angular. That keeps the "what to warm"
+ * decision testable on its own, separately from the "how to fetch and retain
+ * it" half in `thumb-store.ts`.
+ */
+
+/** A tile address within one pyramid level. */
+export interface TileCoord {
+  tx: number;
+  ty: number;
+}
+
+/**
+ * How strong the smoothed pan direction must be on an axis before the ring is
+ * extended on that side. Below this the motion is treated as incidental jitter
+ * and the ring stays symmetric, so a view being nudged around doesn't keep
+ * flip-flopping which side it warms.
+ */
+export const PAN_DIR_BIAS_THRESHOLD = 0.3;
+
+/** Exponential smoothing factor for the pan-direction estimate: how much of
+ *  each new frame's direction is folded in. Low enough that one jittery frame
+ *  can't flip the bias, high enough to track a real gesture within a few frames. */
+export const PAN_DIR_SMOOTHING = 0.4;
+
+/** A smoothed unit-ish pan direction (each component in [-1, 1]). */
+export interface PanDirection {
+  x: number;
+  y: number;
+}
+
+/**
+ * Fold one frame's movement into the smoothed pan direction.
+ *
+ * ``from`` and ``to`` are consecutive view centres in projection units. The
+ * exponential smoothing keeps a single jittery frame from flipping the bias and
+ * lets the direction decay toward zero when the view holds still, so a
+ * stationary view warms its ring symmetrically. Returns a new value rather than
+ * mutating, so the caller owns the state.
+ */
+export function smoothPanDirection(
+  previous: PanDirection,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  smoothing = PAN_DIR_SMOOTHING,
+): PanDirection {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const mag = Math.hypot(dx, dy);
+  const ux = mag > 1e-6 ? dx / mag : 0;
+  const uy = mag > 1e-6 ? dy / mag : 0;
+  return {
+    x: previous.x + (ux - previous.x) * smoothing,
+    y: previous.y + (uy - previous.y) * smoothing,
+  };
+}
+
+/**
+ * The ring of tiles just outside the drawn set: the bounding box of
+ * ``visibleTiles`` grown by one tile on every side (8-connected, so diagonals
+ * are included), minus the box itself.
+ *
+ * The growth is extended by a second tile on whichever sides the view is panning
+ * toward, so a sustained pan warms further ahead in the direction of travel.
+ * Callers pass a ``visibleTiles`` set that already carries a one-tile margin, so
+ * this ring sits one to two tiles beyond what is actually painted.
+ */
+export function offViewRing(visibleTiles: TileCoord[], panDir: PanDirection): TileCoord[] {
+  if (visibleTiles.length === 0) return [];
+  let txMin = Infinity;
+  let txMax = -Infinity;
+  let tyMin = Infinity;
+  let tyMax = -Infinity;
+  for (const { tx, ty } of visibleTiles) {
+    if (tx < txMin) txMin = tx;
+    if (tx > txMax) txMax = tx;
+    if (ty < tyMin) tyMin = ty;
+    if (ty > tyMax) tyMax = ty;
+  }
+  // One ring on every side, plus a directional extra tile on the leading edges.
+  const t = PAN_DIR_BIAS_THRESHOLD;
+  const outTxMin = txMin - (panDir.x < -t ? 2 : 1);
+  const outTxMax = txMax + (panDir.x > t ? 2 : 1);
+  const outTyMin = tyMin - (panDir.y < -t ? 2 : 1);
+  const outTyMax = tyMax + (panDir.y > t ? 2 : 1);
+  const ring: TileCoord[] = [];
+  for (let tx = outTxMin; tx <= outTxMax; tx++) {
+    for (let ty = outTyMin; ty <= outTyMax; ty++) {
+      // Keep only the new border; the interior is the already-drawn box.
+      if (tx >= txMin && tx <= txMax && ty >= tyMin && ty <= tyMax) continue;
+      ring.push({ tx, ty });
+    }
+  }
+  return ring;
+}
+
+/**
+ * The next finer level's tiles covering the current viewport: what a zoom-in
+ * would render.
+ *
+ * A finer level halves the bin radius, so each visible tile maps to a 2×2 block
+ * of finer tiles. The union is returned sorted by distance from the view centre,
+ * since a zoom-in anchors near the centre (or the cursor) and so reveals the
+ * central tiles first. ``centreTx`` / ``centreTy`` are the view centre expressed
+ * in *finer-level tile units*, which is what makes the ranking a plain squared
+ * distance.
+ */
+export function finerTilesForZoom(
+  visibleTiles: TileCoord[],
+  centreTx: number,
+  centreTy: number,
+): TileCoord[] {
+  const seen = new Set<string>();
+  const tiles: { tx: number; ty: number; d2: number }[] = [];
+  for (const { tx, ty } of visibleTiles) {
+    // Each current-level tile spans a 2×2 block at the finer level.
+    for (let dx = 0; dx <= 1; dx++) {
+      for (let dy = 0; dy <= 1; dy++) {
+        const ftx = tx * 2 + dx;
+        const fty = ty * 2 + dy;
+        const key = `${ftx}:${fty}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const ex = ftx + 0.5 - centreTx;
+        const ey = fty + 0.5 - centreTy;
+        tiles.push({ tx: ftx, ty: fty, d2: ex * ex + ey * ey });
+      }
+    }
+  }
+  tiles.sort((a, b) => a.d2 - b.d2);
+  return tiles.map(({ tx, ty }) => ({ tx, ty }));
+}
+
+/**
+ * Re-express a set of source tiles at an adjacent pyramid level, padded by one
+ * tile on every side.
+ *
+ * ``ratio`` is the source level's bin radius over the target level's, so a
+ * coarser target (bigger bins) gives a ratio below 1 and a finer target one
+ * above. Each source tile maps to a target tile plus its 8-connected
+ * neighbourhood, de-duplicated — the padding covers the fact that the two
+ * levels' tile grids don't align, so a source tile can straddle a target
+ * boundary.
+ */
+export function tilesAtLevel(sourceTiles: TileCoord[], ratio: number): TileCoord[] {
+  const seen = new Set<string>();
+  const out: TileCoord[] = [];
+  for (const { tx, ty } of sourceTiles) {
+    const ttx = Math.floor(tx * ratio);
+    const tty = Math.floor(ty * ratio);
+    for (let dx = -1; dx <= 1; dx++) {
+      for (let dy = -1; dy <= 1; dy++) {
+        const key = `${ttx + dx}:${tty + dy}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push({ tx: ttx + dx, ty: tty + dy });
+      }
+    }
+  }
+  return out;
+}

--- a/frontend/src/app/components/browse-canvas/thumb-store.spec.ts
+++ b/frontend/src/app/components/browse-canvas/thumb-store.spec.ts
@@ -1,0 +1,525 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MAX_THUMBS,
+  MAX_THUMBS_FULL_RES,
+  THUMB_NATIVE_MAX_DIM,
+  THUMB_RETRY_BACKOFF_MS,
+  ThumbStore,
+} from './thumb-store';
+
+/**
+ * Unit coverage for the browse canvas's representative-thumbnail store: the
+ * insertion-ordered LRU, the capped/full-res resolution tier, the waveform tint
+ * cache, and the retry backoff that keeps a transient load failure from blanking
+ * a bin for the rest of the session.
+ *
+ * `Image` is stubbed so a "load" is just a call to the handler the store
+ * attached — no network, no decoding. Everything the store promises is
+ * observable through that.
+ */
+
+/** The stub standing in for a real `HTMLImageElement`. */
+interface FakeImage {
+  src: string;
+  decoding: string;
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+  complete: boolean;
+  naturalWidth: number;
+  naturalHeight: number;
+  attrs: Record<string, string>;
+  setAttribute(name: string, value: string): void;
+}
+
+/** Every image the store has constructed this test, in construction order. */
+let created: FakeImage[] = [];
+
+/** Simulate a successful decode of the image fetched for `src`. */
+function finishLoad(img: FakeImage, w = 64, h = 48): void {
+  img.complete = true;
+  img.naturalWidth = w;
+  img.naturalHeight = h;
+  img.onload?.();
+}
+
+/** Simulate a failed fetch. */
+function failLoad(img: FakeImage): void {
+  img.onerror?.();
+}
+
+/** The most recently constructed image (the one a `get`/`warm` just started). */
+const last = () => created[created.length - 1];
+
+beforeEach(() => {
+  // Restore any spy/global a previous test installed: `vi.spyOn` on an
+  // already-spied method reuses the existing mock, so without this the shared
+  // `document.createElement` call counts would accumulate across tests.
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  created = [];
+  vi.stubGlobal(
+    'Image',
+    class {
+      src = '';
+      decoding = '';
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      complete = false;
+      naturalWidth = 0;
+      naturalHeight = 0;
+      attrs: Record<string, string> = {};
+      setAttribute(name: string, value: string) {
+        this.attrs[name] = value;
+      }
+      constructor() {
+        created.push(this as unknown as FakeImage);
+      }
+    },
+  );
+});
+
+/** A store wired to spies, with an injectable clock for the retry backoff. */
+function makeStore(overrides: { accent?: () => string } = {}) {
+  const onLoaded = vi.fn();
+  const clock = { t: 1_000 };
+  const store = new ThumbStore({
+    mediaUrl: (path) => `https://host${path}?ds=7`,
+    onLoaded,
+    accent: overrides.accent ?? (() => '#ff0000'),
+    now: () => clock.t,
+  });
+  return { store, onLoaded, clock };
+}
+
+describe('ThumbStore.wantsFullRes', () => {
+  it('stays on the capped thumbnail while a cell fits within the native cap', () => {
+    // Diameter 2*r*dpr must exceed THUMB_NATIVE_MAX_DIM to flip.
+    expect(ThumbStore.wantsFullRes(THUMB_NATIVE_MAX_DIM / 2, 1)).toBe(false);
+    expect(ThumbStore.wantsFullRes(28, 1)).toBe(false);
+  });
+
+  it('flips once a cell is drawn wider than the capped thumbnail', () => {
+    expect(ThumbStore.wantsFullRes(THUMB_NATIVE_MAX_DIM / 2 + 1, 1)).toBe(true);
+  });
+
+  it('accounts for device pixel ratio, not just CSS size', () => {
+    const radius = THUMB_NATIVE_MAX_DIM / 2 - 10;
+    expect(ThumbStore.wantsFullRes(radius, 1)).toBe(false);
+    expect(ThumbStore.wantsFullRes(radius, 2)).toBe(true);
+  });
+});
+
+describe('ThumbStore fetching', () => {
+  it('starts a fetch on first request and returns null until it decodes', () => {
+    const { store } = makeStore();
+    expect(store.get(1)).toBeNull();
+    expect(created).toHaveLength(1);
+    expect(last().src).toBe('https://host/api/medias/1/thumbnail?ds=7');
+    // Still pending.
+    expect(store.get(1)).toBeNull();
+    expect(created).toHaveLength(1);
+  });
+
+  it('returns the image once it has decoded', () => {
+    const { store } = makeStore();
+    store.get(1);
+    finishLoad(last());
+    expect(store.get(1)).toBe(last());
+  });
+
+  it('repaints when a visible thumbnail lands', () => {
+    const { store, onLoaded } = makeStore();
+    store.get(1);
+    expect(onLoaded).not.toHaveBeenCalled();
+    finishLoad(last());
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a decoded-but-empty image as not ready', () => {
+    const { store } = makeStore();
+    store.get(1);
+    last().complete = true;
+    last().naturalWidth = 0;
+    expect(store.get(1)).toBeNull();
+  });
+
+  it('fetches the full-res endpoint in the full-res tier', () => {
+    const { store } = makeStore();
+    store.setFullRes(true);
+    store.get(1);
+    expect(last().src).toBe('https://host/api/medias/1/image?ds=7');
+  });
+
+  it('peek reads without fetching or bumping recency', () => {
+    const { store } = makeStore();
+    expect(store.peek(1)).toBeUndefined();
+    expect(created).toHaveLength(0);
+    store.get(1);
+    expect(store.peek(1)).toBe(last());
+    expect(created).toHaveLength(1);
+  });
+
+  it('marks off-view warm-ups as low priority and silent', () => {
+    const { store, onLoaded } = makeStore();
+    expect(store.warm(1)).toBe(true);
+    expect(last().attrs['fetchpriority']).toBe('low');
+    finishLoad(last());
+    // A warm-up paints nothing, so it must not schedule a repaint.
+    expect(onLoaded).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fetch an id that is already cached', () => {
+    const { store } = makeStore();
+    store.get(1);
+    expect(store.warm(1)).toBe(false);
+    expect(created).toHaveLength(1);
+  });
+
+  it('reports whether an id is known, so a preload pass can skip it', () => {
+    const { store } = makeStore();
+    expect(store.known(1)).toBe(false);
+    store.get(1);
+    expect(store.known(1)).toBe(true);
+  });
+});
+
+describe('ThumbStore full-res preload guard', () => {
+  // Regression: the idle preloader shared the visible tier, so once the zoom
+  // crossed into full-res every idle pass warmed up to 64 OFF-SCREEN cells with
+  // uncapped originals — potentially gigabytes fetched for cells the user may
+  // never see, since the LRU bound counts entries rather than bytes.
+  it('refuses to warm off-view thumbnails while in the full-res tier', () => {
+    const { store } = makeStore();
+    store.setFullRes(true);
+    expect(store.warm(1)).toBe(false);
+    expect(created).toHaveLength(0);
+  });
+
+  it('still loads full-res on demand for a cell that is actually on screen', () => {
+    const { store } = makeStore();
+    store.setFullRes(true);
+    expect(store.get(1)).toBeNull();
+    expect(created).toHaveLength(1);
+    expect(last().src).toContain('/image');
+  });
+
+  it('resumes warming once the zoom drops back to the capped tier', () => {
+    const { store } = makeStore();
+    store.setFullRes(true);
+    expect(store.warm(1)).toBe(false);
+    store.setFullRes(false);
+    expect(store.warm(1)).toBe(true);
+    expect(last().src).toContain('/thumbnail');
+  });
+
+  it('bounds retention far more tightly in the full-res tier', () => {
+    const { store } = makeStore();
+    expect(store.capacity).toBe(MAX_THUMBS);
+    store.setFullRes(true);
+    expect(store.capacity).toBe(MAX_THUMBS_FULL_RES);
+    expect(MAX_THUMBS_FULL_RES).toBeLessThan(MAX_THUMBS);
+  });
+});
+
+describe('ThumbStore resolution tier', () => {
+  it('reports whether the tier actually changed', () => {
+    const { store } = makeStore();
+    expect(store.isFullRes).toBe(false);
+    expect(store.setFullRes(false)).toBe(false);
+    expect(store.setFullRes(true)).toBe(true);
+    expect(store.isFullRes).toBe(true);
+    expect(store.setFullRes(true)).toBe(false);
+  });
+
+  it('drops the cache when the tier flips so cells reload at the new resolution', () => {
+    const { store } = makeStore();
+    store.get(1);
+    finishLoad(last());
+    expect(store.size).toBe(1);
+    store.setFullRes(true);
+    expect(store.size).toBe(0);
+    // The next request re-fetches, now at full resolution.
+    store.get(1);
+    expect(last().src).toContain('/image');
+  });
+
+  it('leaves the cache alone when the tier is unchanged', () => {
+    const { store } = makeStore();
+    store.get(1);
+    finishLoad(last());
+    store.setFullRes(false);
+    expect(store.size).toBe(1);
+  });
+});
+
+describe('ThumbStore LRU', () => {
+  /** Fill the store with `n` decoded thumbnails, ids 0..n-1. */
+  function fill(store: ThumbStore, n: number): void {
+    for (let i = 0; i < n; i++) {
+      store.get(i);
+      finishLoad(last());
+    }
+  }
+
+  it('evicts the oldest quarter once at capacity', () => {
+    const { store } = makeStore();
+    store.setFullRes(true); // the small cap, so the test stays fast
+    fill(store, MAX_THUMBS_FULL_RES);
+    expect(store.full).toBe(true);
+    // The next insertion triggers one eviction pass down to 75%.
+    store.get(9999);
+    expect(store.size).toBe(Math.floor(MAX_THUMBS_FULL_RES * 0.75) + 1);
+    // The oldest ids went; the newest stayed.
+    expect(store.peek(0)).toBeUndefined();
+    expect(store.peek(MAX_THUMBS_FULL_RES - 1)).toBeDefined();
+  });
+
+  it('bumps recency on a visible paint, so an on-screen thumb outlives an old one', () => {
+    const { store } = makeStore();
+    store.setFullRes(true);
+    fill(store, MAX_THUMBS_FULL_RES);
+    // Id 0 is the oldest — paint it, which re-inserts it as the newest.
+    store.get(0);
+    store.get(9999); // force the eviction pass
+    expect(store.peek(0)).toBeDefined();
+    // Id 1 is now the oldest and goes instead.
+    expect(store.peek(1)).toBeUndefined();
+  });
+
+  it('does not bump recency on a peek, so a pure read cannot save a stale entry', () => {
+    // Only a *painted* thumbnail earns its place; the first-view gate reads the
+    // cache without painting, and must not thereby protect an off-view warm-up
+    // from eviction.
+    const { store } = makeStore();
+    store.setFullRes(true);
+    fill(store, MAX_THUMBS_FULL_RES);
+    expect(store.peek(0)).toBeDefined();
+    store.get(9999); // force the eviction pass
+    expect(store.peek(0)).toBeUndefined();
+  });
+
+  it('reports fullness against the live tier capacity', () => {
+    const { store } = makeStore();
+    store.setFullRes(true);
+    expect(store.full).toBe(false);
+    fill(store, MAX_THUMBS_FULL_RES);
+    expect(store.full).toBe(true);
+  });
+});
+
+describe('ThumbStore retry backoff', () => {
+  // Regression: a failed id went into a permanent set cleared only by a
+  // projection switch or a tier crossing, so one transient 502 left that bin
+  // rendered as flat density shading for the rest of the session.
+  it('records a failure and does not refetch immediately', () => {
+    const { store } = makeStore();
+    store.get(1);
+    failLoad(last());
+    expect(store.failed(1)).toBe(true);
+    expect(store.get(1)).toBeNull();
+    expect(created).toHaveLength(1);
+  });
+
+  it('repaints on a visible failure so the frame stops waiting on that cell', () => {
+    const { store, onLoaded } = makeStore();
+    store.get(1);
+    failLoad(last());
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays silent when an off-view warm-up fails', () => {
+    const { store, onLoaded } = makeStore();
+    store.warm(1);
+    failLoad(last());
+    expect(onLoaded).not.toHaveBeenCalled();
+  });
+
+  it('retries once the backoff has expired', () => {
+    const { store, clock } = makeStore();
+    store.get(1);
+    failLoad(last());
+    clock.t += THUMB_RETRY_BACKOFF_MS[0] - 1;
+    expect(store.get(1)).toBeNull();
+    expect(created).toHaveLength(1);
+    clock.t += 1;
+    expect(store.get(1)).toBeNull();
+    expect(created).toHaveLength(2);
+  });
+
+  it('backs off further after each successive failure', () => {
+    const { store, clock } = makeStore();
+    store.get(1);
+    for (const backoff of THUMB_RETRY_BACKOFF_MS) {
+      failLoad(last());
+      // Just short of the window: no retry.
+      clock.t += backoff - 1;
+      store.get(1);
+      const before = created.length;
+      // Just past it: one retry.
+      clock.t += 1;
+      store.get(1);
+      expect(created.length).toBe(before + 1);
+    }
+  });
+
+  it('gives up after the attempts are spent rather than retrying forever', () => {
+    const { store, clock } = makeStore();
+    store.get(1);
+    for (const backoff of THUMB_RETRY_BACKOFF_MS) {
+      failLoad(last());
+      clock.t += backoff;
+      store.get(1);
+    }
+    // The last scheduled retry has now also failed.
+    failLoad(last());
+    const spent = created.length;
+    clock.t += 1e9;
+    store.get(1);
+    expect(created).toHaveLength(spent);
+    expect(store.failed(1)).toBe(true);
+  });
+
+  it('keeps reporting a failed id as failed through the backoff', () => {
+    // The first-view gate uses this to decide whether to hold the cover: a cell
+    // that failed once must never hold it across the retry schedule.
+    const { store, clock } = makeStore();
+    store.get(1);
+    failLoad(last());
+    clock.t += THUMB_RETRY_BACKOFF_MS[0] + 1;
+    expect(store.failed(1)).toBe(true);
+  });
+
+  it('clears the failure history once a retry succeeds', () => {
+    const { store, clock } = makeStore();
+    store.get(1);
+    failLoad(last());
+    clock.t += THUMB_RETRY_BACKOFF_MS[0];
+    store.get(1);
+    finishLoad(last());
+    expect(store.failed(1)).toBe(false);
+    // A later blip gets the full schedule again, not a spent one.
+    store.clear();
+    store.get(1);
+    failLoad(last());
+    clock.t += THUMB_RETRY_BACKOFF_MS[0];
+    const before = created.length;
+    store.get(1);
+    expect(created.length).toBe(before + 1);
+  });
+
+  it('does not warm an id whose backoff is still pending', () => {
+    const { store } = makeStore();
+    store.warm(1);
+    failLoad(last());
+    expect(store.warm(1)).toBe(false);
+    expect(created).toHaveLength(1);
+  });
+});
+
+describe('ThumbStore waveform tinting', () => {
+  /** A minimal 2D-context stub recording the composite fill. */
+  function stubCanvas() {
+    const calls: string[] = [];
+    const ctx = {
+      globalCompositeOperation: '',
+      fillStyle: '',
+      drawImage: () => calls.push('drawImage'),
+      fillRect: () => calls.push('fillRect'),
+    };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ctx,
+    } as unknown as HTMLCanvasElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(canvas);
+    return { canvas, ctx, calls };
+  }
+
+  it('composites the accent through the mask at the source size', () => {
+    const { ctx, calls } = stubCanvas();
+    const { store } = makeStore({ accent: () => '#00ff00' });
+    const src = { naturalWidth: 32, naturalHeight: 16 } as HTMLImageElement;
+    const tinted = store.tinted(1, src);
+    expect(tinted.width).toBe(32);
+    expect(tinted.height).toBe(16);
+    expect(calls).toEqual(['drawImage', 'fillRect']);
+    expect(ctx.globalCompositeOperation).toBe('source-in');
+    expect(ctx.fillStyle).toBe('#00ff00');
+  });
+
+  it('builds the tint once per clip', () => {
+    stubCanvas();
+    const { store } = makeStore();
+    const src = { naturalWidth: 8, naturalHeight: 8 } as HTMLImageElement;
+    expect(store.tinted(1, src)).toBe(store.tinted(1, src));
+    expect(document.createElement).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-tints against the live accent after a theme flip', () => {
+    stubCanvas();
+    let accent = '#111111';
+    const { store } = makeStore({ accent: () => accent });
+    const src = { naturalWidth: 8, naturalHeight: 8 } as HTMLImageElement;
+    store.tinted(1, src);
+    accent = '#222222';
+    store.clearTinted();
+    const ctx = store.tinted(1, src).getContext('2d')!;
+    expect(ctx.fillStyle).toBe('#222222');
+  });
+
+  it('keeps the raw masks when only the tints are dropped', () => {
+    stubCanvas();
+    const { store } = makeStore();
+    store.get(1);
+    finishLoad(last());
+    store.clearTinted();
+    // The mask itself is theme-agnostic, so nothing needs re-fetching.
+    expect(store.size).toBe(1);
+  });
+
+  it('falls back to a blank canvas when no 2D context is available', () => {
+    const canvas = { width: 0, height: 0, getContext: () => null } as unknown as HTMLCanvasElement;
+    vi.spyOn(document, 'createElement').mockReturnValue(canvas);
+    const { store } = makeStore();
+    const src = { naturalWidth: 4, naturalHeight: 4 } as HTMLImageElement;
+    expect(() => store.tinted(1, src)).not.toThrow();
+  });
+
+  it('handles a zero-sized mask without producing a zero-dimension canvas', () => {
+    stubCanvas();
+    const { store } = makeStore();
+    const tinted = store.tinted(1, { naturalWidth: 0, naturalHeight: 0 } as HTMLImageElement);
+    expect(tinted.width).toBe(1);
+    expect(tinted.height).toBe(1);
+  });
+});
+
+describe('ThumbStore clear', () => {
+  it('drops images, tints and failure history together', () => {
+    stubDocumentCanvas();
+    const { store } = makeStore();
+    store.get(1);
+    finishLoad(last());
+    store.get(2);
+    failLoad(last());
+    expect(store.size).toBe(1);
+    expect(store.failed(2)).toBe(true);
+
+    store.clear();
+    expect(store.size).toBe(0);
+    expect(store.failed(2)).toBe(false);
+    // A cleared id fetches again straight away.
+    store.get(2);
+    expect(store.known(2)).toBe(true);
+  });
+
+  /** Minimal canvas stub for the clear test, which never inspects the context. */
+  function stubDocumentCanvas() {
+    vi.spyOn(document, 'createElement').mockReturnValue({
+      width: 0,
+      height: 0,
+      getContext: () => null,
+    } as unknown as HTMLCanvasElement);
+  }
+});

--- a/frontend/src/app/components/browse-canvas/thumb-store.ts
+++ b/frontend/src/app/components/browse-canvas/thumb-store.ts
@@ -1,0 +1,350 @@
+/**
+ * Representative-thumbnail cache for the browse canvas.
+ *
+ * Every bin the canvas paints in thumbnail mode is drawn with its
+ * representative clip's image, so a single frame can ask for hundreds of
+ * thumbnails and a pan/zoom session for tens of thousands. This module owns
+ * all of the state that makes that affordable:
+ *
+ * - **A count-bounded LRU** over the decoded {@link HTMLImageElement}s, keyed by
+ *   media id. Insertion order *is* the recency order: a visible paint re-inserts
+ *   its entry (see {@link ThumbStore.get}), so off-view warm-ups — which never
+ *   re-insert — are always first in line for eviction.
+ * - **A resolution tier.** Below a zoom threshold cells are painted from the
+ *   downscaled ``/thumbnail`` route; past it a cell is drawn wider than that
+ *   route's native cap, so the full-res ``/image`` is fetched instead. Crossing
+ *   the threshold drops the cache so every cell reloads at the matching
+ *   resolution — the two tiers are never mixed in one cache.
+ * - **A tinted-mask cache.** Audio waveform thumbnails are theme-agnostic alpha
+ *   masks (issue #2369); each is composited to the live accent colour once per
+ *   (clip, theme) rather than once per frame.
+ * - **Retryable failure records.** A load error is remembered with a backoff so
+ *   a transient blip doesn't blank that bin for the rest of the session.
+ *
+ * It is deliberately free of Angular and of the tile pyramid: it knows how to
+ * fetch, retain, evict and tint one image per media id, and nothing about which
+ * ids are worth fetching. Deciding *that* is the caller's job (see
+ * `prefetch-geometry.ts` for the tile-set half).
+ */
+
+/** Longest side (px) the ``/thumbnail`` route caps images at (mirrors
+ * ``vtscore``'s ``DEFAULT_MAX_DIM``). Once a cell is drawn wider than this the
+ * capped thumbnail would upscale, so at those zoom levels the canvas fetches
+ * the full-res ``/image`` instead. */
+export const THUMB_NATIVE_MAX_DIM = 384;
+
+/** LRU capacity while the store holds downscaled ``/thumbnail`` images. Each is
+ * at most {@link THUMB_NATIVE_MAX_DIM} on its longest side, so a full cache is
+ * tens of megabytes — cheap enough to keep a long pan session warm. */
+export const MAX_THUMBS = 2048;
+
+/**
+ * LRU capacity while the store holds full-res ``/image`` originals.
+ *
+ * Sharply lower than {@link MAX_THUMBS} because the entries are a different
+ * order of magnitude: a photo dataset's originals run to megabytes each, so the
+ * 2048-entry bound that keeps the capped tier at tens of megabytes would let
+ * the full-res tier retain gigabytes (the cap counts entries, not bytes).
+ *
+ * The tier only engages once a cell is drawn wider than
+ * {@link THUMB_NATIVE_MAX_DIM}, i.e. past ~384 device px across, so a 1080p
+ * viewport holds on the order of fifteen cells. This leaves better than ten
+ * screens of pan history warm while bounding retention to something a browser
+ * tab can hold.
+ */
+export const MAX_THUMBS_FULL_RES = 192;
+
+/** Fraction of the cache retained by one eviction pass (the oldest quarter is
+ *  dropped), so eviction amortizes over many insertions instead of running on
+ *  every load once the cache is full. */
+const EVICT_RETAIN = 0.75;
+
+/**
+ * Backoff (ms) before a failed thumbnail is retried, indexed by how many
+ * attempts have already failed. A transient failure — a server restart, a
+ * brief network blip, one 502 during a burst of preload fetches — used to
+ * blank that bin permanently: the id went into a failure set that was only
+ * ever cleared by a projection switch or a tier crossing, so the cell rendered
+ * as flat density shading among its thumbnail neighbours for the rest of the
+ * session, with no user-visible way to recover short of leaving the view.
+ *
+ * The schedule grows so a genuinely broken id costs three requests rather than
+ * one per frame, and stops entirely after the last entry: a media whose image
+ * really is missing (deleted file, unsupported codec) should settle into the
+ * flat-density fallback rather than retry forever.
+ */
+export const THUMB_RETRY_BACKOFF_MS = [2_000, 8_000, 32_000];
+
+/** What the store needs from its host to fetch, repaint and tint. */
+export interface ThumbStoreDeps {
+  /** Build a dataset-scoped URL for a media endpoint (``/api/medias/…``). */
+  mediaUrl(path: string): string;
+  /** Schedule a repaint: a *visible* thumbnail has finished decoding, or has
+   *  failed and the frame should stop waiting on it. Never called for an
+   *  off-view warm-up, which has no cell on screen to repaint. */
+  onLoaded(): void;
+  /** The live theme's accent colour, used to tint audio waveform masks. Read
+   *  per tint rather than captured, so a theme flip (which clears the tinted
+   *  cache) re-tints against the new colour. */
+  accent(): string;
+  /** Clock, injectable so the retry backoff is testable without real timers. */
+  now?(): number;
+}
+
+/** A remembered load failure and when it may be retried. */
+interface FailureRecord {
+  /** How many fetches for this id have failed. */
+  attempts: number;
+  /** Timestamp (ms, {@link ThumbStoreDeps.now}) before which no retry is made.
+   *  ``Infinity`` once the attempts are spent — the id is given up on. */
+  retryAt: number;
+}
+
+export class ThumbStore {
+  /** Loaded representative thumbnails, keyed by media id (insertion-ordered LRU). */
+  private readonly images = new Map<number, HTMLImageElement>();
+  /** Media ids whose thumbnail failed, with their retry backoff, so we neither
+   *  refetch every frame nor give up permanently on a transient blip. */
+  private readonly failures = new Map<number, FailureRecord>();
+  /** Waveform masks composited to the live accent, keyed like {@link images}
+   *  and evicted alongside them so a tint can never outlive its source. */
+  private readonly tintedImages = new Map<number, HTMLCanvasElement>();
+  /** Whether the cache currently holds full-res originals rather than capped
+   *  thumbnails. Flipped by {@link setFullRes}, which drops the cache. */
+  private fullRes = false;
+
+  constructor(private readonly deps: ThumbStoreDeps) {}
+
+  private now(): number {
+    return this.deps.now ? this.deps.now() : Date.now();
+  }
+
+  /** Entries retained before eviction, which depends on the live tier. */
+  get capacity(): number {
+    return this.fullRes ? MAX_THUMBS_FULL_RES : MAX_THUMBS;
+  }
+
+  /** How many images are cached (pending loads included). */
+  get size(): number {
+    return this.images.size;
+  }
+
+  /** Whether the cache is at capacity — a warm-up stops here so an off-view
+   *  preload can never evict something that is on screen. */
+  get full(): boolean {
+    return this.images.size >= this.capacity;
+  }
+
+  /** Whether the store is filled with full-res originals. */
+  get isFullRes(): boolean {
+    return this.fullRes;
+  }
+
+  /**
+   * Whether a cell is drawn wide enough that the capped ``/thumbnail`` would
+   * upscale, so the full-res ``/image`` should be fetched instead. Pure, so the
+   * threshold is testable without a canvas.
+   */
+  static wantsFullRes(targetRadius: number, dpr: number): boolean {
+    return 2 * targetRadius * dpr > THUMB_NATIVE_MAX_DIM;
+  }
+
+  /**
+   * Switch the resolution tier, dropping the cache when it actually changes so
+   * cells reload at the matching resolution. Returns whether the tier flipped
+   * (a cheap no-op otherwise), which the caller can use to decide whether a
+   * repaint is owed.
+   */
+  setFullRes(fullRes: boolean): boolean {
+    if (fullRes === this.fullRes) return false;
+    this.fullRes = fullRes;
+    this.clear();
+    return true;
+  }
+
+  /**
+   * The loaded thumbnail for a representative media id, or null while it loads
+   * or if it failed. Kicks off the fetch on first request (and on a retry once
+   * a failure's backoff has expired) and repaints when the image arrives.
+   */
+  get(id: number): HTMLImageElement | null {
+    const cached = this.images.get(id);
+    if (cached) {
+      // Bump recency: re-insert so a thumbnail painted this frame becomes the
+      // newest entry. The map is insertion-ordered (see {@link evict}), so this
+      // keeps currently-visible thumbnails last in line for eviction — off-view
+      // warm-ups (which never bump) are dropped first, so warming the ring can
+      // never evict something that's on screen.
+      this.images.delete(id);
+      this.images.set(id, cached);
+      return cached.complete && cached.naturalWidth > 0 ? cached : null;
+    }
+    this.startLoad(id, false);
+    return null;
+  }
+
+  /**
+   * The cached image for an id *without* bumping its recency or starting a
+   * fetch — a pure read, for callers that only want to know whether a load has
+   * landed (the first-view gate). Undefined when nothing is cached.
+   */
+  peek(id: number): HTMLImageElement | undefined {
+    return this.images.get(id);
+  }
+
+  /** Whether an id is cached or already known-failed, i.e. whether asking for
+   *  it again would start a fetch. */
+  known(id: number): boolean {
+    return this.images.has(id) || this.failures.has(id);
+  }
+
+  /**
+   * Whether this id has a recorded load failure. True through the whole backoff
+   * (not just while a retry is pending), because callers use it to decide
+   * whether to *wait* on a thumbnail: a cell that has failed once must not hold
+   * the first-view cover up across the retry schedule.
+   */
+  failed(id: number): boolean {
+    return this.failures.has(id);
+  }
+
+  /**
+   * Warm an off-view thumbnail at low priority, returning whether a fetch was
+   * actually started (so callers can budget passes by real network cost).
+   *
+   * Refused while the store is in the full-res tier. The tier exists because a
+   * *visible* giant cell would upscale a capped thumbnail, and the comment
+   * justifying it — only a handful of such cells fit on screen — is exactly why
+   * warming is wrong there: a ring warm-up fetches on the order of sixty
+   * off-screen cells, which at full resolution is potentially gigabytes pulled
+   * for cells the user may never pan to. On-demand loading is unaffected, so
+   * panning to such a cell still fills it; only the speculative fetch is
+   * dropped, and it is dropped where speculation is most expensive.
+   */
+  warm(id: number): boolean {
+    if (this.fullRes) return false;
+    return this.startLoad(id, true);
+  }
+
+  /**
+   * Kick off the fetch for a representative id and stash the pending image in
+   * the cache; returns whether a fetch was started. ``preload`` marks an
+   * off-view warm-up: it loads at low network priority and does not repaint
+   * when it lands (the cell isn't on screen), so it never competes with visible
+   * thumbnails. A no-op when the id is already cached, or when a previous
+   * failure's backoff has not yet expired.
+   */
+  private startLoad(id: number, preload: boolean): boolean {
+    if (this.images.has(id)) return false;
+    const failure = this.failures.get(id);
+    if (failure && this.now() < failure.retryAt) return false;
+
+    if (this.full) this.evict();
+
+    const img = new Image();
+    img.decoding = 'async';
+    if (preload) {
+      // Idle warm-up: let the browser schedule it behind visible-thumbnail and
+      // tile requests, and skip the repaint — the cell is off-screen, so a later
+      // draw picks it up from the cache once the user pans to it.
+      img.setAttribute('fetchpriority', 'low');
+    } else {
+      img.onload = () => {
+        // A load that lands clears the failure history: the id is good again,
+        // so a later blip gets the full retry schedule rather than resuming a
+        // spent one.
+        this.failures.delete(id);
+        this.deps.onLoaded();
+      };
+    }
+    img.onerror = () => {
+      this.images.delete(id);
+      this.recordFailure(id, failure);
+      // Repaint so the frame stops waiting on this cell (it now falls back to
+      // flat density shading) instead of stranding the first-view cover until
+      // its backstop timer fires. Warm-ups paint nothing, so they stay silent.
+      if (!preload) this.deps.onLoaded();
+    };
+    // Downscaled /thumbnail by default: a browse projection can hold thousands
+    // of points, so painting full-size bitmaps onto every bin would exhaust
+    // memory. The /thumbnail route serves the frame for video via the same
+    // image_response hook, then downscales it. At the largest zoom levels a cell
+    // is drawn wider than the thumbnail's native resolution, so the full-res
+    // /image is fetched instead — see {@link wantsFullRes}.
+    const endpoint = this.fullRes ? 'image' : 'thumbnail';
+    img.src = this.deps.mediaUrl(`/api/medias/${id}/${endpoint}`);
+    this.images.set(id, img);
+    return true;
+  }
+
+  /** Note a failed attempt and schedule (or give up on) the next retry. */
+  private recordFailure(id: number, previous: FailureRecord | undefined): void {
+    const attempts = (previous?.attempts ?? 0) + 1;
+    const backoff = THUMB_RETRY_BACKOFF_MS[attempts - 1];
+    this.failures.set(id, {
+      attempts,
+      // Out of attempts: give up rather than refetch a genuinely missing image
+      // once per backoff window forever.
+      retryAt: backoff === undefined ? Infinity : this.now() + backoff,
+    });
+  }
+
+  /** Drop the oldest quarter of cached thumbnails (insertion-ordered LRU). */
+  private evict(): void {
+    const target = Math.floor(this.capacity * EVICT_RETAIN);
+    const toRemove = this.images.size - target;
+    let i = 0;
+    for (const key of this.images.keys()) {
+      if (i++ >= toRemove) break;
+      this.images.delete(key);
+      // Drop the matching tinted mask (issue #2369) so it can't outlive its raw
+      // source and leak; it re-tints on demand if the clip is revisited.
+      this.tintedImages.delete(key);
+    }
+  }
+
+  /**
+   * The audio waveform thumbnail tinted to the live theme's accent colour,
+   * built once per (clip, theme) and cached (issue #2369).
+   *
+   * The raw thumbnail is a theme-agnostic alpha mask — a transparent PNG whose
+   * only opaque pixels are the wave. Painting it to an offscreen canvas and
+   * compositing the accent through ``source-in`` recolours just the wave,
+   * leaving the background transparent so the tile's themed surface (filled by
+   * the caller) shows through. The tinted cache is cleared on a theme flip and
+   * whenever the raw cache is, so it never serves a stale colour.
+   */
+  tinted(id: number, src: HTMLImageElement): HTMLCanvasElement {
+    const cached = this.tintedImages.get(id);
+    if (cached) return cached;
+
+    const w = src.naturalWidth || 1;
+    const h = src.naturalHeight || 1;
+    const off = document.createElement('canvas');
+    off.width = w;
+    off.height = h;
+    const octx = off.getContext('2d');
+    if (octx) {
+      octx.drawImage(src, 0, 0);
+      octx.globalCompositeOperation = 'source-in';
+      octx.fillStyle = this.deps.accent();
+      octx.fillRect(0, 0, w, h);
+    }
+    this.tintedImages.set(id, off);
+    return off;
+  }
+
+  /** Drop the tinted masks only, keeping the raw ones — what a theme flip
+   *  needs, since the masks themselves are theme-agnostic. */
+  clearTinted(): void {
+    this.tintedImages.clear();
+  }
+
+  /** Drop everything: images, tints and failure history. Used on a projection
+   *  switch, a tier crossing and teardown. */
+  clear(): void {
+    this.images.clear();
+    this.tintedImages.clear();
+    this.failures.clear();
+  }
+}


### PR DESCRIPTION
Closes #3417

Takes the narrowed scope of #3417 — see "What I did not do" below for where I diverged from the issue and why.

## What landed

**`thumb-store.ts`** — the representative-thumbnail cache: the insertion-ordered LRU, the capped/full-res resolution tier, the audio waveform tint cache, and (new) retryable failure records. Its dependencies are narrow by construction — a URL builder, a repaint callback, an accent colour, and an injectable clock. It knows how to fetch, retain, evict and tint one image per media id, and nothing about which ids are worth fetching.

**`prefetch-geometry.ts`** — the pure tile-set half of the prefetch paths: `offViewRing`, `finerTilesForZoom`, `tilesAtLevel`, `smoothPanDirection`. This was interleaved with the thumbnail code but is really tile-pyramid geometry: it answers "which tiles is the view about to need?", which *both* the tile cache and the thumb store consume. Pure functions of numbers and tile coordinates, so the "what to warm" decision is now testable apart from the "how to fetch it" decision.

Both mirror the `render-perf.ts` shape, each with a spec. The component drops from 3062 to 2883 lines.

## Two bug fixes

Both from the August audit (`docs/plans/codebase-audit-2026-08.md`), folded in while the code was open. Their entries are pruned from the plan in a second commit.

**Full-res preload bytes.** The idle preloader shared the visible resolution tier, so once the zoom crossed into full-res every idle pass warmed up to 64 **off-screen** cells with uncapped originals — potentially gigabytes fetched *and retained* for cells the user may never see, since `MAX_THUMBS` bounds entries rather than bytes. `ThumbStore.warm()` now refuses in that tier, and the tier carries a much smaller LRU cap. On-demand loading is untouched, so panning to such a cell still fills it. The audit offered "always preload the capped endpoint" as an alternative; I did not take it because the cache is keyed by id alone, so a preloaded low-res entry would be *served* at full-res zoom and would need a per-entry tier tag plus a re-fetch-and-flicker upgrade path. Refusing to speculate is the smaller correct change — and the justification for the tier existing (only a handful of such giant cells fit on screen) is exactly why warming a sixty-cell ring there was wrong.

**Permanent `thumbFailed`.** A failed load went into a set cleared only by a projection switch or a tier crossing, so one transient blip left that bin rendered as flat density shading among its neighbours for the rest of the session, with no retry path. Failures now carry an exponential backoff (2s/8s/32s) and give up only once the attempts are spent; a successful load clears the history. A *visible* failure also repaints now, so the frame stops waiting on that cell instead of stranding the first-view cover until its 12s backstop fires.

## What I did not do, and why

The issue also asked for the zoom/settle/pan animation controller, over `{getCanvas, draw, setTransform}`. I traced the real dependency set and that interface isn't viable: `startZoomAnim` → `renderSnapshotBorder` → `drawHex` + `resolveColormap` + `themeColor` + selection + tile cache + `meta` + `geom`; `settleToBounds` → `clampedTransform` + `updateActiveLevel` + `refreshHoverAfterZoom` + `draw`; plus `ngZone.runOutsideAngular`, the `lowFx`/`recordFrameCost` latch, `width`/`height`/`dpr`, and in-place mutation of the shared `transform` object that `draw()` reads by identity. That's an ~18-member port.

`render-perf.ts` works as a model because its interface is a number in, a boolean out. An 18-member port doesn't reduce coupling — it makes the same coupling explicit and adds indirection, while routing the app's riskiest surface (RAF + zoneless notification, which the issue itself flags) through churn for a line-count win. The issue's own framing of the two blocks as "both nearly Angular-free" holds for the thumbnail cache and not for this.

The issue's "~400 lines of thumbnail store" was likewise two concerns: ~180 lines of cache, and tile-geometry code that depends on `meta`/`activeLevel`/`geom`/`tileCache`. Hence two modules rather than one.

## Verification

`./run-tests.sh` — `RUN PASSED`, all gates green, 9668 passed. Re-run after rebasing onto 4ea05c25, so it includes `dev`'s new `vulture whitelist` gate and the loader-façade import changes.

Real chromium as the issue requires, driving the app against the `syn-imgs` fixture (jsdom can't tell us whether the redraw notification path still fires):

- First-view cover lifts; every gesture (wheel zoom in/out, arrow-key glide, drag pan, zoom-to-fit, theme flip) repaints and then settles.
- **Zoneless notification path:** on a throttled cold reload, distinct canvas colours went 44 → 158 across 30 idle samples with zero user input — a thumbnail landing still drives a repaint.
- **Full-res regression:** at 5XL (full-res tier), `/image` fetches held at **6 unique ids across four pans plus idle windows** on a 60-image dataset. The old preloader warmed up to 64 off-screen cells per idle pass, i.e. the whole dataset at full resolution. Stepping back to the capped tier still warms more widely (9 vs 6), confirming preloading was narrowed rather than switched off.
- No console or page errors throughout.

## Rebase note

This branch originally carried a third commit registering "The dirty-key contract" with `scripts/check-extension-docs.py`, because that gate was failing on `dev` and blocking every run. #3479 landed the same fix independently (186a7550). On rebase I dropped mine in favour of `dev`'s, which registers `("UserSyncState",)` where mine also allowed `UserSettingsStore` — the narrower set is the better one for a gate. That was the only conflict; the branch is now exactly the browse-canvas work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NW57sqPztP3k9vD7q76mt9