### PR TITLE
docs(vtscore): rewrite the exporters package doc around ResultsExporter

### DIFF
--- a/vtscore/docs/packages/exporters.md
+++ b/vtscore/docs/packages/exporters.md
@@ -1,12 +1,21 @@
 # `vtscore.exporters`
 
-Result/labelset exporters: plugins that take a labelset or an
-autodetect-results dict and deliver it somewhere - a file on disk, an
-HTTP webhook, an email, an external labelling service. Every exporter is one
-subclass of `LabelsetExporter` plus a module-level `EXPORTER` sentinel,
-discovered by the standard `vtscore.plugins` registry. External code
-adds more by either dropping a module under `vtscore/exporters/<name>/`
-or declaring an entry point in the `vtscore.exporters` group.
+Results exporters: plugins that take a scored run, a detector's
+labelset, or the trained detectors themselves, and deliver it somewhere -
+a file on disk, an HTTP webhook, an email, an external labelling service.
+Every exporter is one subclass of `ResultsExporter` plus a module-level
+`EXPORTER` sentinel, discovered by the standard `vtscore.plugins`
+registry. External code adds more by either dropping a module under
+`vtscore/exporters/<name>/` or declaring an entry point in the
+`vtscore.exporters` group.
+
+**Writing one is documented in
+[`extending/results-exporters.md`](../extending/results-exporters.md).**
+That guide owns the authoring contract - payload kinds, template
+variables, validation, packaging, a worked example. This page is the map
+of what the package already contains: the registry API, the built-in
+exporters, and their per-destination quirks. It deliberately does not
+restate the contract; a second copy is a second thing to rot.
 
 Label *importers* (the reverse direction - pulling labels in from an
 external source) are not here; they live in
@@ -19,7 +28,7 @@ external source) are not here; they live in
 
 | Module | Concern |
 |--------|---------|
-| `vtscore/exporters/base.py` | The `LabelsetExporter` ABC and its siblings |
+| `vtscore/exporters/base.py` | The `ResultsExporter` ABC, `PAYLOAD_KINDS`, and their siblings |
 | `vtscore/exporters/__init__.py` | The auto-discovering registry and its accessors |
 | `vtscore/exporters/server_json_file/` | Write results to a `.json` file on the server |
 | `vtscore/exporters/server_csv_file/` | Write results to a `.csv` file on the server |
@@ -30,8 +39,7 @@ external source) are not here; they live in
 | `vtscore/exporters/portable_detector/` | Write standalone ONNX scoring bundles headlessly |
 
 - [Registry and accessors](#registry-and-accessors)
-- [`LabelsetExporter` ABC](#labelsetexporter-abc)
-- [The export contract](#the-export-contract)
+- [`ResultsExporter` ABC](#resultsexporter-abc)
 - [`PluginField`](#pluginfield)
 - [Built-in exporters](#built-in-exporters)
 - [Template variables in path fields](#template-variables-in-path-fields)
@@ -73,141 +81,92 @@ print([e.name for e in list_exporters()])
 *not* raise `KeyError`. Callers that want a hard failure should check
 the result.
 
-## `LabelsetExporter` ABC
+## `ResultsExporter` ABC
 
-`vtscore/exporters/base.py` - abstract base class. Subclasses set
-the standard `PluginBase` class attributes (`name`, `display_name`,
+`vtscore/exporters/base.py` - abstract base class. Subclasses set the
+standard `PluginBase` class attributes (`name`, `display_name`,
 `description`, `icon`, `fields`, optionally `ui_mode` and
-`hidden_from_picker`) and implement `export()`. The default `icon` is
-`"\U0001f4e4"` (outbox tray).
+`hidden_from_picker`) and implement one method per **payload kind** they
+support. The default `icon` is `"\U0001f4e4"` (outbox tray).
 
 ```python
-from vtscore.exporters.base import LabelsetExporter, PluginField
+from vtscore.exporters.base import PluginField, ResultsExporter
 
 
-class MyExporter(LabelsetExporter):
+class MyExporter(ResultsExporter):
     name = "my_exporter"
     display_name = "My Exporter"
     description = "..."
     fields = [PluginField("path", "Path", "server_path")]
 
-    def export(self, results: dict, field_values: dict) -> dict:
+    def export_find_results(self, results: dict, field_values: dict) -> dict:
         ...
         return {"message": "..."}
 ```
 
-`LabelsetExporter` inherits `PluginBase`, so CLI flags are auto-derived
+An exporter is a *destination*; what gets sent there is a separate axis.
+`PAYLOAD_KINDS` names the three:
+
+| Kind | Method | What it is |
+|------|--------|------------|
+| `find_results` | `export_find_results()` | a scored run - hit lists, scores, thresholds |
+| `labelset` | `export_labelset()` | a detector's labels - origins and vote provenance |
+| `detector_bundles` | `export_cli_detectors()` | the trained classifiers themselves |
+
+`supported_payloads` is **derived** from which of those methods the
+subclass overrode - never declared - and is what each picker filters on,
+so an exporter is only offered for the kinds it can actually read.
+Handing it any other kind raises `UnsupportedPayloadError` (a
+`ValueError` subclass, so the route answers 400 rather than 500).
+
+`ResultsExporter` inherits `PluginBase`, so CLI flags are auto-derived
 from `fields` via `add_cli_arguments()`, JSON metadata comes from
 `to_dict()`, and required-field validation comes from
 `validate_cli_field_values()`. See [`plugins.md`](plugins.md#pluginbase)
 for the inherited surface.
 
-## The export contract
+The full authoring contract - the payload dict shapes, the required
+`"message"` return key and the `"display_results"` / `"open_url"` keys
+the frontend interprets, template-variable declaration, URL and
+server-path validation, entry-point packaging - lives in
+[`extending/results-exporters.md`](../extending/results-exporters.md).
 
-```python
-exporter.export(results: dict, field_values: dict) -> dict
-```
+### `LabelsetExporter` is a permanent alias
 
-`results` is one of two shapes - the exporter detects which:
+`LabelsetExporter` is a module-level alias for `ResultsExporter`, kept
+indefinitely so out-of-tree `from vtscore.exporters.base import
+LabelsetExporter` imports and subclasses keep working. The old name
+described one of the three payloads the class has always accepted; new
+code should use `ResultsExporter`.
 
-- **Autodetect results** (from `/api/auto-detect` or the CLI
-  `--autodetect` flow):
+The single-method `export(results, field_values)` contract that predates
+the payload kinds is likewise still supported: `export_find_results()`
+and `export_labelset()` delegate to it when unoverridden, so a plugin
+that discriminates the two dict shapes itself (`if "labels" in results`)
+needs no changes. Such an exporter is credited with *both* non-detector
+kinds - nothing can tell which it handles - and logs an advisory line at
+import time pointing at the extending guide. No built-in exporter uses
+this path any more; `portable_detector` overrides `export()` only to
+explain that hits are the wrong input for it.
 
-  ```python
-  {
-      "media_type": "audio",
-      "detectors_run": 2,
-      "results": {
-          "detector_name": {
-              "detector_name": "...",
-              "threshold": 0.5,
-              "total_hits": 15,
-              "hits": [{...}, ...],
-          },
-          ...
-      },
-  }
-  ```
+### Streaming
 
-- **Labels** (from the `/api/labels/export` enrich flow):
-
-  ```python
-  {
-      "labels": [
-          {"label": "good", "md5": "...", "filename": "...", "origin": {...}, ...},
-          ...
-      ],
-      "selected_columns": ["label", "filename", "origin", ...],   # optional
-  }
-  ```
-
-The convention is `if "labels" in results: ...` to discriminate. The
-built-in JSON/CSV/webhook/email exporters all handle both shapes;
-custom exporters that only target one of them should raise
-`ValueError` on the other.
-
-### Return value
-
-`export()` returns a `dict` that **must** include a `"message"` key - a
-short human-readable confirmation string. The exporter may also include
-arbitrary extra keys (`"filepath"` for file-based exporters,
-`"status_code"` and `"url"` for the webhook, an external package id for a
-service exporter, …). The route handler renders the message back to the user; the extra
-keys are passed through unchanged.
-
-Two extra keys are *interpreted* by the frontend rather than merely
-passed through:
-
-| Key | Effect |
-|-----|--------|
-| `"display_results"` | The results dict is rendered in the Auto-Detect Results modal. Used by `gui`. |
-| `"open_url"` | An `http(s)` URL the browser opens in a new tab. |
-
-### `open_url`: handing the user off to another site
-
-An exporter can end by sending the user somewhere instead of (or as well
-as) delivering the labelset. That is how a third-party site with **no
-ingest API** receives a selection: you can't POST to it, but you can link
-into it, because its viewer takes identifiers in the query string. Format
-the labelset into that site's own URL and return it as `"open_url"`; the
-Export modal opens it in a new tab.
-
-It also fits a delivery exporter whose remote hands back a permalink to
-what was just uploaded - return the permalink and the user lands on it.
-
-Two things to know when returning one:
-
-- **Set `opens_url = True`** on the exporter class if it *always* returns
-  a URL. The flag rides `GET /api/exporters` and is what lets the button
-  read "Open Labelset in `<name>`" *before* the export runs. An
-  `open_url` from an exporter that leaves the flag `False` still opens;
-  it just can't be advertised up front.
-- **The route re-validates the URL** with
-  `vtscore.security.url_validation.validate_browser_url` and fails the
-  export (500) if it doesn't pass, so no plugin can push a `javascript:`
-  URL into the browser. That guard is a *scheme allowlist*, deliberately
-  not the `validate_url` SSRF guard: the browser makes this request, not
-  the server, so `http://localhost:9000/viewer` is a legitimate target
-  and resolving the host would buy nothing. See
-  [`security`](security.md#browser-url-validation).
-
-Whatever you encode into the URL is visible to the destination site and
-lands in the user's browser history, so keep it to identifiers.
-
-### CLI variant
-
-`LabelsetExporter.export_cli(results, field_values)` defaults to
-delegating to `export()`. Override it when CLI invocation needs a
-different behaviour - the GUI exporter does this so it can print to
-stdout instead of asking the (nonexistent) frontend to render.
+The CLI `--stream-results` path (scoring a media source larger than RAM)
+asks an exporter to write hits incrementally instead of buffering the
+whole run. An exporter opts in with `supports_streaming` and
+`export_cli_streaming()`; it is a `find_results` mode only, with no
+labelset equivalent. Every built-in that delivers a scored run streams,
+except `open_url` - which returns a URL rather than writing anything, so
+it has nothing to write incrementally. `portable_detector` is outside
+the question entirely: it consumes detectors, not hits.
 
 ## `PluginField`
 
 `vtscore/exporters/base.py` re-exports `PluginField` so exporters can
-import it alongside `LabelsetExporter`:
+import it alongside `ResultsExporter`:
 
 ```python
-from vtscore.exporters.base import LabelsetExporter, PluginField
+from vtscore.exporters.base import PluginField, ResultsExporter
 ```
 
 Field semantics - `field_type` literals, `dynamic_options`,
@@ -223,15 +182,19 @@ knowable at runtime fills its dropdown in either place.
 
 ## Built-in exporters
 
-| Name | Target | Notes |
-|------|--------|-------|
-| `server_json_file` | Writes a JSON file to the server filesystem | Atomic write via tmp + rename; supports `{YYYYMMDD-HHMMSS}` / `{YYYYMMDD}` / `{YYYY}` / `{MM}` / `{DD}` / `{detector_name}` / `{username}` template variables in the path; default path under `DATA_DIR` |
-| `server_csv_file` | Writes a CSV file to the server filesystem | Atomic write; auto-detects which optional clip columns (`clip_start`, `clip_end`, `clip_box`) are present; cells beginning with `=`/`+`/`-`/`@`/`\t`/`\r` are quote-prefixed to defeat formula injection |
-| `webhook` | `POST`s the results dict as JSON to a URL | Optional `Authorization` header (`password` field), 30s timeout, redirects disabled, URL validated by `vtscore.security.validate_url` (SSRF guard) |
-| `open_url` | Formats the labelset into a URL and returns it as `open_url` for the browser to open in a new tab | `opens_url = True`. No network call server-side; substitutes `{ids}` / `{count}` into a user-supplied template, URL-encoding the joined identifiers. Truncates to `max_items` (reported in the message) and refuses a URL over ~2000 characters |
-| `email_smtp` | Sends an email via direct MX delivery | Resolves the recipient domain's MX record (`dnspython`), connects on port 25, sends a multipart plain+HTML summary. Requires a sender domain you control |
-| `gui` | Displays results in the browser (GUI) or prints to stdout (CLI) | `hidden_from_picker = True`. The default exporter for the web UI's autodetect modal; in CLI mode `export_cli()` prints origin + name of each Good hit |
-| `portable_detector` | Writes one standalone ONNX scoring bundle per trained detector | `hidden_from_picker = True`, CLI-only. See below - it is the one exporter that consumes detectors rather than results |
+| Name | Payloads | Target | Notes |
+|------|----------|--------|-------|
+| `server_json_file` | `find_results`, `labelset` | Writes a JSON file to the server filesystem | Atomic write via tmp + rename; supports the `{YYYYMMDD-HHMMSS}` / `{YYYYMMDD}` / `{YYYY}` / `{MM}` / `{DD}` / `{detector_name}` / `{detector_id}` / `{username}` template variables in the path; default path under `DATA_DIR` |
+| `server_csv_file` | `find_results`, `labelset` | Writes a CSV file to the server filesystem | Atomic write; auto-detects which optional clip columns (`clip_start`, `clip_end`, `clip_box`) are present; cells beginning with `=`/`+`/`-`/`@`/`\t`/`\r` are quote-prefixed to defeat formula injection |
+| `webhook` | `find_results`, `labelset` | `POST`s the payload dict as JSON to a URL | Optional `Authorization` header (`password` field), 30s timeout, redirects disabled, URL validated by `vtscore.security.validate_url` (SSRF guard) |
+| `open_url` | `find_results`, `labelset` | Formats the labelset into a URL and returns it as `open_url` for the browser to open in a new tab | `opens_url = True`. No network call server-side; substitutes `{ids}` / `{count}` into a user-supplied template, URL-encoding the joined identifiers. Truncates to `max_items` (reported in the message) and refuses a URL over ~2000 characters. The one results-carrying built-in that does not stream |
+| `email_smtp` | `find_results`, `labelset` | Sends an email via direct MX delivery | Resolves the recipient domain's MX record (`dnspython`), connects on port 25, sends a multipart plain+HTML summary. Requires a sender domain you control |
+| `gui` | `find_results`, `labelset` | Displays results in the browser (GUI) or prints to stdout (CLI) | `hidden_from_picker = True`. The default exporter for the web UI's autodetect modal; in CLI mode `export_cli()` prints origin + name of each Good hit |
+| `portable_detector` | `detector_bundles` | Writes one standalone ONNX scoring bundle per trained detector | `hidden_from_picker = True`, CLI-only. See below - it is the one exporter that consumes detectors rather than results |
+
+The Payloads column is not a declaration anywhere in the source: each
+exporter's `supported_payloads` is derived from the methods it overrides,
+so the column is a reading of the code rather than a second copy of it.
 
 `hidden_from_picker = True` keeps an exporter out of the generic
 picker UI. The `gui` exporter is special-cased by the frontend; the
@@ -240,11 +203,13 @@ dedicated portable-export modal.
 
 ### `portable_detector` is shaped differently
 
-Every other exporter consumes the **scored results**. This one consumes
-the **trained classifiers**, so it sets `needs_trained_detectors` and
-the pipeline hands it the detectors via `export_cli_detectors` instead
-of the usual `export` call. It only works on the `--autodetect` /
-`--pipeline` path, which is the only one that produces a trained head.
+Every other exporter consumes a detector's **output**. This one consumes
+the **trained classifiers**, so it sets `needs_trained_detectors` - which
+makes `supported_payloads` report `{"detector_bundles"}` alone - and the
+pipeline hands it the detectors via `export_cli_detectors()` instead of
+the usual `export_find_results()` / `export_labelset()` call. It only
+works on the `--autodetect` / `--pipeline` path, which is the only one
+that produces a trained head.
 
 It is also the sanctioned exception to the "No Persisted Vectors or
 MLPs" rule: the bundle persists the trained MLP (as ONNX, alongside a
@@ -262,15 +227,14 @@ path to disambiguate a multi-detector run.
 ### File-format notes
 
 - **`server_json_file`** (`vtscore/exporters/server_json_file/__init__.py`)
-  writes either the full autodetect-results JSON or, when the input is
-  a `labels` payload, an object filtered to the user-selected columns.
-  Atomic write helper is in `vtscore/exporters/server_json_file/__init__.py`.
+  writes either the full `find_results` JSON or, for a `labelset`
+  payload, an object filtered to the user-selected columns.
 - **`server_csv_file`** (`vtscore/exporters/server_csv_file/__init__.py`)
-  produces one row per hit (autodetect path) or one row per label
-  (labels path). The labels path always re-orders `origin` to the last
+  produces one row per hit (`find_results`) or one row per label
+  (`labelset`). The labelset path always re-orders `origin` to the last
   column so the file can be re-imported losslessly.
 - **`webhook`** (`vtscore/exporters/webhook/__init__.py`) sends the
-  full `results` dict as the JSON body. Returned dict includes
+  full payload dict as the JSON body, whichever kind it is. Returned dict includes
   `status_code` and `url` alongside `message`.
 - **`email_smtp`** (`vtscore/exporters/email_smtp/__init__.py`)
   composes both a plain-text and HTML body and sends both as alternative
@@ -282,18 +246,14 @@ path to disambiguate a multi-detector run.
 A path field declares which placeholders it accepts in its
 `PluginField.template_vars` tuple; the framework's
 `normalize_field_values` pass (`vtscore/plugins/normalize.py`)
-substitutes them - and confines the resolved `server_path` to the
-user's data dir - before `export()` runs:
+substitutes them - and confines the resolved `server_path` to the user's
+data dir - before the exporter runs. The supported placeholders, why you
+must declare rather than substitute them, and what the declaration buys
+you in the GUI are all in
+[`extending/results-exporters.md`](../extending/results-exporters.md#template-variable-interpolation).
 
-| Placeholder | Substituted with |
-|-------------|------------------|
-| `{YYYYMMDD-HHMMSS}` | Current UTC timestamp, e.g. `20260516-143022` - included in the default path so consecutive runs do not silently overwrite each other |
-| `{YYYYMMDD}` / `{YYYY}` / `{MM}` / `{DD}` | Current UTC date parts, so a scheduled (e.g. daily) Auto-Find can write to a path named after today's date, e.g. `results_{YYYY}.{MM}.{DD}.csv` |
-| `{detector_name}` | The active `DetectorContext.name`, sanitised by `vtscore.security.sanitize_template_value` |
-| `{username}` | The current request user (from `vtscore.state.current_user.get_current_user`), sanitised the same way; falls back to `"default"` |
-
-Defaults for `server_json_file` and `server_csv_file` already
-interpolate from `DATA_DIR`:
+What is specific to this package: the defaults for `server_json_file`
+and `server_csv_file` already interpolate from `DATA_DIR`.
 
 ```python
 _DEFAULT_JSON_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.json"
@@ -304,7 +264,8 @@ This is part of the Phase 4 filesystem-seam work: every path placeholder
 resolves against `vtscore.config.DATA_DIR` (which honours
 `$VTSEARCH_DATA_DIR`) so plugin defaults are absolute paths rather than
 implicit-cwd relative paths. Custom exporters writing path defaults
-should follow the same pattern.
+should follow the same pattern. The `{YYYYMMDD-HHMMSS}` stamp is in both
+defaults so consecutive runs do not silently overwrite each other.
 
 The template resolver reads `vtscore.state.current_user.get_current_user`
 (app-tier wires the request-scoped resolver via
@@ -312,78 +273,34 @@ The template resolver reads `vtscore.state.current_user.get_current_user`
 so `{username}` interpolation is only useful when a resolver or the
 thread-local has been set. Library-tier callers that drive an exporter
 directly should either avoid `{username}` in their paths or register a
-user resolver before invoking `export()`.
+user resolver before invoking it.
 
 ## Writing a custom exporter
 
-Drop a sub-package under `vtscore/exporters/<name>/` (or expose it as
-an entry point - see [`plugins.md`](plugins.md#entry-point-integration)
-for the third-party path):
+**Start from
+[`extending/results-exporters.md`](../extending/results-exporters.md).**
+It carries the full walkthrough - a worked third-party exporter, the
+payload-method split, template variables, URL and server-path
+validation, entry-point packaging, and the testing pattern - and it is
+the copy that stays current, because
+`scripts/check-extension-docs.py` holds its contract table to the
+members `ResultsExporter` actually defines.
 
-```python
-# vtscore/exporters/sftp/__init__.py
-from __future__ import annotations
-from typing import Any
+Only two things are specific to adding an exporter *to this package*
+rather than shipping one from your own distribution:
 
-import paramiko
-
-from vtscore.exporters.base import LabelsetExporter, PluginField
-
-
-class SftpLabelsetExporter(LabelsetExporter):
-    name = "sftp"
-    display_name = "SFTP Upload"
-    description = "Upload the results JSON to a remote SFTP server."
-    icon = "\U0001f4e1"
-    fields = [
-        PluginField("host",     "Hostname",    "text"),
-        PluginField("user",     "Username",    "text"),
-        PluginField("password", "Password",    "password"),
-        PluginField(
-            "path", "Remote Path", "text",
-            default="/results/autodetect.json",
-        ),
-    ]
-
-    def export(self, results: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
-        import json
-
-        host = field_values["host"]
-        path = field_values["path"]
-
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        ssh.connect(host, username=field_values["user"], password=field_values["password"])
-        sftp = ssh.open_sftp()
-        with sftp.open(path, "w") as f:
-            f.write(json.dumps(results, indent=2))
-        sftp.close()
-        ssh.close()
-
-        return {"message": f"Uploaded to {host}:{path}"}
-
-
-EXPORTER = SftpLabelsetExporter()
-```
-
-### Checklist
-
-- Subclass `LabelsetExporter`; set `name`, `display_name`,
-  `description`, `fields`.
-- Implement `export(results, field_values) -> dict` returning at
-  minimum `{"message": "..."}`.
-- Decide which result shape(s) you support; raise `ValueError` on
-  shapes you don't.
-- For file destinations, declare the placeholders you accept in the
-  field's `template_vars` and let `normalize_field_values` substitute
-  them; default the path under `vtscore.config.DATA_DIR`. Write through
-  `vtscore.io.atomic_write_bytes` / `atomic_write_text` rather than
-  hand-rolling the tmp-file + `os.replace` ritual.
-- For URL destinations, run the URL through
-  `vtscore.security.validate_url` first (SSRF guard).
-- Expose a module-level `EXPORTER = YourExporter()` constant.
-- (Third-party only) declare a `vtscore.exporters` entry point in
-  your `pyproject.toml`.
+- Drop a sub-package under `vtscore/exporters/<name>/` exposing a
+  module-level `EXPORTER = YourExporter()`. Discovery is by directory,
+  so there is no registration list to edit and no entry point to
+  declare - the entry-point route in the guide is for out-of-tree
+  distributions.
+- Write files through `vtscore.io.atomic_write_bytes` /
+  `atomic_write_text` rather than hand-rolling the tmp-file +
+  `os.replace` ritual, and default any path field under
+  `vtscore.config.DATA_DIR` as the built-ins do (see [Template variables
+  in path fields](#template-variables-in-path-fields)). New
+  dependencies go in `[project.dependencies]` in the repo's
+  `pyproject.toml`; deptry gates that.
 
 ## Cross-references
 

--- a/vtscore/docs/packages/security.md
+++ b/vtscore/docs/packages/security.md
@@ -371,8 +371,8 @@ def validate_browser_url(url: str) -> str:
 ```
 
 Used for the `open_url` an exporter can return so the frontend opens a
-third-party page in a new tab (see
-[`exporters`](exporters.md#open_url-handing-the-user-off-to-another-site)).
+third-party page in a new tab (see [Opening a URL in the
+browser](../extending/results-exporters.md#opening-a-url-in-the-browser)).
 
 This is deliberately **not** the SSRF guard. The fetch is made by the
 user's browser, not by us, so no server-side request exists to forge:


### PR DESCRIPTION
Closes #3444

## The premise, checked

Confirmed, and the counts in the issue are exact. `vtscore/docs/packages/exporters.md` mentioned `LabelsetExporter` 14 times and `ResultsExporter` zero; `PAYLOAD_KINDS`, `supported_payloads`, `export_find_results` and `export_labelset` appeared nowhere; and its worked custom-exporter example implemented the legacy `export()`.

That is not merely an out-of-date name. `ResultsExporter.__init_subclass__` logs an advisory when a subclass overrides only `export()`, and such an exporter is credited with **both** non-detector payload kinds because nothing can tell which shapes it handles — so it is offered in pickers it cannot serve. An author following this page wrote a plugin that warns at import and silently no-ops on half the payloads it is handed. Every in-tree exporter has already migrated to the named methods, so this page was the last place teaching the old contract.

One sub-claim in the issue is **stale**: `vtscore/docs/extending/README.md:40` already says `ResultsExporter` with a permanent-alias note. Nothing to do there.

## Why the restatement itself is the bug

`scripts/check-extension-docs.py` polices `docs/EXTENDING-*.md` and `vtscore/docs/extending/*.md`. `vtscore/docs/packages/` is outside its `DOC_GLOBS`, so the package doc's copy of the contract was unchecked by construction — which is exactly how it rotted while the guide next to it stayed correct. Two smaller drifts had accumulated in the same copy: the template-variable table never gained `{detector_id}`, and the file-format notes still spoke of a "labels path".

So the fix follows the issue's direction: stop restating. The authoring contract lives in `vtscore/docs/extending/results-exporters.md` (gated), and the package doc keeps what a package doc actually owns — the registry API, the ABC's shape, the built-ins and their per-destination quirks.

## What changed

- **ABC section** rewritten around `ResultsExporter` and the three payload kinds, noting that `supported_payloads` is *derived* from the methods overridden and that a wrong kind raises `UnsupportedPayloadError` (a `ValueError`, so 400 not 500). `LabelsetExporter` is demoted to a permanent-alias subsection alongside the still-supported legacy `export()` path.
- **Deleted the restatements** — the export contract and its two payload dict shapes, the `open_url` how-to, the template-variable table, the worked SFTP example and its checklist — each replaced with a link to the extending guide. `vtscore/docs/packages/security.md`'s inbound anchor is repointed at the guide's `open_url` section (the doc gate caught it).
- **Added** a Payloads column to the built-ins table and a Streaming note; neither concept appeared anywhere on this page before.
- **Fixed** the two accumulated drifts noted above.

Net: −222 / +139 lines across two docs.

## Scope

No code changes, per the issue's constraint. The `LabelsetExporter` alias, the legacy `export()` delegation and the `EXPORTER` sentinel are untouched external surface, so no `vtscore/CHANGELOG.md` entry and no version bump are owed. The Payloads column is a reading of each exporter's overrides rather than a second declaration of them, so there is nothing new that can desync.

## Testing

Full `./run-tests.sh`: **RUN PASSED** — 9686 passed, 6 skipped, 2 xfailed; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all OK. `check-docs.py`, `check-vtscore-docs.py` and `check-extension-docs.py` pass individually too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVX8qqGyRnxpPMB4McGPYH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVX8qqGyRnxpPMB4McGPYH)_