### PR TITLE
Back AsyncJob with a ProgressTracker instead of re-implementing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ not list every commit. Use `git log` for the full history.
 
 ## Unreleased
 
+### Fixed
+
+- **The "arranging your items" wait now shows a remaining-time estimate.**
+  Preparing a subset map from Find results renders an ETA chip beside the
+  progress bar, but the projection build's status payload never carried an
+  estimate for it to show, so the chip was always blank. Background jobs are
+  now backed by the same progress tracker the dataset loads use, which derives
+  one from the rate the build is actually sustaining (rebased at each phase
+  boundary, published on a coarse sticky ladder so the figure doesn't twitch),
+  and the projection status payload passes it through as `eta_seconds`.
+
 ### Added
 
 - **New demo dataset: Rico Icons -- screenshots with boxed, labelled icons.**

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5240,6 +5240,12 @@
             "nullable": true,
             "type": "string"
           },
+          "eta_seconds": {
+            "default": null,
+            "description": "Estimated seconds remaining for the whole build, smoothed and snapped to a coarse ladder so the displayed figure does not twitch. ``null`` until the build has run long enough to extrapolate from.",
+            "nullable": true,
+            "type": "number"
+          },
           "has_labels": {
             "default": null,
             "description": "Whether region signpost labels exist for this projection (see GET /api/projection/labels). False until a labeler has run for the current layout.",

--- a/frontend/src/app/models/projection.models.ts
+++ b/frontend/src/app/models/projection.models.ts
@@ -127,6 +127,13 @@ export interface ProjectionMeta {
    * as a bounded indeterminate zone. Mirrors ``ProgressEvent.overall_step_end``.
    */
   overall_step_end?: number | null;
+  /**
+   * Estimated seconds remaining for the whole build, or `null` until the
+   * backend's tracker has enough signal to extrapolate. Already smoothed and
+   * snapped to a coarse ladder server-side — render it, don't re-round it.
+   * Mirrors ``ProgressEvent.eta_seconds``.
+   */
+  eta_seconds?: number | null;
   error?: string;
 }
 

--- a/frontend/src/app/services/browse-subset-prep.service.spec.ts
+++ b/frontend/src/app/services/browse-subset-prep.service.spec.ts
@@ -164,6 +164,30 @@ describe('BrowseSubsetPrepService', () => {
     }
   });
 
+  it('shows the build\'s remaining-time estimate once the backend has one', async () => {
+    vi.useFakeTimers();
+    try {
+      service.start(DS, IDS);
+
+      // No estimate yet: the backend withholds one until the build has run
+      // long enough to extrapolate from, and an absent ETA must render as
+      // nothing rather than a placeholder.
+      metaProvider = () => of(meta({ status: 'building', message: 'Arranging the items…', step: 1, total_steps: 3 }));
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(service.eta()).toBe('');
+
+      // The estimate has to survive the meta → ProgressEvent copy: the chip
+      // reads `eta_seconds` off the copied progress, so a field dropped here
+      // leaves the chip permanently blank with nothing to show it is broken.
+      metaProvider = () =>
+        of(meta({ status: 'building', message: 'building pyramid', step: 2, total_steps: 3, eta_seconds: 450 }));
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(service.eta()).toBe('About 7.5 min left');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('leaves the user in Find when the build fails', async () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/app/services/browse-subset-prep.service.ts
+++ b/frontend/src/app/services/browse-subset-prep.service.ts
@@ -149,6 +149,7 @@ export class BrowseSubsetPrepService {
       total_steps: meta.total_steps ?? null,
       overall: meta.overall ?? null,
       overall_step_end: meta.overall_step_end ?? null,
+      eta_seconds: meta.eta_seconds ?? null,
     });
     return 'continue';
   }

--- a/tests/api/test_events_sse.py
+++ b/tests/api/test_events_sse.py
@@ -182,7 +182,7 @@ class TestProgressTrackerEta:
 
     def test_eta_field_absent_when_extra_not_declared(self):
         """Trackers created without an ``eta_seconds`` extra get no key;
-        the feature is opt-in via :data:`_PROGRESS_COMMON_EXTRAS`."""
+        the feature is opt-in via :data:`PROGRESS_COMMON_EXTRAS`."""
         tracker = ProgressTracker()
         tracker.update("loading", "", 1, 2)
         assert "eta_seconds" not in tracker.get()

--- a/tests_lib/core/test_progress_overall.py
+++ b/tests_lib/core/test_progress_overall.py
@@ -10,11 +10,11 @@ import time
 
 import pytest
 
-from vtscore.concurrency.progress import _ETA_LADDER, ProgressTracker, _PROGRESS_COMMON_EXTRAS
+from vtscore.concurrency.progress import _ETA_LADDER, ProgressTracker, PROGRESS_COMMON_EXTRAS
 
 
 def _tracker() -> ProgressTracker:
-    return ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+    return ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
 
 
 def _shown(tracker: ProgressTracker, raw: float) -> float:

--- a/tests_lib/core/test_timing_recorder_and_fit.py
+++ b/tests_lib/core/test_timing_recorder_and_fit.py
@@ -13,7 +13,7 @@ import math
 import pytest
 
 from vtscore import timing
-from vtscore.concurrency.progress import _PROGRESS_COMMON_EXTRAS, ProgressTracker
+from vtscore.concurrency.progress import PROGRESS_COMMON_EXTRAS, ProgressTracker
 from vtscore.timing import profile as timing_profile
 from vtscore.timing import recorder as timing_recorder
 from vtscore.timing.fit import (
@@ -51,7 +51,7 @@ def _weights(task: str, **kwargs) -> list[float]:
 
 
 def _tracker() -> ProgressTracker:
-    return ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+    return ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
 
 
 @pytest.fixture

--- a/tests_lib/datasets/test_load_profiler.py
+++ b/tests_lib/datasets/test_load_profiler.py
@@ -16,7 +16,7 @@ import json
 
 import pytest
 
-from vtscore.concurrency.progress import _PROGRESS_COMMON_EXTRAS, ProgressTracker
+from vtscore.concurrency.progress import PROGRESS_COMMON_EXTRAS, ProgressTracker
 from vtscore.datasets.stages import _load_profiler
 from vtscore.datasets.stages._load_profiler import (
     _NULL_PROFILER,
@@ -45,7 +45,7 @@ def clean_seen_embedders():
 
 def _make_tracker() -> ProgressTracker:
     """A tracker shaped like the real load tracker (exposes ``step``)."""
-    return ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+    return ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
 
 
 def _drive_phases(tracker: ProgressTracker) -> None:

--- a/tests_lib/integration/test_async_jobs.py
+++ b/tests_lib/integration/test_async_jobs.py
@@ -635,3 +635,101 @@ class TestPhaseProgress:
         job.update_progress(1, 2, "arranging items")
         job.set_phase(2, 3)
         assert job.message == "arranging items"
+
+
+class TestTrackerBackedProgress:
+    """``AsyncJob`` state lives in one :class:`ProgressTracker`, not a copy of it.
+
+    The point of the delegation is that a job stops being a second, poorer
+    implementation of the progress model: whatever the tracker computes for a
+    dataset load (whole-job ``overall``, a smoothed ETA, push subscriptions)
+    a job gets for free, and there is exactly one cancel flag to observe.
+    """
+
+    def test_attribute_writes_land_in_the_tracker_snapshot(self):
+        """The legacy attribute API is a view of the tracker, not a parallel store."""
+        job = AsyncJob(job_id="j1")
+        job.update_progress(3, 10, "training")
+
+        snap = job.progress.get()
+        assert (snap["current"], snap["total"], snap["message"]) == (3, 10, "training")
+
+        # ...and a bare attribute write (the route's ``job.total = n`` seed)
+        # publishes through the tracker too, leaving its neighbours alone.
+        job.total = 20
+        snap = job.progress.get()
+        assert (snap["current"], snap["total"], snap["message"]) == (3, 20, "training")
+
+    def test_phase_structure_yields_a_whole_job_overall_fraction(self):
+        """``overall``/``overall_step_end`` come from the tracker, not the poller.
+
+        Every consumer that renders a whole-job bar used to re-derive this pair
+        from ``step``/``total_steps``/``current``/``total``; now it is computed
+        once, in the place that also owns the step weights.
+        """
+        job = AsyncJob(job_id="j1")
+        job.set_phase(2, 4, "building pyramid")
+        job.update_progress(1, 2, "building pyramid")
+
+        snap = job.progress.get()
+        # Step 2 of 4, half way through it: (1 + 0.5) / 4.
+        assert snap["overall"] == pytest.approx(0.375)
+        assert snap["overall_step_end"] == pytest.approx(0.5)
+
+    def test_overall_is_none_for_a_single_phase_job(self):
+        job = AsyncJob(job_id="j1")
+        job.update_progress(1, 2, "training")
+        snap = job.progress.get()
+        assert snap["overall"] is None
+        assert snap["overall_step_end"] is None
+
+    def test_step_weights_reshape_the_overall_fraction(self):
+        """A job can pace its bar by phase cost — a tracker feature, now reachable."""
+        job = AsyncJob(job_id="j1")
+        job.progress.set_step_weights([1.0, 9.0])
+        job.set_phase(2, 2, "the expensive half")
+
+        # Step 1 was a tenth of the work, so entering step 2 banks 0.1 — not
+        # the 0.5 an equal-weight split would claim.
+        assert job.progress.get()["overall"] == pytest.approx(0.1)
+
+    def test_subscribers_are_pushed_every_job_update(self):
+        """``subscribe()`` is what a push channel would attach to."""
+        seen: list[tuple[int, int]] = []
+        job = AsyncJob(job_id="j1")
+        job.progress.subscribe(lambda snap: seen.append((snap["current"], snap["total"])))
+
+        job.update_progress(1, 3)
+        job.update_progress(2, 3)
+
+        assert seen == [(1, 3), (2, 3)]
+
+    def test_one_cancel_flag_serves_every_cancellation_entry_point(self):
+        """The job's event *is* the tracker's, so no two flags can disagree."""
+        job = AsyncJob(job_id="j1")
+        assert job.cancel_event is job.progress.cancel_event
+
+        job.cancel()
+        assert job.is_cancelled
+        assert job.progress.is_cancelled
+        with pytest.raises(CancelledError):
+            job.progress.check_cancelled()
+        with bind_job_cancellation(job), pytest.raises(CancelledError):
+            check_job_cancelled()
+
+    def test_cancelling_through_the_tracker_stops_a_running_job(self):
+        """Cancel reached via ``job.progress`` unwinds the runner exactly as ``job.cancel()`` does."""
+        mgr = JobManager("tracker-cancel")
+        started = threading.Event()
+
+        def _target(job):
+            started.set()
+            while True:
+                check_job_cancelled()
+                time.sleep(0.01)
+
+        job = mgr.start("sig", _target)
+        assert started.wait(timeout=5)
+        job.progress.cancel()
+        assert job.done_event.wait(timeout=5)
+        assert job.status == "cancelled"

--- a/tests_lib/projection/test_service.py
+++ b/tests_lib/projection/test_service.py
@@ -19,7 +19,8 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from vtscore.concurrency.async_jobs import projection_jobs
+from vtscore.concurrency import progress as progress_mod
+from vtscore.concurrency.async_jobs import AsyncJob, projection_jobs
 from vtscore.projection import Projection, build_pyramid
 from vtscore.projection import service as svc
 from vtscore.state.core import DatasetContext
@@ -333,33 +334,64 @@ class TestLayoutMeta:
 
 
 class TestBuildProgress:
-    class _Job:
-        job_id = "j"
-        message = "arranging items"
-        error = None
-        status = "running"
+    """The build payload is a read of the job's tracker, not a second derivation.
 
-        def __init__(self, step, total_steps, current, total):
-            self.step, self.total_steps = step, total_steps
-            self.current, self.total = current, total
+    Every field here — including the ``overall`` pair this used to stitch by
+    hand — is computed once inside
+    :class:`~vtscore.concurrency.progress.ProgressTracker`, so the payload
+    builder cannot drift from the bar the dataset loads draw.
+    """
+
+    @staticmethod
+    def _job(step, total_steps, current, total, message="arranging items"):
+        job = AsyncJob(job_id="j", status="running")
+        if step:
+            job.set_phase(step, total_steps, message)
+        job.update_progress(current, total, message)
+        return job
 
     def test_stitches_within_phase_counts_into_a_whole_job_fraction(self):
-        body = svc.build_progress(self._Job(2, 3, 1, 4))
+        body = svc.build_progress(self._job(2, 3, 1, 4))
         # Phase 2 of 3, a quarter of the way in: (2 - 1 + 0.25) / 3.
         assert body["overall"] == pytest.approx(1.25 / 3)
         assert body["overall_step_end"] == pytest.approx(2 / 3)
+        assert (body["step"], body["total_steps"]) == (2, 3)
+        assert (body["current"], body["total"]) == (1, 4)
+        assert body["message"] == "arranging items"
 
     def test_an_uncountable_phase_parks_at_its_slice_start(self):
         """The UMAP fit reports no fraction, so the bar must not invent one."""
-        body = svc.build_progress(self._Job(1, 3, 0, 0))
+        body = svc.build_progress(self._job(1, 3, 0, 0))
         assert body["overall"] == pytest.approx(0.0)
         assert body["overall_step_end"] == pytest.approx(1 / 3)
 
     def test_a_phaseless_job_reports_no_overall(self):
-        body = svc.build_progress(self._Job(0, 0, 3, 10))
+        body = svc.build_progress(self._job(0, 0, 3, 10))
         assert body["overall"] is None
         assert body["overall_step_end"] is None
         assert (body["step"], body["total_steps"]) == (None, None)
+
+    def test_eta_is_absent_until_the_build_has_run_long_enough(self):
+        """An estimate from two samples milliseconds apart is noise, not signal."""
+        assert svc.build_progress(self._job(2, 3, 1, 4))["eta_seconds"] is None
+
+    def test_a_sustained_build_publishes_a_remaining_time_estimate(self, monkeypatch):
+        """The estimate the tracker earns reaches the client.
+
+        This is what the hand-rolled payload could not do: an ETA needs the
+        rate history the tracker keeps across updates, which a builder that
+        only sees the current counts has no way to reconstruct.
+        """
+        clock = {"t": 1000.0}
+        monkeypatch.setattr(progress_mod.time, "monotonic", lambda: clock["t"])
+
+        job = AsyncJob(job_id="j", status="running")
+        job.set_phase(1, 2, "arranging items")
+        clock["t"] += 60.0  # a minute of real work...
+        job.update_progress(1, 4, "arranging items")  # ...bought an eighth of the job
+
+        # An eighth in 60 s extrapolates to ~7 min left, snapped to the ladder.
+        assert svc.build_progress(job)["eta_seconds"] == pytest.approx(450.0)
 
 
 class TestTilePayload:

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -10,6 +10,41 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`AsyncJob` is backed by a `ProgressTracker`** (issue #3380). Every job now
+  owns one (`job.progress`) instead of carrying its own copy of the tracker's
+  field set, so background jobs get the parts a hand-rolled copy never had: a
+  smoothed, coarsened `eta_seconds`, the whole-job `overall` /
+  `overall_step_end` fractions with optional per-phase weights
+  (`job.progress.set_step_weights(...)`), and `subscribe()` for pushing
+  snapshots rather than polling them. `job.progress.get()` returns the whole
+  set at once.
+
+  Cancellation collapses to one flag in the same motion: `AsyncJob.cancel_event`
+  **is** the tracker's event, so `job.cancel()`, `job.progress.cancel()`,
+  `job.is_cancelled`, `check_job_cancelled()` and
+  `job.progress.check_cancelled()` all act on a single
+  `threading.Event` and raise a single `CancelledError`.
+
+  **For library consumers:** additive at every documented surface.
+  `current` / `total` / `message` / `step` / `total_steps` and `cancel_event`
+  remain readable and writable under their old names — they are now properties
+  over the tracker rather than dataclass fields, which changes only two things:
+  they can no longer be passed to the `AsyncJob(...)` constructor (nothing in
+  the tree did), and a write publishes a snapshot to subscribers instead of
+  mutating an attribute in place.
+
+- **`ProgressTracker.cancel_event`** — the tracker's cancellation flag, exposed
+  so a holder that must publish exactly one cancel signal can hand out the
+  tracker's event rather than keeping a second one in sync. Prefer `cancel()` /
+  `check_cancelled()` / `is_cancelled` for ordinary use.
+
+- **`PROGRESS_COMMON_EXTRAS`** — the extras every long-running operation
+  declares (`step`, `total_steps`, `error`, `eta_seconds`, `overall`,
+  `overall_step_end`), promoted from the private `_PROGRESS_COMMON_EXTRAS` so a
+  caller constructing its own `ProgressTracker` can opt into the same payload
+  shape the frontend already renders. The private name is gone; it was never
+  contract.
+
 - **`MediaEmbedder.loaded_backbone()` - a supported way to reach an embedder's
   raw model** (issue #3395). Returns `(model, processor)`, loading the model
   first if needed; the second element is `None` for backbones that need no

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -26,6 +26,13 @@ the training loop.
 Results from the most recent successful run are kept by *signature* so a
 follow-up request with an unchanged signature can short-circuit and return
 the previous result - the "re-sort without new votes is free" fast path.
+
+Progress and cancellation are **not** re-implemented here.  Every job owns a
+:class:`~vtscore.concurrency.progress.ProgressTracker` (``job.progress``), so
+a job's counts, phase structure, whole-job ``overall`` fraction, smoothed
+``eta_seconds`` and cancel flag are the same objects the dataset-load and
+sort/eval/find bars already use - and a poller that wants the whole set reads
+``job.progress.get()`` instead of assembling it field by field.
 """
 
 from __future__ import annotations
@@ -38,28 +45,44 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Optional
 
-from vtscore.concurrency.progress import CancelledError
+from vtscore.concurrency.progress import (
+    PROGRESS_COMMON_EXTRAS,
+    CancelledError,
+    ProgressTracker,
+)
 
 
 @dataclass
 class AsyncJob:
-    """State container for a single background training job."""
+    """State container for a single background training job.
+
+    Progress is **not** re-implemented here: every progress field lives in the
+    job's own :class:`~vtscore.concurrency.progress.ProgressTracker`, reached
+    as :attr:`progress` and mirrored by the read/write properties below.  The
+    tracker is what supplies the parts a hand-rolled field set never gets:
+    a smoothed, coarsened ``eta_seconds``, the whole-job ``overall`` /
+    ``overall_step_end`` fractions (optionally weighted per step via
+    ``job.progress.set_step_weights``), and :meth:`~vtscore.concurrency.progress.ProgressTracker.subscribe`
+    for pushing snapshots instead of polling them.  Read the whole set at once
+    with ``job.progress.get()``.
+
+    The tracker also owns the job's cancellation flag, so a job has exactly
+    **one** cancel signal: :meth:`cancel`, :attr:`is_cancelled`,
+    :attr:`cancel_event`, :func:`check_job_cancelled` and
+    ``job.progress.check_cancelled()`` all observe the same
+    :class:`threading.Event`.
+    """
 
     job_id: str
     signature: Any = None
     status: str = "running"  # "pending" | "running" | "done" | "error" | "cancelled"
     result: Any = None
     error: str | None = None
-    current: int = 0
-    total: int = 0
-    message: str = ""
-    #: Optional multi-phase structure for jobs that walk a fixed sequence of
-    #: steps (see :meth:`set_phase`).  ``0`` means "single-phase job"; pollers
-    #: that render a whole-job bar skip the step decoration then.
-    step: int = 0
-    total_steps: int = 0
+    #: This job's progress state.  One tracker per job, so the ETA clock and
+    #: the monotonic ``overall`` clamp start fresh for every run rather than
+    #: inheriting a previous job's pace.
+    progress: ProgressTracker = field(default_factory=lambda: ProgressTracker(dict(PROGRESS_COMMON_EXTRAS)))
     started_at: float = 0.0
-    cancel_event: threading.Event = field(default_factory=threading.Event)
     done_event: threading.Event = field(default_factory=threading.Event)
     # Username of the request that spawned this job, captured at start()
     # time so the worker thread can resolve per-user settings correctly.
@@ -70,19 +93,93 @@ class AsyncJob:
     dataset_id: str = ""
     detector_id: str = ""
 
+    # ------------------------------------------------------------------ #
+    # Progress, delegated to the tracker
+    # ------------------------------------------------------------------ #
+    #
+    # These read/write properties keep the pre-tracker attribute API
+    # (``job.current``, ``job.total = n``, ...) working unchanged for the
+    # routes and job targets that use it, while the values themselves live in
+    # exactly one place.  A write publishes through the tracker, so it also
+    # recomputes the derived fields and fans the snapshot out to subscribers.
+
+    def _publish(
+        self,
+        *,
+        current: int | None = None,
+        total: int | None = None,
+        message: str | None = None,
+        step: int | None = None,
+        total_steps: int | None = None,
+    ) -> None:
+        """Publish a partial progress change through the tracker.
+
+        The tracker's :meth:`~vtscore.concurrency.progress.ProgressTracker.update`
+        takes the whole bar at once, so unspecified fields are carried over from
+        the current snapshot.  Like the pre-tracker fields this assumed, a job
+        has a single progress writer (its worker thread); the one exception is
+        a route seeding ``job.total`` right after :meth:`JobManager.start`,
+        which happens before the target's first report.
+        """
+        snap = self.progress.get()
+        self.progress.update(
+            self.status,
+            snap.get("message", "") if message is None else message,
+            snap.get("current", 0) if current is None else current,
+            snap.get("total", 0) if total is None else total,
+            step=snap.get("step") if step is None else step,
+            total_steps=snap.get("total_steps") if total_steps is None else total_steps,
+        )
+
+    @property
+    def current(self) -> int:
+        return int(self.progress.get().get("current") or 0)
+
+    @current.setter
+    def current(self, value: int) -> None:
+        self._publish(current=int(value))
+
+    @property
+    def total(self) -> int:
+        return int(self.progress.get().get("total") or 0)
+
+    @total.setter
+    def total(self, value: int) -> None:
+        self._publish(total=int(value))
+
+    @property
+    def message(self) -> str:
+        return self.progress.get().get("message") or ""
+
+    @message.setter
+    def message(self, value: str) -> None:
+        self._publish(message=value)
+
+    @property
+    def step(self) -> int:
+        """Which phase of :attr:`total_steps` is running; ``0`` = single-phase."""
+        return int(self.progress.get().get("step") or 0)
+
+    @property
+    def total_steps(self) -> int:
+        """How many coarse phases this job walks; ``0`` = single-phase."""
+        return int(self.progress.get().get("total_steps") or 0)
+
+    @property
+    def cancel_event(self) -> threading.Event:
+        """The job's cancellation flag - the tracker's own event, not a copy."""
+        return self.progress.cancel_event
+
     @property
     def is_cancelled(self) -> bool:
-        return self.cancel_event.is_set()
+        return self.progress.is_cancelled
 
     def cancel(self) -> None:
-        self.cancel_event.set()
+        self.progress.cancel()
 
     def update_progress(self, current: int, total: int, message: str = "") -> None:
         """Update progress counters atomically (single writer per job)."""
-        self.current = current
-        self.total = total
-        if message:
-            self.message = message
+        self._publish(current=current, total=total, message=message or None)
 
     def set_phase(self, step: int, total_steps: int, message: str = "") -> None:
         """Enter phase *step* of *total_steps*, resetting the within-phase counts.
@@ -91,14 +188,10 @@ class AsyncJob:
         tile → name-regions) calls this at each boundary so a poller can render
         **one** whole-job bar instead of three bars that each restart at zero.
         The within-phase ``current``/``total`` are zeroed because they belong to
-        the phase being left, not the one being entered.
+        the phase being left, not the one being entered; the tracker stitches
+        the two levels into the ``overall`` fraction and a whole-job ETA.
         """
-        self.step = step
-        self.total_steps = total_steps
-        self.current = 0
-        self.total = 0
-        if message:
-            self.message = message
+        self._publish(step=step, total_steps=total_steps, current=0, total=0, message=message or None)
 
 
 # ---------------------------------------------------------------------- #
@@ -114,6 +207,14 @@ class AsyncJob:
 # step).  When the job's ``cancel_event`` is set, the next poll raises
 # :class:`CancelledError`, which unwinds the training/eval stack and is
 # caught in :meth:`JobManager._run_inner` to mark the job ``cancelled``.
+#
+# That event is the job's :class:`~vtscore.concurrency.progress.ProgressTracker`
+# event, not a second flag beside it, so there is exactly one way to cancel a
+# job and one flag to observe it through: :meth:`AsyncJob.cancel` and
+# ``job.progress.cancel()`` are the same signal, and :func:`check_job_cancelled`
+# and ``job.progress.check_cancelled()`` both raise the same
+# :class:`CancelledError` off it.  Library code deep in a compute loop can poll
+# whichever it already has a handle on.
 #
 # The binding is thread-local and restored on scope exit, and every job
 # runs on its own fresh daemon thread, so no cancellation state leaks

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -458,6 +458,19 @@ class ProgressTracker:
         """Return ``True`` if cancellation has been requested."""
         return self._cancel_event.is_set()
 
+    @property
+    def cancel_event(self) -> threading.Event:
+        """The cooperative-cancellation flag itself.
+
+        Exposed so a holder that must publish *one* cancel signal (see
+        :class:`~vtscore.concurrency.async_jobs.AsyncJob`, whose ``cancel_event``
+        is this object) can hand out the tracker's event rather than keeping a
+        second one that has to be kept in sync.  Prefer :meth:`cancel` /
+        :meth:`check_cancelled` / :attr:`is_cancelled` for ordinary use; reach
+        for the event only to ``wait()`` on it.
+        """
+        return self._cancel_event
+
     def reset_cancel(self) -> None:
         """Clear the cancellation flag.
 
@@ -541,10 +554,11 @@ def resolve_progress_callback() -> ProgressCallback:
 #: like load→embed→stage), an ``error`` string, and a smoothed ``eta_seconds``
 #: filled in automatically by :meth:`ProgressTracker._compute_eta`. Every
 #: singleton tracker - and every per-task tracker created by
-#: :class:`LoadingTasksTracker` - exposes these so the frontend can render any
-#: progress payload with the same ``ProgressEvent`` interface (see
-#: ``frontend/src/app/models/api.models.ts``).
-_PROGRESS_COMMON_EXTRAS: dict[str, Any] = {
+#: :class:`LoadingTasksTracker`, and every per-job tracker on an
+#: :class:`~vtscore.concurrency.async_jobs.AsyncJob` - exposes these so the
+#: frontend can render any progress payload with the same ``ProgressEvent``
+#: interface (see ``frontend/src/app/models/api.models.ts``).
+PROGRESS_COMMON_EXTRAS: dict[str, Any] = {
     "step": None,
     "total_steps": None,
     "error": None,
@@ -627,7 +641,7 @@ class LoadingTasksTracker:
         shared progress extras. Returns the per-task :class:`ProgressTracker`
         instance.
         """
-        fields = dict(_PROGRESS_COMMON_EXTRAS)
+        fields = dict(PROGRESS_COMMON_EXTRAS)
         if extra_fields:
             fields.update(extra_fields)
         tracker = ProgressTracker(extra_fields=fields)
@@ -818,13 +832,13 @@ detector_loading_tasks = LoadingTasksTracker()
 # ---------------------------------------------------------------------------
 
 #: Sort-specific progress (used by text-sort operations).
-sort_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+sort_progress = ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
 
 #: Eval progress (used by train-and-score / voting-iterations analysis).
-eval_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+eval_progress = ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
 
 #: Find progress (used by the /api/find multi-dataset×model scoring operation).
-find_progress = ProgressTracker(extra_fields=dict(_PROGRESS_COMMON_EXTRAS))
+find_progress = ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/docs/packages/concurrency.md
+++ b/vtscore/docs/packages/concurrency.md
@@ -70,15 +70,31 @@ returns immediately with a job ID.
 State container for one background job (`async_jobs.py`). Fields:
 `job_id` (UUID4 hex), `signature` (caller-supplied fingerprint),
 `status` (`"pending"` / `"running"` / `"done"` / `"error"` /
-`"cancelled"`), `result`, `error`, `current` / `total` / `message`
-(progress counters), `started_at`, `cancel_event` / `done_event`
+`"cancelled"`), `result`, `error`, `progress` (this job's own
+`ProgressTracker` - see below), `started_at`, `done_event`
 (`threading.Event`), `user` (captured at `start()` for per-user settings
 resolution), `dataset_id` / `detector_id` (captured at `start()`;
 consumed by `list_active_pairs()`).
 
-Methods: `cancel()` sets `cancel_event`; `is_cancelled` reads it;
-`update_progress(current, total, message="")` updates the three progress
-fields (single-writer per job).
+**Progress is the tracker's, not a copy of it.** `current` / `total` /
+`message` / `step` / `total_steps` are read/write properties over
+`job.progress`, so a job automatically gets everything the tracker
+computes and a job-shaped re-implementation would not: a smoothed,
+coarsened `eta_seconds`, the whole-job `overall` / `overall_step_end`
+fractions (optionally weighted per phase via
+`job.progress.set_step_weights(...)`), and `subscribe()` for pushing
+snapshots rather than polling them. Read the whole set at once with
+`job.progress.get()`.
+
+Methods: `update_progress(current, total, message="")` publishes the
+within-phase counts (single-writer per job); `set_phase(step,
+total_steps, message="")` enters a coarse phase and zeroes the counts
+belonging to the one being left.
+
+Cancellation likewise has one flag, not two: `cancel_event` **is**
+`job.progress.cancel_event`, so `cancel()`, `is_cancelled`,
+`job.progress.check_cancelled()` and `check_job_cancelled()` all observe
+the same event and raise the same `CancelledError`.
 
 ### `JobManager`
 
@@ -381,8 +397,11 @@ free: the callbacks the load pipeline binds call `check_cancelled()` on
 their own tracker before recording the tick, so reporting progress *is*
 the cancellation check.
 
-`AsyncJob` cancellation is the analogous pattern but uses the job's own
-event: the target function checks `job.is_cancelled` and returns.
+`AsyncJob` cancellation is the same pattern reached through a job: the
+job's event *is* its tracker's, so a target may check `job.is_cancelled`
+and return, or let `check_job_cancelled()` / `job.progress.check_cancelled()`
+raise `CancelledError` from deep inside a compute loop for `JobManager`
+to catch.
 
 **Cancellation is one-shot per operation.** A tracker that outlives one
 operation needs `reset_cancel()` before the next, so a previous

--- a/vtscore/projection/service.py
+++ b/vtscore/projection/service.py
@@ -118,25 +118,26 @@ def build_progress(job) -> dict:
     (the fraction at which the running phase's slice ends) is published
     alongside so the client can shade the parked-to-slice-end span as a bounded
     indeterminate zone: "somewhere in here" is all the fit can honestly say.
+
+    Every field is read straight off the job's
+    :class:`~vtscore.concurrency.progress.ProgressTracker` snapshot rather than
+    recomputed here.  That is what earns the build an ``eta_seconds``: the
+    tracker derives one from the rate the job is actually sustaining, rebasing
+    at each phase boundary and publishing it on a coarse sticky ladder, none of
+    which a payload builder that only sees the current counts could do.
     """
-    total_steps = job.total_steps or 0
-    step = job.step or 0
-    within = job.current / job.total if job.total > 0 else 0.0
-    overall = None
-    overall_step_end = None
-    if total_steps > 0 and step > 0:
-        overall = min(1.0, max(0.0, (step - 1 + within) / total_steps))
-        overall_step_end = max(min(1.0, step / total_steps), overall)
+    snap = job.progress.get()
     return {
         "status": "building",
         "job_id": job.job_id,
-        "current": job.current,
-        "total": job.total,
-        "message": job.message,
-        "step": step or None,
-        "total_steps": total_steps or None,
-        "overall": overall,
-        "overall_step_end": overall_step_end,
+        "current": snap.get("current") or 0,
+        "total": snap.get("total") or 0,
+        "message": snap.get("message") or "",
+        "step": snap.get("step") or None,
+        "total_steps": snap.get("total_steps") or None,
+        "overall": snap.get("overall"),
+        "overall_step_end": snap.get("overall_step_end"),
+        "eta_seconds": snap.get("eta_seconds"),
     }
 
 

--- a/vtsearch/schemas/projection.py
+++ b/vtsearch/schemas/projection.py
@@ -80,6 +80,17 @@ class ProjectionMetaSchema(Schema):
             ),
         },
     )
+    eta_seconds = fields.Float(
+        load_default=None,
+        metadata={
+            "description": (
+                "Estimated seconds remaining for the whole build, smoothed and "
+                "snapped to a coarse ladder so the displayed figure does not "
+                "twitch. ``null`` until the build has run long enough to "
+                "extrapolate from."
+            ),
+        },
+    )
     error = fields.String(load_default=None)
 
 


### PR DESCRIPTION
`AsyncJob` carried its own copy of the progress model — `current`, `total`, `message`, `step`, `total_steps` and a `cancel_event` — which is the same field set `ProgressTracker` owns, minus everything the tracker computes on top of it. Consumers paid for the gap twice over:

- `vtscore/projection/service.py:build_progress` re-derived the whole-job `overall` / `overall_step_end` pair by hand: a lossy copy of `ProgressTracker._compute_overall` with no step weights, no monotonic clamp, and no way to produce an ETA at all.
- `find-view.component.html:88` renders `browsePrep.eta()`, which reads `eta_seconds` off the subset-prep progress — a field the projection status payload never carried. **The chip has been permanently blank.**

## What changed

Every job now owns a `ProgressTracker` (`job.progress`), and the old attributes are read/write properties over it. Nothing at the call sites changes shape — `job.update_progress(...)`, `job.set_phase(...)` and the eval route's `job.total = n` seed all still work — but they publish through the tracker, so a job gets the smoothed ETA, the weighted `overall` pair and `subscribe()` for free, and `job.progress.get()` returns the whole set at once.

Cancellation collapses to one flag in the same motion: `AsyncJob.cancel_event` **is** the tracker's event, so `job.cancel()`, `job.progress.cancel()`, `check_job_cancelled()` and `job.progress.check_cancelled()` all act on a single `threading.Event` and raise a single `CancelledError`. Deep compute loops can poll whichever handle they already hold.

`build_progress` reads the tracker snapshot instead of recomputing it, which is what earns the build an `eta_seconds`. That field is added to `ProjectionMetaSchema` and `ProjectionMeta`, and copied through `browse-subset-prep`'s meta → `ProgressEvent` hop, so the chip finally shows something. Verified end to end through the marshmallow schema: a build that banked an eighth of the job in 60 s serializes `eta_seconds: 450.0`, which `formatEta` renders as "About 7.5 min left".

`_PROGRESS_COMMON_EXTRAS` is promoted to `PROGRESS_COMMON_EXTRAS` so a caller building its own tracker can opt into the shape the frontend already renders.

## Scope note

The issue also proposed a `jobs` SSE channel in `events.py`. I left that out deliberately, and rescoped the issue accordingly. The framing behind it — "training/projection jobs poll over REST while imports push over SSE" — overstates what a channel would buy: those polls fetch **results** (`/api/learned-sort/result`, `/api/eval/train-and-score/result`, `/api/projection/meta`), not just progress, so the polling stays either way, and the eval bar's progress *already* pushes over the `eval` channel. A dynamic per-job channel would also need broker plumbing closer to `LoadingTasksTracker` than to the fixed `_TRACKER_CHANNELS` dict the issue points at. `subscribe()` is now available on every job if that changes.

Two smaller corrections to the issue text: cancellation existed in **two** raising forms, not three (`async_jobs.py:156` and `progress.py:454`; the pending-slot flip sets a status without raising), and `bind_job_cancellation` never set an event — it binds a thread-local, and the second event was the `AsyncJob` field, which is what this removes.

## Testing

`./run-tests.sh` — 9734 passed, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

New coverage:
- `tests_lib/integration/test_async_jobs.py::TestTrackerBackedProgress` — attribute writes land in the tracker snapshot, phase structure yields the `overall` pair, step weights reshape it, subscribers get pushed, one cancel flag serves every entry point, and a cancel through `job.progress` unwinds a running job.
- `tests_lib/projection/test_service.py::TestBuildProgress` — the hand-rolled `_Job` stub is replaced by real `AsyncJob`s (the stub was only possible because the payload builder re-derived everything), plus the ETA's absence early and its arrival once the build sustains a rate.
- `browse-subset-prep.service.spec.ts` — the ETA chip stays empty with no estimate and renders one when the backend has it. Confirmed the spec fails when the `eta_seconds` copy is removed.

Closes #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118fcMMbXgWAT7vLgR4UwJE

---
_Generated by [Claude Code](https://claude.ai/code/session_0118fcMMbXgWAT7vLgR4UwJE)_