### PR TITLE
Move the Dashboard's table selection into DashboardSelectionService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ not list every commit. Use `git log` for the full history.
 
 ### Changed
 
+- **Your Dashboard selection now survives leaving the Dashboard.** Going to
+  Train and back used to drop the highlighted rows and blank the top bar to
+  "Select a dataset" -- even though the pair you had just opened was still
+  loaded -- because the selection lived on the Dashboard component and died
+  with it. It now lives in `DashboardSelectionService`, so the rows come back
+  highlighted and the top bar keeps naming them. The detector grid's
+  Drafts/AutoRun tab travels with the selection it scopes, so returning can no
+  longer leave a hidden AutoRun row feeding the section actions. (Issue #3445.)
+
 - **Switching between two loaded detectors no longer throws away the labeling
   indicators' cached work.** The Smart / Stable per-step cache retrains one MLP
   per label-history step, and it used to be a single slot stamped with whichever

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -160,9 +160,13 @@ the component —
 - `DashboardLoadingTasksService` — per-task loading rows, and the
   poll-until-settled-then-refresh bookkeeping.
 - `DashboardSelectionService` — the highlighted table rows (which drive
-  Train / Find / Combine / Delete), bridged to the top-bar pulldowns so they
-  show what is *selected* while the Dashboard is on screen, not merely what is
-  loaded.
+  Train / Find / Combine / Delete), *owned* here rather than mirrored from the
+  component, so the top-bar pulldowns show what is *selected* while the
+  Dashboard is on screen (not merely what is loaded) by reading signals
+  directly, and the selection survives a round trip to another view. Both
+  grids share one `toggle(kind, id, additive)` ladder, and the ids the top bar
+  reads are `computed` over the selection and the registry — the pulldown
+  needs no push, and there is no per-mutation mirror call to forget.
 
 The Add-Dataset and New-Detector flows are *not* owned by the Dashboard at
 all: `NewThingFlowsService` is a singleton opener, and the modals are rendered

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.spec.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.spec.ts
@@ -227,23 +227,50 @@ describe('ContextPulldownComponent', () => {
       await createPulldown('dataset');
       dashSelection.setDashboardVisible(true);
       setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
-      const selectSpy = vi.spyOn(dashSelection, 'requestSelect');
       const switchSpy = vi.spyOn(contextSwitch, 'switchTo');
 
       component.pickRow(component.rows.find((r) => r.id === 'd2')!);
 
-      expect(selectSpy).toHaveBeenCalledWith('dataset', 'd2');
+      expect([...dashSelection.ids('dataset')]).toEqual(['d2']);
       expect(switchSpy).not.toHaveBeenCalled();
     });
 
     it('collapses a multi-selection to the "Multiple" label', async () => {
       await createPulldown('dataset');
       dashSelection.setDashboardVisible(true);
-      dashSelection.setDatasetIds(['d1', 'd2']);
+      dashSelection.selectOnly('dataset', ['d1', 'd2']);
       setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
 
       expect(component.rows.filter((r) => r.active).length).toBe(2);
       expect(component.activeName).toBe('Multiple');
+    });
+
+    it('repaints the trigger when the selection changes with no Dashboard mounted', async () => {
+      // The selection lives in the service, so the bar tracks it off its own
+      // reads. Nothing pushes into the pulldown here — no Dashboard exists in
+      // this TestBed — and the assertion is on rendered DOM, so a missing
+      // notification shows up as a stale label rather than a passing spec.
+      await createPulldown('dataset');
+      dashSelection.setDashboardVisible(true);
+      setRegistry([makeDataset('d1', 'Alpha'), makeDataset('d2', 'Beta')]);
+      const value = () =>
+        (fixture.nativeElement as HTMLElement).querySelector('.trigger-value')!.textContent!.trim();
+      expect(value()).toBe('Select a dataset');
+
+      dashSelection.toggle('dataset', 'd2', false);
+      await settleZoneless(fixture);
+      expect(value()).toBe('Beta');
+
+      dashSelection.toggle('dataset', 'd1', true);
+      await settleZoneless(fixture);
+      expect(value()).toBe('Multiple');
+
+      // Leaving the Dashboard falls back to the loaded context, and that
+      // switch has to repaint too.
+      activeContext.setIntent('d1', '');
+      dashSelection.setDashboardVisible(false);
+      await settleZoneless(fixture);
+      expect(value()).toBe('Alpha');
     });
   });
 
@@ -368,6 +395,24 @@ describe('ContextPulldownComponent', () => {
       TestBed.tick();
 
       expect(switchSpy).toHaveBeenCalledWith('d1', 'mNew');
+    });
+
+    it('selects a newly created detector on the Dashboard, even if already picked', async () => {
+      // On the Dashboard the new item is selected rather than loaded. The
+      // Dashboard's own registry auto-select may get there first, so this must
+      // not be the pick *ladder* — that would toggle the sole selection off.
+      await createPulldown('detector');
+      dashSelection.setDashboardVisible(true);
+      setRegistry([makeDataset('d1', 'DS')], [makeDetector('mNew', 'Fresh')]);
+      dashSelection.selectOnly('detector', ['mNew']);
+      const switchSpy = vi.spyOn(contextSwitch, 'switchTo').mockImplementation(() => {});
+
+      component.addNew();
+      newThingFlows.emitDetectorCreated('mNew');
+      TestBed.tick();
+
+      expect([...dashSelection.ids('detector')]).toEqual(['mNew']);
+      expect(switchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostListener, inject, input, OnDestroy, OnInit, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, input, OnDestroy, OnInit, viewChild } from '@angular/core';
 import { TitleCasePipe } from '@angular/common';
 import { NavigationEnd, Router } from '@angular/router';
 
@@ -129,6 +129,22 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
    *  needing a separate per-row subscription. */
   private busyPairs: Map<string, string[]> = new Map();
 
+  constructor() {
+    // On the Dashboard the bar shows the table selection instead of the
+    // loaded context. Rebuild when visibility flips or either half's
+    // selection changes (both halves matter here because a row's
+    // compatibility/busy state depends on the *other* half's pick). An
+    // `effect` rather than a subscription, so the bar stays live off its own
+    // reads: nothing has to remember to push into it, and it keeps
+    // repainting whether or not the Dashboard is mounted.
+    effect(() => {
+      this.dashSelection.dashboardVisible();
+      this.dashSelection.datasetIds();
+      this.dashSelection.detectorIds();
+      this.rebuildRows();
+    });
+  }
+
   ngOnInit(): void {
     this.datasetState.datasets$.pipe(takeUntil(this.destroy$)).subscribe(() => {
       this.rebuildRows();
@@ -139,19 +155,6 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     // moment the user picks a row, rather than waiting for any
     // dataset/detector load to finish.
     this.activeContext.intentPair$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.rebuildRows());
-    // On the Dashboard the bar mirrors the table selection instead of the
-    // loaded context. Rebuild when visibility flips or either half's
-    // selection changes (both halves matter here because a row's
-    // compatibility/busy state depends on the *other* half's pick).
-    this.dashSelection.dashboardVisible$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.rebuildRows());
-    this.dashSelection.datasetIds$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(() => this.rebuildRows());
-    this.dashSelection.detectorIds$
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => this.rebuildRows());
     this.datasetState.error$.pipe(takeUntil(this.destroy$)).subscribe((err) => {
@@ -309,12 +312,12 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   pickRow(row: PulldownRow): void {
-    // On the Dashboard the pulldown mirrors the tables: a pick is a plain
-    // single-select of that row (which toggles off if it was the sole
+    // On the Dashboard the pulldown shows the tables' selection: a pick is a
+    // plain single-select of that row (which toggles off if it was the sole
     // pick), never a context load. Off the Dashboard it switches the
     // active/loaded pair as before.
-    if (this.dashSelection.dashboardVisible) {
-      this.dashSelection.requestSelect(this.kind(), row.id);
+    if (this.dashSelection.dashboardVisible()) {
+      this.dashSelection.toggle(this.kind(), row.id, false);
       this.close();
       return;
     }
@@ -340,8 +343,8 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     } else {
       // Seed the new-detector form's media type from the partner dataset:
       // the single selected dataset on the Dashboard, else the active one.
-      const otherDsId = this.dashSelection.dashboardVisible
-        ? singleId(this.dashSelection.datasetIds)
+      const otherDsId = this.dashSelection.dashboardVisible()
+        ? singleId(this.dashSelection.datasetIds())
         : this.activeContext.intentDatasetId;
       const other = otherDsId
         ? this.datasetState.datasets.find((d) => d.id === otherDsId)
@@ -484,9 +487,11 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   private switchToNewItem(id: string): void {
     // On the Dashboard a freshly-added item becomes the selected row (the
     // Dashboard also auto-selects new ids, so this just keeps them aligned)
-    // rather than being loaded as the active pair.
-    if (this.dashSelection.dashboardVisible) {
-      this.dashSelection.requestSelect(this.kind(), id);
+    // rather than being loaded as the active pair. `selectOnly`, not the pick
+    // ladder: this is "make the new thing the selection", and the ladder would
+    // toggle it back *off* if the Dashboard's own auto-select got there first.
+    if (this.dashSelection.dashboardVisible()) {
+      this.dashSelection.selectOnly(this.kind(), [id]);
       return;
     }
     if (this.isDataset) {
@@ -504,12 +509,12 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     //    than one — the closed label collapses that to "Multiple").
     //  - Elsewhere, the single intent id (what the user picked), not what's
     //    loaded, so picking a row feels instant while a load runs behind it.
-    const dashMode = this.dashSelection.dashboardVisible;
+    const dashMode = this.dashSelection.dashboardVisible();
     const dsIds = dashMode
-      ? this.dashSelection.datasetIds
+      ? this.dashSelection.datasetIds()
       : idList(this.activeContext.intentDatasetId);
     const detIds = dashMode
-      ? this.dashSelection.detectorIds
+      ? this.dashSelection.detectorIds()
       : idList(this.activeContext.intentModelId);
 
     // The row's own selected set (highlight + label) versus the *other*

--- a/frontend/src/app/components/dashboard/dashboard.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.spec.ts
@@ -7,6 +7,7 @@ import { LoadingTask } from '../../models/api.models';
 import { LabelSessionService } from '../../services/label-session.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { ActiveContextService } from '../../services/active-context.service';
+import { DashboardSelectionService } from '../../services/dashboard-selection.service';
 import { provideZoneless } from '../../testing/zoneless-testbed';
 import { provideHttpTesting } from '../../testing/test-providers';
 
@@ -14,6 +15,7 @@ describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
   let httpMock: HttpTestingController;
+  let selection: DashboardSelectionService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -24,6 +26,7 @@ describe('DashboardComponent', () => {
     fixture = TestBed.createComponent(DashboardComponent);
     component = fixture.componentInstance;
     httpMock = TestBed.inject(HttpTestingController);
+    selection = TestBed.inject(DashboardSelectionService);
   });
 
   afterEach(() => {
@@ -295,6 +298,41 @@ describe('DashboardComponent', () => {
     expect(activeContext.intentModelId).toBe('m0');
   });
 
+  it('keeps the selection across a Dashboard round trip', () => {
+    // The selection lives in `DashboardSelectionService`, not in the
+    // component, so leaving for the label view and coming back leaves the
+    // same rows highlighted (and the same name in the top bar) instead of
+    // resetting to whatever the registry auto-select would pick.
+    const datasets = [
+      { id: 'd1', name: 'First' },
+      { id: 'd2', name: 'Second' },
+    ];
+    const detectors = [
+      { id: 'm1', name: 'Draft', media_type: 'audio' },
+      { id: 'm2', name: 'Frozen', media_type: 'audio', autofind: true },
+    ];
+    flushInitialRequests(datasets, detectors);
+    selection.selectOnly('dataset', ['d2']);
+    component.setDetectorTab('autorun');
+    selection.selectOnly('detector', ['m2']);
+
+    fixture.destroy();
+    expect(selection.dashboardVisible()).toBe(false);
+    // The pulldown keeps reading the service off the Dashboard, so the ids
+    // survive the unmount rather than being reset by it.
+    expect(selection.datasetIds()).toEqual(['d2']);
+
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+    flushInitialRequests(datasets, detectors);
+
+    expect(component.selectedDatasetIds.has('d2')).toBe(true);
+    // The tab travels with the selection it scopes: a returning user must not
+    // land on Drafts with a hidden AutoRun row still feeding the actions.
+    expect(component.detectorTab()).toBe('autorun');
+    expect(component.selectedDetectorIds.has('m2')).toBe(true);
+  });
+
   it('should toggle dataset selection on click', () => {
     flushInitialRequests();
     const event = new MouseEvent('click');
@@ -367,8 +405,8 @@ describe('DashboardComponent', () => {
   describe('button state', () => {
     it('should disable Label when nothing selected', () => {
       flushInitialRequests();
-      component.selectedDatasetIds.clear();
-      component.selectedDetectorIds.clear();
+      selection.clear('dataset');
+      selection.clear('detector');
       expect(component.labelEnabled).toBe(false);
     });
 
@@ -396,8 +434,8 @@ describe('DashboardComponent', () => {
 
     it('should disable Find with no selections', () => {
       flushInitialRequests();
-      component.selectedDatasetIds.clear();
-      component.selectedDetectorIds.clear();
+      selection.clear('dataset');
+      selection.clear('detector');
       expect(component.findEnabled).toBe(false);
     });
 
@@ -423,7 +461,7 @@ describe('DashboardComponent', () => {
       ];
       const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests(datasets, models);
-      component.selectedDatasetIds.add('d2');
+      selection.toggle('dataset', 'd2', true);
       expect(component.findEnabled).toBe(false);
     });
 
@@ -437,8 +475,8 @@ describe('DashboardComponent', () => {
         { id: 'm2', name: 'M2', media_type: 'image', num_training: 5 },
       ];
       flushInitialRequests(datasets, models);
-      component.selectedDatasetIds.add('d2');
-      component.selectedDetectorIds.add('m2');
+      selection.toggle('dataset', 'd2', true);
+      selection.toggle('detector', 'm2', true);
       expect(component.findEnabled).toBe(true);
     });
 
@@ -503,7 +541,7 @@ describe('DashboardComponent', () => {
   describe('label hints', () => {
     it('should hint about missing dataset', () => {
       flushInitialRequests();
-      component.selectedDatasetIds.clear();
+      selection.clear('dataset');
       expect(component.labelHint).toBe('Select a dataset in the table above.');
     });
 
@@ -511,7 +549,7 @@ describe('DashboardComponent', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
       flushInitialRequests(datasets);
       // Single dataset is auto-selected; no detector selected.
-      component.selectedDetectorIds.clear();
+      selection.clear('detector');
       expect(component.labelHint).toBe('Create a new detector and start training');
     });
 
@@ -521,8 +559,8 @@ describe('DashboardComponent', () => {
         { id: 'd2', name: 'DS2', media_type: 'audio' },
       ];
       flushInitialRequests(datasets);
-      component.selectedDatasetIds.add('d1');
-      component.selectedDatasetIds.add('d2');
+      selection.toggle('dataset', 'd1', true);
+      selection.toggle('dataset', 'd2', true);
       expect(component.labelHint).toBe('Select exactly 1 dataset');
     });
 
@@ -533,9 +571,8 @@ describe('DashboardComponent', () => {
         { id: 'm2', name: 'M2', media_type: 'audio' },
       ];
       flushInitialRequests(datasets, models);
-      component.selectedDatasetIds.add('d1');
-      component.selectedDetectorIds.add('m1');
-      component.selectedDetectorIds.add('m2');
+      selection.selectOnly('dataset', ['d1']);
+      selection.selectOnly('detector', ['m1', 'm2']);
       expect(component.labelHint).toBe('Select exactly 1 detector');
     });
 
@@ -557,8 +594,8 @@ describe('DashboardComponent', () => {
   describe('find hints', () => {
     it('should hint about missing dataset and model', () => {
       flushInitialRequests();
-      component.selectedDatasetIds.clear();
-      component.selectedDetectorIds.clear();
+      selection.clear('dataset');
+      selection.clear('detector');
       expect(component.findHint).toBe('Select a dataset and detector above.');
     });
 
@@ -566,7 +603,7 @@ describe('DashboardComponent', () => {
       const models = [{ id: 'm1', name: 'M', media_type: 'audio' }];
       flushInitialRequests([], models);
       // Single detector is auto-selected; no dataset selected.
-      component.selectedDatasetIds.clear();
+      selection.clear('dataset');
       expect(component.findHint).toBe('Select a dataset in the table above.');
     });
 
@@ -574,7 +611,7 @@ describe('DashboardComponent', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio' }];
       flushInitialRequests(datasets);
       // Single dataset is auto-selected; no detector selected.
-      component.selectedDetectorIds.clear();
+      selection.clear('detector');
       expect(component.findHint).toBe('Select a detector in the table above.');
     });
 
@@ -618,7 +655,7 @@ describe('DashboardComponent', () => {
   it('should delete a dataset after confirmation', async () => {
     const datasets = [{ id: 'd1', name: 'ToDelete', media_type: 'audio' }];
     flushInitialRequests(datasets);
-    component.selectedDatasetIds.add('d1');
+    selection.selectOnly('dataset', ['d1']);
 
     // Mock dialog confirmation
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
@@ -646,8 +683,7 @@ describe('DashboardComponent', () => {
 
     const activeCtx = TestBed.inject(ActiveContextService);
     activeCtx.setActivePair('d1', '');
-    component.selectedDatasetIds.add('d1');
-    component.selectedDatasetIds.add('d2');
+    selection.selectOnly('dataset', ['d1', 'd2']);
 
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
 
@@ -680,8 +716,8 @@ describe('DashboardComponent', () => {
 
     const activeCtx = TestBed.inject(ActiveContextService);
     activeCtx.setActivePair('d1', 'm1');
-    component.selectedDatasetIds.clear();
-    component.selectedDatasetIds.add('d2');
+    selection.clear('dataset');
+    selection.toggle('dataset', 'd2', true);
 
     vi.spyOn(component['dialog'], 'confirmDestructive').mockReturnValue(Promise.resolve(true));
 
@@ -761,7 +797,7 @@ describe('DashboardComponent', () => {
 
     it('does nothing when no dataset is selected', () => {
       flushInitialRequests();
-      component.selectedDatasetIds.clear();
+      selection.clear('dataset');
       const routerSpy = vi.spyOn(component['router'], 'navigate').mockResolvedValue(true);
       component.onLabel();
       expect(routerSpy).not.toHaveBeenCalled();
@@ -770,7 +806,7 @@ describe('DashboardComponent', () => {
     it('opens the new-detector modal (no navigation) when no model is selected', () => {
       const datasets = [{ id: 'd1', name: 'DS', media_type: 'audio', loaded: true }];
       flushInitialRequests(datasets, []);
-      component.selectedDetectorIds.clear();
+      selection.clear('detector');
       const routerSpy = vi.spyOn(component['router'], 'navigate').mockResolvedValue(true);
 
       component.onLabel();

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, HostListener, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, HostListener, inject, OnDestroy, OnInit, Signal, signal } from '@angular/core';
 
 import { NavigationCancel, NavigationEnd, NavigationError, Router } from '@angular/router';
 import { EMPTY, Subject, timer } from 'rxjs';
@@ -16,7 +16,7 @@ import { ActiveContextService } from '../../services/active-context.service';
 import { ContextSwitchService } from '../../services/context-switch.service';
 import { AuthService } from '../../services/auth.service';
 import { HuggingFaceAuthService } from '../../services/huggingface-auth.service';
-import { DashboardSelectionService } from '../../services/dashboard-selection.service';
+import { DashboardSelectionService, DetectorTab, SelectionKind, SelectionState } from '../../services/dashboard-selection.service';
 import { NewThingFlowsService } from '../../services/new-thing-flows.service';
 import { DashboardModalsService } from '../../services/dashboard-modals.service';
 import { DashboardLoadingTasksService } from '../../services/dashboard-loading-tasks.service';
@@ -101,13 +101,25 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private progressEvents = inject(ProgressEventsService);
   private settingsState = inject(SettingsStateService);
 
-  selectedDatasetIds: Set<string> = new Set();
-  selectedDetectorIds: Set<string> = new Set();
+  /** The highlighted rows, owned by `DashboardSelectionService` (a root
+   *  singleton, so the top bar reads them without this component and they
+   *  survive a round trip to another view). Exposed as read-only getters
+   *  over the service's signals: a read during template evaluation is
+   *  tracked, so a selection change repaints under zoneless OnPush. Writes
+   *  go through the service's `toggle` / `selectOnly` / … ladder. */
+  get selectedDatasetIds(): ReadonlySet<string> {
+    return this.dashSelection.ids('dataset');
+  }
 
-  /** Which detector-grid tab is showing: Drafts (editable, `!autofind`) or
-   *  AutoRun (frozen, `autofind` — auto-run against each dataset on import).
-   *  A detector lives in exactly one tab; the ⋯ menu moves it between them. */
-  readonly detectorTab = signal<'drafts' | 'autorun'>('drafts');
+  get selectedDetectorIds(): ReadonlySet<string> {
+    return this.dashSelection.ids('detector');
+  }
+
+  /** Which detector-grid tab is showing. Lives in the selection service
+   *  alongside the selection it scopes; see {@link setDetectorTab}. */
+  get detectorTab(): Signal<DetectorTab> {
+    return this.dashSelection.detectorTab;
+  }
 
   // Confirm flags hold the trash icon at 90° while the confirm dialog is up,
   // and play a reverse animation back to 0° once the dialog resolves. Written
@@ -202,6 +214,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   private findPolling$ = new Subject<void>();
+  /** Registry ids this mount has already seen, so `reconcileSelection` can
+   *  tell "just appeared" from "was here when we arrived". Component state on
+   *  purpose: a fresh mount has seen nothing, so a returning user's existing
+   *  rows are not mistaken for new arrivals and do not steal the selection. */
   private knownDatasetIds = new Set<string>();
   private knownDetectorIds = new Set<string>();
   /** Dataset IDs we've already asked the backend to preload an embedder
@@ -232,19 +248,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    // While the Dashboard is on screen the top-bar pulldowns mirror the
-    // table selection (rather than the loaded context); flag that here and
-    // push the current selection so the bar is correct on first paint.
+    // While the Dashboard is on screen the top-bar pulldowns show the table
+    // selection rather than the loaded context; flag that here. The selection
+    // itself already lives in the service, so there is nothing to push.
     this.dashSelection.setDashboardVisible(true);
-    this.pushTopBarLabels();
-    // Pulldown → table: a pick inside the top-bar pulldown selects the
-    // matching row exactly as a plain (non-additive) table click would.
-    this.dashSelection.selectRequest$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(({ kind, id }) => {
-        if (kind === 'dataset') this.applyDatasetSelection(id, false);
-        else this.applyDetectorSelection(id, false);
-      });
     this.authService.status$
       .pipe(takeUntil(this.destroy$))
       .subscribe((status) => {
@@ -255,49 +262,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetState.datasets$
       .pipe(takeUntil(this.destroy$))
       .subscribe((datasets) => {
-        const currentIds = new Set(datasets.map((d) => d.id));
-        // Prune selections that no longer exist in the registry
-        for (const id of this.selectedDatasetIds) {
-          if (!currentIds.has(id)) this.selectedDatasetIds.delete(id);
-        }
-        const newIds = [...currentIds].filter((id) => !this.knownDatasetIds.has(id));
-        if (newIds.length > 0 && this.knownDatasetIds.size > 0) {
-          // Items were added after initial load; select only the new ones
-          this.selectedDatasetIds.clear();
-          for (const id of newIds) {
-            this.selectedDatasetIds.add(id);
-          }
-        } else if (datasets.length === 1 && this.selectedDatasetIds.size === 0) {
-          // First load with exactly one item; auto-select it
-          this.selectedDatasetIds.add(datasets[0].id);
-        }
-        this.knownDatasetIds = currentIds;
-        this.pushTopBarLabels();
+        this.reconcileSelection('dataset', datasets.map((d) => d.id));
         this.preloadSelectedEmbedders();
       });
     this.datasetState.detectors$
       .pipe(takeUntil(this.destroy$))
       .subscribe((models) => {
-        const currentIds = new Set(models.map((m) => m.id));
-        // Prune selections that no longer exist in the registry
-        for (const id of this.selectedDetectorIds) {
-          if (!currentIds.has(id)) this.selectedDetectorIds.delete(id);
-        }
-        const newIds = [...currentIds].filter((id) => !this.knownDetectorIds.has(id));
-        if (newIds.length > 0 && this.knownDetectorIds.size > 0) {
-          // Items were added after initial load; select only the new ones.
-          // New detectors are always drafts, so surface the tab they land on.
-          this.selectedDetectorIds.clear();
-          for (const id of newIds) {
-            this.selectedDetectorIds.add(id);
-          }
-          this.detectorTab.set('drafts');
-        } else if (models.length === 1 && this.selectedDetectorIds.size === 0) {
-          // First load with exactly one item; auto-select it
-          this.selectedDetectorIds.add(models[0].id);
-        }
-        this.knownDetectorIds = currentIds;
-        this.pushTopBarLabels();
+        this.reconcileSelection('detector', models.map((m) => m.id));
       });
     this.refresh();
     this.startDiskUsagePolling();
@@ -371,8 +342,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.datasetState.refresh();
     if (this.trainAfterModelCreation && modelId) {
       this.trainAfterModelCreation = false;
-      this.selectedDetectorIds.clear();
-      this.selectedDetectorIds.add(modelId);
+      this.dashSelection.selectOnly('detector', [modelId]);
       this.knownDetectorIds.add(modelId);
       this.datasetState.detectors$
         .pipe(
@@ -459,14 +429,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.detectorTab() === 'autorun' ? this.autorunDetectors : this.draftDetectors;
   }
 
-  /** Switch detector-grid tabs. Selection is per-tab: a hidden selection
-   *  would silently feed the section actions and the Train/Find buttons, so
-   *  it's cleared on every switch. */
-  setDetectorTab(tab: 'drafts' | 'autorun'): void {
-    if (this.detectorTab() === tab) return;
-    this.detectorTab.set(tab);
-    this.selectedDetectorIds.clear();
-    this.pushTopBarLabels();
+  /** Switch detector-grid tabs. The service owns the tab and clears the
+   *  per-tab selection; see `DashboardSelectionService.setDetectorTab`. */
+  setDetectorTab(tab: DetectorTab): void {
+    this.dashSelection.setDetectorTab(tab);
   }
 
   get loading(): boolean {
@@ -492,74 +458,41 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
   // --- Dataset selection ---
 
-  /** Mirror the current table selection to the top-bar pulldowns. Called
-   *  after every selection mutation; the pulldowns resolve names/counts
-   *  from these id lists (filtered to ids still in the registry so a
-   *  pruned-away id can't inflate the "Multiple" count). */
-  private pushTopBarLabels(): void {
-    const datasetIds = this.datasets
-      .filter((d) => this.selectedDatasetIds.has(d.id))
-      .map((d) => d.id);
-    const detectorIds = this.detectors
-      .filter((d) => this.selectedDetectorIds.has(d.id))
-      .map((d) => d.id);
-    this.dashSelection.setDatasetIds(datasetIds);
-    this.dashSelection.setDetectorIds(detectorIds);
-    // While the Dashboard is on screen the pulldowns read the mirrored table
-    // selection above; the moment it unmounts they fall back to the
-    // active-context *intent*. Without also mirroring a lone pick into that
-    // intent, a freshly imported/created (implicitly selected) item is
-    // forgotten by the pulldowns as soon as you leave the Dashboard by any
-    // route that doesn't load a context — the picker snaps back to "Select
-    // a …". Mirror only an unambiguous single selection; a 0- or
-    // multi-selection leaves intent untouched so we never blank out the
-    // intent of an already-loaded pair. Intent-only (never `setActive`), so
-    // the HTTP interceptor keeps tagging the still-loaded pair, per the H25
-    // intent/active split.
-    const soleDataset = datasetIds.length === 1 ? datasetIds[0] : this.activeContext.intentDatasetId;
-    const soleDetector =
-      detectorIds.length === 1 ? detectorIds[0] : this.activeContext.intentModelId;
-    this.activeContext.setIntent(soleDataset, soleDetector);
+  /**
+   * Reconcile one grid's selection against a fresh registry listing: prune
+   * ids that no longer exist, then auto-select whatever just appeared (or
+   * the lone row on a first load). Shared by both grids — the only
+   * asymmetry is that a new detector is always a draft, so its tab is
+   * surfaced before the new rows are selected.
+   */
+  private reconcileSelection(kind: SelectionKind, ids: string[]): void {
+    const currentIds = new Set(ids);
+    const known = kind === 'dataset' ? this.knownDatasetIds : this.knownDetectorIds;
+    this.dashSelection.retain(kind, currentIds);
+    const newIds = [...currentIds].filter((id) => !known.has(id));
+    if (newIds.length > 0 && known.size > 0) {
+      // Items were added after initial load; select only the new ones.
+      if (kind === 'detector') this.dashSelection.setDetectorTab('drafts');
+      this.dashSelection.selectOnly(kind, newIds);
+    } else if (currentIds.size === 1 && this.dashSelection.count(kind) === 0) {
+      // First load with exactly one item; auto-select it.
+      this.dashSelection.selectOnly(kind, currentIds);
+    }
+    if (kind === 'dataset') this.knownDatasetIds = currentIds;
+    else this.knownDetectorIds = currentIds;
   }
 
   toggleDatasetSelection(id: string, event: MouseEvent): void {
-    this.applyDatasetSelection(id, event.ctrlKey || event.metaKey);
-  }
-
-  /** Core dataset-selection logic shared by the table row handler and the
-   *  top-bar pulldown's pick request. `additive` (Ctrl/Cmd) toggles a
-   *  single id in/out of a multi-selection; otherwise it's a plain
-   *  single-select that toggles off when it's already the sole pick. */
-  private applyDatasetSelection(id: string, additive: boolean): void {
-    if (additive) {
-      if (this.selectedDatasetIds.has(id)) {
-        this.selectedDatasetIds.delete(id);
-      } else {
-        this.selectedDatasetIds.add(id);
-      }
-    } else {
-      if (this.selectedDatasetIds.has(id) && this.selectedDatasetIds.size === 1) {
-        this.selectedDatasetIds.clear();
-      } else {
-        this.selectedDatasetIds.clear();
-        this.selectedDatasetIds.add(id);
-      }
-    }
-    this.pushTopBarLabels();
+    this.dashSelection.toggle('dataset', id, event.ctrlKey || event.metaKey);
     this.preloadSelectedEmbedders();
   }
 
   isDatasetSelected(id: string): boolean {
-    return this.selectedDatasetIds.has(id);
+    return this.dashSelection.has('dataset', id);
   }
 
   toggleDatasetCheckbox(id: string): void {
-    if (this.selectedDatasetIds.has(id)) {
-      this.selectedDatasetIds.delete(id);
-    } else {
-      this.selectedDatasetIds.add(id);
-    }
-    this.pushTopBarLabels();
+    this.dashSelection.toggle('dataset', id, true);
     this.preloadSelectedEmbedders();
   }
 
@@ -578,22 +511,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
   }
 
-  get datasetSelectionState(): 'none' | 'some' | 'all' {
-    const sel = this.selectedDatasetIds.size;
-    if (sel === 0) return 'none';
-    if (sel >= this.datasets.length) return 'all';
-    return 'some';
+  get datasetSelectionState(): SelectionState {
+    return this.dashSelection.selectionState('dataset', this.datasets.length);
   }
 
   toggleAllDatasets(): void {
-    if (this.datasetSelectionState === 'all') {
-      this.selectedDatasetIds.clear();
-    } else {
-      for (const d of this.datasets) {
-        this.selectedDatasetIds.add(d.id);
-      }
-    }
-    this.pushTopBarLabels();
+    this.dashSelection.toggleAll('dataset', this.datasets.map((d) => d.id));
     this.preloadSelectedEmbedders();
   }
 
@@ -688,7 +611,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     for (const dataset of targets) {
       this.datasetsRegistryApi.deleteRegistered(dataset.id).subscribe({
         next: () => {
-          this.selectedDatasetIds.delete(dataset.id);
+          this.dashSelection.deselect('dataset', dataset.id);
           if (this.activeContext.datasetId === dataset.id || this.activeContext.intentDatasetId === dataset.id) {
             this.activeContext.setActivePair('', '');
           }
@@ -707,57 +630,23 @@ export class DashboardComponent implements OnInit, OnDestroy {
   // --- Model selection ---
 
   toggleDetectorSelection(id: string, event: MouseEvent): void {
-    this.applyDetectorSelection(id, event.ctrlKey || event.metaKey);
-  }
-
-  /** Detector counterpart to `applyDatasetSelection`; see that method. */
-  private applyDetectorSelection(id: string, additive: boolean): void {
-    if (additive) {
-      if (this.selectedDetectorIds.has(id)) {
-        this.selectedDetectorIds.delete(id);
-      } else {
-        this.selectedDetectorIds.add(id);
-      }
-    } else {
-      if (this.selectedDetectorIds.has(id) && this.selectedDetectorIds.size === 1) {
-        this.selectedDetectorIds.clear();
-      } else {
-        this.selectedDetectorIds.clear();
-        this.selectedDetectorIds.add(id);
-      }
-    }
-    this.pushTopBarLabels();
+    this.dashSelection.toggle('detector', id, event.ctrlKey || event.metaKey);
   }
 
   isDetectorSelected(id: string): boolean {
-    return this.selectedDetectorIds.has(id);
+    return this.dashSelection.has('detector', id);
   }
 
   toggleDetectorCheckbox(id: string): void {
-    if (this.selectedDetectorIds.has(id)) {
-      this.selectedDetectorIds.delete(id);
-    } else {
-      this.selectedDetectorIds.add(id);
-    }
-    this.pushTopBarLabels();
+    this.dashSelection.toggle('detector', id, true);
   }
 
-  get detectorSelectionState(): 'none' | 'some' | 'all' {
-    const sel = this.selectedDetectorIds.size;
-    if (sel === 0) return 'none';
-    if (sel >= this.visibleDetectors.length) return 'all';
-    return 'some';
+  get detectorSelectionState(): SelectionState {
+    return this.dashSelection.selectionState('detector', this.visibleDetectors.length);
   }
 
   toggleAllDetectors(): void {
-    if (this.detectorSelectionState === 'all') {
-      this.selectedDetectorIds.clear();
-    } else {
-      for (const m of this.visibleDetectors) {
-        this.selectedDetectorIds.add(m.id);
-      }
-    }
-    this.pushTopBarLabels();
+    this.dashSelection.toggleAll('detector', this.visibleDetectors.map((m) => m.id));
   }
 
   async deleteSelectedDetectors(): Promise<void> {
@@ -783,7 +672,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     for (const model of targets) {
       this.detectorsRegistryApi.deleteFromRegistry(model.id).subscribe({
         next: () => {
-          this.selectedDetectorIds.delete(model.id);
+          this.dashSelection.deselect('detector', model.id);
           if (this.activeContext.modelId === model.id || this.activeContext.intentModelId === model.id) {
             this.activeContext.setActivePair(this.activeContext.datasetId, '');
           }
@@ -865,7 +754,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (!ok) return;
     this.datasetsRegistryApi.deleteRegistered(dataset.id).subscribe({
       next: () => {
-        this.selectedDatasetIds.delete(dataset.id);
+        this.dashSelection.deselect('dataset', dataset.id);
         if (this.activeContext.datasetId === dataset.id || this.activeContext.intentDatasetId === dataset.id) {
           this.activeContext.setActivePair('', '');
         }
@@ -931,8 +820,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   setDetectorAutorun(model: DetectorRegistryEntry, autorun: boolean): void {
     this.detectorsRegistryApi.setAutofind(model.id, autorun).subscribe({
       next: () => {
-        this.selectedDetectorIds.delete(model.id);
-        this.pushTopBarLabels();
+        this.dashSelection.deselect('detector', model.id);
         this.datasetState.refresh();
       },
       error: () => {
@@ -953,7 +841,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     if (!ok) return;
     this.detectorsRegistryApi.deleteFromRegistry(model.id).subscribe({
       next: () => {
-        this.selectedDetectorIds.delete(model.id);
+        this.dashSelection.deselect('detector', model.id);
         if (this.activeContext.modelId === model.id || this.activeContext.intentModelId === model.id) {
           this.activeContext.setActivePair(this.activeContext.datasetId, '');
         }

--- a/frontend/src/app/services/dashboard-selection.service.spec.ts
+++ b/frontend/src/app/services/dashboard-selection.service.spec.ts
@@ -1,0 +1,168 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ActiveContextService } from './active-context.service';
+import { DashboardSelectionService } from './dashboard-selection.service';
+import { DatasetStateService } from './dataset-state.service';
+import { DatasetRegistryEntry } from '../models/api.models';
+import { DetectorRegistryEntry } from '../generated/api-client/models/detector-registry-entry';
+import { provideZoneless } from '../testing/zoneless-testbed';
+import { provideHttpTesting } from '../testing/test-providers';
+
+/**
+ * The Dashboard's table selection lives here rather than in the component, so
+ * the top bar reads it directly instead of being pushed to after every
+ * mutation. These specs pin the ladder both grids share, the registry
+ * filtering the pulldown depends on, and the single intent mirror that
+ * replaced the old `pushTopBarLabels()` call sites.
+ */
+describe('DashboardSelectionService', () => {
+  let service: DashboardSelectionService;
+  let datasetState: DatasetStateService;
+  let activeContext: ActiveContextService;
+
+  /** Push registry contents straight into the signal-backed state (no HTTP),
+   *  the same way the pulldown spec seeds it. */
+  function setRegistry(datasetIds: string[], detectorIds: string[] = []): void {
+    const ds = datasetState as unknown as {
+      _datasets: { set: (v: unknown) => void };
+      _detectors: { set: (v: unknown) => void };
+    };
+    ds._datasets.set(datasetIds.map((id) => ({ id, name: id }) as DatasetRegistryEntry));
+    ds._detectors.set(detectorIds.map((id) => ({ id, name: id }) as DetectorRegistryEntry));
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [...provideZoneless(), ...provideHttpTesting()],
+    });
+    service = TestBed.inject(DashboardSelectionService);
+    datasetState = TestBed.inject(DatasetStateService);
+    activeContext = TestBed.inject(ActiveContextService);
+    setRegistry(['d1', 'd2', 'd3'], ['m1', 'm2']);
+  });
+
+  describe('the shared toggle ladder', () => {
+    it('single-selects, and toggles off when re-picking the sole selection', () => {
+      service.toggle('dataset', 'd1', false);
+      expect([...service.ids('dataset')]).toEqual(['d1']);
+      service.toggle('dataset', 'd2', false);
+      expect([...service.ids('dataset')]).toEqual(['d2']);
+      service.toggle('dataset', 'd2', false);
+      expect([...service.ids('dataset')]).toEqual([]);
+    });
+
+    it('replaces a multi-selection with a plain pick rather than toggling off', () => {
+      service.selectOnly('dataset', ['d1', 'd2']);
+      service.toggle('dataset', 'd1', false);
+      expect([...service.ids('dataset')]).toEqual(['d1']);
+    });
+
+    it('adds and removes with the additive (Ctrl/Cmd, or checkbox) modifier', () => {
+      service.toggle('dataset', 'd1', true);
+      service.toggle('dataset', 'd2', true);
+      expect([...service.ids('dataset')].sort()).toEqual(['d1', 'd2']);
+      service.toggle('dataset', 'd1', true);
+      expect([...service.ids('dataset')]).toEqual(['d2']);
+    });
+
+    it('runs the same ladder for detectors, independently of datasets', () => {
+      service.toggle('dataset', 'd1', false);
+      service.toggle('detector', 'm1', false);
+      service.toggle('detector', 'm1', false);
+      expect([...service.ids('dataset')]).toEqual(['d1']);
+      expect([...service.ids('detector')]).toEqual([]);
+    });
+  });
+
+  describe('select-all and the header tri-state', () => {
+    it('reports none / some / all against the rows the grid shows', () => {
+      expect(service.selectionState('dataset', 3)).toBe('none');
+      service.toggle('dataset', 'd1', true);
+      expect(service.selectionState('dataset', 3)).toBe('some');
+      service.selectOnly('dataset', ['d1', 'd2', 'd3']);
+      expect(service.selectionState('dataset', 3)).toBe('all');
+    });
+
+    it('selects exactly the visible rows, then clears when they are all picked', () => {
+      // The detector grid passes only its visible tab's rows.
+      service.toggleAll('detector', ['m1']);
+      expect([...service.ids('detector')]).toEqual(['m1']);
+      service.toggleAll('detector', ['m1']);
+      expect([...service.ids('detector')]).toEqual([]);
+    });
+  });
+
+  it('prunes ids that have left the registry, and keeps the rest', () => {
+    service.selectOnly('dataset', ['d1', 'd2']);
+    service.retain('dataset', new Set(['d2', 'd3']));
+    expect([...service.ids('dataset')]).toEqual(['d2']);
+  });
+
+  it('drops one id on deselect and leaves an absent id alone', () => {
+    service.selectOnly('dataset', ['d1', 'd2']);
+    service.deselect('dataset', 'd1');
+    service.deselect('dataset', 'd9');
+    expect([...service.ids('dataset')]).toEqual(['d2']);
+  });
+
+  it('clears the detector selection when the grid tab changes, but not on a no-op switch', () => {
+    service.selectOnly('detector', ['m1']);
+    service.setDetectorTab('drafts');
+    expect([...service.ids('detector')]).toEqual(['m1']);
+    service.setDetectorTab('autorun');
+    expect(service.detectorTab()).toBe('autorun');
+    expect([...service.ids('detector')]).toEqual([]);
+  });
+
+  describe('the ids the top bar reads', () => {
+    it('filters to rows that still exist, in registry order', () => {
+      service.selectOnly('dataset', ['d3', 'd1', 'gone']);
+      expect(service.datasetIds()).toEqual(['d1', 'd3']);
+    });
+
+    it('follows the registry when a selected row disappears, before any prune', () => {
+      service.selectOnly('detector', ['m1', 'm2']);
+      expect(service.detectorIds()).toEqual(['m1', 'm2']);
+      setRegistry(['d1'], ['m2']);
+      expect(service.detectorIds()).toEqual(['m2']);
+    });
+  });
+
+  describe('mirroring a lone pick into the active-context intent', () => {
+    it('mirrors an unambiguous single selection while the Dashboard is up', () => {
+      service.setDashboardVisible(true);
+      service.toggle('dataset', 'd1', false);
+      service.toggle('detector', 'm2', false);
+      TestBed.tick();
+      expect(activeContext.intentDatasetId).toBe('d1');
+      expect(activeContext.intentModelId).toBe('m2');
+    });
+
+    it('leaves a loaded pair alone on an empty or multiple selection', () => {
+      activeContext.setActivePair('d3', 'm1');
+      service.setDashboardVisible(true);
+      service.selectOnly('dataset', ['d1', 'd2']);
+      TestBed.tick();
+      expect(activeContext.intentDatasetId).toBe('d3');
+      expect(activeContext.intentModelId).toBe('m1');
+    });
+
+    it('does not mirror while the Dashboard is off screen', () => {
+      activeContext.setActivePair('d3', 'm1');
+      service.toggle('dataset', 'd1', false);
+      TestBed.tick();
+      expect(activeContext.intentDatasetId).toBe('d3');
+    });
+  });
+
+  it('keeps the selection when the Dashboard unmounts, so a round trip restores it', () => {
+    service.setDashboardVisible(true);
+    service.selectOnly('dataset', ['d2']);
+    service.setDetectorTab('autorun');
+    service.setDashboardVisible(false);
+    expect([...service.ids('dataset')]).toEqual(['d2']);
+    service.setDashboardVisible(true);
+    expect([...service.ids('dataset')]).toEqual(['d2']);
+    expect(service.detectorTab()).toBe('autorun');
+  });
+});

--- a/frontend/src/app/services/dashboard-selection.service.ts
+++ b/frontend/src/app/services/dashboard-selection.service.ts
@@ -1,74 +1,197 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { computed, effect, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import { ActiveContextService } from './active-context.service';
+import { DatasetStateService } from './dataset-state.service';
 
 export type SelectionKind = 'dataset' | 'detector';
 
+/** Which detector-grid tab is showing: Drafts (editable, `!autofind`) or
+ *  AutoRun (frozen, `autofind` — auto-run against each dataset on import).
+ *  A detector lives in exactly one tab; the ⋯ menu moves it between them. */
+export type DetectorTab = 'drafts' | 'autorun';
+
+/** Header master-checkbox tri-state for one grid. */
+export type SelectionState = 'none' | 'some' | 'all';
+
 /**
- * Bridges the Dashboard's table row-selection to the top-bar
- * `vt-context-pulldown`s so the blue bar reflects what the user has
- * highlighted, not merely what is loaded into the backend.
+ * Owns the Dashboard's table row-selection, so the top-bar
+ * `vt-context-pulldown`s can show what the user has highlighted rather than
+ * merely what is loaded into the backend.
  *
  * Two selection concepts coexist:
  *  - **active/loaded context** (`ActiveContextService`) — the pair the
  *    backend has loaded, which the pulldown shows on the label/find/browse
  *    views (there are no tables there to select from).
- *  - **table selection** (the Dashboard's `selectedDatasetIds` /
- *    `selectedDetectorIds`) — the highlighted rows that drive Train / Find /
- *    Combine / Delete.
+ *  - **table selection** (this service) — the highlighted rows that drive
+ *    Train / Find / Combine / Delete.
  *
- * While the Dashboard is on screen the pulldown mirrors the *table
- * selection* (this service); once the user navigates away the Dashboard is
- * destroyed, `dashboardVisible` flips to false, and the pulldown falls back
- * to the active/loaded context. That view-awareness rides on the Dashboard's
+ * While the Dashboard is on screen the pulldown reads the *table selection*
+ * from here; once the user navigates away the Dashboard is destroyed,
+ * `dashboardVisible` flips to false, and the pulldown falls back to the
+ * active/loaded context. That view-awareness rides on the Dashboard's
  * component lifecycle rather than the router, so it needs no URL parsing.
+ *
+ * The selection itself is *not* tied to that lifecycle: it lives here, in a
+ * root singleton, so a round trip to the label view and back leaves the same
+ * rows highlighted (and the same names in the top bar) rather than resetting
+ * to whatever the registry auto-selects. `detectorTab` lives here for the
+ * same reason — "selection is per-tab" has to survive the round trip too,
+ * or a returning user gets a hidden selection feeding the section actions.
+ *
+ * Everything a template or pulldown reads is a signal, so there is no mirror
+ * to push and no push to forget: `datasetIds` / `detectorIds` are `computed`
+ * over the selection and the registry, and the one write-out that isn't a
+ * read (mirroring an unambiguous single pick into the active-context intent)
+ * is a single `effect` rather than a call at every mutation site.
  */
 @Injectable({ providedIn: 'root' })
 export class DashboardSelectionService {
-  /** True while the Dashboard component is mounted. Set in its
+  private datasetState = inject(DatasetStateService);
+  private activeContext = inject(ActiveContextService);
+
+  private readonly visible = signal(false);
+  /** True while the Dashboard component is mounted. Set from its
    *  `ngOnInit` / `ngOnDestroy`. */
-  private readonly dashboardVisibleSubject = new BehaviorSubject<boolean>(false);
-  readonly dashboardVisible$ = this.dashboardVisibleSubject.asObservable();
+  readonly dashboardVisible: Signal<boolean> = this.visible.asReadonly();
 
-  /** Currently-selected dataset / detector ids, mirrored from the
-   *  Dashboard's selection Sets (filtered to ids that still exist in the
-   *  registry, so counts stay accurate). */
-  private readonly datasetIdsSubject = new BehaviorSubject<string[]>([]);
-  private readonly detectorIdsSubject = new BehaviorSubject<string[]>([]);
-  readonly datasetIds$ = this.datasetIdsSubject.asObservable();
-  readonly detectorIds$ = this.detectorIdsSubject.asObservable();
+  /** The selected ids per grid. Held as immutable `Set`s behind signals:
+   *  every mutation publishes a fresh Set, so a template read (or a
+   *  `computed`) is notified — a mutated-in-place Set is not. */
+  private readonly sets: Record<SelectionKind, WritableSignal<ReadonlySet<string>>> = {
+    dataset: signal<ReadonlySet<string>>(new Set<string>()),
+    detector: signal<ReadonlySet<string>>(new Set<string>()),
+  };
 
-  /** Pulldown → Dashboard: request a plain (non-additive) single-select of
-   *  one id, exactly as if the user had clicked that table row. */
-  private readonly selectRequestSubject = new Subject<{ kind: SelectionKind; id: string }>();
-  readonly selectRequest$ = this.selectRequestSubject.asObservable();
+  private readonly tab = signal<DetectorTab>('drafts');
+  readonly detectorTab: Signal<DetectorTab> = this.tab.asReadonly();
 
-  get dashboardVisible(): boolean {
-    return this.dashboardVisibleSubject.value;
-  }
+  /** Selected ids that still exist in the registry, in registry order.
+   *  Filtered so a row deleted out from under the selection can't inflate
+   *  the pulldown's "Multiple" count before the prune lands. */
+  readonly datasetIds = computed(() =>
+    this.datasetState.datasets.filter((d) => this.sets.dataset().has(d.id)).map((d) => d.id),
+  );
+  readonly detectorIds = computed(() =>
+    this.datasetState.detectors.filter((d) => this.sets.detector().has(d.id)).map((d) => d.id),
+  );
 
-  get datasetIds(): string[] {
-    return this.datasetIdsSubject.value;
-  }
-
-  get detectorIds(): string[] {
-    return this.detectorIdsSubject.value;
+  constructor() {
+    // While the Dashboard is on screen the pulldowns read the selection
+    // above; the moment it unmounts they fall back to the active-context
+    // *intent*. Without also mirroring a lone pick into that intent, a
+    // freshly imported/created (implicitly selected) item is forgotten by
+    // the pulldowns as soon as you leave the Dashboard by any route that
+    // doesn't load a context — the picker snaps back to "Select a …".
+    // Mirror only an unambiguous single selection; a 0- or multi-selection
+    // leaves intent untouched so we never blank out the intent of an
+    // already-loaded pair. Intent-only (never `setActive`), so the HTTP
+    // interceptor keeps tagging the still-loaded pair, per the H25
+    // intent/active split.
+    effect(() => {
+      const datasetIds = this.datasetIds();
+      const detectorIds = this.detectorIds();
+      if (!this.dashboardVisible()) return;
+      const soleDataset = datasetIds.length === 1 ? datasetIds[0] : this.activeContext.intentDatasetId;
+      const soleDetector =
+        detectorIds.length === 1 ? detectorIds[0] : this.activeContext.intentModelId;
+      this.activeContext.setIntent(soleDataset, soleDetector);
+    });
   }
 
   setDashboardVisible(visible: boolean): void {
-    if (this.dashboardVisibleSubject.value !== visible) {
-      this.dashboardVisibleSubject.next(visible);
+    this.visible.set(visible);
+  }
+
+  /** Switch detector-grid tabs. Selection is per-tab: a hidden selection
+   *  would silently feed the section actions and the Train/Find buttons, so
+   *  it's cleared on every switch. */
+  setDetectorTab(tab: DetectorTab): void {
+    if (this.tab() === tab) return;
+    this.tab.set(tab);
+    this.clear('detector');
+  }
+
+  // --- Selection reads ---
+
+  /** The raw selected-id set for one grid, unfiltered by the registry. */
+  ids(kind: SelectionKind): ReadonlySet<string> {
+    return this.sets[kind]();
+  }
+
+  has(kind: SelectionKind, id: string): boolean {
+    return this.sets[kind]().has(id);
+  }
+
+  count(kind: SelectionKind): number {
+    return this.sets[kind]().size;
+  }
+
+  /** Tri-state for the grid's header master-checkbox. `total` is the number
+   *  of rows the grid currently *shows* (the detector grid's visible tab, not
+   *  the whole registry). */
+  selectionState(kind: SelectionKind, total: number): SelectionState {
+    const selected = this.count(kind);
+    if (selected === 0) return 'none';
+    return selected >= total ? 'all' : 'some';
+  }
+
+  // --- Selection writes ---
+
+  /**
+   * The row-click ladder, shared by both grids and by the top-bar pulldown.
+   * `additive` (Ctrl/Cmd, or a checkbox click) toggles a single id in/out of
+   * a multi-selection; otherwise it's a plain single-select that toggles off
+   * when it's already the sole pick.
+   */
+  toggle(kind: SelectionKind, id: string, additive: boolean): void {
+    const current = this.sets[kind]();
+    if (additive) {
+      const next = new Set(current);
+      if (!next.delete(id)) next.add(id);
+      this.write(kind, next);
+    } else if (current.has(id) && current.size === 1) {
+      this.write(kind, new Set());
+    } else {
+      this.write(kind, new Set([id]));
     }
   }
 
-  setDatasetIds(ids: string[]): void {
-    this.datasetIdsSubject.next(ids);
+  /** Select-all ladder for the header master-checkbox: clear when everything
+   *  visible is already picked, otherwise pick exactly the visible rows. */
+  toggleAll(kind: SelectionKind, visibleIds: string[]): void {
+    if (this.selectionState(kind, visibleIds.length) === 'all') this.write(kind, new Set());
+    else this.write(kind, new Set(visibleIds));
   }
 
-  setDetectorIds(ids: string[]): void {
-    this.detectorIdsSubject.next(ids);
+  /** Replace the selection outright (used by the registry auto-select). */
+  selectOnly(kind: SelectionKind, ids: Iterable<string>): void {
+    this.write(kind, new Set(ids));
   }
 
-  requestSelect(kind: SelectionKind, id: string): void {
-    this.selectRequestSubject.next({ kind, id });
+  clear(kind: SelectionKind): void {
+    this.write(kind, new Set());
+  }
+
+  /** Drop one id (a row the user just deleted). */
+  deselect(kind: SelectionKind, id: string): void {
+    const current = this.sets[kind]();
+    if (!current.has(id)) return;
+    const next = new Set(current);
+    next.delete(id);
+    this.write(kind, next);
+  }
+
+  /** Prune the selection to ids that still exist in the registry. */
+  retain(kind: SelectionKind, existing: ReadonlySet<string>): void {
+    const current = this.sets[kind]();
+    const next = new Set([...current].filter((id) => existing.has(id)));
+    this.write(kind, next);
+  }
+
+  /** Publish a new set, skipping the write when nothing changed so an
+   *  idempotent prune/reselect doesn't re-run every downstream `computed`. */
+  private write(kind: SelectionKind, next: ReadonlySet<string>): void {
+    const current = this.sets[kind]();
+    if (current.size === next.size && [...next].every((id) => current.has(id))) return;
+    this.sets[kind].set(next);
   }
 }


### PR DESCRIPTION
The Dashboard held its row selection in two plain `Set`s and hand-mirrored them into `DashboardSelectionService` with `pushTopBarLabels()` after every mutation — **eleven** call sites (the issue counted seven), no guard, and nothing to catch the twelfth. The dataset and detector ladders were structural twins, and the top bar could only be driven by the pulldown pushing a `selectRequest$` back into a *mounted* Dashboard.

## What changed

The service owns the state now:

- **One ladder, two grids.** Two signals hold the selected ids (immutable `Set`s, republished on every write) behind `toggle(kind, id, additive)` plus `toggleAll` / `selectOnly` / `retain` / `deselect`. The `applyDatasetSelection` / `applyDetectorSelection` twins and their `isXSelected` / `toggleXCheckbox` / `xSelectionState` / `toggleAllX` siblings collapse into delegations, and the two registry-reconcile blocks in `ngOnInit` become one kind-parameterised `reconcileSelection`.
- **`pushTopBarLabels` is a `computed`.** `datasetIds` / `detectorIds` derive from the selection and the registry, so the method and all eleven call sites are gone. The one thing that was a *write* rather than a read — mirroring an unambiguous single pick into the active-context intent — is a single `effect`, gated on `dashboardVisible` exactly as the old code was gated on being mounted.
- **`selectRequest$` is deleted.** The pulldown calls `toggle(...)` directly, and reads the three signals through one `effect` instead of three subscriptions (per `docs/FRONTEND.md` §5, "consumers use `effect()`, not `subscribe()`").
- The Dashboard keeps `selectedDatasetIds` / `selectedDetectorIds` as **read-only getters** over those signals, so its ~60 read sites are unchanged — and now repaint through signal tracking rather than incidentally, since a mutated-in-place `Set` notified nobody.

Net: −286 / +564 across the diff, with the Dashboard component itself losing ~130 lines.

## Two behaviour changes, both in the user's favour

They fall out of the state outliving the component, and are deliberate:

- **The selection survives leaving the Dashboard.** Before, going to Train and back dropped the highlighted rows and blanked the top bar to "Select a dataset" — even though the pair you had just opened was still loaded. Reproduced in chromium against `dev`; fixed here.
- **`detectorTab` moves into the service** with the selection it scopes, so a returning user can't land on Drafts with a hidden AutoRun row still feeding the section actions.

One smaller fix in the same path: the pulldown's add-new handoff now calls `selectOnly` rather than the pick ladder — it means "make the new thing the selection", and the ladder would toggle it back *off* if the Dashboard's own auto-select got there first (today that's only avoided by subscription ordering).

## Verification

- `./run-tests.sh` full: **RUN PASSED** — 9668 passed, all gates green.
- New `dashboard-selection.service.spec.ts` (15 cases: the ladder, select-all tri-state, prune, tab-clearing, registry filtering, the intent mirror's three cases, the round trip). New Dashboard spec for the round trip, and a pulldown spec asserting the **rendered** trigger label repaints from a service-side selection change with no Dashboard in the TestBed — that one fails if the `effect` is removed (verified by sabotage).
- **Real chromium** (`launchChromium()`), not only jsdom, with the registry faked at the network layer: the bar tracks table clicks, ctrl-click collapses to "Multiple", a pulldown pick selects the row and re-picking clears it, and both halves survive leaving via **Train** and returning via the top bar's **Dashboard** button. The same script against `dev` fails the four round-trip checks — that's the papercut above.

No screenshot reshoot: the markup and classes are unchanged, and `capture.ts`'s `h.dashboard()` full-page-loads before every shot, so no shot can see the cross-navigation persistence.

Closes #3445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CwoWKQHw3qkJZKqdXQyeA

---
_Generated by [Claude Code](https://claude.ai/code/session_016CwoWKQHw3qkJZKqdXQyeA)_