### PR TITLE
Fix the dep-install PreToolUse hook, which never once fired

### DIFF
--- a/.claude/hooks/ensure-test-deps-gate.py
+++ b/.claude/hooks/ensure-test-deps-gate.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""PreToolUse gate: install the project's dependencies before a command needs them.
+
+A remote container starts with none of VTSearch's stack installed, so a bare
+`pytest ...` or `npm run build:prod` fails on an import error rather than on
+anything real. `run-tests.sh` guards itself by invoking
+`.claude/hooks/ensure-test-deps.sh` directly, and CLAUDE.md's command list
+prepends the same call -- this hook is the safety net for every *other* way a
+session reaches for the test stack.
+
+It used to live inline in `.claude/settings.json` as::
+
+    if echo "$TOOL_INPUT" | grep -qE 'pytest|...'; then bash ...ensure-test-deps.sh; fi
+
+which never once fired: the harness delivers the tool call on **stdin** and
+sets no `TOOL_INPUT` variable, so the grep read an empty string every time.
+`run-tests.sh` masked it, which is why a dead safety net kept looking alive
+for so long (issue #3440). Reading the payload is now `hook_payload.read_payload`,
+shared with `require-issue-labels.py` so the two cannot drift apart again.
+
+The gate never blocks. A failed install exits 1 (a non-blocking hook error the
+user sees) rather than 2, so the command still runs and fails on its own terms
+-- an install problem should surface as the tool's own error, not as a refusal
+to let the tool run.
+
+Note that the match is on the command *text*, so a command that merely mentions
+`pytest` in an echo will also trigger the install. That is the intended trade:
+a spurious install costs one cold-container wait, a missed one costs a
+confusing `ModuleNotFoundError`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from hook_payload import read_payload, tool_arguments  # noqa: E402
+
+TOOL_SUFFIX = "Bash"
+
+# Kept verbatim from the inline matcher this script replaces.
+NEEDS_DEPS = re.compile(r"pytest|ng test|ng serve|npm run|npm test")
+
+# Overridable so the tests can assert the gate's *decision* without paying for
+# a real dependency install.
+INSTALLER = Path(os.environ.get("VTSEARCH_DEPS_INSTALLER") or Path(__file__).resolve().parent / "ensure-test-deps.sh")
+
+
+def main() -> int:
+    args = tool_arguments(read_payload(), TOOL_SUFFIX, bare_keys=("command",))
+    if args is None:
+        return 0
+
+    if not NEEDS_DEPS.search(str(args.get("command") or "")):
+        return 0
+
+    result = subprocess.run(["bash", str(INSTALLER)], check=False)  # noqa: S603,S607  # repo-local installer, no shell
+    if result.returncode != 0:
+        print(f"ensure-test-deps.sh failed (exit {result.returncode}); running the command anyway.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/hook_payload.py
+++ b/.claude/hooks/hook_payload.py
@@ -1,0 +1,60 @@
+"""One reading of the PreToolUse payload contract, shared by every hook.
+
+Two hooks used to disagree about how the harness delivers a tool call.
+`require-issue-labels.py` read stdin and fell back to `$TOOL_INPUT`;
+`.claude/settings.json` matched Bash commands with an inline
+`echo "$TOOL_INPUT" | grep ...`. The harness delivers on **stdin** and sets no
+`TOOL_INPUT` variable at all, so the second one grepped an empty string and
+never fired -- silently, for its whole life, while looking like a working
+safety net (issue #3440).
+
+Two hooks holding two guesses is what let one of them be wrong unnoticed, so
+the contract lives here once and both import it. A third hook that reads the
+payload some other way is the bug coming back.
+
+**Verified against a live session**, not inferred: a real `Bash` tool call whose
+command contained `pytest` left `$TOOL_INPUT` empty and never reached the
+installer, while an `mcp__github__issue_write` call in the same session was
+parsed and blocked through the stdin path. The env fallback below is kept
+anyway -- it costs two lines and covers a harness that changes its mind.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Iterable
+
+
+def read_payload() -> dict:
+    """Parse the PreToolUse payload, preferring stdin and falling back to env."""
+    raw = ""
+    if not sys.stdin.isatty():
+        raw = sys.stdin.read().strip()
+    if not raw:
+        raw = os.environ.get("TOOL_INPUT", "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def tool_arguments(payload: dict, tool_suffix: str, bare_keys: Iterable[str]) -> dict | None:
+    """Return the call's arguments, or None if the payload is for another tool.
+
+    Handles both the nested envelope (`{"tool_name", "tool_input"}`) and a bare
+    arguments dict, since the two shapes have both been observed. A bare dict
+    carries no tool name, so it is identified by its own shape: `bare_keys` are
+    the argument names that only this tool's calls would all carry.
+    """
+    name = payload.get("tool_name") or payload.get("toolName") or ""
+    args = payload.get("tool_input") or payload.get("toolInput")
+    if isinstance(args, dict):
+        return args if name.endswith(tool_suffix) else None
+    if all(key in payload for key in bare_keys):
+        return payload
+    return None

--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -35,10 +35,13 @@ than letting the check be dodged by rewording the body.
 
 from __future__ import annotations
 
-import json
-import os
 import re
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from hook_payload import read_payload, tool_arguments  # noqa: E402
 
 TOOL_SUFFIX = "issue_write"
 
@@ -77,38 +80,6 @@ WEAK_SIGNALS = [
     r"\brecall@",
     r"\bprecision@",
 ]
-
-
-def _read_payload() -> dict:
-    """Parse the PreToolUse payload, preferring stdin and falling back to env."""
-    raw = ""
-    if not sys.stdin.isatty():
-        raw = sys.stdin.read().strip()
-    if not raw:
-        raw = os.environ.get("TOOL_INPUT", "").strip()
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return parsed if isinstance(parsed, dict) else {}
-
-
-def _tool_input(payload: dict) -> dict | None:
-    """Return the issue_write arguments, or None if this is not our tool.
-
-    Handles both the nested envelope (`{"tool_name", "tool_input"}`) and a
-    bare arguments dict, since the two shapes have both been observed.
-    """
-    name = payload.get("tool_name") or payload.get("toolName") or ""
-    args = payload.get("tool_input") or payload.get("toolInput")
-    if isinstance(args, dict):
-        return args if name.endswith(TOOL_SUFFIX) else None
-    # Bare arguments: identify it by its own shape rather than by a tool name.
-    if "method" in payload and "repo" in payload:
-        return payload
-    return None
 
 
 def _looks_like_an_experiment(text: str) -> bool:
@@ -198,7 +169,7 @@ CLOSE_FOOTER = (
 
 
 def main() -> int:
-    args = _tool_input(_read_payload())
+    args = tool_arguments(read_payload(), TOOL_SUFFIX, bare_keys=("method", "repo"))
     if args is None:
         return 0
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | grep -qE 'pytest|ng test|ng serve|npm run|npm test'; then bash ${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ensure-test-deps.sh; fi"
+            "command": "python3 ${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/ensure-test-deps-gate.py"
           }
         ]
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,10 +239,11 @@ extend_exclude = [
     "model_cache",
 ]
 
-# Sibling modules that slides/figs/src/*.py import off their own directory
-# (they are scripts run by path, not an installed package, so deptry reads the
-# imports as third-party). Everything else under slides/ is still checked.
-known_first_party = ["coco_fixture", "report_svg", "slide_figure"]
+# Sibling modules that slides/figs/src/*.py and .claude/hooks/*.py import off
+# their own directory (they are scripts run by path, not an installed package,
+# so deptry reads the imports as third-party). Everything else under slides/
+# and .claude/ is still checked.
+known_first_party = ["coco_fixture", "report_svg", "slide_figure", "hook_payload"]
 
 # Module name → distribution name. Deptry needs these when the importable
 # module differs from the PyPI package.

--- a/tests/core/test_ensure_test_deps_hook.py
+++ b/tests/core/test_ensure_test_deps_hook.py
@@ -1,0 +1,147 @@
+"""Tests for the .claude/hooks/ensure-test-deps-gate.py PreToolUse gate.
+
+The gate installs the project's stack before a command that needs it, and its
+predecessor -- an inline `echo "$TOOL_INPUT" | grep ...` in settings.json --
+never fired once: the harness delivers the tool call on stdin and sets no
+`TOOL_INPUT` variable, so the grep matched against an empty string forever
+(issue #3440). `run-tests.sh` calls the installer directly, which masked the
+failure and left a dead safety net looking alive.
+
+These are a regression guard, not the verification: a synthesized payload can
+only re-encode whatever contract the test author assumed, which is the exact
+mistake that produced the bug. The contract was pinned by watching a live
+session -- see `.claude/hooks/hook_payload.py`. What is checkable here is that
+the gate reads the channel the harness actually uses, that it stays wired up in
+settings.json, and that it never blocks a tool call.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS = Path(__file__).resolve().parents[2] / ".claude" / "hooks"
+GATE = HOOKS / "ensure-test-deps-gate.py"
+INSTALLER = HOOKS / "ensure-test-deps.sh"
+
+ALLOW = 0
+# A PreToolUse hook blocks on exit 2. The gate must never return it: a
+# dependency problem should surface as the command's own error.
+BLOCK = 2
+
+
+@pytest.fixture
+def stub_installer(tmp_path):
+    """Stand in for ensure-test-deps.sh, recording whether the gate ran it."""
+    receipt = tmp_path / "installed"
+    script = tmp_path / "stub-installer.sh"
+    script.write_text(f"#!/bin/bash\ntouch {receipt}\n")
+    return script, receipt
+
+
+def run_gate(payload, installer: Path, *, on_stdin: bool = True) -> subprocess.CompletedProcess:
+    raw = payload if isinstance(payload, str) else json.dumps(payload)
+    env = {**os.environ, "VTSEARCH_DEPS_INSTALLER": str(installer)}
+    if not on_stdin:
+        env["TOOL_INPUT"] = raw
+        raw = ""
+    return subprocess.run(  # noqa: S603  # interpreter + repo-local hook path, no shell
+        [sys.executable, str(GATE)], input=raw, capture_output=True, text=True, timeout=60, env=env
+    )
+
+
+def bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command, "description": "a description"}}
+
+
+class TestPayloadDelivery:
+    """The bug was a wrong guess about *where* the payload arrives."""
+
+    def test_a_stdin_payload_triggers_the_install(self, stub_installer):
+        script, receipt = stub_installer
+        assert run_gate(bash("python -m pytest tests/ -q"), script).returncode == ALLOW
+        assert receipt.exists(), "the gate did not read the payload the harness actually sends"
+
+    def test_an_env_payload_still_triggers_the_install(self, stub_installer):
+        """The env fallback is vestigial, but it must not rot silently."""
+        script, receipt = stub_installer
+        assert run_gate(bash("python -m pytest tests/ -q"), script, on_stdin=False).returncode == ALLOW
+        assert receipt.exists()
+
+    def test_bare_argument_payload_is_still_matched(self, stub_installer):
+        """Some harness versions pass the arguments dict without an envelope."""
+        script, receipt = stub_installer
+        assert run_gate({"command": "npm run build:prod"}, script).returncode == ALLOW
+        assert receipt.exists()
+
+
+class TestMatching:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python -m pytest tests/ tests_lib/ -q",
+            "cd frontend && npm run build:prod",
+            "cd frontend && npm test",
+            "ng serve --port 4200",
+            "ng test",
+        ],
+    )
+    def test_commands_that_need_the_stack_install_it(self, stub_installer, command):
+        script, receipt = stub_installer
+        assert run_gate(bash(command), script).returncode == ALLOW
+        assert receipt.exists()
+
+    @pytest.mark.parametrize("command", ["git status", "ls -la docs/", "ruff check .", "echo hello"])
+    def test_unrelated_commands_do_not_install(self, stub_installer, command):
+        script, receipt = stub_installer
+        assert run_gate(bash(command), script).returncode == ALLOW
+        assert not receipt.exists()
+
+
+class TestPassthrough:
+    """A hook that fails closed would wedge ordinary work."""
+
+    def test_other_tools_are_ignored(self, stub_installer):
+        script, receipt = stub_installer
+        payload = {"tool_name": "Read", "tool_input": {"file_path": "/tmp/pytest.log"}}
+        assert run_gate(payload, script).returncode == ALLOW
+        assert not receipt.exists()
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "   ", "not json at all", "[]", "null", '"a string"'],
+        ids=["empty", "blank", "garbage", "list", "null", "string"],
+    )
+    def test_unparseable_payloads_allow(self, stub_installer, raw):
+        script, receipt = stub_installer
+        assert run_gate(raw, script).returncode == ALLOW
+        assert not receipt.exists()
+
+    def test_a_failing_installer_does_not_block_the_command(self, tmp_path):
+        """Exit 1 is a visible hook error; exit 2 would refuse to run the command."""
+        script = tmp_path / "broken-installer.sh"
+        script.write_text("#!/bin/bash\necho 'pip exploded' >&2\nexit 1\n")
+        result = run_gate(bash("python -m pytest -q"), script)
+        assert result.returncode != BLOCK
+        assert "failed" in result.stderr
+
+
+class TestWiring:
+    """The gate is inert unless settings.json actually points at it."""
+
+    def test_gate_and_installer_both_exist(self):
+        assert GATE.is_file()
+        assert INSTALLER.is_file(), "the gate's default installer path must resolve"
+
+    def test_registered_as_a_pretooluse_hook_for_bash(self):
+        settings = json.loads((HOOKS.parent / "settings.json").read_text())
+        entry = next(h for h in settings["hooks"]["PreToolUse"] if h["matcher"] == "Bash")
+        assert any(GATE.name in hook["command"] for hook in entry["hooks"])
+
+    def test_no_hook_command_reads_the_env_var_the_harness_never_sets(self):
+        """The original defect, in the shape it took: an inline `$TOOL_INPUT` matcher."""
+        settings = (HOOKS.parent / "settings.json").read_text()
+        assert "TOOL_INPUT" not in settings


### PR DESCRIPTION
Closes #3440.

## The premise holds, and it is worse than "low impact"

The Bash matcher in `.claude/settings.json` greped `$TOOL_INPUT`, an environment variable the harness does not set. It matched against an empty string on every tool call and **never ran the installer, once, in its entire life**. `run-tests.sh` invokes `ensure-test-deps.sh` directly, which masked the failure completely — so what was in the repo was not a safety net but a convincing picture of one. That is the part worth fixing: a hook that is merely absent gets noticed the first time it is needed; a hook that is present and inert does not.

## Verified live, not inferred

The issue's binding constraint was that the defect *is* an assumed delivery contract, so a fix built on a second assumption would be the same bug with a new sign. Two live observations from a real session, on a container with no dependencies installed and no install marker present:

1. A real `Bash` tool call whose command contained the literal string `pytest` produced **no install marker and no delay**. The old matcher does not fire.
2. An `mcp__github__issue_write` call in the same session was parsed and blocked by `require-issue-labels.py`, which reads **stdin first** and falls back to `$TOOL_INPUT`. Since (1) proves the env var is empty, the payload reached it on stdin.

The payload arrives on **stdin**. After the refactor below, observation (2) was repeated against the shared reader and still blocked correctly — so the exact code the new gate uses is confirmed against a real harness payload, not a synthesized one.

## What changed

The root cause is not the one wrong matcher; it is **two hooks holding two independent guesses at one contract**, which is precisely what let one of them be wrong unnoticed.

- **`.claude/hooks/hook_payload.py`** (new) — the contract, read once. `read_payload()` (stdin first, env fallback) and `tool_arguments()` (handles both the nested `{"tool_name", "tool_input"}` envelope and a bare arguments dict).
- **`.claude/hooks/ensure-test-deps-gate.py`** (new) — replaces the inline matcher. Same command regex, verbatim. It **never blocks**: a failed install exits 1 (a visible, non-blocking hook error) rather than 2, so the command still runs and fails on its own terms. A dependency problem should surface as the tool's own error, not as a refusal to let the tool run.
- **`require-issue-labels.py`** — drops its private copy of the reader and imports the shared one. Behaviour is unchanged; its 24 existing tests pass untouched, and it was re-verified live.
- **`pyproject.toml`** — `hook_payload` added to deptry's `known_first_party`, alongside the existing entries for `slides/figs/src`'s sibling modules (same situation: a script run by path, not an installed package).

## Tests

`tests/core/test_ensure_test_deps_hook.py`, mirroring the existing `test_issue_label_hook.py` pattern: both delivery channels, both envelope shapes, the match/no-match commands, unparseable payloads, a failing installer that must not block, and a `TestWiring` class asserting the gate stays registered and that `TOOL_INPUT` no longer appears anywhere in `settings.json`.

These are a **regression guard, not the verification** — a synthesized payload can only re-encode the author's assumption, which is the mistake that produced the bug. The contract was pinned by watching a live session; the tests keep it pinned.

## One honest limitation

Claude Code snapshots `settings.json` hooks at session start, so the *rewired matcher* could not be fired from the session that changed it — only the payload reader it depends on could be, and was. The first confirmation in a fresh session is free and unmissable: the first `pytest`-mentioning `Bash` command will print `Installing project dependencies (first test run this session)...`, which no session has ever seen from this hook before.

`./run-tests.sh` full run: **9709 passed, 6 skipped**, all gates green (ruff, format, codespell, docs, deptry, OpenAPI, pyright, pip-audit, vulture whitelist, npm audit, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AauYPy68NsRCqCTFzLHYrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01AauYPy68NsRCqCTFzLHYrn)_