### PR TITLE
achievements: build the response shape once; drop the settings privates

### DIFF
--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -18,7 +18,7 @@ import pathlib
 import pytest
 
 import app as app_module  # noqa: F401  (triggers conftest media init)
-from vtsearch import achievements
+from vtsearch import achievements, achievements_catalog
 from vtsearch import settings as settings_mod
 
 
@@ -448,7 +448,7 @@ class TestReadmeReader:
 
     def _phrase_for(self, doc_id: str) -> str:
         """Lookup the canonical phrase for *doc_id* from the private list."""
-        for d in achievements._DOCS_RAW:
+        for d in achievements_catalog._DOCS_RAW:
             if d["id"] == doc_id:
                 return d["phrase"]
         raise KeyError(doc_id)
@@ -519,16 +519,18 @@ class TestReadmeReaderDocsDriftGuard:
 
     def test_each_doc_contains_its_phrase(self):
         repo_root = pathlib.Path(__file__).resolve().parents[2]
-        for doc in achievements._DOCS_RAW:
+        for doc in achievements_catalog._DOCS_RAW:
             text = (repo_root / doc["path"]).read_text(encoding="utf-8")
-            assert achievements._normalize_phrase(doc["phrase"]) in achievements._normalize_phrase(text), (
+            assert achievements_catalog._normalize_phrase(doc["phrase"]) in achievements_catalog._normalize_phrase(
+                text
+            ), (
                 f"Doc {doc['path']} is missing its Readme Reader phrase "
                 f"{doc['phrase']!r}; update either the doc footer or "
-                f"_DOCS_RAW in vtsearch/achievements.py."
+                f"_DOCS_RAW in vtsearch/achievements_catalog.py."
             )
 
     def test_no_two_docs_share_a_phrase(self):
-        phrases = [achievements._normalize_phrase(d["phrase"]) for d in achievements._DOCS_RAW]
+        phrases = [achievements_catalog._normalize_phrase(d["phrase"]) for d in achievements_catalog._DOCS_RAW]
         assert len(phrases) == len(set(phrases))
 
 
@@ -539,7 +541,7 @@ class TestReadmeReaderDocsDriftGuard:
 
 class TestReadmeReaderApi:
     def _phrase_for(self, doc_id: str) -> str:
-        for d in achievements._DOCS_RAW:
+        for d in achievements_catalog._DOCS_RAW:
             if d["id"] == doc_id:
                 return d["phrase"]
         raise KeyError(doc_id)
@@ -973,6 +975,27 @@ class TestDisableAchievements:
             assert a["tier_idx"] == -1
         assert state["pending_announcements"] == []
         assert all(d["read"] is False for d in state["docs"])
+
+    def test_disabled_payload_is_identical_to_a_fresh_enabled_one(self):
+        """The opted-out shell and a zero-progress real user agree exactly.
+
+        Both branches of ``get_full_state`` used to hand-build the response
+        dict, and the disabled one hardcoded ``next_threshold`` instead of
+        computing it. They happened to agree, but nothing held them there.
+        This pins the invariant: a user with no progress and a user who opted
+        out see byte-identical payloads.
+        """
+        fresh = achievements.get_full_state()
+        settings_mod.set_enable_achievements(False)
+        disabled = achievements.get_full_state()
+        assert disabled == fresh
+
+    def test_disabled_payload_reports_the_real_first_threshold(self):
+        settings_mod.set_enable_achievements(False)
+        state = achievements.get_full_state()
+        by_id = {a["id"]: a for a in state["achievements"]}
+        for a in achievements.ACHIEVEMENTS:
+            assert by_id[a["id"]]["next_threshold"] == a["tiers"][0]
 
     def test_get_full_state_zeroes_existing_counters_when_disabled(self):
         # Accrue real progress first.

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -750,6 +750,33 @@ class TestConcurrentWrites:
         assert final["theme"] == "dark"
         assert final["achievement_state"]["counters"]["votes_cast"] == 101
 
+    def test_snapshot_user_returns_stored_keys_only(self, isolated_settings):
+        """``snapshot_user`` is the public multi-key read counterpart to
+        ``mutate_user``: a detached copy of what is *stored*, with no defaults
+        merged in and no server-tier read-through."""
+        from vtsearch.auth import get_current_user
+        from vtsearch.settings import mutate_user, snapshot_user
+
+        username = get_current_user()
+        mutate_user(lambda c: c.update({"theme": "light", "achievement_state": {"counters": {"votes_cast": 7}}}))
+
+        snap = snapshot_user(username)
+        assert snap["theme"] == "light"
+        assert snap["achievement_state"]["counters"]["votes_cast"] == 7
+        # No defaults merged in (unlike ``get_user_settings``): the snapshot
+        # carries exactly what is on disk for this user.
+        assert snap == json.loads(isolated_settings._user.read_text())
+        assert set(snap) < set(settings_mod.get_user_settings())
+
+        # The top-level dict is a copy: mutating it must not touch the cache.
+        snap["theme"] = "dark"
+        assert snapshot_user(username)["theme"] == "light"
+
+    def test_snapshot_user_is_empty_for_an_unknown_user(self):
+        from vtsearch.settings import snapshot_user
+
+        assert snapshot_user("nobody-here") == {}
+
     def test_add_autofind_detector_rmw(self, isolated_settings):
         """Concurrent ``add_autofind_detector`` calls must not lose entries.
 

--- a/vtsearch/achievements.py
+++ b/vtsearch/achievements.py
@@ -30,181 +30,51 @@ the toast is a fire-once affair independent of whether they ever open it.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from vtsearch.achievements_catalog import (
+    ACHIEVEMENTS,
+    DOCS,
+    EXCLUDED_DATASET_IMPORTERS,
+    HOURS_OF_DAY,
+    MEDIA_TYPES,
+    STREAK_GAP_SECONDS,
+    TIER_NAMES,
+    _ACH_BY_ID,
+    _DOC_BY_ID,
+    _DOC_HASHES,
+    _hash_phrase,
+)
 from vtsearch.auth import get_current_user
-from vtsearch.settings import _ensure_user_loaded, _settings_lock, mutate_user
+from vtsearch.settings import mutate_user, snapshot_user
 
+
+#: The static catalog is re-exported so callers — routes, tests, the shim —
+#: keep reaching these names through ``vtsearch.achievements``; the split into
+#: :mod:`vtsearch.achievements_catalog` is internal.
+__all__ = [
+    "ACHIEVEMENTS",
+    "DOCS",
+    "EXCLUDED_DATASET_IMPORTERS",
+    "HOURS_OF_DAY",
+    "MEDIA_TYPES",
+    "STREAK_GAP_SECONDS",
+    "TIER_NAMES",
+    "acknowledge",
+    "get_full_state",
+    "mark_toasted",
+    "record_dataset_load",
+    "record_detector_import",
+    "record_doc_phrase",
+    "record_find",
+    "record_vote",
+    "wipe_state",
+]
 
 logger = logging.getLogger(__name__)
-
-#: Tier display names, indexed 0..3.
-TIER_NAMES: tuple[str, ...] = ("Bronze", "Silver", "Gold", "Platinum")
-
-#: Achievement category definitions.  Each tier list MUST be ascending and
-#: aligned with :data:`TIER_NAMES`.
-ACHIEVEMENTS: list[dict[str, Any]] = [
-    {
-        "id": "datasets_loaded",
-        "name": "Data: Set",
-        "description": "Load datasets you imported. Demos and synthetic don't count.",
-        "icon": "cubes",
-        "tiers": [1, 10, 100, 1000],
-    },
-    {
-        "id": "votes_cast",
-        "name": "Get Out the Vote",
-        "description": "Every Good or Bad you cast on a media item.",
-        "icon": "checkbox-checked",
-        "tiers": [100, 1000, 10000, 100000],
-    },
-    {
-        "id": "detectors_trained",
-        "name": "Teacher's Pet",
-        "description": "Each detector you trained, counted on its first vote.",
-        "icon": "graduation",
-        "tiers": [2, 20, 200, 2000],
-    },
-    {
-        "id": "detectors_imported",
-        "name": "Detector Collector",
-        "description": "Detectors built up from imported labels.",
-        "icon": "robot",
-        "tiers": [1, 10, 100, 1000],
-    },
-    {
-        "id": "find_media",
-        "name": "Finders Keepers",
-        "description": "Media items scored by Find (GUI and CLI combined).",
-        "icon": "search",
-        "tiers": [2000, 20000, 200000, 2000000],
-    },
-    {
-        "id": "days_active",
-        "name": "Your Days are Numbered",
-        "description": "Distinct calendar days on which you cast at least one vote.",
-        "icon": "calendar",
-        "tiers": [2, 20, 200, 2000],
-    },
-    {
-        "id": "media_types_touched",
-        "name": "Multi Media",
-        "description": "Distinct media types you've voted on (audio, image, text, video, document).",
-        "icon": "palette",
-        "tiers": [2, 3, 4, 5],
-    },
-    {
-        "id": "vote_streak",
-        "name": "Marathoner",
-        "description": "Longest run of consecutive votes with at most a 10-minute gap.",
-        "icon": "running",
-        "tiers": [200, 400, 600, 1000],
-    },
-    {
-        "id": "hours_voted",
-        "name": "Around the Clock",
-        "description": "Distinct hours of the day (0-23) in which you've cast at least one vote.",
-        "icon": "clock",
-        "tiers": [6, 12, 20, 24],
-    },
-    {
-        "id": "docs_read",
-        "name": "Readme Reader",
-        "description": (
-            "Find the code phrase at the bottom of each documentation page and "
-            "paste it in to claim credit. Four docs hide a phrase; Platinum is "
-            "all four."
-        ),
-        "icon": "file-text",
-        "tiers": [1, 2, 3, 4],
-    },
-]
-
-_ACH_BY_ID: dict[str, dict[str, Any]] = {a["id"]: a for a in ACHIEVEMENTS}
-
-#: Importer names whose successful dataset loads do NOT count toward
-#: ``datasets_loaded``.  These are the demo/synthetic data paths users
-#: don't have ownership over.
-EXCLUDED_DATASET_IMPORTERS: frozenset[str] = frozenset({"demo", "synthetic"})
-
-#: Maximum gap (in seconds) between two consecutive votes that still keeps the
-#: Marathoner streak alive.  Anything strictly greater than this resets the
-#: streak counter to 1 on the next vote.
-STREAK_GAP_SECONDS: float = 10 * 60
-
-#: Canonical media types tracked by the "Multi Media" achievement, in display
-#: order, paired with their human-readable labels.  The achievement's tiers
-#: (max 5) assume exactly these five types; :func:`get_full_state` reports a
-#: per-type ticked flag so the UI can show which ones the user has voted on.
-MEDIA_TYPES: list[dict[str, str]] = [
-    {"id": "audio", "name": "Audio"},
-    {"id": "image", "name": "Image"},
-    {"id": "text", "name": "Text"},
-    {"id": "video", "name": "Video"},
-    {"id": "document", "name": "Document"},
-]
-
-#: Hours of the day tracked by the "Around the Clock" achievement, bucketed
-#: in the voter's local wall-clock time (see :func:`_user_tz_offset_minutes`).
-HOURS_OF_DAY: tuple[int, ...] = tuple(range(24))
-
-#: Readme Reader docs.  Each entry pairs a doc with the code phrase printed at
-#: the bottom of it.  The phrase is matched server-side: the user pastes their
-#: guess and we compare it to ``_DOC_HASHES`` (SHA-256 of the normalised
-#: phrase).  Phrases are kept in source so the test suite can verify each doc's
-#: footer is in sync, but :func:`get_full_state` never returns them to the
-#: client; it returns only the per-doc read state.
-#:
-#: ``path`` is repo-relative so the docs route can stream the raw markdown.
-_DOCS_RAW: list[dict[str, str]] = [
-    {
-        "id": "readme",
-        "name": "README",
-        "path": "README.md",
-        "phrase": "all aboard the embedding express",
-    },
-    {
-        "id": "user_guide",
-        "name": "User Guide",
-        "path": "docs/user/USER_GUIDE.md",
-        "phrase": "label like nobody's watching",
-    },
-    {
-        "id": "cli",
-        "name": "CLI",
-        "path": "docs/CLI.md",
-        "phrase": "command palette unlocked",
-    },
-    {
-        "id": "api",
-        "name": "HTTP API",
-        "path": "docs/API.md",
-        "phrase": "json all the way down",
-    },
-]
-
-
-def _normalize_phrase(phrase: str) -> str:
-    """Lower-case + collapse internal whitespace + strip; the canonical form
-    used for hashing and matching.  Tolerant to copy-paste artefacts (extra
-    spaces, trailing newline, accidental capitalisation)."""
-    return " ".join(phrase.lower().split())
-
-
-def _hash_phrase(phrase: str) -> str:
-    return hashlib.sha256(_normalize_phrase(phrase).encode("utf-8")).hexdigest()
-
-
-#: ``doc_id → sha256(normalised phrase)``.  Precomputed at import time.
-_DOC_HASHES: dict[str, str] = {d["id"]: _hash_phrase(d["phrase"]) for d in _DOCS_RAW}
-
-#: Public, phrase-free copy of the doc list for serialisation.
-DOCS: list[dict[str, str]] = [{"id": d["id"], "name": d["name"], "path": d["path"]} for d in _DOCS_RAW]
-_DOC_BY_ID: dict[str, dict[str, str]] = {d["id"]: d for d in DOCS}
 
 
 def _ensure_state(settings: dict[str, Any]) -> dict[str, Any]:
@@ -571,90 +441,72 @@ def get_full_state() -> dict[str, Any]:
     "Around the Clock" expandable panels: each entry's ``seen`` flag says
     whether the user has cast a vote in that media type / hour-of-day bucket.
     """
+    # A user who opted out gets the same payload built from an empty state:
+    # ``_ensure_state`` fills a fresh dict with zeroed counters and -1
+    # watermarks, which :func:`_state_payload` renders as every category
+    # locked, nothing pending, and nothing seen. Building the shell through
+    # the same code path is what keeps the two branches from drifting.
     if _is_disabled():
-        zeroed: list[dict[str, Any]] = []
-        for a in ACHIEVEMENTS:
-            zeroed.append(
-                {
-                    "id": a["id"],
-                    "name": a["name"],
-                    "description": a["description"],
-                    "icon": a["icon"],
-                    "tiers": list(a["tiers"]),
-                    "counter": 0,
-                    "tier_idx": -1,
-                    "next_threshold": a["tiers"][0],
-                }
-            )
-        return {
-            "tier_names": list(TIER_NAMES),
-            "achievements": zeroed,
-            "pending_announcements": [],
-            "pending_toasts": [],
-            "docs": [{"id": d["id"], "name": d["name"], "path": d["path"], "read": False} for d in DOCS],
-            "media_types": [{"id": m["id"], "name": m["name"], "seen": False} for m in MEDIA_TYPES],
-            "hours": [{"hour": h, "seen": False} for h in HOURS_OF_DAY],
-        }
-    username = get_current_user()
-    _ensure_user_loaded(username)
-    with _settings_lock:
-        # Snapshot the cache once so the read-side view is consistent
-        # while we walk the achievement table. We don't mutate here, so
-        # there's no need to take the cross-process file lock.
-        from vtsearch.settings import _user_caches
+        return _state_payload(_ensure_state({}))
+    return _state_payload(_ensure_state(snapshot_user(get_current_user())))
 
-        s = dict(_user_caches.get(username, {}))
-        state = _ensure_state(s)
-        achievements: list[dict[str, Any]] = []
-        pending: list[dict[str, Any]] = []
-        toasts: list[dict[str, Any]] = []
-        for a in ACHIEVEMENTS:
-            cid = a["id"]
-            counter = int(state["counters"].get(cid, 0))
-            tier_idx = _current_tier_idx(cid, counter)
-            announced_idx = int(state["announced"].get(cid, -1))
-            toasted_idx = int(state["toasted"].get(cid, -1))
-            next_threshold: int | None = a["tiers"][tier_idx + 1] if tier_idx + 1 < len(a["tiers"]) else None
-            achievements.append(
-                {
-                    "id": cid,
-                    "name": a["name"],
-                    "description": a["description"],
-                    "icon": a["icon"],
-                    "tiers": list(a["tiers"]),
-                    "counter": counter,
-                    "tier_idx": tier_idx,
-                    "next_threshold": next_threshold,
-                }
-            )
 
-            def _milestone(i: int, _a: dict[str, Any] = a, _cid: str = cid) -> dict[str, Any]:
-                return {
-                    "id": _cid,
-                    "name": _a["name"],
-                    "icon": _a["icon"],
-                    "tier_idx": i,
-                    "tier_name": TIER_NAMES[i],
-                    "threshold": _a["tiers"][i],
-                }
+def _state_payload(state: dict[str, Any]) -> dict[str, Any]:
+    """Render an ``achievement_state`` dict into the frontend payload.
 
-            pending.extend(_milestone(i) for i in range(announced_idx + 1, tier_idx + 1))
-            toasts.extend(_milestone(i) for i in range(toasted_idx + 1, tier_idx + 1))
-        read_ids = set(state.get("docs_read_ids", []))
-        docs = [{"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids} for d in DOCS]
-        seen_types = set(state.get("media_types_seen", []))
-        media_types = [{"id": m["id"], "name": m["name"], "seen": m["id"] in seen_types} for m in MEDIA_TYPES]
-        seen_hours = set(state.get("hours_seen", []))
-        hours = [{"hour": h, "seen": h in seen_hours} for h in HOURS_OF_DAY]
-        return {
-            "tier_names": list(TIER_NAMES),
-            "achievements": achievements,
-            "pending_announcements": pending,
-            "pending_toasts": toasts,
-            "docs": docs,
-            "media_types": media_types,
-            "hours": hours,
-        }
+    Pure: takes the state, walks the static catalog, and returns the shape
+    documented on :func:`get_full_state`. Both the enabled and the opted-out
+    branches go through here, so there is exactly one definition of the
+    response shape.
+    """
+    achievements: list[dict[str, Any]] = []
+    pending: list[dict[str, Any]] = []
+    toasts: list[dict[str, Any]] = []
+    for a in ACHIEVEMENTS:
+        cid = a["id"]
+        counter = int(state["counters"].get(cid, 0))
+        tier_idx = _current_tier_idx(cid, counter)
+        announced_idx = int(state["announced"].get(cid, -1))
+        toasted_idx = int(state["toasted"].get(cid, -1))
+        next_threshold: int | None = a["tiers"][tier_idx + 1] if tier_idx + 1 < len(a["tiers"]) else None
+        achievements.append(
+            {
+                "id": cid,
+                "name": a["name"],
+                "description": a["description"],
+                "icon": a["icon"],
+                "tiers": list(a["tiers"]),
+                "counter": counter,
+                "tier_idx": tier_idx,
+                "next_threshold": next_threshold,
+            }
+        )
+
+        def _milestone(i: int, _a: dict[str, Any] = a, _cid: str = cid) -> dict[str, Any]:
+            return {
+                "id": _cid,
+                "name": _a["name"],
+                "icon": _a["icon"],
+                "tier_idx": i,
+                "tier_name": TIER_NAMES[i],
+                "threshold": _a["tiers"][i],
+            }
+
+        pending.extend(_milestone(i) for i in range(announced_idx + 1, tier_idx + 1))
+        toasts.extend(_milestone(i) for i in range(toasted_idx + 1, tier_idx + 1))
+
+    read_ids = set(state.get("docs_read_ids", []))
+    seen_types = set(state.get("media_types_seen", []))
+    seen_hours = set(state.get("hours_seen", []))
+    return {
+        "tier_names": list(TIER_NAMES),
+        "achievements": achievements,
+        "pending_announcements": pending,
+        "pending_toasts": toasts,
+        "docs": [{"id": d["id"], "name": d["name"], "path": d["path"], "read": d["id"] in read_ids} for d in DOCS],
+        "media_types": [{"id": m["id"], "name": m["name"], "seen": m["id"] in seen_types} for m in MEDIA_TYPES],
+        "hours": [{"hour": h, "seen": h in seen_hours} for h in HOURS_OF_DAY],
+    }
 
 
 def acknowledge(category_id: str, tier_idx: int) -> bool:

--- a/vtsearch/achievements_catalog.py
+++ b/vtsearch/achievements_catalog.py
@@ -1,0 +1,182 @@
+"""Static achievement catalog: the declarations, none of the state machine.
+
+This module is pure data plus the two tiny pure helpers that derive tables
+from it (:func:`_normalize_phrase` / :func:`_hash_phrase`).  It imports
+nothing from the rest of the app, so it can be read — and edited, when a new
+achievement category or Readme Reader doc is added — without carrying the
+counter/watermark logic in :mod:`vtsearch.achievements` in your head.
+
+:mod:`vtsearch.achievements` re-exports every public name here, so callers
+keep importing them from there; this split is an internal reorganisation, not
+a new import surface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+
+#: Tier display names, indexed 0..3.
+TIER_NAMES: tuple[str, ...] = ("Bronze", "Silver", "Gold", "Platinum")
+
+#: Achievement category definitions.  Each tier list MUST be ascending and
+#: aligned with :data:`TIER_NAMES`.
+ACHIEVEMENTS: list[dict[str, Any]] = [
+    {
+        "id": "datasets_loaded",
+        "name": "Data: Set",
+        "description": "Load datasets you imported. Demos and synthetic don't count.",
+        "icon": "cubes",
+        "tiers": [1, 10, 100, 1000],
+    },
+    {
+        "id": "votes_cast",
+        "name": "Get Out the Vote",
+        "description": "Every Good or Bad you cast on a media item.",
+        "icon": "checkbox-checked",
+        "tiers": [100, 1000, 10000, 100000],
+    },
+    {
+        "id": "detectors_trained",
+        "name": "Teacher's Pet",
+        "description": "Each detector you trained, counted on its first vote.",
+        "icon": "graduation",
+        "tiers": [2, 20, 200, 2000],
+    },
+    {
+        "id": "detectors_imported",
+        "name": "Detector Collector",
+        "description": "Detectors built up from imported labels.",
+        "icon": "robot",
+        "tiers": [1, 10, 100, 1000],
+    },
+    {
+        "id": "find_media",
+        "name": "Finders Keepers",
+        "description": "Media items scored by Find (GUI and CLI combined).",
+        "icon": "search",
+        "tiers": [2000, 20000, 200000, 2000000],
+    },
+    {
+        "id": "days_active",
+        "name": "Your Days are Numbered",
+        "description": "Distinct calendar days on which you cast at least one vote.",
+        "icon": "calendar",
+        "tiers": [2, 20, 200, 2000],
+    },
+    {
+        "id": "media_types_touched",
+        "name": "Multi Media",
+        "description": "Distinct media types you've voted on (audio, image, text, video, document).",
+        "icon": "palette",
+        "tiers": [2, 3, 4, 5],
+    },
+    {
+        "id": "vote_streak",
+        "name": "Marathoner",
+        "description": "Longest run of consecutive votes with at most a 10-minute gap.",
+        "icon": "running",
+        "tiers": [200, 400, 600, 1000],
+    },
+    {
+        "id": "hours_voted",
+        "name": "Around the Clock",
+        "description": "Distinct hours of the day (0-23) in which you've cast at least one vote.",
+        "icon": "clock",
+        "tiers": [6, 12, 20, 24],
+    },
+    {
+        "id": "docs_read",
+        "name": "Readme Reader",
+        "description": (
+            "Find the code phrase at the bottom of each documentation page and "
+            "paste it in to claim credit. Four docs hide a phrase; Platinum is "
+            "all four."
+        ),
+        "icon": "file-text",
+        "tiers": [1, 2, 3, 4],
+    },
+]
+
+_ACH_BY_ID: dict[str, dict[str, Any]] = {a["id"]: a for a in ACHIEVEMENTS}
+
+#: Importer names whose successful dataset loads do NOT count toward
+#: ``datasets_loaded``.  These are the demo/synthetic data paths users
+#: don't have ownership over.
+EXCLUDED_DATASET_IMPORTERS: frozenset[str] = frozenset({"demo", "synthetic"})
+
+#: Maximum gap (in seconds) between two consecutive votes that still keeps the
+#: Marathoner streak alive.  Anything strictly greater than this resets the
+#: streak counter to 1 on the next vote.
+STREAK_GAP_SECONDS: float = 10 * 60
+
+#: Canonical media types tracked by the "Multi Media" achievement, in display
+#: order, paired with their human-readable labels.  The achievement's tiers
+#: (max 5) assume exactly these five types; :func:`~vtsearch.achievements.get_full_state` reports a
+#: per-type ticked flag so the UI can show which ones the user has voted on.
+MEDIA_TYPES: list[dict[str, str]] = [
+    {"id": "audio", "name": "Audio"},
+    {"id": "image", "name": "Image"},
+    {"id": "text", "name": "Text"},
+    {"id": "video", "name": "Video"},
+    {"id": "document", "name": "Document"},
+]
+
+#: Hours of the day tracked by the "Around the Clock" achievement, bucketed
+#: in the voter's local wall-clock time (see ``vtsearch.achievements._user_tz_offset_minutes``).
+HOURS_OF_DAY: tuple[int, ...] = tuple(range(24))
+
+#: Readme Reader docs.  Each entry pairs a doc with the code phrase printed at
+#: the bottom of it.  The phrase is matched server-side: the user pastes their
+#: guess and we compare it to ``_DOC_HASHES`` (SHA-256 of the normalised
+#: phrase).  Phrases are kept in source so the test suite can verify each doc's
+#: footer is in sync, but :func:`~vtsearch.achievements.get_full_state` never returns them to the
+#: client; it returns only the per-doc read state.
+#:
+#: ``path`` is repo-relative so the docs route can stream the raw markdown.
+_DOCS_RAW: list[dict[str, str]] = [
+    {
+        "id": "readme",
+        "name": "README",
+        "path": "README.md",
+        "phrase": "all aboard the embedding express",
+    },
+    {
+        "id": "user_guide",
+        "name": "User Guide",
+        "path": "docs/user/USER_GUIDE.md",
+        "phrase": "label like nobody's watching",
+    },
+    {
+        "id": "cli",
+        "name": "CLI",
+        "path": "docs/CLI.md",
+        "phrase": "command palette unlocked",
+    },
+    {
+        "id": "api",
+        "name": "HTTP API",
+        "path": "docs/API.md",
+        "phrase": "json all the way down",
+    },
+]
+
+
+def _normalize_phrase(phrase: str) -> str:
+    """Lower-case + collapse internal whitespace + strip; the canonical form
+    used for hashing and matching.  Tolerant to copy-paste artefacts (extra
+    spaces, trailing newline, accidental capitalisation)."""
+    return " ".join(phrase.lower().split())
+
+
+def _hash_phrase(phrase: str) -> str:
+    return hashlib.sha256(_normalize_phrase(phrase).encode("utf-8")).hexdigest()
+
+
+#: ``doc_id → sha256(normalised phrase)``.  Precomputed at import time.
+_DOC_HASHES: dict[str, str] = {d["id"]: _hash_phrase(d["phrase"]) for d in _DOCS_RAW}
+
+#: Public, phrase-free copy of the doc list for serialisation.
+DOCS: list[dict[str, str]] = [{"id": d["id"], "name": d["name"], "path": d["path"]} for d in _DOCS_RAW]
+_DOC_BY_ID: dict[str, dict[str, str]] = {d["id"]: d for d in DOCS}

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -340,14 +340,16 @@ _EXCLUDE_FROM_SOURCE_EXPORT = {
 # Caches
 # ---------------------------------------------------------------------------
 
-# The mutable engine state below lives here (not on the store) because
-# other modules import these containers by name: ``vtsearch.achievements``
-# reads ``_user_caches`` / ``_settings_lock``, and the sync-source tests
-# poke ``_sync_state``. The :class:`~vtsearch.settings_store.UserSettingsStore`
-# instance (created at the bottom of this module) is handed these same
-# objects by reference, so both views mutate one set of containers. The
-# reassignable scalars (``server_cache``, ``legacy_migrated``) and the
-# per-user sync locks live solely on the store.
+# The mutable engine state below lives here (not on the store) because the
+# test suite imports these containers by name: the sync-source tests poke
+# ``_sync_state`` and ``_user_caches``, and the thread-safety test asserts on
+# ``_settings_lock``. No *production* module reads them any more - app code
+# that wants a multi-key read of a user's tier calls :func:`snapshot_user`.
+# The :class:`~vtsearch.settings_store.UserSettingsStore` instance (created at
+# the bottom of this module) is handed these same objects by reference, so
+# both views mutate one set of containers. The reassignable scalars
+# (``server_cache``, ``legacy_migrated``) and the per-user sync locks live
+# solely on the store.
 
 # Per-user caches keyed by username.
 _user_caches: dict[str, dict[str, Any]] = {}
@@ -574,6 +576,30 @@ def get_defaults() -> dict[str, Any]:
     return result
 
 
+def snapshot_user(username: str) -> dict[str, Any]:
+    """Return a consistent copy of *username*'s raw per-user settings cache.
+
+    This is the public read counterpart to :func:`mutate_user`: it loads the
+    user's tier if cold, then copies the cache under ``_settings_lock`` so the
+    caller walks a view that no concurrent writer can tear.  Callers that need
+    to read several related keys at once (rather than one key via an accessor)
+    should use this instead of reaching for ``_user_caches`` directly.
+
+    The returned dict holds only what is *stored* for the user - no defaults
+    are filled in, and no server-tier read-through is applied.  Use
+    :func:`get_user_settings` when you want the defaults merged in.
+
+    ``_ensure_user_loaded`` runs outside ``_settings_lock`` because a cold
+    cache takes the cross-process file lock (and, via a due sync,
+    ``_apply_settings``'s setters take it again); the canonical order is
+    file_lock -> settings_lock, so holding the settings lock across it would
+    deadlock against a concurrent writer.
+    """
+    _ensure_user_loaded(username)
+    with _settings_lock:
+        return dict(_user_caches.get(username, {}))
+
+
 def get_user_settings() -> dict[str, Any]:
     """Return the current user's per-user settings (with defaults filled in).
 
@@ -584,15 +610,7 @@ def get_user_settings() -> dict[str, Any]:
     """
     from vtsearch.auth import get_current_user
 
-    username = get_current_user()
-    # ``_ensure_user_loaded`` may trigger sync-from-source which calls
-    # setters that acquire ``_file_lock``. Calling it outside
-    # ``_settings_lock`` keeps the canonical lock order
-    # (file_lock → settings_lock) and avoids an AB-BA deadlock with
-    # concurrent writers.
-    _ensure_user_loaded(username)
-    with _settings_lock:
-        user_copy = dict(_user_caches.get(username, {}))
+    user_copy = snapshot_user(get_current_user())
     result = dict(_user_defaults())
     result.update(user_copy)
     # Same legacy migration as ``get_all`` so settings exports carry a value


### PR DESCRIPTION
Closes #3430

## One response shape, not two

`get_full_state` hand-built the full payload in both branches — the opted-out shell and the real one. The two had already started to drift *in expression*: the disabled branch hardcoded `next_threshold` as `tiers[0]` where the enabled branch computed it from `tier_idx`.

Worth stating plainly, since the issue implies otherwise: **they were not actually divergent in output.** With `counter == 0` the enabled branch resolves `tier_idx` to `-1` and computes `tiers[0]` — the same number the shell hardcoded. So this fixes duplication, not a live bug. What made it worth doing is that nothing *held* them together; the next category-level field added to one branch would have silently gone missing from the other.

Both branches now go through one pure renderer, `_state_payload(state)`. The opted-out shell is `_state_payload(_ensure_state({}))`: a fresh empty state fills in zeroed counters and `-1` watermarks, which renders as every category locked, `pending_announcements`/`pending_toasts` empty, and every doc/media-type/hour flag `False` — exactly what the old branch spelled out by hand.

## Public read API instead of three settings privates

`achievements.py` imported `_ensure_user_loaded` and `_settings_lock` at module level, plus a function-local `from vtsearch.settings import _user_caches`, to take a consistent read snapshot of the user's tier. That open-coded pattern carries a real hazard — `_ensure_user_loaded` must run *outside* `_settings_lock`, because a cold cache takes the cross-process file lock and the canonical order is file_lock → settings_lock.

That is now `settings.snapshot_user(username)`, which owns the lock-ordering rule in one docstring. `get_user_settings` was open-coding the identical sequence and now uses it too.

One caveat on the payoff the issue anticipated: this does **not** yet free `UserSettingsStore` to own its containers. `_user_caches` and `_settings_lock` are still reached by name from four test files (`tests/io/test_sync_sources.py`, `tests/core/test_achievements.py`, `tests/core/test_signpost_vocab_setting.py`, `tests/integration/test_thread_safety.py`). What changed is that no *production* module reads them any more, so the comment in `settings.py` explaining why they stay module-global is narrowed to say exactly that. Moving them onto the store is a separate change that has to touch those tests.

## Catalog split out

The static declarations (`TIER_NAMES`, `ACHIEVEMENTS`, `MEDIA_TYPES`, `HOURS_OF_DAY`, the Readme Reader docs and their hash table) move to `vtsearch/achievements_catalog.py` — pure data plus the two tiny pure helpers that derive tables from it, importing nothing from the rest of the app. `achievements.py` drops from 719 to ~520 lines and holds only the state machine.

Every public name is re-exported through `__all__`, so routes, the shim, and tests keep importing them from `vtsearch.achievements` unchanged. The two *private* names only tests reached for (`_DOCS_RAW`, `_normalize_phrase`) now come from the catalog module directly, which is their real home.

## Tests

Three new tests, all pinning invariants rather than restating the implementation:

- `test_disabled_payload_is_identical_to_a_fresh_enabled_one` — the opted-out payload equals a zero-progress user's, exactly. This is the guard that was missing; it would have caught a real divergence in the old code.
- `test_disabled_payload_reports_the_real_first_threshold` — pins `next_threshold` against the catalog rather than a hardcoded literal.
- `test_snapshot_user_returns_stored_keys_only` / `..._is_empty_for_an_unknown_user` — the new settings API returns a detached copy of what is stored, with no defaults merged and no server-tier read-through.

Full `./run-tests.sh`: **9690 passed, 6 skipped**, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfaUBxrfoo6Ed2fHA4aK5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfaUBxrfoo6Ed2fHA4aK5o)_