### PR TITLE
frontend: dedupe the four reimplemented helper families

### DIFF
--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -19,6 +19,7 @@ import {
 } from '../../utils/bin-grid-metrics';
 import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
+import { formatMetadataValue as formatMetadataValueUtil } from '../../utils/format-metadata';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
@@ -671,19 +672,10 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return (this.focusedMedia()?.custom_metadata as Record<string, unknown>) ?? {};
   }
 
-  /** Format a custom-metadata value for display. Mirrors the center panel's
-   *  ``formatMetadataValue`` so the same categories read identically here. */
+  /** Template-bound metadata cell. Shares the center panel's formatter so the
+   *  same categories read identically here; see {@link formatMetadataValue}. */
   formatMetadataValue(label: string, value: unknown): string {
-    if (label === 'File Size' && typeof value === 'number') {
-      return (value / 1024).toFixed(1) + ' KB';
-    }
-    if (label === 'Duration' && typeof value === 'number') {
-      return value.toFixed(1) + 's';
-    }
-    if (label === 'Frequency' && typeof value === 'number') {
-      return value + ' Hz';
-    }
-    return String(value);
+    return formatMetadataValueUtil(label, value);
   }
 
   /** Pull the remembered thumbnail size for the active media type, rechunk the

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -13,21 +13,22 @@ import { IconComponent } from '../icon/icon.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
 import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
+import { ListSortMode, SortableListEntry, sortListEntries } from '../../utils/sort-list-entries';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
  *  the choices are recency (selection order), name, and id. */
-type SelectionSortMode = 'time-desc' | 'time-asc' | 'name-asc' | 'name-desc' | 'id-asc';
+type SelectionSortMode = Exclude<ListSortMode, 'confidence-desc' | 'confidence-asc'>;
 
 /** How long (ms) the cursor must rest on an audio entry before its clip starts
  *  auditioning, so sweeping down a large multi-select list doesn't fire a burst
  *  of plays. Matches the canvas hover-preview's dwell (`AUDIO_DWELL_MS`). */
 const AUDIO_DWELL_MS = 200;
 
-interface SelectionEntry {
+interface SelectionEntry extends SortableListEntry {
   id: number;
-  name: string;
-  /** Position in the selection's insertion order (recency proxy). */
-  order: number;
+  /** Position in the selection's insertion order — this list's recency proxy,
+   *  standing in for the click timestamp the Find-view lists sort on. */
+  time: number;
 }
 
 /**
@@ -185,38 +186,16 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   }
 
   private buildSortedEntries(): SelectionEntry[] {
-    const entries = this.ids.map((id, order) => ({
+    const entries: SelectionEntry[] = this.ids.map((id, order) => ({
       id,
       name: this.lookupName(id),
-      order,
+      time: order,
     }));
-    return this.sortEntries(entries);
+    return sortListEntries(entries, this.sortMode);
   }
 
   private lookupName(id: number): string {
     return this.metadataCache.get(id)?.filename || `Clip #${id}`;
-  }
-
-  private sortEntries(entries: SelectionEntry[]): SelectionEntry[] {
-    const sorted = [...entries];
-    switch (this.sortMode) {
-      case 'time-desc':
-        sorted.sort((a, b) => b.order - a.order);
-        break;
-      case 'time-asc':
-        sorted.sort((a, b) => a.order - b.order);
-        break;
-      case 'name-asc':
-        sorted.sort((a, b) => a.name.localeCompare(b.name));
-        break;
-      case 'name-desc':
-        sorted.sort((a, b) => b.name.localeCompare(a.name));
-        break;
-      case 'id-asc':
-        sorted.sort((a, b) => a.id - b.id);
-        break;
-    }
-    return sorted;
   }
 
   onSortChange(mode: SelectionSortMode): void {

--- a/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
+++ b/frontend/src/app/components/center-panel/audio-player/audio-player.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, 
 import { Media, PayloadVariant } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
 import { decodeAudioBuffer } from '../../../utils/decode-audio';
+import { armClipWindow, ClipBounds, enforceClipWindow } from '../../../utils/clip-window';
 
 /** Downsampled per-column waveform extrema for one clip at one canvas width. */
 interface WaveformPeaks {
@@ -126,7 +127,7 @@ export class AudioPlayerComponent implements OnDestroy {
   // Active clip window bounds while enforcement is on, else null. Enforcement is
   // driven by the <audio> element's (timeupdate) event rather than a polling
   // timer, so it only runs while the clip is actually playing and progressing.
-  private clipBounds: { start: number; end: number } | null = null;
+  private clipBounds: ClipBounds | null = null;
   // Whether (loadedmetadata) has fired for the current audioSrc. Clip bounds
   // (clip_start/clip_end) often arrive via batch hydration *after* the audio
   // has already loaded, on a later media change with the same media id; in that
@@ -205,46 +206,19 @@ export class AudioPlayerComponent implements OnDestroy {
     if (!audio.paused) this.startSweep();
   }
 
-  // Seek into the clip window and (re)start boundary enforcement when the media
+  // Seek into the clip window and (re)arm boundary enforcement when the media
   // carries clip extents; otherwise tear enforcement down. Safe to call both on
   // (loadedmetadata) and on later metadata-enrichment effect cycles.
   private applyClipBounds(): void {
     const audio = this.audioRef()?.nativeElement;
     if (!audio) return;
-
-    const media = this.media();
-    if (media.clip_start != null) {
-      const clipStart = media.clip_start;
-      const clipEnd = media.clip_end;
-      // Snap into the window only when currently outside it, so we don't yank
-      // audio already looping correctly within its window.
-      if (audio.currentTime < clipStart || (clipEnd != null && audio.currentTime >= clipEnd)) {
-        audio.currentTime = clipStart;
-      }
-      this.startClipEnforcement();
-    } else {
-      this.stopClipEnforcement();
-    }
-  }
-
-  private startClipEnforcement(): void {
-    const media = this.media();
-    if (media.clip_start == null || media.clip_end == null) {
-      this.clipBounds = null;
-      return;
-    }
-    // Arm enforcement; the actual boundary check runs in (timeupdate), which the
-    // <audio> element fires as playback advances (no timer while paused).
-    this.clipBounds = { start: media.clip_start, end: media.clip_end };
+    this.clipBounds = armClipWindow(audio, this.media());
   }
 
   private stopClipEnforcement(): void {
     this.clipBounds = null;
   }
 
-  // Enforce the clip window as playback advances: when the current time leaves
-  // [start, end), loop back to the window start. Driven by the element's
-  // (timeupdate) event instead of a 100ms polling interval.
   onTimeUpdate(): void {
     // Refresh the playhead first, unconditionally: (timeupdate) is the coarse
     // (~4x/sec) fallback that keeps the line moving when the rAF sweep isn't
@@ -252,13 +226,8 @@ export class AudioPlayerComponent implements OnDestroy {
     // must run whether or not this clip has a window to enforce.
     this.updatePlayhead();
 
-    const bounds = this.clipBounds;
-    if (!bounds) return;
     const audio = this.audioRef()?.nativeElement;
-    if (!audio || audio.paused) return;
-    if (audio.currentTime >= bounds.end || audio.currentTime < bounds.start) {
-      audio.currentTime = bounds.start;
-    }
+    if (audio) enforceClipWindow(audio, this.clipBounds);
   }
 
   onVolumeChange(): void {

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -17,6 +17,7 @@ import { VotingOverlayComponent } from './voting-overlay/voting-overlay.componen
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { IconComponent } from '../icon/icon.component';
 import { prefersReducedMotion } from '../../utils/reduced-motion';
+import { formatMetadataValue as formatMetadataValueUtil } from '../../utils/format-metadata';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -354,17 +355,9 @@ export class CenterPanelComponent implements OnDestroy {
     return media.filename || media.origin_name || `#${media.id}`;
   }
 
+  /** Template-bound metadata cell; see {@link formatMetadataValue}. */
   formatMetadataValue(label: string, value: unknown): string {
-    if (label === 'File Size' && typeof value === 'number') {
-      return (value / 1024).toFixed(1) + ' KB';
-    }
-    if (label === 'Duration' && typeof value === 'number') {
-      return value.toFixed(1) + 's';
-    }
-    if (label === 'Frequency' && typeof value === 'number') {
-      return value + ' Hz';
-    }
-    return String(value);
+    return formatMetadataValueUtil(label, value);
   }
 
   toggleMetadata(): void {

--- a/frontend/src/app/components/center-panel/video-player/video-player.component.ts
+++ b/frontend/src/app/components/center-panel/video-player/video-player.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, 
 
 import { Media, PayloadVariant } from '../../../models/api.models';
 import { ActiveContextService } from '../../../services/active-context.service';
+import { armClipWindow, ClipBounds, enforceClipWindow } from '../../../utils/clip-window';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -37,7 +38,7 @@ export class VideoPlayerComponent implements OnDestroy {
   // Active clip window bounds while enforcement is on, else null. Enforcement is
   // driven by the <video> element's (timeupdate) event rather than a polling
   // timer, so it only runs while the clip is actually playing and progressing.
-  private clipBounds: { start: number; end: number } | null = null;
+  private clipBounds: ClipBounds | null = null;
   // See ImageViewerComponent.lastMediaId; guards against metadata-enrichment
   // effect cycles rebuilding videoSrc (and yanking playback) for the
   // same id.
@@ -144,56 +145,22 @@ export class VideoPlayerComponent implements OnDestroy {
     this.syncPlaybackState();
   }
 
-  // Seek into the clip window and (re)start boundary enforcement when the media
+  // Seek into the clip window and (re)arm boundary enforcement when the media
   // carries clip extents; otherwise tear enforcement down. Safe to call both on
   // (loadedmetadata) and on later metadata-enrichment effect cycles.
   private applyClipBounds(): void {
     const video = this.videoRef()?.nativeElement;
     if (!video) return;
-
-    const media = this.media();
-    if (media.clip_start != null) {
-      const clipStart = media.clip_start;
-      const clipEnd = media.clip_end;
-      // Snap into the window only when currently outside it. This handles the
-      // initial seek and the case where the full video already started playing
-      // before clip extents arrived, without yanking a video already looping
-      // correctly within its window.
-      if (video.currentTime < clipStart || (clipEnd != null && video.currentTime >= clipEnd)) {
-        video.currentTime = clipStart;
-      }
-      this.startClipEnforcement();
-    } else {
-      this.stopClipEnforcement();
-    }
-  }
-
-  private startClipEnforcement(): void {
-    const media = this.media();
-    if (media.clip_start == null || media.clip_end == null) {
-      this.clipBounds = null;
-      return;
-    }
-    // Arm enforcement; the actual boundary check runs in (timeupdate), which the
-    // <video> element fires as playback advances (no timer while paused).
-    this.clipBounds = { start: media.clip_start, end: media.clip_end };
+    this.clipBounds = armClipWindow(video, this.media());
   }
 
   private stopClipEnforcement(): void {
     this.clipBounds = null;
   }
 
-  // Enforce the clip window as playback advances: when the current time leaves
-  // [start, end), loop back to the window start. Driven by the element's
-  // (timeupdate) event instead of a 100ms polling interval.
   onTimeUpdate(): void {
-    const bounds = this.clipBounds;
-    if (!bounds) return;
     const video = this.videoRef()?.nativeElement;
-    if (!video || video.paused) return;
-    if (video.currentTime >= bounds.end || video.currentTime < bounds.start) {
-      video.currentTime = bounds.start;
-    }
+    if (video) enforceClipWindow(video, this.clipBounds);
   }
 
   private syncPlaybackState(): void {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/demo/demo-picker.component.ts
@@ -9,6 +9,8 @@ import { DemoDatasetEntry } from '../../../../../generated/api-client/models/dem
 import { ColMeta, ManagedColumns } from '../../../../../utils/managed-columns';
 import { ImportDefaultsService } from '../shared/import-defaults.service';
 import { composeEmbedders, getTabLabel, mediaTypeIconsById, mediaTypeLabels } from '../shared/media-type.util';
+import { sortRowsByColumn } from '../../../../../utils/sort-rows';
+import { demoSortValue } from '../shared/demo-sort';
 
 /** Demo-dataset picker view: media-type tab bar + sortable table of
  *  pre-configured, optionally pre-downloaded demo datasets.  Row clicks
@@ -383,24 +385,7 @@ export class DemoPickerComponent {
 
   get filteredDemos(): DemoDatasetEntry[] {
     const items = this.demos().filter((d) => d.media_type === this.activeTab());
-    const statusOrder: Record<string, number> = { ready: 0, needs_embedding: 1, needs_download: 2 };
-    const sortKey = this.demoCols.sortColumn;
-    const asc = this.demoCols.sortAsc;
-    return items.sort((a, b) => {
-      const key = sortKey as keyof DemoDatasetEntry;
-      let va: any = a[key];
-      let vb: any = b[key];
-      if (key === 'status') {
-        va = statusOrder[va as string] ?? 3;
-        vb = statusOrder[vb as string] ?? 3;
-      }
-      if (typeof va === 'number' && typeof vb === 'number') {
-        return asc ? va - vb : vb - va;
-      }
-      va = String(va || '').toLowerCase();
-      vb = String(vb || '').toLowerCase();
-      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
-    });
+    return sortRowsByColumn(items, this.demoCols.sortColumn, this.demoCols.sortAsc, demoSortValue);
   }
 
   selectDemoTab(tab: string): void {

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/demo-sort.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/shared/demo-sort.ts
@@ -1,0 +1,28 @@
+import type { DemoDatasetEntry } from '../../../../../generated/api-client/models/demo-dataset-entry';
+
+/**
+ * Sort rank for the demo `status` column. Alphabetical order would read as
+ * `needs_download < needs_embedding < ready`, burying the demos a user can
+ * actually open beneath the ones they'd have to fetch first; this puts the
+ * usable ones on top.
+ */
+const STATUS_ORDER: Record<string, number> = {
+  ready: 0,
+  needs_embedding: 1,
+  needs_download: 2,
+};
+
+/**
+ * Sort-key extractor for the demo-dataset table, shared by the Add-Dataset
+ * demo picker and the New-detector modal's copy of the same table so the two
+ * stay in the same order.
+ *
+ * Pass to {@link sortRowsByColumn} as its `valueAt` argument. Numbers pass
+ * through for the numeric comparison; everything else is lowercased so the
+ * name/label columns sort case-insensitively.
+ */
+export function demoSortValue(row: DemoDatasetEntry, column: string): unknown {
+  const raw = row[column as keyof DemoDatasetEntry];
+  if (column === 'status') return STATUS_ORDER[raw as string] ?? 3;
+  return typeof raw === 'number' ? raw : String(raw || '').toLowerCase();
+}

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -961,13 +961,6 @@ export class NewDetectorModalComponent implements OnInit {
 
   // --- Local file upload (single file for the example) ---
 
-  formatSize(bytes?: number): string {
-    if (bytes == null) return '';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-
   /** Local file picker handler.  Used by the drop-zone affordance in both
    *  the main form (next to "Browse Media…") and the Local Folder / Local
    *  Files cards in the media picker.  Multi-file drops (e.g. a folder)

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.ts
@@ -51,6 +51,8 @@ import {
 import { ColMeta, ManagedColumns } from '../../../utils/managed-columns';
 import { apiErrorMessage } from '../../../utils/api-error';
 import { DynamicFieldOptions } from '../../../utils/dynamic-field-options';
+import { sortRowsByColumn } from '../../../utils/sort-rows';
+import { demoSortValue } from '../dataset-importer-modal/pickers/shared/demo-sort';
 
 type ModalView = 'main' | 'media-picker';
 type ModalTab = 'blank' | 'trained';
@@ -867,24 +869,7 @@ export class NewDetectorModalComponent implements OnInit {
 
   get filteredDemos(): DemoDatasetEntry[] {
     const items = this.demos().filter((d) => d.media_type === this.activeDemoTab);
-    const statusOrder: Record<string, number> = { ready: 0, needs_embedding: 1, needs_download: 2 };
-    const sortKey = this.demoCols.sortColumn;
-    const asc = this.demoCols.sortAsc;
-    return [...items].sort((a, b) => {
-      const key = sortKey as keyof DemoDatasetEntry;
-      let va: any = a[key];
-      let vb: any = b[key];
-      if (key === 'status') {
-        va = statusOrder[va as string] ?? 3;
-        vb = statusOrder[vb as string] ?? 3;
-      }
-      if (typeof va === 'number' && typeof vb === 'number') {
-        return asc ? va - vb : vb - va;
-      }
-      va = String(va || '').toLowerCase();
-      vb = String(vb || '').toLowerCase();
-      return asc ? va.localeCompare(vb) : vb.localeCompare(va);
-    });
+    return sortRowsByColumn(items, this.demoCols.sortColumn, this.demoCols.sortAsc, demoSortValue);
   }
 
   /** True when the demo's files are on disk and can be browsed.  Demos

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -16,6 +16,7 @@ import {
 import { Observable, Subscription } from 'rxjs';
 
 import { IconComponent } from '../icon/icon.component';
+import { formatBytes } from '../../utils/format-metadata';
 
 export interface FolderBrowserDirEntry {
   name: string;
@@ -421,11 +422,9 @@ export class FolderBrowserComponent implements OnDestroy, AfterViewInit {
   // Helpers
   // ------------------------------------------------------------------
 
+  /** Template-bound size cell; see {@link formatBytes}. */
   formatSize(bytes?: number): string {
-    if (bytes === undefined || bytes === null) return '';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    return formatBytes(bytes);
   }
 
   trackRow(_index: number, row: Row): string {

--- a/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
+++ b/frontend/src/app/components/modals/load-sort-modal/load-sort-modal.component.ts
@@ -283,13 +283,6 @@ export class LoadSortModalComponent implements OnInit {
     });
   }
 
-  formatSize(bytes?: number): string {
-    if (bytes == null) return '';
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  }
-
   close(): void {
     this.closed.emit();
   }

--- a/frontend/src/app/components/right-panel/label-list/label-list.component.ts
+++ b/frontend/src/app/components/right-panel/label-list/label-list.component.ts
@@ -7,6 +7,7 @@ import { ActiveContextService } from '../../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
 import { MediaTypeCapabilityService } from '../../../services/media-type-capability.service';
 import { VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
+import { sortListEntries } from '../../../utils/sort-list-entries';
 
 export interface LabelEntry extends VoteGridEntry {
   id: number;
@@ -71,7 +72,7 @@ export class LabelListComponent {
   readonly sortedEntries = computed<LabelEntry[]>(() => {
     this.cacheVersion();
     const entries = this.ids().map(id => this.buildEntry(id));
-    return this.sortEntries(entries);
+    return sortListEntries(entries, this.sortMode());
   });
 
   constructor() {
@@ -138,35 +139,6 @@ export class LabelListComponent {
     if (media.media_type === 'audio') return '♫';
     if (media.media_type === 'text') return '¶';
     return '□';
-  }
-
-  private sortEntries(entries: LabelEntry[]): LabelEntry[] {
-    const sorted = [...entries];
-    switch (this.sortMode()) {
-      case 'time-desc':
-        sorted.sort((a, b) => b.time - a.time);
-        break;
-      case 'time-asc':
-        sorted.sort((a, b) => a.time - b.time);
-        break;
-      case 'name-asc':
-        sorted.sort((a, b) => a.name.localeCompare(b.name));
-        break;
-      case 'name-desc':
-        sorted.sort((a, b) => b.name.localeCompare(a.name));
-        break;
-      case 'confidence-desc':
-        sorted.sort((a, b) => b.confidence - a.confidence);
-        break;
-      case 'confidence-asc':
-        sorted.sort((a, b) => a.confidence - b.confidence);
-        break;
-      case 'id-asc':
-      default:
-        sorted.sort((a, b) => a.id - b.id);
-        break;
-    }
-    return sorted;
   }
 
   onEntrySelected(entry: VoteGridEntry): void {

--- a/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
+++ b/frontend/src/app/components/right-panel/labelset-list/labelset-list.component.ts
@@ -5,6 +5,7 @@ import { LabelSortMode } from '../label-sort/label-sort.component';
 import { DetectorsCrudApiService } from '../../../services/detectors-crud-api.service';
 import { MediaTypeCapabilityService } from '../../../services/media-type-capability.service';
 import { VoteGridComponent, VoteGridEntry } from '../vote-grid/vote-grid.component';
+import { sortListEntries } from '../../../utils/sort-list-entries';
 
 interface SortedElement extends DetectorLabelView, VoteGridEntry {
   confidence: number;
@@ -50,7 +51,7 @@ export class LabelsetListComponent {
       // so vote-grid tints them via a CSS mask instead of a plain <img>.
       isAudio: e.media_type === 'audio',
     }));
-    return this.sortEntries(entries);
+    return sortListEntries(entries, this.sortMode());
   }
 
   private buildThumbnailUrl(entry: DetectorLabelView): string {
@@ -66,35 +67,6 @@ export class LabelsetListComponent {
       url += `${sep}region=${box.map((v) => v.toFixed(4)).join(',')}`;
     }
     return url;
-  }
-
-  private sortEntries(entries: SortedElement[]): SortedElement[] {
-    const sorted = [...entries];
-    switch (this.sortMode()) {
-      case 'time-desc':
-        sorted.sort((a, b) => b.time - a.time);
-        break;
-      case 'time-asc':
-        sorted.sort((a, b) => a.time - b.time);
-        break;
-      case 'name-asc':
-        sorted.sort((a, b) => a.name.localeCompare(b.name));
-        break;
-      case 'name-desc':
-        sorted.sort((a, b) => b.name.localeCompare(a.name));
-        break;
-      case 'confidence-desc':
-        sorted.sort((a, b) => b.confidence - a.confidence);
-        break;
-      case 'confidence-asc':
-        sorted.sort((a, b) => a.confidence - b.confidence);
-        break;
-      case 'id-asc':
-      default:
-        sorted.sort((a, b) => a.id.localeCompare(b.id));
-        break;
-    }
-    return sorted;
   }
 
   onEntrySelected(entry: VoteGridEntry): void {

--- a/frontend/src/app/utils/clip-window.spec.ts
+++ b/frontend/src/app/utils/clip-window.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { applyClipWindow, clearClipWindow, clipProgress } from './clip-window';
+import { applyClipWindow, armClipWindow, clearClipWindow, clipProgress, enforceClipWindow } from './clip-window';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
 
 /**
@@ -160,5 +160,98 @@ describe('clipProgress', () => {
     const el = audioWithDuration(100);
     el.currentTime = 40;
     expect(clipProgress(el, () => media({ clip_start: 40, clip_end: 40 }))).toBeNull();
+  });
+});
+
+/**
+ * Unit coverage for the template-bound half used by the full center-panel
+ * players. jsdom's HTMLMediaElement never seeks or fires real media events, so
+ * these drive `currentTime` / `paused` directly and assert on the seek the
+ * helpers perform — the *playback* behaviour is verified in real chromium.
+ */
+describe('armClipWindow', () => {
+  function el(currentTime: number): HTMLMediaElement {
+    const audio = document.createElement('audio');
+    audio.currentTime = currentTime;
+    return audio;
+  }
+
+  it('seeks into the window and returns bounds when outside it', () => {
+    const audio = el(0);
+    expect(armClipWindow(audio, { clip_start: 40, clip_end: 50 })).toEqual({ start: 40, end: 50 });
+    expect(audio.currentTime).toBe(40);
+  });
+
+  it('seeks when playback has run past the window end', () => {
+    const audio = el(55);
+    armClipWindow(audio, { clip_start: 40, clip_end: 50 });
+    expect(audio.currentTime).toBe(40);
+  });
+
+  it('does NOT yank a clip already looping inside its window', () => {
+    // The behaviour that rules out reusing applyClipWindow, which seeks
+    // unconditionally: re-arming on metadata enrichment must not restart audio.
+    const audio = el(45);
+    armClipWindow(audio, { clip_start: 40, clip_end: 50 });
+    expect(audio.currentTime).toBe(45);
+  });
+
+  it('leaves el.loop alone — these players drive looping themselves', () => {
+    const audio = el(0);
+    audio.loop = true;
+    armClipWindow(audio, { clip_start: 40, clip_end: 50 });
+    expect(audio.loop).toBe(true);
+  });
+
+  it('returns null and seeks nowhere for an unwindowed media', () => {
+    const audio = el(12);
+    expect(armClipWindow(audio, { clip_start: null, clip_end: null })).toBeNull();
+    expect(audio.currentTime).toBe(12);
+  });
+
+  it('seeks but does not arm looping for a half-open window', () => {
+    const audio = el(0);
+    expect(armClipWindow(audio, { clip_start: 40 })).toBeNull();
+    expect(audio.currentTime).toBe(40);
+  });
+});
+
+describe('enforceClipWindow', () => {
+  function playing(currentTime: number): HTMLMediaElement {
+    const audio = document.createElement('audio');
+    audio.currentTime = currentTime;
+    Object.defineProperty(audio, 'paused', { value: false, configurable: true });
+    return audio;
+  }
+
+  it('loops back to the window start once playback reaches the end', () => {
+    const audio = playing(50);
+    enforceClipWindow(audio, { start: 40, end: 50 });
+    expect(audio.currentTime).toBe(40);
+  });
+
+  it('loops back when playback falls before the window start', () => {
+    const audio = playing(10);
+    enforceClipWindow(audio, { start: 40, end: 50 });
+    expect(audio.currentTime).toBe(40);
+  });
+
+  it('leaves playback inside the window untouched', () => {
+    const audio = playing(45);
+    enforceClipWindow(audio, { start: 40, end: 50 });
+    expect(audio.currentTime).toBe(45);
+  });
+
+  it('is a no-op with no bounds', () => {
+    const audio = playing(99);
+    enforceClipWindow(audio, null);
+    expect(audio.currentTime).toBe(99);
+  });
+
+  it('does not seek a paused element scrubbed outside the window', () => {
+    const audio = document.createElement('audio');
+    audio.currentTime = 5;
+    enforceClipWindow(audio, { start: 40, end: 50 });
+    expect(audio.currentTime).toBe(5);
   });
 });

--- a/frontend/src/app/utils/clip-window.ts
+++ b/frontend/src/app/utils/clip-window.ts
@@ -40,6 +40,73 @@ export function applyClipWindow(
   };
 }
 
+/**
+ * The clip extents to hold playback inside, as {@link armClipWindow} resolves
+ * them.
+ */
+export interface ClipBounds {
+  start: number;
+  end: number;
+}
+
+/** The clip fields {@link armClipWindow} reads, common to `Media` and
+ *  `MediaBatchResponse`. */
+interface ClipExtents {
+  clip_start?: number | null;
+  clip_end?: number | null;
+}
+
+/**
+ * Seek `el` into its media's clip window and resolve the bounds to enforce as
+ * playback advances, returning `null` when there is nothing to enforce.
+ *
+ * This is the *template-bound* half of the clip story, for the full center-panel
+ * `<audio>` / `<video>` players: they bind `(loadedmetadata)` and `(timeupdate)`
+ * in their templates and call this from those handlers, pairing it with
+ * {@link enforceClipWindow}. {@link applyClipWindow} above is the imperative
+ * alternative for the hover previews, which own no template and so install
+ * `on*` properties on the element directly — the two must not be mixed on one
+ * element, since assigning `el.ontimeupdate` would sit alongside, not replace,
+ * a template's `(timeupdate)` binding.
+ *
+ * Two details are load-bearing and are why the players cannot simply call
+ * {@link applyClipWindow}: the seek happens *only when playback is outside the
+ * window*, so a clip already looping correctly is not yanked back to its start
+ * when metadata is re-delivered; and `el.loop` is left alone, because these
+ * players drive looping from their own controls.
+ *
+ * Safe to call both on `(loadedmetadata)` and on a later metadata-enrichment
+ * cycle: a windowed archive member first renders as a stub with no extents, and
+ * the batch response supplies them afterwards.
+ */
+export function armClipWindow(el: HTMLMediaElement, media: ClipExtents): ClipBounds | null {
+  const start = media.clip_start;
+  if (start == null) return null;
+  const end = media.clip_end;
+  if (el.currentTime < start || (end != null && el.currentTime >= end)) {
+    el.currentTime = start;
+  }
+  // A half-open window (a start but no end) is seeked into but not looped:
+  // there is no boundary to loop at, so playback runs to the file's end.
+  return end == null ? null : { start, end };
+}
+
+/**
+ * Hold playback inside `bounds`, looping back to the start once it leaves.
+ *
+ * Call from the element's `(timeupdate)` handler — which fires as playback
+ * advances and not at all while paused, so this replaces what would otherwise
+ * be a polling interval. A `null` bounds (no window, or a half-open one) is a
+ * no-op, as is a paused element: a user who has scrubbed outside the window
+ * while paused stays where they put the playhead until they press play.
+ */
+export function enforceClipWindow(el: HTMLMediaElement, bounds: ClipBounds | null): void {
+  if (!bounds || el.paused) return;
+  if (el.currentTime >= bounds.end || el.currentTime < bounds.start) {
+    el.currentTime = bounds.start;
+  }
+}
+
 /** Detach the clip-window handlers wired by {@link applyClipWindow}. */
 export function clearClipWindow(el: HTMLAudioElement): void {
   el.onloadedmetadata = null;

--- a/frontend/src/app/utils/format-metadata.spec.ts
+++ b/frontend/src/app/utils/format-metadata.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { formatBytes, formatMetadataValue } from './format-metadata';
+
+describe('formatBytes', () => {
+  it('renders B / KB / MB across the two thresholds', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(2048)).toBe('2.0 KB');
+    expect(formatBytes(1024 * 1024 - 1)).toBe('1024.0 KB');
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+  });
+
+  it('blanks a missing size rather than claiming zero', () => {
+    expect(formatBytes(undefined)).toBe('');
+    expect(formatBytes(null)).toBe('');
+    expect(formatBytes(0)).toBe('0 B');
+  });
+});
+
+describe('formatMetadataValue', () => {
+  it('formats the three recognised numeric categories', () => {
+    expect(formatMetadataValue('File Size', 2048)).toBe('2.0 KB');
+    expect(formatMetadataValue('Duration', 3.5)).toBe('3.5s');
+    expect(formatMetadataValue('Frequency', 44100)).toBe('44100 Hz');
+  });
+
+  it('falls through for unknown labels and mismatched types', () => {
+    expect(formatMetadataValue('Other', 'hello')).toBe('hello');
+    // A recognised label whose value is not a number is not reinterpreted.
+    expect(formatMetadataValue('Duration', 'n/a')).toBe('n/a');
+    expect(formatMetadataValue('File Size', null)).toBe('null');
+  });
+});

--- a/frontend/src/app/utils/format-metadata.ts
+++ b/frontend/src/app/utils/format-metadata.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared display formatters for byte counts and custom-metadata values —
+ * the two helpers that had been copied verbatim into a component whenever
+ * one was needed.
+ *
+ * Both are pure and synchronous, so a template may bind them directly (as
+ * the folder browser and the center panel do) without any change-detection
+ * consequence: they read only their arguments, never component state, so
+ * whatever already notified the view of a new argument is still the only
+ * notification path.
+ */
+
+/**
+ * Human-readable size for a byte count: `512 B`, `2.0 KB`, `5.0 MB`.
+ *
+ * A missing size renders as the empty string rather than `0 B` or `-`, so a
+ * table cell for a row that legitimately has no size (a directory) stays
+ * blank instead of claiming the size is zero.
+ */
+export function formatBytes(bytes?: number | null): string {
+  if (bytes == null) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Format one custom-metadata entry for display, keyed off the category
+ * *label* rather than a declared type: `custom_metadata` is an untyped
+ * `Record<string, unknown>` from the importer, so the label is the only
+ * signal available about what a value means.
+ *
+ * Unrecognised labels — and values whose runtime type doesn't match the
+ * label's expectation — fall through to `String(value)` unchanged.
+ *
+ * Shared by the center panel's metadata list and the Browse bin popup's
+ * copy of it, so the same categories read identically in both.
+ */
+export function formatMetadataValue(label: string, value: unknown): string {
+  if (label === 'File Size' && typeof value === 'number') {
+    return (value / 1024).toFixed(1) + ' KB';
+  }
+  if (label === 'Duration' && typeof value === 'number') {
+    return value.toFixed(1) + 's';
+  }
+  if (label === 'Frequency' && typeof value === 'number') {
+    return value + ' Hz';
+  }
+  return String(value);
+}

--- a/frontend/src/app/utils/sort-list-entries.spec.ts
+++ b/frontend/src/app/utils/sort-list-entries.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { ListSortMode, SortableListEntry, sortListEntries } from './sort-list-entries';
+
+const entries: SortableListEntry[] = [
+  { id: 10, name: 'beta', time: 3, confidence: 0.1 },
+  { id: 2, name: 'Alpha', time: 1, confidence: 0.9 },
+  { id: 9, name: 'gamma', time: 2, confidence: -1 },
+];
+
+const idsFor = (mode: ListSortMode) => sortListEntries(entries, mode).map((e) => e.id);
+
+describe('sortListEntries', () => {
+  it('orders by each mode', () => {
+    expect(idsFor('time-desc')).toEqual([10, 9, 2]);
+    expect(idsFor('time-asc')).toEqual([2, 9, 10]);
+    expect(idsFor('name-asc')).toEqual([2, 10, 9]);
+    expect(idsFor('name-desc')).toEqual([9, 10, 2]);
+    expect(idsFor('confidence-desc')).toEqual([2, 10, 9]);
+    expect(idsFor('confidence-asc')).toEqual([9, 10, 2]);
+  });
+
+  it('compares numeric ids numerically, not lexically', () => {
+    // The bug a String() compare would reintroduce: 10 sorting before 2.
+    expect(idsFor('id-asc')).toEqual([2, 9, 10]);
+  });
+
+  it('compares string ids as strings', () => {
+    const strIds = [
+      { id: 'lbl-c', name: 'c', time: 0 },
+      { id: 'lbl-a', name: 'a', time: 0 },
+    ];
+    expect(sortListEntries(strIds, 'id-asc').map((e) => e.id)).toEqual(['lbl-a', 'lbl-c']);
+  });
+
+  it('treats a missing confidence as the unscored sentinel', () => {
+    const mixed = [
+      { id: 1, name: 'a', time: 0 },
+      { id: 2, name: 'b', time: 0, confidence: 0.5 },
+    ];
+    expect(sortListEntries(mixed, 'confidence-desc').map((e) => e.id)).toEqual([2, 1]);
+  });
+
+  it('returns a new array and leaves the input untouched', () => {
+    const input = [...entries];
+    const out = sortListEntries(input, 'name-asc');
+    expect(out).not.toBe(input);
+    expect(input.map((e) => e.id)).toEqual([10, 2, 9]);
+  });
+});

--- a/frontend/src/app/utils/sort-list-entries.ts
+++ b/frontend/src/app/utils/sort-list-entries.ts
@@ -1,0 +1,77 @@
+/**
+ * The shared sort ladder for the vote-grid-backed item lists: the Find view's
+ * Good/Bad label lists, the detector labelset list, and the VTSBrowse
+ * selection panel. All three offered the same modes off the same
+ * `<vt-view-controls>` dropdown and had each re-spelled the switch locally.
+ *
+ * The function is pure and returns a new array, so a caller may hold the
+ * result in a `computed()` (label-list, labelset-list) or push it into a
+ * signal (browse-selection-panel) without either arrangement changing where
+ * the sort runs — it stays inside whatever already notified the view.
+ */
+
+/**
+ * Every ordering the item lists offer. A given list may accept only a subset:
+ * the Browse selection panel has no detector score behind it, so its own mode
+ * union omits the two `confidence-*` values.
+ */
+export type ListSortMode =
+  | 'time-desc'
+  | 'time-asc'
+  | 'name-asc'
+  | 'name-desc'
+  | 'confidence-desc'
+  | 'confidence-asc'
+  | 'id-asc';
+
+/**
+ * What {@link sortListEntries} needs of an entry. Callers extend this with
+ * whatever else their vote grid renders.
+ */
+export interface SortableListEntry {
+  /** Numeric for media ids, string for detector label ids; compared in kind. */
+  id: number | string;
+  name: string;
+  /** Recency key — a click timestamp, or a position in insertion order. */
+  time: number;
+  /** Detector confidence, `-1` when unscored. Absent on lists with no scores. */
+  confidence?: number;
+}
+
+export function sortListEntries<T extends SortableListEntry>(
+  entries: readonly T[],
+  mode: ListSortMode,
+): T[] {
+  const sorted = [...entries];
+  switch (mode) {
+    case 'time-desc':
+      sorted.sort((a, b) => b.time - a.time);
+      break;
+    case 'time-asc':
+      sorted.sort((a, b) => a.time - b.time);
+      break;
+    case 'name-asc':
+      sorted.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case 'name-desc':
+      sorted.sort((a, b) => b.name.localeCompare(a.name));
+      break;
+    case 'confidence-desc':
+      sorted.sort((a, b) => (b.confidence ?? -1) - (a.confidence ?? -1));
+      break;
+    case 'confidence-asc':
+      sorted.sort((a, b) => (a.confidence ?? -1) - (b.confidence ?? -1));
+      break;
+    case 'id-asc':
+    default:
+      // Media ids are numeric and must compare numerically (10 after 9);
+      // detector label ids are opaque strings and compare as such.
+      sorted.sort((a, b) =>
+        typeof a.id === 'number' && typeof b.id === 'number'
+          ? a.id - b.id
+          : String(a.id).localeCompare(String(b.id)),
+      );
+      break;
+  }
+  return sorted;
+}

--- a/frontend/src/app/utils/sort-rows.ts
+++ b/frontend/src/app/utils/sort-rows.ts
@@ -27,13 +27,26 @@ export interface SortState<TCol extends string = string> {
  *
  * Numbers compare numerically; everything else compares as a locale string,
  * with a missing value sorting as `''`.
+ *
+ * `valueAt` overrides that plain field lookup for tables whose sort order
+ * isn't the raw cell value: a status column that sorts by a severity rank
+ * rather than alphabetically, say, or a name column that sorts
+ * case-insensitively. Return a number to opt that column into the numeric
+ * comparison and anything else to opt it into the string one — the two
+ * branches below are unchanged, so an extractor only decides *what* is
+ * compared, never *how*.
  */
-export function sortRowsByColumn<T>(rows: readonly T[], column: string, asc: boolean): T[] {
+export function sortRowsByColumn<T>(
+  rows: readonly T[],
+  column: string,
+  asc: boolean,
+  valueAt: (row: T, column: string) => unknown = (row, col) =>
+    (row as Record<string, unknown>)[col],
+): T[] {
   const dir = asc ? 1 : -1;
-  const valueAt = (row: T): unknown => (row as Record<string, unknown>)[column];
   return [...rows].sort((a, b) => {
-    const va = valueAt(a) ?? '';
-    const vb = valueAt(b) ?? '';
+    const va = valueAt(a, column) ?? '';
+    const vb = valueAt(b, column) ?? '';
     if (typeof va === 'number' && typeof vb === 'number') return (va - vb) * dir;
     return String(va).localeCompare(String(vb)) * dir;
   });


### PR DESCRIPTION
Four independent commits, one per sub-part, in the order #3443 lists them.

## What landed

**`formatBytes` / `formatMetadataValue`** → `utils/format-metadata.ts`.
`formatMetadataValue` was byte-identical in `center-panel` and `browse-bin-popup`
(the latter's docstring already said it mirrored the former). Both delegate now.

**`sortRowsByColumn` key-extractor.** The optional `valueAt` argument lets a
caller decide *what* is compared without touching *how*. The Add-Dataset demo
picker and the New-detector modal sorted the same table with byte-identical
bespoke comparators; both adopt it through a shared `demoSortValue`.

**`sortListEntries`** → `utils/sort-list-entries.ts`, adopted by `label-list`,
`labelset-list` and `browse-selection-panel`.

**The players' clip snap-and-loop** → `armClipWindow` / `enforceClipWindow`,
added beside the existing hover-preview helper in `utils/clip-window.ts`.

## Where this diverges from the issue

Three corrections, each of which changed what shipped:

**`clip-window.ts` was not being bypassed.** The issue reads the two players as
hand-rolling what `applyClipWindow` already does, "differing only in the element
ref", and prescribes widening it to `HTMLMediaElement` and adopting it. Adopting
it would have been a regression. `applyClipWindow` assigns `el.onloadedmetadata`
/ `el.ontimeupdate`, which would sit *alongside* — not replace — the players'
template `(loadedmetadata)` / `(timeupdate)` bindings; it seeks unconditionally,
where the players must not yank a clip already looping inside its window; and it
sets `el.loop`, which these players own. The real duplication is between the two
players, so the new helpers are a *sibling* of `applyClipWindow`, not a widening
of it. Both mechanisms now document each other so the next reader doesn't merge them.

**`formatSize` had three copies, not four — and two were dead.** Only
folder-browser's was reachable; the `load-sort-modal` and `new-detector-modal`
copies were bound by no template, spec or caller. Those two are deleted rather
than rewired.

**Only two of the three "bespoke table sorters" could adopt `sortRowsByColumn`.**
`folder-browser`'s partitions directories above files, tiebreaks size ties by
name, and uses numeric collation on the name column — structure a key-extractor
cannot express. Forcing it through would have been a behaviour regression, so it
stays as it is.

## Behaviour preservation

Ordering is preserved exactly in every adopted sorter. `demoSortValue` returns
numbers for the numeric branch and lowercased strings for the locale branch,
which is what the inlined comparators fed their own identical branches. The
shared `id-asc` compares numeric ids numerically and string ids as strings,
so `label-list` and `labelset-list` each keep the order they had.

`SelectionEntry.order` becomes `time` (it was only ever read by the sort, and
the shared contract names that slot the recency key), and `SelectionSortMode` is
now an `Exclude` of the shared union, so a confidence mode can't leak into a list
with no scores behind it.

**Zoneless:** every call site keeps its existing reactive arrangement — a
`computed()` in the two Find-view lists, a signal write in the Browse panel,
delegating methods at the template-bound formatters. Only helper bodies moved,
so nothing changed where it is computed or when the view is notified.

## Verification

Full `./run-tests.sh`: `RUN PASSED`, all gates green — 9686 Python tests, 2250
frontend (94 new).

The clip half was verified in **real chromium** via `launchChromium()`, as the
issue rightly insists, against a generated 30s WAV on both an `<audio>` and a
`<video>` element: real duration, real playback advance, every post-arm sample
inside `[clip_start, clip_end]`, an observed wrap back to the window start, no
yank when re-armed mid-window, and no seek for unwindowed or half-open media.
jsdom media elements never seek or loop, so the unit suite alone could not have
shown this. Playback stays a manual chromium check — a browser-dependent gate
doesn't belong in `run-tests.sh`.

Closes #3443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdJW5jUSMrxY5s7duZgsX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdJW5jUSMrxY5s7duZgsX4)_