### PR TITLE
Make the calibration experiment defaults match the shipped algorithm

### DIFF
--- a/docs/plans/calibration-experiment.md
+++ b/docs/plans/calibration-experiment.md
@@ -40,7 +40,10 @@ strategy.
   2 seeds (4-GPU QOS cap) and only measured the sign-corrected `pnorm` on the
   post-#2784 pass. A 4-seed replication would tighten the tree regret Wilcoxon
   (currently p = 0.013 at 2 seeds) and give `pnorm` a clean, non-inverted read
-  from t = 0.
+  from t = 0. Both the tree geometry and the re-pools are **opt-in** since #3400
+  (they were defaults, and every analyzer discards their rows), so this re-run
+  sets `CALIB_PATCH_STYLES=max_patch,max_patch_pca_hac
+  CALIB_REPOOL_VARIANTS=topk,pnorm` and declares `patch_style` to preflight.
 
 <!-- item-sep -->
 

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -87,12 +87,23 @@ files here are how it was produced.
 | Dataset | Embedder | Style(s) | Calibration |
 |---|---|---|---|
 | `visual_genome_m` | `siglip`, `siglip_l` | `whole_image` | row-wise |
-| `visual_genome_m` | `dinov3_patch` | `max_patch`, `max_patch_pca_hac` | grouped (bag max-pool) |
+| `visual_genome_m` | `dinov3_patch` | `max_patch` | grouped (bag max-pool) |
 | `caltech101_m` | `siglip`, `siglip_l` | `whole_image` | row-wise |
 
-The `max_patch_pca_hac` arm additionally emits two **remedial re-pools** of its
-own per-node scores (`topk` k=4, `pnorm` extreme-value normalisation), each with
-its own recalibrated threshold, tagged in the `pool_variant` column.
+Two #2781 arms are **off by default** now that their questions are closed, and a
+study that wants either adds it back explicitly (and declares the divergence to
+`preflight.sh`):
+
+- `max_patch_pca_hac` (`CALIB_PATCH_STYLES`) — the raw-patch tree geometry. It
+  lost the Max-Patch study at the operating point (PR #2749) and #2886 removed
+  the tree it delegates to from ingest, so carrying it doubled the GPU cost of
+  every patch cell to measure a geometry production does not have.
+- `topk` / `pnorm` (`CALIB_REPOOL_VARIANTS`) — the **remedial re-pools** of that
+  arm's own per-node scores (`topk` k=4, `pnorm` extreme-value normalisation),
+  each with its own recalibrated threshold, tagged in the `pool_variant` column.
+  Both failed (`docs/plans/set-scorer-experiment.md`), and every analyzer filters
+  `pool_variant` back down to the base rows, so the arms produced rows nothing
+  reads.
 
 ## Stages
 
@@ -108,9 +119,11 @@ its own recalibrated threshold, tagged in the `pool_variant` column.
    deliverables, writes `results/summary.json`, `results/agg/*.csv`,
    `results/figures/*.png`, and a `results/REPORT.md` draft.
 
-Under `CALIB_SAFE_THRESHOLDS=1` each step also emits one row per **cut variant**
-(`gmm_variant`; `_SAFE_GMM_VARIANTS`) and a per-(step, geometry) **cut
-decomposition** frame (`CUT_DIAGNOSTIC_COLUMNS`) to `task_<idx>__cutdiag.csv`.
+On the fused threshold path (`CALIB_SAFE_THRESHOLDS`, **on by default** since
+#3400 because the app has had no switch since #2799) each step also emits one row
+per **cut variant** (`gmm_variant`; `_SAFE_GMM_VARIANTS`) and a per-(step,
+geometry) **cut decomposition** frame (`CUT_DIAGNOSTIC_COLUMNS`) to
+`task_<idx>__cutdiag.csv`.
 Two alternative analyzers read those: `analyze_safe.py` (the #2799 safe-on/off
 question) and `analyze_cut.py` (the #2836 question of *which* cut and *why*).
 
@@ -152,8 +165,14 @@ alongside them harmlessly), and writes all study output under
 ## Fixed config (pre-registered)
 
 `inclusion=0` (cost = FPR + FNR), `sim_fraction=0.5`, `calibrate_count=2`,
-`calibration_fraction=0.5`, `safe_thresholds=False`, MLP trainer, 150 votes,
-4 seeds. Env knobs mirror the `MAXPATCH_*` set under the `CALIB_*` prefix.
+`calibration_fraction=0.5`, MLP trainer, 150 votes, 4 seeds. Env knobs mirror
+the `MAXPATCH_*` set under the `CALIB_*` prefix.
+
+`safe_thresholds` was pre-registered `False` here and is **`True` now** (#3400):
+#2781 pre-registered the unfused control while it was still a shipped path, and
+#2799 removed the switch from the app. A default is only "what a user gets" for
+as long as the app agrees, so this one follows the app and a study wanting the
+control sets `CALIB_SAFE_THRESHOLDS=0` and declares the divergence.
 
 ## Safe-threshold GMM study (issue #2799)
 
@@ -162,7 +181,8 @@ cd /exp/$USER/projects/vts-calib/scripts/experiments/calibration
 bash launch_safe.sh      # safe_thresholds ON, VG only, 30 votes, 8 seeds
 ```
 
-`launch_safe.sh` re-drives the same pipeline with `CALIB_SAFE_THRESHOLDS=1`:
+`launch_safe.sh` re-drives the same pipeline on the fused path (pinned with
+`CALIB_SAFE_THRESHOLDS=1`, which is also the default since #3400):
 every step then emits one extra row per safe-threshold GMM variant
 (`gmm_variant` column — fit geometry x cut rule x fit space, plus an
 `xcal_only` control), and the analyze stage runs `analyze_safe.py` instead of

--- a/scripts/experiments/calibration/experiment_config.py
+++ b/scripts/experiments/calibration/experiment_config.py
@@ -9,8 +9,10 @@ which opens on one space's text sort and learns in another's:
 
 * ``visual_genome_m`` (boxed; ground-truth regions):
   ``siglip`` / ``siglip_l`` × ``whole_image`` (row-wise conformal), and
-  ``dinov3_patch`` × {``max_patch``, ``max_patch_pca_hac``} (grouped bag
-  calibration).
+  ``dinov3_patch`` × ``max_patch`` (grouped bag calibration).  The raw-patch
+  tree geometry ``max_patch_pca_hac`` and its ``topk`` / ``pnorm`` re-pools were
+  #2781 arms and are off by default now that both questions are closed; see
+  :data:`PATCH_STYLES` and :data:`REPOOL_VARIANTS`.
 
   **Only the ``dinov3_patch`` arms actually region-vote.** Region voting needs a
   stored ``patch_grid`` to pool the dragged box and ``patch_regions`` to
@@ -18,8 +20,7 @@ which opens on one space's text sort and learns in another's:
   :data:`REGION_VOTING_BY_DATASET` degrades to whole-image training *and*
   whole-image scoring for them, and they blend under the **binary** schedule.
   This docstring previously called the whole set "region voting", which is how
-  #2877 came to report a binary-voting environment as a region-voting one.  The raw-patch tree arm additionally re-pools its own per-node
-  scores under ``topk`` and ``pnorm`` (remedial variants, emitted as extra rows).
+  #2877 came to report a binary-voting environment as a region-voting one.
 * ``caltech101_m`` (binary voting; boxless): ``siglip`` / ``siglip_l`` ×
   ``whole_image`` only — the ordinary row-wise conformal path most users hit.
 
@@ -336,12 +337,32 @@ def region_voting_for(dataset: str, embedder: str) -> bool:
 
 
 # --- Styles per embedder kind ---
-PATCH_STYLES = os.environ.get("CALIB_PATCH_STYLES", "max_patch,max_patch_pca_hac").split(",")
+#: Patch geometries every patch-capable arm runs.  **The shipped one, alone**
+#: (kept a literal rather than importing ``PRODUCTION_PATCH_STYLE``, because
+#: this module is imported by tooling that has no vtscore tree; preflight
+#: check 12 is what holds the two together).
+#:
+#: This default used to be ``max_patch,max_patch_pca_hac``, because the #2781
+#: study wanted that contrast - and a study default is not a shipped default
+#: (``lessons/2026-08-12-a-study-default-is-not-a-shipped-default.md``).
+#: ``max_patch_pca_hac`` lost the Max-Patch study at the operating point
+#: (PR #2749) and #2886 removed the HAC tree it delegates to from ingest, so
+#: carrying it here doubled the GPU cost of every patch cell to measure a
+#: geometry production does not have.  A study that wants the tree arm back
+#: adds it explicitly and declares the divergence.
+PATCH_STYLES = os.environ.get("CALIB_PATCH_STYLES", "max_patch").split(",")
 SINGLE_STYLES = ["whole_image"]
 
 #: The style whose per-node scores get re-pooled into the remedial arms.
 REPOOL_STYLE = "max_patch_pca_hac"
-REPOOL_VARIANTS = [v for v in os.environ.get("CALIB_REPOOL_VARIANTS", "topk,pnorm").split(",") if v]
+#: The #2781 re-pool arms, **off by default: the question is closed.**  Both
+#: pre-registered fixed re-pools failed (``docs/plans/set-scorer-experiment.md``:
+#: ``topk`` made regret worse, sign-corrected ``pnorm`` closed ~21% of the gap),
+#: and every analyzer filters ``pool_variant`` back down to the base rows
+#: (``_cells_io.BASE_POOL_VARIANTS``), so the arms cost a re-calibration and a
+#: re-pool per step per cell to produce rows nothing reads.  The live version of
+#: the question is learned set-pooling, not another fixed rule.
+REPOOL_VARIANTS = [v for v in os.environ.get("CALIB_REPOOL_VARIANTS", "").split(",") if v]
 REPOOL_TOPK = int(os.environ.get("CALIB_REPOOL_TOPK", "4"))
 
 #: Inclusion values the fold orderings are re-thresholded at for the budget sweep.
@@ -454,9 +475,24 @@ def exclusion_arm_name() -> str:
     return f"f{EXCLUSION_MIN_REMAINDER:g}"
 
 
-#: The #2781 study pre-registered safe_thresholds OFF (conformal path only);
-#: the #2799 safe-threshold GMM study flips this on via CALIB_SAFE_THRESHOLDS=1.
-SAFE_THRESHOLDS = os.environ.get("CALIB_SAFE_THRESHOLDS", "0") == "1"
+#: The **shipped** threshold path: fuse the haystack into the cut.  `docs/ML.md`:
+#: "Every trained threshold fuses the haystack into the cut.  There is no
+#: setting for this."  The app has had no switch since #2799, so an unset knob
+#: has to resolve to the fused path or the harness measures a detector nobody
+#: has.
+#:
+#: This defaulted to ``"0"`` until #3400 - the #2781-era pre-registered control,
+#: which was a shipped default when #2781 ran and stopped being one when #2799
+#: shipped.  Twenty-one launchers papered over it with an explicit
+#: ``CALIB_SAFE_THRESHOLDS=1``; the ones that (correctly) set no behavioural knob
+#: at all - ``launch_bench.sh`` and ``launch_scale.sh`` among them, both of which
+#: say in their own headers that they ride shipped defaults on purpose - silently
+#: measured the unfused control.  Same failure family as
+#: ``lessons/2026-08-12-a-study-default-is-not-a-shipped-default.md``.
+#:
+#: A study that wants the unfused control sets ``=0`` and declares the
+#: divergence to preflight (``--diverges safe_thresholds``).
+SAFE_THRESHOLDS = os.environ.get("CALIB_SAFE_THRESHOLDS", "1") == "1"
 MEDIA_TYPE = "image"
 
 #: The #2852 anchored-mixture study (design + pre-registered decision rules:
@@ -468,7 +504,12 @@ ANCHORED = os.environ.get("CALIB_ANCHORED", "0") == "1"
 #: Anchor-weight grid: each labelled score counts as this many haystack scores
 #: in the anchored EM.  Log-spaced from "one label = one haystack point" to
 #: "labels dominate the fit" - the fusion knob the sweep exists to place.
-ANCHORED_WEIGHTS = [float(w) for w in os.environ.get("CALIB_ANCHORED_WEIGHTS", "1,3,10,30,100").split(",") if w]
+#:
+#: **The shipped weight comes first.**  The grid was ``1,3,10,30,100`` when the
+#: #2852 sweep placed the knob; #2861 read it, and ``FOLD_ANCHOR_WEIGHT`` shipped
+#: at 0.3 - below the whole grid, so a re-run swept challengers with no shipped
+#: arm to pair them against.  Log-spaced from the shipped value upward.
+ANCHORED_WEIGHTS = [float(w) for w in os.environ.get("CALIB_ANCHORED_WEIGHTS", "0.3,1,3,10,30").split(",") if w]
 #: #3329: emit the goodness-of-fit side frame (``__fitq.csv``).  Off by default
 #: - it costs one extra unanchored EM fit per emitted step per geometry, which
 #: is pure overhead for every study that is not asking whether the mixture fits.
@@ -478,10 +519,14 @@ FIT_QUALITY = os.environ.get("CALIB_FIT_QUALITY", "0") == "1"
 #: trajectory at a fifth of the fit cost of every step.
 FIT_QUALITY_STRIDE = int(os.environ.get("CALIB_FIT_QUALITY_STRIDE", "5"))
 
-#: Cut rules re-cutting each anchored fit: production midpoint, and the
-#: rate-optimal crossing (well-founded on an anchored fit, where the
+#: Cut rules re-cutting each anchored fit: the **shipped** rule first
+#: (``FOLD_ANCHOR_CUT_RULE``, today ``mid_tilt``), then the plain midpoint and
+#: the rate-optimal crossing (well-founded on an anchored fit, where the
 #: components *are* the classes - the #2836 identification term is gone).
-ANCHORED_RULES = [r for r in os.environ.get("CALIB_ANCHORED_RULES", "mid,rate").split(",") if r]
+#: ``mid`` was the shipped rule when #2852 registered this grid and stopped
+#: being one when ``mid_tilt`` shipped, which left the default grid with no
+#: production arm in it - preflight check 12 has flagged it ever since.
+ANCHORED_RULES = [r for r in os.environ.get("CALIB_ANCHORED_RULES", "mid_tilt,mid,rate").split(",") if r]
 #: Fold-anchored + rank-transfer arms cost one sim-set scoring pass per
 #: calibration fold per step; disable to keep only the cheap final-model arms.
 ANCHORED_FOLD_ARMS = os.environ.get("CALIB_ANCHORED_FOLD_ARMS", "1") == "1"

--- a/scripts/experiments/calibration/launch_acq_2877.sh
+++ b/scripts/experiments/calibration/launch_acq_2877.sh
@@ -142,9 +142,12 @@ arm_dir() { printf '%s/%s/%s' "$BASE" "$1" "$2"; }
 
 # --- science knobs -----------------------------------------------------------
 # The SHIPPED threshold path.  `docs/ML.md`: "Every trained threshold fuses the
-# haystack into the cut.  There is no setting for this."  The harness default is
-# the #2781-era unfused control, and the acquisition cut is taken off the FUSED
-# threshold, so leaving this alone would sweep an arm axis that never executes.
+# haystack into the cut.  There is no setting for this."  Named rather than left
+# unset: the acquisition cut is taken off the FUSED threshold, so this is the
+# premise of the arm axis rather than incidental, and the run's path is readable
+# here instead of from a harness default three modules away.  (That default was
+# the #2781-era unfused control until #3400; the pin is what kept this study off
+# it, and is also what keeps it right when submitted into an older worktree.)
 export CALIB_SAFE_THRESHOLDS=1
 # Every arm chains `noop.py`; the analysis is CROSS-ARM and CROSS-MODE and is
 # submitted once, dependent on every array.

--- a/scripts/experiments/calibration/launch_bench.sh
+++ b/scripts/experiments/calibration/launch_bench.sh
@@ -69,16 +69,24 @@ export CALIB_REPOOL_VARIANTS=""
 export CALIB_SCHEDULE_VARIANTS=""
 export CALIB_FOLD_COUNTS=""
 
-# PRODUCTION GEOMETRY ONLY.  The calibration study's default is
-# "max_patch,max_patch_pca_hac" because that study wanted the contrast -- but a
-# *study* default is not a *shipped* default.  Per vtscore/eval/patch_styles.py,
-# `max_patch` IS the production patch pipeline, while the HAC hybrids lost the
-# Max-Patch study at the operating point (PR #2749) and production no longer
-# carries the tree they delegate to; they survive only for an open calibration
-# follow-up.  Running them here would put non-production rows in a benchmark
-# whose whole purpose is "what does a current user get", and would double the
-# cost of every patch cell.
+# PRODUCTION GEOMETRY ONLY.  Per vtscore/eval/patch_styles.py, `max_patch` IS
+# the production patch pipeline, while the HAC hybrids lost the Max-Patch study
+# at the operating point (PR #2749) and production no longer carries the tree
+# they delegate to.  Running them here would put non-production rows in a
+# benchmark whose whole purpose is "what does a current user get", and would
+# double the cost of every patch cell.  (The calibration study's default WAS
+# "max_patch,max_patch_pca_hac" -- a *study* default, not a *shipped* one -- and
+# this pin is why that never reached the benchmark.  #3400 fixed the default
+# itself; the pin stays, because it is also what holds when this launcher
+# submits into an older worktree.)
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
+
+# THE SHIPPED THRESHOLD PATH, for the same reason.  `docs/ML.md`: "Every trained
+# threshold fuses the haystack into the cut.  There is no setting for this."
+# The harness default was the #2781-era unfused control until #3400, so this
+# baseline WAS measuring a threshold no user can get -- the exact hazard the
+# geometry pin above was added for, one knob over.
+export CALIB_SAFE_THRESHOLDS="${CALIB_SAFE_THRESHOLDS:-1}"
 
 LOGS="$CALIB_EXP/logs"
 mkdir -p "$LOGS" "$CALIB_RESULTS/cells"
@@ -108,7 +116,7 @@ ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
 # Explicit, not via --export=ALL.  This one decides whether the run measures the
 # production geometry or silently adds a retired arm, so it must not depend on
 # the submitting shell's environment surviving into the job.
-ENVX="$ENVX CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES"
+ENVX="$ENVX CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES CALIB_SAFE_THRESHOLDS=$CALIB_SAFE_THRESHOLDS"
 
 # A submission is not a launch: --parsable returns an EMPTY id when the submit
 # filter refuses the job (#2897 lost both arms this way).

--- a/scripts/experiments/calibration/launch_calfrac_3287.sh
+++ b/scripts/experiments/calibration/launch_calfrac_3287.sh
@@ -69,10 +69,13 @@ esac
 
 # --- science knobs -----------------------------------------------------------
 # The SHIPPED threshold path.  `docs/ML.md`: "Every trained threshold fuses the
-# haystack into the cut.  There is no setting for this."  The harness default
-# for `CALIB_SAFE_THRESHOLDS` is 0 - the #2781-era unfused control - so leaving
-# it alone would have swept this knob on a threshold nobody ships.  This is
-# exactly what preflight check 12 exists to catch.
+# haystack into the cut.  There is no setting for this."  Named rather than left
+# unset: the fraction this study sweeps splits a fold INSIDE the fused path, so
+# the path is the premise of the sweep, not incidental.  (The harness default
+# was 0 - the #2781-era unfused control - until #3400; the pin is what kept this
+# study off it, and is also what keeps it right when submitted into an older
+# worktree.  Preflight check 12 now reads the resolved value, so an unset knob
+# can no longer pass while the run measures the control.)
 export CALIB_SAFE_THRESHOLDS=1
 # Anchored / fold-count / cut-inclusion arms all stay OFF (their defaults).
 # None of them is on the axis this study sweeps, and the region cell's cost is

--- a/scripts/experiments/calibration/launch_errdump.sh
+++ b/scripts/experiments/calibration/launch_errdump.sh
@@ -131,6 +131,12 @@ ENVX="$ENVX $GRID CALIB_MAX_STEPS=150"
 # raising on a cell that is doing exactly what was asked.
 ENVX="$ENVX CALIB_REQUIRE_OPENING=$OPENING"
 ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
+# The SHIPPED threshold path, pinned rather than inherited.  It defaulted to the
+# #2781-era unfused control until #3400, so a grid written before then ran on a
+# threshold the app cannot produce: dumping its errors under today's default
+# would explain predictions the source cell never made.  Set
+# `CALIB_SAFE_THRESHOLDS=0` to re-run a pre-#3400 cell as it actually ran.
+ENVX="$ENVX CALIB_SAFE_THRESHOLDS=${CALIB_SAFE_THRESHOLDS:-1}"
 ENVX="$ENVX VTS_DUMP_TEST_SCORES=$DUMP"
 
 for spec in "$@"; do

--- a/scripts/experiments/calibration/launch_exclusion_3308.sh
+++ b/scripts/experiments/calibration/launch_exclusion_3308.sh
@@ -93,10 +93,12 @@ esac
 
 # --- science knobs -----------------------------------------------------------
 # The SHIPPED threshold path.  `docs/ML.md`: "Every trained threshold fuses the
-# haystack into the cut.  There is no setting for this."  The harness default
-# for `CALIB_SAFE_THRESHOLDS` is 0 - the #2781-era unfused control - and the
-# exclusion lives INSIDE the fused path, so leaving this alone would sweep an
-# arm axis that never executes.  Preflight check 12 is what catches that.
+# haystack into the cut.  There is no setting for this."  Named rather than left
+# unset: the exclusion lives INSIDE the fused path, so the path is the premise
+# of this study's arm axis rather than incidental.  (The harness default was 0 -
+# the #2781-era unfused control - until #3400; the pin is what kept this study
+# off it, and is also what keeps it right when submitted into an older
+# worktree.)
 export CALIB_SAFE_THRESHOLDS=1
 # Anchored / fold-count / cut-inclusion grids stay OFF (their defaults): none is
 # on this study's axis, and the region cell's cost is dominated by whatever

--- a/scripts/experiments/calibration/launch_fitq_3329.sh
+++ b/scripts/experiments/calibration/launch_fitq_3329.sh
@@ -76,11 +76,14 @@ export CALIB_N_SEEDS="${CALIB_N_SEEDS:-8}"
 export CALIB_MAX_STEPS="${CALIB_MAX_STEPS:-100}"
 export CALIB_CELL_ORDER="${CALIB_CELL_ORDER:-seed}"
 
-# THE SHIPPED PATH, NOT THE HARNESS DEFAULT.  `CALIB_SAFE_THRESHOLDS` defaults
-# to 0, which runs pure cross-calibration - a threshold the app can no longer
-# produce.  This study's whole fold scope reads `FoldAnchoredCut.fits`, which
-# only exists on the fused path, so leaving this at its default would silently
-# emit no fold rows at all and measure the unanchored fit twice.
+# THE SHIPPED PATH, NAMED RATHER THAN INHERITED.  This study's whole fold scope
+# reads `FoldAnchoredCut.fits`, which only exists on the fused path: without it
+# the run silently emits no fold rows at all and measures the unanchored fit
+# twice.  That is the premise of the study, so it is stated here rather than
+# inherited.  (`CALIB_SAFE_THRESHOLDS` defaulted to 0 - pure cross-calibration,
+# a threshold the app can no longer produce - until #3400; the pin is what kept
+# this study off it, and is also what keeps it right when submitted into an
+# older worktree.)
 export CALIB_SAFE_THRESHOLDS=1
 
 # The #3329 frame itself.

--- a/scripts/experiments/calibration/launch_horizon.sh
+++ b/scripts/experiments/calibration/launch_horizon.sh
@@ -31,6 +31,13 @@
 # profile's results dir, not the source's), which is what keeps
 # `_cells_io.assert_one_opening` quiet about them.
 #
+# #3400 opened a second seam of the same kind: `CALIB_SAFE_THRESHOLDS` defaulted
+# to the #2781-era unfused control, so every benchmark grid written before that
+# ran on a threshold the app cannot produce.  A continuation is pinned to the
+# SHIPPED path below, which is the right threshold and the wrong one for
+# reproducing a pre-#3400 grid -- set `CALIB_SAFE_THRESHOLDS=0` to continue one
+# of those verbatim, and read the difference as the seam it is.
+#
 # Per-step cost RISES with the vote count (each Good vote adds patch rows to the
 # training set): measured at 3.7 s/step early against 7.3 s/step at vote 150 for a
 # patch cell, so a horizon extension is superlinear in wall time and has to be
@@ -93,6 +100,7 @@ profile_env() {
   ENVX="$ENVX VTSEARCH_DATA_DIR=$VTSEARCH_DATA_DIR VTSEARCH_MODELS_DIR=$VTSEARCH_MODELS_DIR HF_HOME=$HF_HOME"
   ENVX="$ENVX VTS_REPO=$WT $GRID CALIB_MAX_STEPS=$HORIZON"
   ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
+  ENVX="$ENVX CALIB_SAFE_THRESHOLDS=${CALIB_SAFE_THRESHOLDS:-1}"
   ENVX="$ENVX CALIB_REQUIRE_OPENING=$OPENING"
 }
 

--- a/scripts/experiments/calibration/launch_scale.sh
+++ b/scripts/experiments/calibration/launch_scale.sh
@@ -88,6 +88,12 @@ export CALIB_REPOOL_VARIANTS=""
 export CALIB_SCHEDULE_VARIANTS=""
 export CALIB_FOLD_COUNTS=""
 export CALIB_PATCH_STYLES="${CALIB_PATCH_STYLES:-max_patch}"
+# The SHIPPED threshold path, named for the same reason the geometry above is:
+# "shipped defaults only" is this study's premise, and a harness default is not
+# automatically a shipped one.  `CALIB_SAFE_THRESHOLDS` defaulted to the
+# #2781-era unfused control until #3400, so the band contrast was being read off
+# a threshold no user can get.
+export CALIB_SAFE_THRESHOLDS="${CALIB_SAFE_THRESHOLDS:-1}"
 
 # Declare the opening this study is FOR (#3278), rather than leaving it to be
 # decided per cell by whether a query happens to exist.  The pair guards itself
@@ -164,7 +170,7 @@ ENVX="$ENVX CALIB_N_SEEDS=$CALIB_N_SEEDS CALIB_MAX_STEPS=$CALIB_MAX_STEPS"
 # different cell.
 ENVX="$ENVX CALIB_CELL_ORDER=$CALIB_CELL_ORDER"
 ENVX="$ENVX CALIB_REPOOL_VARIANTS= CALIB_SCHEDULE_VARIANTS= CALIB_FOLD_COUNTS="
-ENVX="$ENVX CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES"
+ENVX="$ENVX CALIB_PATCH_STYLES=$CALIB_PATCH_STYLES CALIB_SAFE_THRESHOLDS=$CALIB_SAFE_THRESHOLDS"
 # `REQUIRE_SEED_QUERY` filters CATEGORIES, so it reaches the cell list: it has to
 # travel with the rest or a task enumerates a different grid than the launcher
 # counted.  `REQUIRE_OPENING` is checked per cell and travels beside it.

--- a/scripts/experiments/preflight.sh
+++ b/scripts/experiments/preflight.sh
@@ -567,6 +567,14 @@ sys.path.insert(0, str(pathlib.Path(repo) / "scripts" / "experiments" / "calibra
 import common  # noqa: E402
 
 common.setup_env()
+# Imported with the RUN'S OWN ENVIRONMENT, so every knob below reads the value
+# this run will actually use - the env var if it set one, else the harness
+# default.  Re-deriving the defaults here as literals is what let #3400's three
+# stale ones sit unnoticed: the check compared a launcher's pin against the app
+# and never noticed that *not pinning* resolved to a study-era value.  An unset
+# knob is only "the shipped arm" if the harness resolves it there, so that is
+# what gets compared.
+import experiment_config as C  # noqa: E402
 from vtscore.eval.voting_iterations import PRODUCTION_HEAD, PRODUCTION_PATCH_STYLE  # noqa: E402
 from vtscore.training import thresholds as T  # noqa: E402
 
@@ -586,12 +594,20 @@ def pinned(knob, var, shipped):
         rows.append((knob, v, str(shipped)))
 
 
-def must_contain(knob, var, shipped, default):
-    """A set-valued knob: the shipped value has to be IN it, or the run has no
-    arm to compare its challengers against."""
-    v = env(var) or default
-    if str(shipped) not in [p.strip() for p in v.split(",")]:
-        rows.append((knob, v, "a set containing " + str(shipped)))
+def must_contain(knob, var, shipped, effective):
+    """A set-valued knob: the shipped value has to be IN what the run resolves
+    it to, or the run has no arm to compare its challengers against.
+
+    *effective* is the resolved list off ``experiment_config``, so this catches a
+    stale harness default exactly as it catches a stale launcher pin - and says
+    which of the two it is, because the remedy differs (drop the pin vs. fix the
+    default).
+    """
+    got = [str(x).strip() for x in effective]
+    if str(shipped) in got:
+        return
+    source = "pinned in %s" % var if env(var) else "harness default; %s is unset" % var
+    rows.append((knob, "%s (%s)" % (",".join(got), source), "a set containing " + str(shipped)))
 
 
 pinned("head", "CALIB_HEAD", PRODUCTION_HEAD)
@@ -609,9 +625,11 @@ if v is not None:
     rows.append(("calibration_fraction", v, "<unset> = the app's per-space default (%s)" % per_space))
 
 # The app has no safe-thresholds switch any more (#2799): fusion is always on.
-v = env("CALIB_SAFE_THRESHOLDS")
-if v is not None and v != "1":
-    rows.append(("safe_thresholds", v, "1 (the app has no switch)"))
+# Read off the resolved config rather than the env var, because until #3400 the
+# harness default was 0: an unset var passed this check while the run measured
+# the unfused control - the one arm the app can no longer produce.
+if not C.SAFE_THRESHOLDS:
+    rows.append(("safe_thresholds", env("CALIB_SAFE_THRESHOLDS") or "<unset> = 0", "1 (the app has no switch)"))
 
 # An explicit schedule overrides the app's per-mode default (#2841).
 v = env("CALIB_BLEND_SCHEDULE")
@@ -650,12 +668,14 @@ if v is not None and v.strip().lower() not in ("", "default", "app"):
 # reader cannot tell the real ones from the noise.  Check them when the family is
 # actually on; say plainly that they were skipped when it is not.
 if os.environ.get("CALIB_ANCHORED") == "1":
-    must_contain("cut_rule", "CALIB_ANCHORED_RULES", T.FOLD_ANCHOR_CUT_RULE, "mid,rate")
-    must_contain("fold_combine", "CALIB_ANCHORED_FOLD_COMBINES", T.FOLD_ANCHOR_COMBINE, "qmean,qmedian")
-    must_contain("anchor_weight", "CALIB_ANCHORED_WEIGHTS", "%g" % T.FOLD_ANCHOR_WEIGHT, "1,3,10,30,100")
+    must_contain("cut_rule", "CALIB_ANCHORED_RULES", T.FOLD_ANCHOR_CUT_RULE, C.ANCHORED_RULES)
+    must_contain("fold_combine", "CALIB_ANCHORED_FOLD_COMBINES", T.FOLD_ANCHOR_COMBINE, C.ANCHORED_FOLD_COMBINES)
+    must_contain(
+        "anchor_weight", "CALIB_ANCHORED_WEIGHTS", "%g" % T.FOLD_ANCHOR_WEIGHT, ["%g" % w for w in C.ANCHORED_WEIGHTS]
+    )
 else:
     print("SKIPPED\tanchored grid (CALIB_ANCHORED is not 1, so no anchored row is emitted)")
-must_contain("patch_style", "CALIB_PATCH_STYLES", PRODUCTION_PATCH_STYLE, "max_patch,max_patch_pca_hac")
+must_contain("patch_style", "CALIB_PATCH_STYLES", PRODUCTION_PATCH_STYLE, C.PATCH_STYLES)
 
 if not rows:
     print("MATCHES")

--- a/vtscore/eval/arms_anchored.py
+++ b/vtscore/eval/arms_anchored.py
@@ -16,6 +16,9 @@ import numpy as np
 from vtscore.eval.row_metrics import operating_metrics, round6
 from vtscore.training.thresholds import (
     CUT_KIND_INTERIOR,
+    FOLD_ANCHOR_COMBINE,
+    FOLD_ANCHOR_CUT_RULE,
+    FOLD_ANCHOR_WEIGHT,
     anchored_gmm_fit,
     fold_anchored_gmm_threshold,
     gmm_cut_from_fit,
@@ -27,13 +30,22 @@ from vtscore.training.thresholds import (
 #: within-step variant; the GRID run overrides these via
 #: ``simulate_voting_iterations``'s ``anchored_*`` parameters to exhaust the
 #: grid registered in ``docs/plans/population-anchored-calibration.md``.
-_ANCHORED_WEIGHTS: tuple[float, ...] = (1.0, 10.0, 100.0)
+#:
+#: **Every grid leads with the shipped value** (:data:`FOLD_ANCHOR_WEIGHT`,
+#: :data:`FOLD_ANCHOR_CUT_RULE`, :data:`FOLD_ANCHOR_COMBINE`).  A sweep whose
+#: default grid omits the operating point the app ships has no arm to pair its
+#: challengers against, which is what these grids had become: they were
+#: registered when #2852 was placing the knob, #2861 read that sweep, and the
+#: values it settled on (0.3, ``mid_tilt``) then shipped from *underneath* the
+#: grid.  Same failure family as
+#: ``scripts/experiments/lessons/2026-08-12-a-study-default-is-not-a-shipped-default.md``.
+_ANCHORED_WEIGHTS: tuple[float, ...] = (FOLD_ANCHOR_WEIGHT, 1.0, 10.0, 100.0)
 
 
-_ANCHORED_RULES: tuple[str, ...] = ("mid", "rate")
+_ANCHORED_RULES: tuple[str, ...] = (FOLD_ANCHOR_CUT_RULE, "mid", "rate")
 
 
-_ANCHORED_FOLD_COMBINES: tuple[str, ...] = ("qmean",)
+_ANCHORED_FOLD_COMBINES: tuple[str, ...] = (FOLD_ANCHOR_COMBINE,)
 
 
 def _anchored_variant_rows(


### PR DESCRIPTION
Three defaults in `scripts/experiments/calibration/experiment_config.py` held study-era values that had stopped being shipped values, so a run that set no behavioural knob measured a detector nobody has. Verified from the config, all 32 launchers, and `preflight.sh`; no experiment run needed.

## The premise checks out

- **`CALIB_SAFE_THRESHOLDS` defaulted to `0`** — the #2781-era unfused control — while `simulate_voting_iterations` defaults `safe_thresholds=True` "matching the app", and `docs/ML.md` says there is no setting for it. 21 launchers papered over it with an explicit `=1`. The ones that didn't include **`launch_bench.sh` and `launch_scale.sh`**, both of which say in their own headers that they ride shipped defaults *on purpose* ("this study asks what does a current VTSearch user get?"). They were measuring a threshold no user can get.
- **`ANCHORED_WEIGHTS` / `ANCHORED_RULES`** no longer contained `FOLD_ANCHOR_WEIGHT = 0.3` / `FOLD_ANCHOR_CUT_RULE = "mid_tilt"`. `launch_anchored.sh` deliberately relies on "the registered defaults", so a re-run would sweep challengers with no shipped arm to pair them against — and preflight has been failing on it.
- **`PATCH_STYLES`** carried `max_patch_pca_hac`, whose tree #2886 removed from ingest — doubling the GPU cost of every default patch cell.
- **`REPOOL_VARIANTS`** ran `topk,pnorm`; both failed (`docs/plans/set-scorer-experiment.md`) and `_cells_io._base_rows` filters `pool_variant` back down to the base rows, so the arms paid a re-calibration + re-pool per step per cell for rows nothing reads.

## What changed

**Defaults** (`experiment_config.py`): `CALIB_SAFE_THRESHOLDS` → `1`; `CALIB_ANCHORED_WEIGHTS` → `0.3,1,3,10,30`; `CALIB_ANCHORED_RULES` → `mid_tilt,mid,rate`; `CALIB_PATCH_STYLES` → `max_patch`; `CALIB_REPOOL_VARIANTS` → empty. Each carries a comment saying what it used to be and why that stopped being true.

**`preflight.sh` check 12 now compares the *resolved* value, not the env var.** It imports `experiment_config` under the run's own environment instead of re-deriving the harness defaults as literals beside the shipped constants. That duplication is what let these sit unnoticed: the check compared a launcher's *pin* against the app and never noticed that *not pinning* resolved to a study-era value — an unset `CALIB_SAFE_THRESHOLDS` passed while the run measured the control. It also now reports whether a divergence came from a pin or from the default, since the remedy differs. Exercised by hand across six configurations (unset → `MATCHES`; each stale value → the right `DIVERGES` row).

**Launcher pins kept, comments fixed.** The issue proposed deleting the 21 redundant `export CALIB_SAFE_THRESHOLDS=1`; this PR keeps them, because a launcher submits into a pinned worktree (`VTS_REPO=/exp/$USER/projects/vts-*`) whose `experiment_config.py` may predate this change, four propagate the variable by name into sbatch under `set -u`, and the repo's own recorded preference (`launch_transfer_2883.sh`, `launch_safe_ab.sh` on `CALIB_HEAD`) is to name the knob in the launcher rather than inherit "a default three modules away". Only the ~4 comments that *asserted* the old default are rewritten.

- `launch_bench.sh` and `launch_scale.sh` gain the same pin (and the ENVX propagation), for exactly the reason they already pin the patch geometry.
- `launch_horizon.sh` and `launch_errdump.sh` re-run cells of *finished* grids, so they pin it overridably (`${CALIB_SAFE_THRESHOLDS:-1}`) and document that reproducing a pre-change grid needs `=0`.

**`vtscore/eval/arms_anchored.py`** carried the same drift as library-tier fallbacks (`_ANCHORED_WEIGHTS` without 0.3, `_ANCHORED_RULES` without `mid_tilt`). Each grid now leads with the shipped constant it sweeps around.

Docs updated: the calibration README's arms table and fixed-config section, and the still-open `pnorm` re-run item in `docs/plans/calibration-experiment.md`, which now says the tree arm and the re-pools are opt-in and how to ask for them.

## Testing

Full `./run-tests.sh`: **RUN PASSED** — 9715 passed, 6 skipped, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

Closes #3400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiY3Ds3LT1pXc8hwHhRbU7

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiY3Ds3LT1pXc8hwHhRbU7)_