### PR TITLE
frontend: add ActiveDatasetService and by-id registry indexes

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -346,7 +346,7 @@ The backend resolves per-dataset and per-detector state from the
 `X-Dataset-Id` / `X-Detector-Id` request headers (see
 [ARCHITECTURE.md § Multi-dataset support](ARCHITECTURE.md#multi-dataset-support)).
 The frontend's job is to make sure those headers name a pair the backend has
-actually loaded. Four pieces cooperate.
+actually loaded. Five pieces cooperate.
 
 ### `ActiveContextService` — two layers, not one
 
@@ -368,6 +368,53 @@ highlights; `active` lags until a load completes and is promoted explicitly.
   prep step captures the id at start and discards its result if the id has
   moved. Cancelling in-flight work is best-effort; this check is the
   correctness guarantee.
+
+### `ActiveDatasetService` / `ActiveDetectorService` — the ids as *entries*
+
+`ActiveContextService` carries **ids**, on an RxJS layer a `computed` can't
+track. Almost every consumer wants the registry *entry* behind the id — its
+name, its media type, its embedder — so each one used to redo the same
+`datasets.find(d => d.id === …)` by hand. That read whatever happened to be
+loaded at call time and never updated when the registry landed a moment later:
+the lifecycle gap that left an export filename detector-less when the modal
+opened first (#2819).
+
+The two services close it, one per half, with the same five members:
+
+```
+activeId      the id the backend has loaded ('' when none)
+intentId      the id the user picked
+datasetId /   activeId || intentId — name the user's pick immediately
+  detectorId  rather than blanking for the duration of a load
+dataset /     the registry entry, or null (nothing selected, or the
+  detector    registry fetch is still in flight)
+datasetName / the entry's name, or ''
+  detectorName
+```
+
+Reach for these from **components**: a `computed`/`effect`/template read
+repopulates on its own once the registry or an in-flight switch settles.
+
+Two places deliberately keep the imperative lookup, and should:
+
+- **Route guards** run once, before activation, and have already awaited the
+  registry — there is nothing left to arrive.
+- **Pre-reactive services** (`ActiveContextWatcherService`) resolve the pair
+  from the arrays their own `combineLatest` emitted; reading a signal instead
+  would resolve against a *different* snapshot than the one being handled.
+
+Both still index rather than scan: `DatasetStateService` exposes `datasetById`
+/ `detectorById`, `computed` Maps over the two registries. They are the shared
+lookup the services are built on, and reading one is signal-tracked exactly
+like reading `datasets` — so swapping a `find` for a `.get` is a readability
+change, never a reactivity one.
+
+Note what these services are *not* for. A lookup that resolves something other
+than the active pair — the Dashboard's multi-select, the id being switched
+*to*, an entry from an HTTP response body — is a different question that
+happens to share the `find(d => d.id === …)` shape. Use the Maps there if the
+predicate is a plain id match; do not route it through the active-context
+services.
 
 ### `ContextSwitchService` — the only way to *change* the pair
 

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,7 +1,14 @@
-import { ChangeDetectionStrategy, Component, effect, HostListener, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  HostListener,
+  inject,
+  signal,
+} from '@angular/core';
 import { Router, RouterOutlet, NavigationEnd } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { combineLatest } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { DialogHostComponent } from './components/dialog-host/dialog-host.component';
 import { ToastContainerComponent } from './components/toast-container/toast-container.component';
@@ -21,7 +28,8 @@ import { DatasetImporterModalComponent } from './components/dashboard/dataset-im
 import { NewDetectorModalComponent } from './components/dashboard/new-detector-modal/new-detector-modal.component';
 import { MediaStateService } from './services/media-state.service';
 import { DatasetStateService } from './services/dataset-state.service';
-import { ActiveContextService } from './services/active-context.service';
+import { ActiveDatasetService } from './services/active-dataset.service';
+import { ActiveDetectorService } from './services/active-detector.service';
 import { RecentSessionsService } from './services/recent-sessions.service';
 import { AuthService } from './services/auth.service';
 import { HuggingFaceAuthService } from './services/huggingface-auth.service';
@@ -66,7 +74,8 @@ export class AppComponent {
   private router = inject(Router);
   private mediaState = inject(MediaStateService);
   private datasetState = inject(DatasetStateService);
-  private activeContext = inject(ActiveContextService);
+  private readonly activeDataset = inject(ActiveDatasetService);
+  private readonly activeDetector = inject(ActiveDetectorService);
   private recent = inject(RecentSessionsService);
   auth = inject(AuthService);
   achievements = inject(AchievementsService);
@@ -90,14 +99,21 @@ export class AppComponent {
   helpClosing = false;
   // Written from the router-events subscribe (async); template-bound.
   readonly isOnLabelView = signal(false);
-  private isOnBrowseView = false;
+  private readonly isOnBrowseView = signal(false);
   settingsViewTab = '';
   /** True when the current route consumes the active pair (label / find)
    *  and the pair is not compatible, so the explainer takes over the
-   *  router-outlet area in that state. Written from `recomputeExplainer()`,
-   *  which runs from the router-events and pair/registry `combineLatest`
-   *  subscribes (async), so a signal so the explainer toggles under zoneless. */
-  readonly showIncompatibleExplainer = signal(false);
+   *  router-outlet area in that state.
+   *
+   *  A `computed` over the route signals and the two active-context
+   *  services, so it has no separate recompute step to forget to run: it
+   *  re-evaluates when the route changes, when the pair changes, and when
+   *  the registry lands (the case that matters on a cold deep-link, where
+   *  the ids resolve to entries only after the fetch returns). */
+  readonly showIncompatibleExplainer = computed(() => {
+    if (!this.isOnLabelView() || this.isOnBrowseView()) return false;
+    return !isPairCompatible(this.activeDataset.dataset(), this.activeDetector.detector());
+  });
 
   // Written from the `newThingFlows.importer$`/`newDetector$` subscribes (async).
   readonly importerFlow = signal<ImporterFlowState>({
@@ -144,20 +160,14 @@ export class AppComponent {
     this.router.events
       .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
       .subscribe((e) => {
-        this.isOnBrowseView = e.urlAfterRedirects.startsWith('/browse');
+        const onBrowse = e.urlAfterRedirects.startsWith('/browse');
+        this.isOnBrowseView.set(onBrowse);
         this.isOnLabelView.set(
           e.urlAfterRedirects.startsWith('/label') ||
             e.urlAfterRedirects.startsWith('/find') ||
-            this.isOnBrowseView,
+            onBrowse,
         );
-        this.recomputeExplainer();
       });
-
-    combineLatest([
-      this.activeContext.pair$,
-      this.datasetState.datasets$,
-      this.datasetState.detectors$,
-    ]).subscribe(() => this.recomputeExplainer());
 
     this.newThingFlows.importer$.subscribe((state) => {
       this.importerFlow.set(state);
@@ -191,20 +201,6 @@ export class AppComponent {
     const query = params.toString();
     const newUrl = window.location.pathname + (query ? `?${query}` : '') + window.location.hash;
     window.history.replaceState({}, '', newUrl);
-  }
-
-  private recomputeExplainer(): void {
-    if (!this.isOnLabelView() || this.isOnBrowseView) {
-      this.showIncompatibleExplainer.set(false);
-      return;
-    }
-    const ds = this.activeContext.datasetId
-      ? this.datasetState.datasets.find((d) => d.id === this.activeContext.datasetId) ?? null
-      : null;
-    const det = this.activeContext.modelId
-      ? this.datasetState.detectors.find((d) => d.id === this.activeContext.modelId) ?? null
-      : null;
-    this.showIncompatibleExplainer.set(!isPairCompatible(ds, det));
   }
 
   toggleMenu(event: Event): void {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -343,9 +343,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
       const otherDsId = this.dashSelection.dashboardVisible
         ? singleId(this.dashSelection.datasetIds)
         : this.activeContext.intentDatasetId;
-      const other = otherDsId
-        ? this.datasetState.datasets.find((d) => d.id === otherDsId)
-        : null;
+      const other = otherDsId ? this.datasetState.datasetById().get(otherDsId) : null;
       this.newThingFlows.openNewDetector({
         defaultMediaType: other?.media_type || '',
         datasetEmbedder: other?.embedder || '',
@@ -499,6 +497,8 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   private rebuildRows(): void {
     const datasets = this.datasetState.datasets;
     const detectors = this.datasetState.detectors;
+    const datasetById = this.datasetState.datasetById();
+    const detectorById = this.datasetState.detectorById();
     // Two sources for what counts as "active":
     //  - On the Dashboard, the highlighted table rows (which can be more
     //    than one — the closed label collapses that to "Multiple").
@@ -519,12 +519,12 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     const selected = new Set(this.selectedIds);
     if (this.isDataset) {
       const activeDetId = singleId(detIds);
-      const activeDetector = activeDetId ? detectors.find((d) => d.id === activeDetId) : null;
+      const activeDetector = activeDetId ? detectorById.get(activeDetId) ?? null : null;
       const sorted = this.applySort(datasets);
       this.rows = sorted.map((d) => this.datasetRow(d, selected, activeDetector));
     } else {
       const activeDsId = singleId(dsIds);
-      const activeDataset = activeDsId ? datasets.find((d) => d.id === activeDsId) : null;
+      const activeDataset = activeDsId ? datasetById.get(activeDsId) ?? null : null;
       const sorted = this.applySort(detectors);
       this.rows = sorted.map((d) => this.detectorRow(d, selected, activeDataset));
     }

--- a/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
+++ b/frontend/src/app/components/context-pulldown/incompatible-pair-explainer.component.ts
@@ -1,10 +1,8 @@
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 import { Router } from '@angular/router';
-import { Subject, combineLatest } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
-import { DatasetStateService } from '../../services/dataset-state.service';
-import { ActiveContextService } from '../../services/active-context.service';
+import { ActiveDatasetService } from '../../services/active-dataset.service';
+import { ActiveDetectorService } from '../../services/active-detector.service';
 import { PulldownControlService } from '../../services/pulldown-control.service';
 import { DatasetRegistryEntry } from '../../models/api.models';
 import { DetectorRegistryEntry } from '../../generated/api-client/models/detector-registry-entry';
@@ -26,37 +24,28 @@ import { DetectorRegistryEntry } from '../../generated/api-client/models/detecto
   templateUrl: './incompatible-pair-explainer.component.html',
   styleUrl: './incompatible-pair-explainer.component.scss',
 })
-export class IncompatiblePairExplainerComponent implements OnInit, OnDestroy {
+export class IncompatiblePairExplainerComponent {
   private router = inject(Router);
-  private activeContext = inject(ActiveContextService);
-  private datasetState = inject(DatasetStateService);
+  private activeDataset = inject(ActiveDatasetService);
+  private activeDetector = inject(ActiveDetectorService);
   private pulldownControl = inject(PulldownControlService);
 
-  dataset: DatasetRegistryEntry | null = null;
-  detector: DetectorRegistryEntry | null = null;
-
-  private destroy$ = new Subject<void>();
-
-  ngOnInit(): void {
-    combineLatest([
-      this.activeContext.pair$,
-      this.datasetState.datasets$,
-      this.datasetState.detectors$,
-    ])
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(([pair, datasets, detectors]) => {
-        this.dataset = pair.datasetId
-          ? datasets.find((d) => d.id === pair.datasetId) ?? null
-          : null;
-        this.detector = pair.modelId
-          ? detectors.find((d) => d.id === pair.modelId) ?? null
-          : null;
-      });
+  // Signal reads behind getters, not fields written from a subscribe.
+  //
+  // The old subscribe assigned plain fields on an OnPush component without
+  // `markForCheck()`, which under zoneless CD schedules nothing. It repainted
+  // anyway, and still would: `AppComponent` only mounts this component once
+  // it has decided the pair is incompatible, so the fields are always read
+  // fresh at first paint, and a later change unmounts it rather than
+  // updating it in place. The pattern was one refactor away from being a
+  // real staleness bug, not a bug today — reading the signal inside a
+  // template-evaluated getter is tracked, so it cannot become one.
+  get dataset(): DatasetRegistryEntry | null {
+    return this.activeDataset.dataset();
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
+  get detector(): DetectorRegistryEntry | null {
+    return this.activeDetector.detector();
   }
 
   get bothMissing(): boolean {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1191,7 +1191,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get activeDatasetMediaType(): string {
     if (this.selectedDatasetIds.size === 1) {
       const selId = [...this.selectedDatasetIds][0];
-      const sel = this.datasets.find((d) => d.id === selId);
+      const sel = this.datasetState.datasetById().get(selId);
       if (sel?.media_type) return sel.media_type;
     }
     const loaded = this.datasets.find((d) => d.loaded);
@@ -1209,7 +1209,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   get activeDatasetEmbedder(): string {
     if (this.selectedDatasetIds.size === 1) {
       const selId = [...this.selectedDatasetIds][0];
-      const sel = this.datasets.find((d) => d.id === selId);
+      const sel = this.datasetState.datasetById().get(selId);
       if (sel?.embedder) return sel.embedder;
     }
     const loaded = this.datasets.find((d) => d.loaded);

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.spec.ts
@@ -195,7 +195,13 @@ describe('FindStatsModalComponent — training-domain overlap', () => {
       imports: [FindStatsModalComponent],
       providers: [
         ...provideHttpTesting(),
-        { provide: DatasetStateService, useValue: { datasets } },
+        {
+          provide: DatasetStateService,
+          useValue: {
+            datasets,
+            datasetById: () => new Map(datasets.map((d) => [d.id, d])),
+          },
+        },
       ],
     }).compileComponents();
 

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.ts
@@ -5,6 +5,7 @@ import { DetectorsFindApiService } from '../../../services/detectors-find-api.se
 import { DatasetsRegistryApiService } from '../../../services/datasets-registry-api.service';
 import { DatasetStateService } from '../../../services/dataset-state.service';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { ActiveDatasetService } from '../../../services/active-dataset.service';
 import type { FindStatsResponse } from '../../../generated/api-client/models/find-stats-response';
 import type { FindEvidenceCoverageResponse } from '../../../generated/api-client/models/find-evidence-coverage-response';
 import type { DatasetDomainShiftResponse } from '../../../generated/api-client/models/dataset-domain-shift-response';
@@ -38,6 +39,7 @@ export class FindStatsModalComponent implements OnInit {
   private registryApi = inject(DatasetsRegistryApiService);
   private datasetState = inject(DatasetStateService);
   private activeCtx = inject(ActiveContextService);
+  private activeDataset = inject(ActiveDatasetService);
 
   readonly closed = output<void>();
 
@@ -103,7 +105,7 @@ export class FindStatsModalComponent implements OnInit {
   private initDomainOverlap(): void {
     const activeId = this.activeCtx.datasetId;
     const datasets = this.datasetState.datasets;
-    const activeEmbedder = datasets.find((d) => d.id === activeId)?.embedder ?? '';
+    const activeEmbedder = this.activeDataset.dataset()?.embedder ?? '';
     const candidates = datasets.filter(
       (d) => d.loaded && d.id !== activeId && (d.embedder ?? '') === activeEmbedder,
     );

--- a/frontend/src/app/guards/active-context.guard.ts
+++ b/frontend/src/app/guards/active-context.guard.ts
@@ -52,8 +52,8 @@ export const activeContextGuard: CanActivateFn = (route) => {
     filter((loaded) => loaded),
     take(1),
     switchMap((): Observable<boolean | UrlTree> => {
-      const dataset = datasetState.datasets.find((d) => d.id === datasetId);
-      const detector = datasetState.detectors.find((d) => d.id === detectorId);
+      const dataset = datasetState.datasetById().get(datasetId);
+      const detector = datasetState.detectorById().get(detectorId);
 
       if (!dataset) {
         toast.error({

--- a/frontend/src/app/guards/browse-context.guard.ts
+++ b/frontend/src/app/guards/browse-context.guard.ts
@@ -36,7 +36,7 @@ export const browseContextGuard: CanActivateFn = (route) => {
     filter((loaded) => loaded),
     take(1),
     switchMap((): Observable<true | UrlTree> => {
-      const dataset = datasetState.datasets.find((d) => d.id === datasetId);
+      const dataset = datasetState.datasetById().get(datasetId);
 
       if (!dataset) {
         toast.error({

--- a/frontend/src/app/services/active-dataset.service.spec.ts
+++ b/frontend/src/app/services/active-dataset.service.spec.ts
@@ -1,0 +1,98 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { ActiveContextService } from './active-context.service';
+import { ActiveDatasetService } from './active-dataset.service';
+import { DatasetStateService } from './dataset-state.service';
+import { provideHttpTesting } from '../testing/test-providers';
+
+describe('ActiveDatasetService', () => {
+  let service: ActiveDatasetService;
+  let activeContext: ActiveContextService;
+  let datasetState: DatasetStateService;
+  let httpMock: HttpTestingController;
+
+  /** Land a dataset registry payload, as the app-level refresh would. */
+  function flushRegistry(datasets: { id: string; name: string }[]): void {
+    datasetState.refresh();
+    httpMock.expectOne('/api/datasets/registry').flush({ datasets });
+    httpMock.expectOne('/api/detectors/registry').flush({ detectors: [] });
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [...provideHttpTesting()],
+    });
+    service = TestBed.inject(ActiveDatasetService);
+    activeContext = TestBed.inject(ActiveContextService);
+    datasetState = TestBed.inject(DatasetStateService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('reports no dataset before anything is selected', () => {
+    expect(service.datasetId()).toBe('');
+    expect(service.dataset()).toBeNull();
+    expect(service.datasetName()).toBe('');
+  });
+
+  it('resolves the active id to its registry name', () => {
+    flushRegistry([
+      { id: 'ds1', name: 'Field recordings' },
+      { id: 'ds2', name: 'Street noise' },
+    ]);
+    activeContext.setActivePair('ds2', 'd1');
+    expect(service.datasetId()).toBe('ds2');
+    expect(service.dataset()?.name).toBe('Street noise');
+    expect(service.datasetName()).toBe('Street noise');
+  });
+
+  // The dataset half of the lifecycle gap behind issue #2819: a consumer
+  // reading the entry before the registry lands used to latch null forever.
+  it('fills in the name when the registry lands after the selection', () => {
+    activeContext.setActivePair('ds1', '');
+    expect(service.datasetName()).toBe('');
+
+    flushRegistry([{ id: 'ds1', name: 'Field recordings' }]);
+    expect(service.datasetName()).toBe('Field recordings');
+  });
+
+  it('names the user pick while the switch is still loading', () => {
+    flushRegistry([{ id: 'ds1', name: 'Field recordings' }]);
+    // Intent leads active for the duration of the dataset/detector load.
+    activeContext.setIntent('ds1', 'd1');
+    expect(service.activeId()).toBe('');
+    expect(service.intentId()).toBe('ds1');
+    expect(service.datasetName()).toBe('Field recordings');
+  });
+
+  it('prefers the active dataset over an in-flight switch to another one', () => {
+    flushRegistry([
+      { id: 'ds1', name: 'Field recordings' },
+      { id: 'ds2', name: 'Street noise' },
+    ]);
+    activeContext.setActivePair('ds1', 'd1');
+    activeContext.setIntent('ds2', 'd1');
+    // Until the load promotes ds2, the loaded dataset is still ds1.
+    expect(service.datasetName()).toBe('Field recordings');
+
+    activeContext.setActive('ds2', 'd1');
+    expect(service.datasetName()).toBe('Street noise');
+  });
+
+  it('clears the name when the selection is cleared', () => {
+    flushRegistry([{ id: 'ds1', name: 'Field recordings' }]);
+    activeContext.setActivePair('ds1', 'd1');
+    activeContext.clear();
+    expect(service.datasetId()).toBe('');
+    expect(service.datasetName()).toBe('');
+  });
+
+  it('reports an empty name for an id the registry does not know', () => {
+    flushRegistry([{ id: 'ds1', name: 'Field recordings' }]);
+    activeContext.setActivePair('gone', 'd1');
+    expect(service.dataset()).toBeNull();
+    expect(service.datasetName()).toBe('');
+  });
+});

--- a/frontend/src/app/services/active-dataset.service.ts
+++ b/frontend/src/app/services/active-dataset.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { DatasetRegistryEntry } from '../models/api.models';
+import { ActiveContextService } from './active-context.service';
+import { DatasetStateService } from './dataset-state.service';
+
+/**
+ * Signal view of *which dataset the user is working with*, resolved from the
+ * active-context id to its registry entry.
+ *
+ * The dataset-half twin of {@link ActiveDetectorService}, and it exists for
+ * the same reason: `ActiveContextService` carries ids only, on an RxJS layer
+ * a `computed` can't track, so a consumer that wanted the entry (for its
+ * name, its media type, its embedder) re-did the `datasets.find(...)` lookup
+ * imperatively — reading whatever happened to be loaded at call time, and
+ * never updating when the registry landed a moment later.
+ *
+ * The two services are deliberately separate objects rather than one
+ * `ActiveContext` facade with four fields: consumers overwhelmingly want one
+ * half, and keeping them apart means a component that only names the detector
+ * doesn't take a dependency on the dataset registry.
+ *
+ * Deliberately *not* fields on `ActiveContextService`: that one is injected by
+ * the HTTP interceptor, and pulling in registry state (which itself depends on
+ * `HttpClient`) would make the interceptor's dependency graph cyclic.
+ */
+@Injectable({ providedIn: 'root' })
+export class ActiveDatasetService {
+  private readonly activeContext = inject(ActiveContextService);
+  private readonly datasetState = inject(DatasetStateService);
+
+  /** Dataset id currently loaded into the backend (`''` when none). */
+  readonly activeId = toSignal(this.activeContext.datasetId$, { initialValue: '' });
+
+  /** Dataset id the user picked, which leads {@link activeId} for as long as
+   *  a context switch is still loading. */
+  readonly intentId = toSignal(this.activeContext.intentDatasetId$, { initialValue: '' });
+
+  /**
+   * The id to describe: the active dataset, or — when nothing is active yet —
+   * the one being switched to, so the UI can name the user's pick immediately
+   * instead of blanking for the duration of the load.
+   */
+  readonly datasetId = computed(() => this.activeId() || this.intentId());
+
+  /** Registry entry for {@link datasetId}: null when nothing is selected, and
+   *  also while the registry fetch is still in flight. */
+  readonly dataset = computed<DatasetRegistryEntry | null>(() => {
+    const id = this.datasetId();
+    if (!id) return null;
+    return this.datasetState.datasetById().get(id) ?? null;
+  });
+
+  /** Display name of the selected dataset; `''` when unknown (nothing
+   *  selected, or the registry hasn't resolved the id yet). */
+  readonly datasetName = computed(() => this.dataset()?.name ?? '');
+}

--- a/frontend/src/app/services/active-detector.service.ts
+++ b/frontend/src/app/services/active-detector.service.ts
@@ -49,7 +49,7 @@ export class ActiveDetectorService {
   readonly detector = computed<DetectorRegistryEntry | null>(() => {
     const id = this.detectorId();
     if (!id) return null;
-    return this.datasetState.detectors.find((d) => d.id === id) ?? null;
+    return this.datasetState.detectorById().get(id) ?? null;
   });
 
   /** Display name of the selected detector; `''` when unknown (nothing

--- a/frontend/src/app/services/context-switch.service.spec.ts
+++ b/frontend/src/app/services/context-switch.service.spec.ts
@@ -93,6 +93,12 @@ describe('ContextSwitchService: H25 active/intent layering', () => {
       get detectors(): DetectorRegistryEntry[] {
         return detectors;
       },
+      // Computed on call, like the real service's `computed` Maps: the
+      // arrays above are reassigned per test.
+      datasetById: (): ReadonlyMap<string, DatasetRegistryEntry> =>
+        new Map(datasets.map((d) => [d.id, d])),
+      detectorById: (): ReadonlyMap<string, DetectorRegistryEntry> =>
+        new Map(detectors.map((d) => [d.id, d])),
       setLoading: (_loading: boolean): void => {
         /* no-op for tests */
       },

--- a/frontend/src/app/services/context-switch.service.ts
+++ b/frontend/src/app/services/context-switch.service.ts
@@ -157,10 +157,8 @@ export class ContextSwitchService {
     // with an id the backend hasn't loaded yet.
     this.activeContext.setIntent(datasetId, detectorId);
 
-    const datasets = this.datasetState.datasets;
-    const detectors = this.datasetState.detectors;
-    const dataset = datasetId ? datasets.find((d) => d.id === datasetId) : null;
-    const detector = detectorId ? detectors.find((d) => d.id === detectorId) : null;
+    const dataset = datasetId ? this.datasetState.datasetById().get(datasetId) ?? null : null;
+    const detector = detectorId ? this.datasetState.detectorById().get(detectorId) ?? null : null;
 
     const needsDatasetLoad = !!dataset && !dataset.loaded;
     // Re-embed labels when the active dataset's embedder differs from the

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { Injectable, OnDestroy, Signal, computed, inject, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { Subject, forkJoin, of } from 'rxjs';
 import { catchError, switchMap, takeUntil } from 'rxjs/operators';
@@ -88,6 +88,28 @@ export class DatasetStateService implements OnDestroy {
   get detectors(): DetectorRegistryEntry[] {
     return this._detectors();
   }
+
+  // By-id indexes over the two registries. Every consumer that wants "the
+  // entry for this id" used to scan the array with `find(d => d.id === x)`;
+  // the Maps give them one shared, memoised lookup instead. Reading them is
+  // signal-tracked exactly like reading `datasets` / `detectors`, so this is
+  // a readability change and never a reactivity one: a `computed` recomputes
+  // the Map only when the underlying registry array is replaced.
+  //
+  // The point is not the O(1) — the registries hold tens of entries, so the
+  // scan was never a cost. It is that `datasetById().get(id)` says what it
+  // means, and that `ActiveDatasetService` / `ActiveDetectorService` can be
+  // one-liners over a single index rather than each re-deriving a lookup.
+
+  /** Dataset registry keyed by id. */
+  readonly datasetById: Signal<ReadonlyMap<string, DatasetRegistryEntry>> = computed(
+    () => new Map(this._datasets().map((d) => [d.id, d])),
+  );
+
+  /** Detector registry keyed by id. */
+  readonly detectorById: Signal<ReadonlyMap<string, DetectorRegistryEntry>> = computed(
+    () => new Map(this._detectors().map((d) => [d.id, d])),
+  );
 
   get loading(): boolean {
     return this._loading();


### PR DESCRIPTION
Closes #3449.

## On the premise

The issue's **Direction** is right and is implemented here. Its **framing** is not, and the difference changed the scope, so it is worth stating plainly.

**Right:** `ActiveDetectorService` genuinely had no dataset counterpart, and `AppComponent` was hand-rolling exactly what that service would have given it. `DatasetStateService` genuinely exposed arrays only, so every by-id lookup was open-coded.

**Wrong: "abandoned at 15 call sites."** That is a count of the `find(d => d.id === …)` *shape*, not of active-context resolution. Walking all 15:

| Sites | What they actually resolve | Migrate? |
|---|---|---|
| `app.component.ts` ×2, `incompatible-pair-explainer` ×2, `find-stats-modal` ×1 | the active pair | **yes** — done here |
| `dashboard.component.ts` ×8 | the Dashboard's own multi-select (`selectedDatasetIds`), or "first loaded dataset" | no — a different question |
| `context-switch.service.ts` ×2 | the ids being switched **to** | no |
| `context-pulldown.component.ts` ×1 | a set difference, to spot a newly-added dataset — not an id lookup at all | no |
| `label-view` ×1, `dashboard` ×1 | entries in an **HTTP response body**, not the registry | no |
| guards ×3, `active-context-watcher` ×2 | carved out by the issue itself | no |

So roughly 4 of the 15 were the migration the title describes; routing an `ActiveDatasetService` through the Dashboard's multi-select would have been actively wrong. The issue is complete as scoped, not partially done — but it is complete at ~4 sites, not 15.

**Also wrong: "all 15 are O(n) scans."** True and irrelevant — the registries hold tens of entries. The Maps are worth adding for readability and for giving the two services one shared lookup; they are not a performance fix, and the code comment says so, so nobody later mistakes them for one.

## What changed

- **`DatasetStateService`** gains `datasetById` / `detectorById`, `computed` Maps over the two registries. Reading one is signal-tracked exactly like reading `datasets`, so swapping a `find` for a `.get` is a readability change and never a reactivity one.
- **`ActiveDatasetService`** (new) mirrors `ActiveDetectorService` member for member: `activeId`, `intentId`, `datasetId`, `dataset`, `datasetName`. Same spec coverage, including the #2819 lifecycle gap (registry landing after the selection).
- **`AppComponent`**'s incompatible-pair explainer becomes a `computed` over the route signals and the two services, replacing a `recomputeExplainer()` that had to be invoked from two separate subscribes — the shape where a third trigger gets forgotten. `isOnBrowseView` becomes a signal so the computed can track it.
- **`IncompatiblePairExplainerComponent`** drops its `combineLatest` for two signal-reading getters, so the template is untouched.
- **Guards, `ContextSwitchService`, the pulldown, the Dashboard** keep their imperative reads and just index instead of scanning.

## Verification

`./run-tests.sh` (re-run after the rebase below): **RUN PASSED**, 9668 passed / 6 skipped, every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest, `build:prod` warning-free).

Per the issue's constraint, also **verified in real chromium** (`launchChromium()`), not only jsdom — a 12-check pass over cold deep-links to a compatible pair and to a media-type-incompatible pair (synthetic audio dataset + image detector), plus live pulldown switches in both directions with no reload, asserting the top-bar labels and the explainer's own text.

**All 12 checks pass identically on this branch and on `dev`.** That is the intended result and worth recording: I had first written that the explainer's plain-field-from-a-subscribe was a live zoneless bug, ran the same checks against `dev` to demonstrate it, and it wasn't one — `AppComponent` only mounts the component once the pair is known and unmounts rather than updating it in place. The commit message and the code comment were corrected to call it a latent hazard. The migration is a clean-up with no behaviour change, which is what a refactor of this kind should be.

## Rebase note

This PR originally carried a second commit registering `docs/EXTENDING-plugins.md`'s "The dirty-key contract" with the extension-docs gate, which was failing on `dev` at the time. `186a7550` landed the same fix on `dev` independently — same section, same `UserSyncState` registration, different comment wording — so on rebase that commit resolved to `dev`'s version and dropped itself. Nothing was lost; the PR is now the single frontend commit it should have been.

## Docs

`docs/FRONTEND.md` §6 grows a subsection for the two services: the shared member list, when to reach for them, which call sites keep the imperative lookup and why (guards are one-shot and post-registry; pre-reactive services must resolve against the snapshot their own `combineLatest` emitted), and an explicit note that a lookup which resolves something *other* than the active pair should not be routed through them — the distinction this issue's own site count missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JS2pxkj8aRGTAUTKZhjn2