### PR TITLE
Extract PairScopeService: enforce the pair-change reset ordering instead of documenting it twice

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -267,6 +267,7 @@ The ones worth knowing before changing anything:
 | `VtDialogService` | `confirm()` / `prompt()` as promises, rendered by `dialog-host` |
 | `NewThingFlowsService` | Singleton openers for the Add-Dataset / New-Detector flows |
 | `MediaMetadataCacheService` | Lazy batched fetch of full metadata for whatever is in the viewport |
+| `PairScopeService` | **Component-provided** (`find-view`, `label-view`): the active pair's lifetime, the `scoped()` teardown operator, and the pair-change reset in its one correct order |
 | `KeyboardService`, `ThemeService`, `AchievementsService`, `AuthService` | App-wide concerns wired in `AppComponent` |
 
 `adaptive-poll.ts` is not a service but a shared operator; see
@@ -531,11 +532,21 @@ component is very much still alive. It legitimately takes one of two shapes,
 and both are correct as written:
 
 - A **scope subject** fired on each reset, for a family of streams that share
-  a lifetime shorter than the component's: `pairScope$` (`find-view`,
-  `label-view`) tears down everything belonging to the dataset/detector pair
-  being left, `findPolling$` (`dashboard`) and `stopPolling$`
-  (`VoteStateService`) cancel a superseded poll. Name it for the scope it
-  bounds, never `destroy$`.
+  a lifetime shorter than the component's: `findPolling$` (`dashboard`) and
+  `stopPolling$` (`VoteStateService`) cancel a superseded poll. Name it for the
+  scope it bounds, never `destroy$`.
+
+  The dataset/detector pair's scope is the one case where the subject is not a
+  component field: `PairScopeService` (component-provided on `find-view` and
+  `label-view`) keeps it private and exposes `pairScope.scoped()` as the pipe
+  operator, because the *ordering* around firing it is load-bearing. A pair
+  switch must supersede **before** any of the new pair's state is installed, or
+  a late response repaints the old pair's ranking over the new one's — a silent
+  wrong-results bug, not a crash. Both views used to spell that sequence out in
+  a comment and enforce nothing; `resetForNewPair()` is now the only caller that
+  can fire the scope, so the order is not a caller's to get wrong. The service's
+  own `ngOnDestroy` covers destroy-time teardown, so a view must not (and need
+  not) fire the scope by hand.
 - A **re-assigned `Subscription` field** that unsubscribes the previous value
   before storing the next: `text-viewer`'s `sub`, `folder-browser`'s
   `currentSub`, `browse-bin-popup`'s `scrollSub` (re-keyed to the viewport

--- a/frontend/src/app/components/find-view/find-view.component.html
+++ b/frontend/src/app/components/find-view/find-view.component.html
@@ -22,7 +22,7 @@
       [focusMode]="focusModeLeft()"
       [loadSortLabel]="sortState.loadSortLabel"
       [textQuery]="sortState.textQuery"
-      [datasetName]="datasetName()"
+      [datasetName]="pairScope.datasetName()"
       [panelMode]="'find'"
       [disabled]="waiting"
       [autopilotCollapsed]="false"

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -11,7 +11,6 @@ import { FindStatsModalComponent } from '../modals/find-stats-modal/find-stats-m
 import type { LabelFilter } from '../../services/sorting-api.service';
 import { MediasApiService } from '../../services/medias-api.service';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
-import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
 import { DatasetsCrudApiService } from '../../services/datasets-crud-api.service';
 import { DashboardLoadingTasksService } from '../../services/dashboard-loading-tasks.service';
 import { ToastService } from '../../services/toast.service';
@@ -22,6 +21,7 @@ import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService, SortedItem } from '../../services/sort-state.service';
 import { SortingApiService } from '../../services/sorting-api.service';
+import { PairScopeService } from '../../services/pair-scope.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { ProgressEventsService } from '../../services/progress-events.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
@@ -58,11 +58,11 @@ const INCLUSION_POST_DEBOUNCE_MS = 150;
   ],
   templateUrl: './find-view.component.html',
   styleUrl: './find-view.component.scss',
+  providers: [PairScopeService],
 })
 export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private mediasApi = inject(MediasApiService);
   private detectorsFindApi = inject(DetectorsFindApiService);
-  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private datasetsCrudApi = inject(DatasetsCrudApiService);
   private loadingTasksSvc = inject(DashboardLoadingTasksService);
   private toast = inject(ToastService);
@@ -79,6 +79,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private browseSubset = inject(BrowseSubsetService);
   /** Public: the wait overlay binds this service's progress signals directly. */
   browsePrep = inject(BrowseSubsetPrepService);
+  /** Component-provided. Public: the header binds `pairScope.datasetName()`. */
+  readonly pairScope = inject(PairScopeService);
 
   readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
   readonly centerPanel = viewChild(CenterPanelComponent);
@@ -88,7 +90,6 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   // they must be signals — a plain-field write from those contexts would not
   // schedule CD and the view would go stale (zoneless-migration.md, Phase 2.5,
   // Recipe B & F).
-  readonly datasetName = signal('');
   readonly gridGoalWidthLeft = signal(80);
   readonly focusModeLeft = signal<'click' | 'hover'>('click');
   readonly focusModeRight = signal<'click' | 'hover'>('click');
@@ -135,23 +136,6 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
   /**
-   * Fires whenever the active (dataset, detector) pair changes — and on
-   * destroy. Every request whose response writes *pair-scoped* state (the
-   * ranking, the threshold, the inclusion slider, the dataset name, the vote
-   * cache) is piped through `takeUntil(this.pairScope$)` rather than
-   * `destroy$`, so the work started for the pair we're leaving is torn down
-   * the instant the pair switches.
-   *
-   * Without it, a scoring run — minutes long on a large dataset — outlives the
-   * switch: whichever response lands last wins, so the *old* pair's ranking and
-   * threshold get installed into the new context, and `advanceToBoundary()`
-   * selects a media id that may not exist in the new dataset (broken viewer,
-   * image 404s). Even when the old response lands *first*, its `finalize()`
-   * drops the wait overlay and re-enables voting while the new run is still
-   * going. `takeUntil` here also aborts the stale XHR client-side.
-   */
-  private pairScope$ = new Subject<void>();
-  /**
    * Inclusion-slider values awaiting their `POST /api/inclusion`, funnelled
    * through a single debounced `switchMap` pipeline (wired in the constructor).
    *
@@ -192,8 +176,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
             switchMap(() => this.sortingApi.setInclusion(value)),
             // Pair-scoped like every other threshold write: a response landing
             // after a switch must not install the old pair's cutoff into the
-            // new context (see `pairScope$`).
-            takeUntil(this.pairScope$),
+            // new context (see `PairScopeService`).
+            this.pairScope.scoped(),
             // A failed POST just leaves the cutoff where it was. Swallow it
             // inside the inner observable so the error can't tear down the
             // long-lived outer pipeline and silence every later slide.
@@ -279,25 +263,20 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // VoteStateService), so a fresh Dashboard → Find navigation still holds the
     // previous session's ranking and votes.  Against a *smaller* dataset that
     // stale ranking briefly renders ids that only existed in the prior dataset,
-    // firing a storm of image 404s.  Reset it here (mirroring reloadForNewPair)
-    // before loading — but NOT when returning from the Browser, where the
+    // firing a storm of image 404s.  Reset it here — the same clear the pair
+    // switch runs — but NOT when returning from the Browser, where the
     // preserved ranking + verifications are exactly what we want to keep (see
     // the runFindLabel guard below).
     const returningFromBrowse = this.browseSubset.consumeReturningToFind();
     if (!returningFromBrowse) {
-      this.sortState.setSortResults([], 0);
-      this.sortState.setSortStatus('');
-      this.sortState.setSortProgress(0, 0);
-      this.voteState.clear();
+      this.pairScope.clearPairState();
     }
     this.mediaState.loadMedias();
     this.voteState.loadVotes();
     // The left work queue (ranking minus verified items) is the
     // `unverifiedSortOrder` computed, which tracks sortOrder + verifiedIds.
     this.loadSettings();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
-      next: (status) => { this.datasetName.set(status.display_name || ''); },
-    });
+    this.pairScope.loadDatasetName();
 
     // When medias arrive, the media-type sync runs from a constructor effect
     // on `mediaState.mediasSignal()`.
@@ -308,11 +287,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // Good/Bad), and the loadVotes() above refreshes them; re-running find here
     // would re-score with the unchanged model and could re-promote those items,
     // undoing the verification. Keep the verifications instead.
-    // Seed the inclusion slider from the active detector's context value
-    // (GET /api/inclusion resolves per-detector, falling back to the
-    // user-settings default the first time it's read). This keeps Find's
-    // slider in step with whatever the detector was last trained at.
-    this.seedInclusion();
+    this.pairScope.seedInclusion();
 
     if (!returningFromBrowse) {
       this.runFindLabel();
@@ -335,32 +310,13 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private reloadForNewPair(): void {
-    // Supersede the pair we're leaving *first*: every in-flight request scoped
-    // to it dies here, before any of the new pair's state is installed, so no
-    // late response can write the old ranking/threshold into the new context.
-    // The old scoring run's `finalize()` runs as part of this teardown, which
-    // is why it can't clobber the fresh run started at the bottom of this
-    // method — that run begins after the teardown has already settled.
-    this.pairScope$.next();
-    this.sortState.setSortResults([], 0);
-    this.sortState.setSortStatus('');
-    this.sortState.setSortProgress(0, 0);
-    this.voteState.clear();
-    this.mediaState.loadMedias();
+    // Supersede → clear → reload, in that order and enforced there; see
+    // `PairScopeService.resetForNewPair`. Find has nothing to quiesce: its
+    // scoring subscription carries a `finalize` that resets the busy flag and
+    // the progress poll as part of the teardown above.
+    this.pairScope.resetForNewPair();
     this.voteState.loadVotes();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
-      next: (status) => { this.datasetName.set(status.display_name || ''); },
-    });
-    this.seedInclusion();
     this.runFindLabel();
-  }
-
-  /** Pull the active detector's per-detector inclusion into the slider. */
-  private seedInclusion(): void {
-    this.sortingApi
-      .getInclusion()
-      .pipe(takeUntil(this.pairScope$))
-      .subscribe({ next: (resp) => this.sortState.setInclusion(resp.inclusion) });
   }
 
   ngAfterViewInit(): void {
@@ -369,8 +325,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.stopProgressPolling();
-    this.pairScope$.next();
-    this.pairScope$.complete();
+    // `pairScope` is component-provided, so Angular fires its scope on destroy.
     this.destroy$.next();
     this.destroy$.complete();
     this.inclusionRequests$.complete();
@@ -457,8 +412,8 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(
         // Pair-scoped, NOT lifetime-scoped: scoring runs for minutes, so a pair
         // switch mid-run must kill this subscription before its response can
-        // rank the new pair with the old pair's scores (see `pairScope$`).
-        takeUntil(this.pairScope$),
+        // rank the new pair with the old pair's scores (see `PairScopeService`).
+        this.pairScope.scoped(),
         finalize(() => {
           this.stopProgressPolling();
           this.sortState.setSortBusy(false);
@@ -610,7 +565,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const name = m?.filename || m?.origin_name || `#${event.id}`;
     this.voteState
       .submitToggleVoteAndRecord(event.id, event.vote, name)
-      .pipe(takeUntil(this.pairScope$))
+      .pipe(this.pairScope.scoped())
       .subscribe({
         next: () => {
           this.onMediaVoted(event);
@@ -861,7 +816,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private toDatasetFromIds(ids: number[]): void {
     if (ids.length === 0) return;
     const detectorName = this.activeDetector.detectorName() || 'Detector';
-    const base = [this.datasetName(), detectorName, 'Results'].filter((s) => !!s).join(' ');
+    const base = [this.pairScope.datasetName(), detectorName, 'Results'].filter((s) => !!s).join(' ');
 
     this.dialog.prompt('Name the new dataset', base).then((name) => {
       const trimmed = (name ?? '').trim();

--- a/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
+++ b/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
@@ -42,11 +42,15 @@ describe('FindViewComponent (zoneless canary)', () => {
   });
 
   afterEach(() => {
-    fixture.componentInstance.ngOnDestroy();
+    // `fixture.destroy()` runs the component's own `ngOnDestroy` *and*
+    // destroys the component-provided `PairScopeService`, which is what
+    // cancels the in-flight pair-scoped requests (a bare `ngOnDestroy()` call
+    // no longer does — the view stopped firing the scope by hand). Destroy
+    // first, then drain; a cancelled request cannot be flushed.
+    fixture.destroy();
     httpMock.match(() => true).forEach((req) => {
       if (!req.cancelled) req.flush([]);
     });
-    fixture.destroy();
   });
 
   // Drain find-view's init loads, holding back only the dataset-status response
@@ -179,7 +183,7 @@ describe('FindViewComponent (zoneless canary)', () => {
  * context, and `advanceToBoundary()` then selected a media id that need not
  * exist in the new dataset. Even the old response landing first was harmful —
  * its `finalize()` dropped the wait overlay while the new run was still going.
- * The run is now scoped to the pair (`pairScope$`), so a switch tears it down.
+ * The run is now scoped to the pair (`PairScopeService`), so a switch tears it down.
  */
 describe('FindViewComponent (pair-switch supersession)', () => {
   let fixture: ComponentFixture<FindViewComponent>;
@@ -203,11 +207,15 @@ describe('FindViewComponent (pair-switch supersession)', () => {
   });
 
   afterEach(() => {
-    fixture.componentInstance.ngOnDestroy();
+    // `fixture.destroy()` runs the component's own `ngOnDestroy` *and*
+    // destroys the component-provided `PairScopeService`, which is what
+    // cancels the in-flight pair-scoped requests (a bare `ngOnDestroy()` call
+    // no longer does — the view stopped firing the scope by hand). Destroy
+    // first, then drain; a cancelled request cannot be flushed.
+    fixture.destroy();
     httpMock.match(() => true).forEach((req) => {
       if (!req.cancelled) req.flush([]);
     });
-    fixture.destroy();
   });
 
   // Same drain as the canary above, plus the dataset-status read (no assertion
@@ -318,11 +326,15 @@ describe('FindViewComponent (inclusion supersession)', () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    fixture.componentInstance.ngOnDestroy();
+    // `fixture.destroy()` runs the component's own `ngOnDestroy` *and*
+    // destroys the component-provided `PairScopeService`, which is what
+    // cancels the in-flight pair-scoped requests (a bare `ngOnDestroy()` call
+    // no longer does — the view stopped firing the scope by hand). Destroy
+    // first, then drain; a cancelled request cannot be flushed.
+    fixture.destroy();
     httpMock.match(() => true).forEach((req) => {
       if (!req.cancelled) req.flush([]);
     });
-    fixture.destroy();
   });
 
   // Same drain as the canary above; no pair is active, so `runFindLabel` no-ops

--- a/frontend/src/app/components/label-view/label-view.component.html
+++ b/frontend/src/app/components/label-view/label-view.component.html
@@ -42,7 +42,7 @@
       (loadMore)="onLoadMore()"
       (indicatorClick)="onIndicatorClick($event)"
       (sortCancel)="onSortCancel()"
-      [datasetName]="datasetName()"
+      [datasetName]="pairScope.datasetName()"
       [autopilotCollapsed]="autopilotCollapsed()"
       [autopilotEnabled]="autopilotEnabled()"
       [autopilotDisabled]="autopilotDisabled"

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -17,11 +17,11 @@ import {
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { ToastService } from '../../services/toast.service';
 import { SortingApiService } from '../../services/sorting-api.service';
+import { PairScopeService } from '../../services/pair-scope.service';
 import { adaptivePoll } from '../../services/adaptive-poll';
 import { DetectorsFindApiService } from '../../services/detectors-find-api.service';
 import { DetectorsRegistryApiService } from '../../services/detectors-registry-api.service';
 import { MediasApiService } from '../../services/medias-api.service';
-import { DatasetsRegistryApiService } from '../../services/datasets-registry-api.service';
 import { LabelSessionService } from '../../services/label-session.service';
 import { MediaStateService } from '../../services/media-state.service';
 import { VoteStateService } from '../../services/vote-state.service';
@@ -58,7 +58,7 @@ import { buildMediaContextMenuItems } from './media-context-menu-items';
     MediaCropModalComponent,
     PanelResizeDirective
 ],
-  providers: [LabelViewPanelStateService],
+  providers: [LabelViewPanelStateService, PairScopeService],
   templateUrl: './label-view.component.html',
   styleUrl: './label-view.component.scss',
 })
@@ -67,7 +67,6 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private detectorsFindApi = inject(DetectorsFindApiService);
   private detectorsRegistryApi = inject(DetectorsRegistryApiService);
   private mediasApi = inject(MediasApiService);
-  private datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private labelSession = inject(LabelSessionService);
   mediaState = inject(MediaStateService);
   voteState = inject(VoteStateService);
@@ -81,11 +80,12 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private newThingFlows = inject(NewThingFlowsService);
   private toast = inject(ToastService);
   panelState = inject(LabelViewPanelStateService);
+  /** Component-provided. Public: the header binds `pairScope.datasetName()`. */
+  readonly pairScope = inject(PairScopeService);
 
   readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
   readonly centerPanel = viewChild(CenterPanelComponent);
 
-  readonly datasetName = signal('');
   /** Name of the trainable model owning the labels shown on the right pane.
    *  Empty when no trainable model is active; the right pane then falls
    *  back to cid-based vote display. */
@@ -157,24 +157,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly CENTER_MIN = 100;
   readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
   private destroy$ = new Subject<void>();
-  /**
-   * Fires whenever the active (dataset, detector) pair changes — and on
-   * destroy. Every request whose response writes *pair-scoped* state (the sort
-   * window, the inclusion slider, the dataset name, the selected media) is
-   * piped through `takeUntil(this.pairScope$)` rather than `destroy$`, so the
-   * work started for the pair we're leaving is torn down the instant the pair
-   * switches.
-   *
-   * Without it, a detector-scoring POST or a learned-sort job poll outlives the
-   * switch and calls `applySortWindow` into whatever pair happens to be active
-   * when it finally settles — installing the previous pair's ranking and
-   * threshold, then auto-selecting an id that may not exist in the new dataset.
-   * `takeUntil` also aborts the stale request client-side. NOTE: subscriptions
-   * started from `modelId$` (which emits *before* `pair$`) must stay on
-   * `destroy$`, or `reloadForNewPair`'s teardown would kill the request they
-   * just issued for the new pair.
-   */
-  private pairScope$ = new Subject<void>();
+  // NOTE: a subscription started from `modelId$` (which emits *before*
+  // `pair$`) must stay on `destroy$`, or `reloadForNewPair`'s teardown would
+  // kill the request it just issued for the new pair.
   private statusPolling$: Subscription | null = null;
   private scoringProgressPoll$: Subscription | null = null;
   private learnedSortPending = false;
@@ -309,15 +294,13 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.loadTrainingVotes();
     this.loadSettings();
     this.startStatusPolling();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
-      next: (status) => { this.datasetName.set(status.display_name || ''); },
-    });
+    this.pairScope.loadDatasetName();
 
     this.activeContext.modelId$
       .pipe(takeUntil(this.destroy$))
       .subscribe((modelId) => this.refreshTrainableModelName(modelId));
     this.refreshTrainableModelName(this.activeContext.modelId);
-    this.seedInclusion();
+    this.pairScope.seedInclusion();
 
     // Reload data when the active pair changes via the top-bar switcher.
     // Skip the first emission; `ngOnInit` above already triggered the
@@ -377,28 +360,20 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  and starts a fresh job otherwise; either way the user lands on
    *  learned-sorted content without a manual mode toggle. */
   private reloadForNewPair(): void {
-    // Supersede the pair we're leaving *first*: every in-flight request scoped
-    // to it dies here, before any of the new pair's state is installed, so no
-    // late scoring/learned-sort response can `applySortWindow` into the new
-    // context. Those subscriptions carry no `finalize`, so the busy flag and
-    // the scoring progress feed they own are reset explicitly below.
-    this.pairScope$.next();
-    this.stopScoringProgressPoll();
-    this.currentLearnedSortJobId = null;
-    this.sortState.setSortBusy(false);
-    this.pendingRehydrateLearned = false;
-    this.sortState.setSortResults([], 0);
-    this.sortState.setSortStatus('');
-    this.sortState.setSortProgress(0, 0);
-    this.voteState.clear();
-    this.pendingSnapOnLoad = true;
-    this.mediaState.loadMedias();
-    this.loadTrainingVotes();
-    this.datasetsRegistryApi.getStatus().pipe(takeUntil(this.pairScope$)).subscribe({
-      next: (status) => { this.datasetName.set(status.display_name || ''); },
+    // Supersede → quiesce → clear → reload, in that order and enforced there;
+    // see `PairScopeService.resetForNewPair`.
+    this.pairScope.resetForNewPair(() => {
+      // Train's scoring and learned-sort subscriptions carry no `finalize`, so
+      // the busy flag, the job id and the progress feed they own are reset here
+      // — after the supersede, so nothing can re-set them.
+      this.stopScoringProgressPoll();
+      this.currentLearnedSortJobId = null;
+      this.sortState.setSortBusy(false);
+      this.pendingRehydrateLearned = false;
+      // Read by the medias effect when the reload below lands.
+      this.pendingSnapOnLoad = true;
     });
-    // Re-seed the slider for the detector we just switched to.
-    this.seedInclusion();
+    this.loadTrainingVotes();
 
     // Arm the rehydrate effect: it fires `onLearnedSort` once the reloaded
     // votes land (counts go 0 → available) if the user is still in learned mode.
@@ -422,7 +397,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private loadTrainingVotes(): void {
     this.detectorsFindApi
       .endFindSession()
-      .pipe(takeUntil(this.pairScope$))
+      .pipe(this.pairScope.scoped())
       .subscribe({
         next: () => this.voteState.loadVotes(),
         error: () => this.voteState.loadVotes(),
@@ -435,8 +410,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cancelAutoPop('right');
     this.cancelSnapOnLoad();
     if (this.animatePopTimer) clearTimeout(this.animatePopTimer);
-    this.pairScope$.next();
-    this.pairScope$.complete();
+    // `pairScope` is component-provided, so Angular fires its scope on destroy.
     this.destroy$.next();
     this.destroy$.complete();
     this.voteState.stopPolling();
@@ -692,7 +666,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const offset = this.sortState.sortOrder?.length ?? 0;
     this.sortingApi
       .getSortPage(token, offset, 200)
-      .pipe(takeUntil(this.pairScope$))
+      .pipe(this.pairScope.scoped())
       .subscribe({
         next: (page) => {
           const items = (page.results ?? []).map((r) => ({
@@ -711,7 +685,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortState.setTextQuery(text);
     this.sortState.setSortBusy(true);
     this.sortState.setSortStatus('Sorting…');
-    this.sortingApi.sort({ text }).pipe(takeUntil(this.pairScope$)).subscribe({
+    this.sortingApi.sort({ text }).pipe(this.pairScope.scoped()).subscribe({
       next: (response) => {
         this.applySortWindow(response);
         this.sortState.setSortBusy(false);
@@ -729,7 +703,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!this.voteState.learnedSortAvailable) return;
     this.sortState.setSortBusy(true);
     this.sortState.setSortStatus('Training…');
-    this.sortingApi.learnedSort().pipe(takeUntil(this.pairScope$)).subscribe({
+    this.sortingApi.learnedSort().pipe(this.pairScope.scoped()).subscribe({
       next: (response) => {
         if (response.status === 'done') {
           this.applyLearnedSortResult(response, autoSelect);
@@ -799,8 +773,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       .pipe(
         // Pair-scoped: a training job can outlive the pair it was started for,
         // and its result must not be applied to whatever pair is active when it
-        // finally settles (see `pairScope$`).
-        takeUntil(this.pairScope$),
+        // finally settles (see `PairScopeService`).
+        this.pairScope.scoped(),
         filter((res) => res.status !== 'running'),
         take(1),
       )
@@ -891,7 +865,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
     // Pair-scoped: scoring runs for minutes on a large dataset, so a pair switch
     // mid-run must kill this before it ranks the new pair with old scores.
-    this.detectorsFindApi.findLabel({ detector_id: modelId }).pipe(takeUntil(this.pairScope$)).subscribe({
+    this.detectorsFindApi.findLabel({ detector_id: modelId }).pipe(this.pairScope.scoped()).subscribe({
       next: (raw) => {
         const response = raw as {
           results: { id: number; score: number; best_region?: number[] }[];
@@ -945,7 +919,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       // the atlas probe by a node's median score), so it takes the acquisition
       // cut alongside the Hard pick.
       .getCoverageAtlasNext(scores, this.sortState.acqThreshold ?? undefined)
-      .pipe(takeUntil(this.pairScope$))
+      .pipe(this.pairScope.scoped())
       .subscribe({
         next: (response) => {
           if (response.id !== null) {
@@ -960,22 +934,9 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
 
   // --- Inclusion ---
 
-  /**
-   * Seed the slider from the active detector's per-detector inclusion
-   * (GET /api/inclusion, which falls back to the user-settings default the
-   * first time it's read for a detector). Called on entry and on every
-   * detector switch so the slider tracks the detector, not a stale global.
-   */
-  private seedInclusion(): void {
-    this.sortingApi
-      .getInclusion()
-      .pipe(takeUntil(this.pairScope$))
-      .subscribe({ next: (resp) => this.sortState.setInclusion(resp.inclusion) });
-  }
-
   onInclusionChange(value: number): void {
     this.sortState.setInclusion(value);
-    this.sortingApi.setInclusion(value).pipe(takeUntil(this.pairScope$)).subscribe();
+    this.sortingApi.setInclusion(value).pipe(this.pairScope.scoped()).subscribe();
     this.autoSelectNext();
     if (this.sortState.sortMode === 'learned' && this.voteState.learnedSortAvailable) {
       this.scheduleLearnedSort(false);
@@ -1048,7 +1009,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.sortState.setSortStatus('Sorting by example…');
     this.sortingApi
       .exampleSortById({ media_id: mediaId, crop_params: cropParams })
-      .pipe(takeUntil(this.pairScope$))
+      .pipe(this.pairScope.scoped())
       .subscribe({
         next: (response) => {
           this.sortState.setSortMode('load');
@@ -1141,7 +1102,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   onHoverVote(event: { id: number; vote: 'good' | 'bad' }): void {
     this.voteState
       .submitToggleVoteAndRecord(event.id, event.vote, this.mediaDisplayName(event.id))
-      .pipe(takeUntil(this.pairScope$))
+      .pipe(this.pairScope.scoped())
       .subscribe({
         next: () => {
           this.onMediaVoted(event);
@@ -1286,7 +1247,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (filenames.length > 0) {
       this.sortState.setSortBusy(true);
       this.sortState.setSortStatus(filenames.length > 1 ? 'Sorting by examples…' : 'Sorting by example…');
-      this.sortingApi.exampleSortServer({ filenames }).pipe(takeUntil(this.pairScope$)).subscribe({
+      this.sortingApi.exampleSortServer({ filenames }).pipe(this.pairScope.scoped()).subscribe({
         next: (response) => {
           this.applySortWindow(response);
           this.sortState.setSortBusy(false);

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -45,13 +45,16 @@ describe('LabelViewComponent (zoneless dataset-name canary)', () => {
   });
 
   afterEach(() => {
-    fixture.componentInstance.ngOnDestroy();
-    // Drain the timer-driven pollers (labeling-status / votes) and any
-    // child-panel reads still in flight; cancelled requests can't be flushed.
+    // Destroy first: `fixture.destroy()` runs the component's own `ngOnDestroy`
+    // *and* destroys the component-provided `PairScopeService`, which is what
+    // cancels the in-flight pair-scoped requests (a bare `ngOnDestroy()` call no
+    // longer does). Then drain the timer-driven pollers (labeling-status /
+    // votes) and any child-panel reads still in flight; cancelled requests
+    // can't be flushed.
+    fixture.destroy();
     httpMock.match(() => true).forEach((req) => {
       if (!req.cancelled) req.flush([]);
     });
-    fixture.destroy();
   });
 
   // Drain label-view's init loads, holding back only the dataset-status
@@ -187,7 +190,12 @@ describe('LabelViewComponent', () => {
   }
 
   afterEach(async () => {
-    component.ngOnDestroy();
+    // Destroy first. This runs `ngOnDestroy`, tears down the component view +
+    // its child views (no template can be re-checked), disposes the component
+    // injector — with the medias/settings rxResource loaders bound to it — and
+    // destroys the component-provided `PairScopeService`, whose teardown is
+    // what cancels the in-flight pair-scoped requests.
+    fixture.destroy();
     // Kill the shared VoteStateService poll explicitly. Under zoneless (no
     // zone.js patching test timers) a leftover `timer(0, N)` poll keeps firing
     // real macrotasks across spec boundaries; once the TestBed injector is reset
@@ -196,17 +204,13 @@ describe('LabelViewComponent', () => {
     // Drain any outstanding polling requests from right-panel or label-view
     // (the timer-driven /api/votes and /api/labeling-status pollers, the
     // metadata-batch fetch from selectMedia, plus anything a test left in
-    // flight). ngOnDestroy unsubscribes the component's own streams,
+    // flight). The destroy above unsubscribed the component's own streams,
     // which cancels their in-flight requests; cancelled requests can't be
     // flushed, so skip them. Flush an empty array so the metadata-batch
     // handler (which iterates the body) doesn't choke on a non-iterable.
     httpMock.match(() => true).forEach(req => {
       if (!req.cancelled) req.flush([]);
     });
-    // Destroy the fixture so the component view + its child views are gone (no
-    // template can be re-checked) and the component injector — with the
-    // medias/settings rxResource loaders bound to it — is disposed.
-    fixture.destroy();
     // Drain one macrotask while the TestBed injector is still alive. Without
     // zone.js the framework no longer tracks the app's timers/microtasks, so the
     // SSE pollers' `timer(0, N)` first emissions and root-singleton rxResource

--- a/frontend/src/app/services/pair-scope.service.spec.ts
+++ b/frontend/src/app/services/pair-scope.service.spec.ts
@@ -1,0 +1,129 @@
+import { Component, inject } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { Subject } from 'rxjs';
+
+import { PairScopeService } from './pair-scope.service';
+import { SortStateService } from './sort-state.service';
+import { VoteStateService } from './vote-state.service';
+import { configureZoneless } from '../testing/zoneless-testbed';
+import { provideHttpTesting } from '../testing/test-providers';
+
+@Component({ selector: 'vt-pair-scope-host', standalone: true, template: '', providers: [PairScopeService] })
+class HostComponent {
+  readonly pairScope = inject(PairScopeService);
+}
+
+/**
+ * `PairScopeService` exists to make the pair-change ordering rule *enforced*
+ * rather than described in a comment in each view (#3448). These specs pin the
+ * three claims its doc comment makes, so a future edit that reorders the reset
+ * fails here instead of shipping a silent stale-results bug.
+ */
+describe('PairScopeService', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let service: PairScopeService;
+  let httpMock: HttpTestingController;
+  let sortState: SortStateService;
+  let voteState: VoteStateService;
+
+  beforeEach(() => {
+    configureZoneless({ imports: [HostComponent], providers: [...provideHttpTesting()] });
+    fixture = TestBed.createComponent(HostComponent);
+    service = fixture.componentInstance.pairScope;
+    httpMock = TestBed.inject(HttpTestingController);
+    sortState = TestBed.inject(SortStateService);
+    voteState = TestBed.inject(VoteStateService);
+  });
+
+  afterEach(() => {
+    // The reset fires GETs the individual specs do not always drain.
+    httpMock.match(() => true).forEach((req) => req.flush({}));
+    httpMock.verify();
+  });
+
+  it('scoped() completes its stream when the pair changes', () => {
+    const src = new Subject<number>();
+    const seen: number[] = [];
+    let completed = false;
+    src.pipe(service.scoped()).subscribe({
+      next: (v) => seen.push(v),
+      complete: () => { completed = true; },
+    });
+
+    src.next(1);
+    service.resetForNewPair();
+    src.next(2);
+
+    expect(seen).toEqual([1]);
+    expect(completed).toBe(true);
+  });
+
+  it('supersedes before it installs any of the new pair state', () => {
+    // A pair-scoped request in flight for the pair we are about to leave.
+    service.loadDatasetName();
+    const stale = httpMock.expectOne('/api/dataset/status');
+    expect(stale.cancelled).toBe(false);
+
+    // The order under test: if `resetForNewPair` cleared or reloaded *before*
+    // firing the scope, this response would still be live and would write the
+    // old pair's display name over the new pair's.
+    service.resetForNewPair();
+
+    expect(stale.cancelled).toBe(true);
+    // The XHR is aborted, so there is no longer any way for it to land — the
+    // testing controller refuses to flush a cancelled request at all.
+    expect(() => stale.flush({ display_name: 'OLD PAIR' })).toThrow();
+    expect(service.datasetName()).toBe('');
+  });
+
+  it('runs the quiesce hook after the supersede and before the reloads', () => {
+    const order: string[] = [];
+
+    service.loadDatasetName();
+    const stale = httpMock.expectOne('/api/dataset/status');
+
+    service.resetForNewPair(() => {
+      // Already superseded: the request issued for the old pair is dead.
+      order.push(stale.cancelled ? 'after-supersede' : 'before-supersede');
+      // Not yet reloaded: the new pair's requests have not gone out.
+      order.push(httpMock.match('/api/dataset/status').length === 0 ? 'before-reload' : 'after-reload');
+    });
+
+    expect(order).toEqual(['after-supersede', 'before-reload']);
+  });
+
+  it('clears the pair-scoped sort and vote state, then reloads for the new pair', () => {
+    sortState.setSortResults([{ id: 1, score: 0.9 }], 0.5);
+    sortState.setSortStatus('scoring');
+    sortState.setSortProgress(3, 10);
+    const clearSpy = vi.spyOn(voteState, 'clear');
+
+    service.resetForNewPair();
+
+    expect(sortState.sortOrder).toEqual([]);
+    expect(sortState.sortStatus).toBe('');
+    expect(sortState.sortProgress).toBe(0);
+    expect(clearSpy).toHaveBeenCalledOnce();
+    // Reloads for the new pair went out.
+    expect(httpMock.match('/api/dataset/status').length).toBe(1);
+    expect(httpMock.match('/api/inclusion').length).toBe(1);
+  });
+
+  it('seedInclusion pushes the per-detector value into SortStateService', () => {
+    service.seedInclusion();
+    httpMock.expectOne('/api/inclusion').flush({ inclusion: -4, threshold: 0.3 });
+    expect(sortState.inclusion).toBe(-4);
+  });
+
+  it('fires the scope when the host component is destroyed, with no manual teardown', () => {
+    service.loadDatasetName();
+    const inFlight = httpMock.expectOne('/api/dataset/status');
+
+    // No view calls `scope$.next()` in its own `ngOnDestroy` any more; Angular
+    // destroys the component-provided service, which is what tears this down.
+    fixture.destroy();
+
+    expect(inFlight.cancelled).toBe(true);
+  });
+});

--- a/frontend/src/app/services/pair-scope.service.ts
+++ b/frontend/src/app/services/pair-scope.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { MonoTypeOperatorFunction, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { DatasetsRegistryApiService } from './datasets-registry-api.service';
+import { MediaStateService } from './media-state.service';
+import { SortStateService } from './sort-state.service';
+import { SortingApiService } from './sorting-api.service';
+import { VoteStateService } from './vote-state.service';
+
+/**
+ * The lifetime of the active (dataset, detector) pair, and the reset that ends
+ * it. **Component-provided** (`providers: [PairScopeService]` on `vt-find-view`
+ * / `vt-label-view`), never `providedIn: 'root'`: the scope it bounds is a
+ * component's, and the two views must not share one subject.
+ *
+ * ## Why this is a service and not two copies of a comment
+ *
+ * Every request whose response writes *pair-scoped* state — the ranking, the
+ * threshold, the inclusion slider, the dataset name, the vote cache — must be
+ * piped through {@link scoped} rather than a `destroy$`, so the work started
+ * for the pair we are leaving is torn down the instant the pair switches.
+ *
+ * Without it a scoring run — minutes long on a large dataset — outlives the
+ * switch: whichever response lands last wins, so the *old* pair's ranking and
+ * threshold get installed into the new context, and the auto-select lands on a
+ * media id that may not exist in the new dataset (broken viewer, image 404s).
+ * Even when the old response lands *first*, its `finalize()` drops the wait
+ * overlay and re-enables voting while the new run is still going. `takeUntil`
+ * also aborts the stale XHR client-side.
+ *
+ * The failure is silent — stale results repaint over fresh ones; nothing
+ * throws — so the ordering rule below is **enforced here rather than described
+ * in each view**: {@link resetForNewPair} is the only way to fire the scope,
+ * and it supersedes before it touches any of the new pair's state.
+ *
+ * `ngOnDestroy` on a component-provided service runs when the host component is
+ * destroyed, so the destroy-time teardown is automatic; a view must not (and
+ * need not) fire the scope by hand.
+ *
+ * NOTE for callers: a subscription started from `ActiveContextService.modelId$`
+ * — which emits *before* `pair$` — must stay on the component's `destroy$`, or
+ * {@link resetForNewPair}'s teardown would kill the request it just issued for
+ * the *new* pair.
+ */
+@Injectable()
+export class PairScopeService implements OnDestroy {
+  private readonly datasetsRegistryApi = inject(DatasetsRegistryApiService);
+  private readonly sortingApi = inject(SortingApiService);
+  private readonly mediaState = inject(MediaStateService);
+  private readonly sortState = inject(SortStateService);
+  private readonly voteState = inject(VoteStateService);
+
+  /** Fires whenever the active pair changes — and on host destroy. Private:
+   *  the ordering rule is only enforceable while `next()` has one caller. */
+  private readonly scope$ = new Subject<void>();
+
+  /** Display name of the active dataset, refreshed on entry and on every pair
+   *  change. Signal-backed so the un-bound `getStatus` subscribe schedules
+   *  change detection under zoneless (see `docs/FRONTEND.md` §5). */
+  readonly datasetName = signal('');
+
+  /**
+   * Teardown operator for a pair-scoped request: `pipe(pairScope.scoped())`.
+   *
+   * This is *cancellation*, not lifetime teardown — the component is very much
+   * still alive across a pair switch — so `takeUntilDestroyed()` cannot express
+   * it (see `docs/FRONTEND.md` §7, "Subscription teardown vs. cancellation").
+   */
+  scoped<T>(): MonoTypeOperatorFunction<T> {
+    return takeUntil(this.scope$);
+  }
+
+  /** Refresh {@link datasetName} for the active pair. */
+  loadDatasetName(): void {
+    this.datasetsRegistryApi.getStatus().pipe(this.scoped()).subscribe({
+      next: (status) => this.datasetName.set(status.display_name || ''),
+    });
+  }
+
+  /**
+   * Seed the inclusion slider from the active detector's per-detector value.
+   *
+   * `GET /api/inclusion` resolves per-detector, falling back to the
+   * user-settings default the first time it is read, so this keeps the slider
+   * tracking the detector rather than a stale global.
+   *
+   * This lives here rather than on `SortStateService` (as #3448 first proposed)
+   * because `SortStateService` is a `providedIn: 'root'` signal store that
+   * injects nothing: hosting a pair-scoped HTTP call on it would mean either
+   * reinventing pair-scoped cancellation inside a singleton or passing a
+   * component's scope subject *into* the singleton. #3428 flags the same trap.
+   */
+  seedInclusion(): void {
+    this.sortingApi
+      .getInclusion()
+      .pipe(this.scoped())
+      .subscribe({ next: (resp) => this.sortState.setInclusion(resp.inclusion) });
+  }
+
+  /**
+   * Drop the ephemeral state the pair we are leaving wrote.
+   *
+   * Split out of {@link resetForNewPair} for find-view's entry path, which
+   * applies the same clear on a fresh navigation (Find and Train share
+   * singleton sub-view state, so a Dashboard → Find entry would otherwise
+   * render the previous session's ranking against a possibly smaller dataset).
+   */
+  clearPairState(): void {
+    this.sortState.setSortResults([], 0);
+    this.sortState.setSortStatus('');
+    this.sortState.setSortProgress(0, 0);
+    this.voteState.clear();
+  }
+
+  /**
+   * The pair-change reset, in the one order that is correct.
+   *
+   * 1. **Supersede.** Every in-flight request scoped to the pair we are leaving
+   *    dies here, *before* any of the new pair's state is installed, so no late
+   *    response can write the old ranking/threshold into the new context. A
+   *    scoping run's `finalize()` runs as part of this teardown, which is why it
+   *    cannot clobber the fresh run a caller starts in its tail: that run begins
+   *    after the teardown has already settled.
+   * 2. **Quiesce.** Anything a superseded subscription owned but had no
+   *    `finalize` to reset — a progress poll, a busy flag, a job id. Runs after
+   *    the supersede (so nothing can re-set it) and before the reloads.
+   * 3. **Clear**, then **reload** for the new pair.
+   *
+   * Callers run their view-specific tail (the vote load, a re-score) after this
+   * returns.
+   *
+   * @param quiesce Optional step 2 hook, run inside the reset so its placement
+   *                relative to the supersede is not a caller's to get wrong.
+   */
+  resetForNewPair(quiesce?: () => void): void {
+    this.scope$.next();
+    quiesce?.();
+    this.clearPairState();
+    this.mediaState.loadMedias();
+    this.loadDatasetName();
+    this.seedInclusion();
+  }
+
+  ngOnDestroy(): void {
+    this.scope$.next();
+    this.scope$.complete();
+  }
+}


### PR DESCRIPTION
Closes #3448

## On the premise

Mostly right, with one overstatement worth correcting and one addition the issue missed.

**"`seedInclusion()` is byte-identical" — true.** Both bodies were the same six lines modulo the doc comment.

**"`reloadForNewPair` opens with an identical sequence" — an overstatement.** The two methods share a skeleton (supersede → clear ranking/status/progress → clear votes → reload medias → reload the dataset name → re-seed inclusion), but label-view interleaves five view-specific lines inside it and loads votes through `loadTrainingVotes()` (which ends the find session first) rather than `voteState.loadVotes()`. That is why this is not a lift-and-shift: the shared reset has to leave a hole where the view-specific quiesce goes, or the extraction silently reorders a teardown whose ordering is the whole point.

**"Documented twice and enforced nowhere" — true, and the strongest reason to do this.** Also true of two things the issue did not mention:

- The `/api/dataset/status` → `datasetName` block was duplicated **four** times (entry + reset, in each view).
- The clear block appears a **fifth** time in find-view's `ngOnInit`, under a comment that literally says `(mirroring reloadForNewPair)`.
- Each view fired `pairScope$.next(); pairScope$.complete();` by hand in `ngOnDestroy` — a step a new view can simply forget.

## What changed

`frontend/src/app/services/pair-scope.service.ts`, **component-provided** on both views (matching `BrowseSelectionService` / `LabelViewPanelStateService`), owns the pair's lifetime:

- `scope$` is **private**; `scoped()` is the pipe operator. `resetForNewPair()` is the only thing that can fire the scope, so supersede-before-install is not a caller's to get wrong.
- `resetForNewPair(quiesce?)` takes the view-specific step-2 hook. Label-view's progress poll, busy flag, job id and snap flag run through it, which places them after the supersede and before the reloads *by construction* rather than by convention.
- `clearPairState()` is split out for find-view's entry path, so the "mirroring reloadForNewPair" comment is now the same call rather than a claim.
- `datasetName` and `seedInclusion()` move onto the service; `ngOnDestroy` on the service handles destroy-time teardown, so neither view fires the scope by hand.

Net: −164 / +384 lines, of which the new service and its spec are +277.

## Where this diverges from the issue's Direction

The issue proposed moving `seedInclusion` onto `SortStateService`. It landed on `PairScopeService` instead. `SortStateService` is a `providedIn: 'root'` signal store that injects nothing; hosting a pair-scoped HTTP call there means either reinventing pair-scoped cancellation inside a singleton or passing a component's scope subject *into* the singleton. #3428 flags that exact trap in its own constraints, and #3448 asked the two to be coordinated — this is that coordination. Nothing is left owed on #3448 by the divergence.

## Verification

`./run-tests.sh` full run: **9668 passed, 6 skipped, 2 xpassed**; pyright, pip-audit, vulture whitelist, npm audit and the 2143-test Vitest suite all green.

The issue asked for **real chromium**, including rapid switches racing an in-flight reload, and it was right to: the failure mode is silent, and jsdom's mocked XHR cannot produce it. A harness drove the running app in chromium (two synthetic datasets, two detectors), switching pairs through the production channels — the top-bar pulldown in Train, a route-param swap in Find, which fixes its pulldowns — with `GET /api/dataset/status` held open 4s via `page.route` so a superseded response is genuinely in flight across the next switch:

```
PASS  label-view: entry renders the dataset name / thumbnails for the entered pair
PASS  label-view: a pair switch repaints the NEW dataset name
PASS  label-view: the switch re-fired the pair-scoped reloads (40 api calls)
PASS  label-view: every thumbnail belongs to the new pair
PASS  label-view: the superseded in-flight requests are aborted (2 × /api/dataset/status)
PASS  label-view: after the race the header shows the FINAL pair, not a late response
PASS  label-view: no superseded pair's thumbnails survived into the ranking grid
PASS  label-view: a detector-only switch re-seeds the inclusion slider
PASS  find-view: entry renders the dataset name
PASS  find-view: a route-param pair swap repaints the NEW dataset name
PASS  find-view: every thumbnail belongs to the new pair
PASS  find-view: the superseded requests (scoring run included) are aborted
PASS  find-view: after the race the header shows the FINAL pair
PASS  find-view: no superseded pair's thumbnails survived into the ranking grid
PASS  find-view: the scoring wait overlay is not stranded after the race
PASS  no console/page errors during the whole run
```

Two checks fail, on **both** this branch and the pre-refactor build, byte-identically: after the 3-way race the centre viewer still shows the media selected under the superseded pair. That is a pre-existing selection-teardown gap, not a regression here, and fixing it would change observable behaviour inside a refactor whose value depends on being behaviour-identical. Filed as #3489 with the repro.

## Notes for review

- The zoneless specs now call `fixture.destroy()` **before** draining outstanding requests. A bare `component.ngOnDestroy()` no longer cancels the pair-scoped requests — Angular's destruction of the component-provided service does — so the old order flushed a live `find-label` request with `[]` and tripped an unhandled `response.results.map` error. `pair-scope.service.spec.ts` pins that destroy-time teardown directly, so the claim is tested rather than assumed.
- `DatasetsRegistryApiService` is no longer injected by either view; the service owns the only remaining call.
- `docs/FRONTEND.md` §4 gains the service, and §7's cancellation section now explains why this one scope subject is not a component field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q52g6HzLfAUe7CGvWqnLHc


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q52g6HzLfAUe7CGvWqnLHc)_