### PR TITLE
feat(browse): show the remaining-time estimate on the full-dataset map build

### DIFF
--- a/frontend/src/app/components/browse-view/browse-view.component.html
+++ b/frontend/src/app/components/browse-view/browse-view.component.html
@@ -17,11 +17,15 @@
           [value]="buildBar().value"
           [max]="buildBar().max"
         />
-        <!-- Reserved-height lines so the count/detail appearing or disappearing
-             doesn't re-center the column and shift the bar above it. -->
+        <!-- Reserved-height lines so the count/ETA/detail appearing or
+             disappearing doesn't re-center the column and shift the bar above
+             it. -->
         <span class="browse-status-count">
           @if (buildTotal() > 0) {
             {{ buildProgress() }} / {{ buildTotal() }}
+          }
+          @if (buildEtaText()) {
+            <span class="browse-status-eta">{{ buildEtaText() }}</span>
           }
         </span>
         <span class="browse-status-detail">{{ buildDetail() }}</span>

--- a/frontend/src/app/components/browse-view/browse-view.component.scss
+++ b/frontend/src/app/components/browse-view/browse-view.component.scss
@@ -30,14 +30,20 @@
   color: var(--color-good);
 }
 
-// Reserve the lines even when empty so toggling the count/detail never
-// re-centers the column and shifts the bar above.
+// Reserve the lines even when empty so toggling the count/ETA/detail never
+// re-centers the column and shifts the bar above. Both children sit on one
+// line, so the height is a single line whether or not the estimate is showing.
+// `.browse-status-eta` deliberately carries no rule of its own: it is a
+// template/spec hook whose colour is the muted one it inherits from here.
 .browse-status-count {
   font-size: var(--font-sm);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   line-height: 1.4;
   min-height: 1.4em;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
 }
 
 .browse-status-detail {

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -39,7 +39,7 @@ import {
 } from '../browse-canvas/hex-render.util';
 import type { ProjectionMeta, RegionLabelPayload } from '../../models/projection.models';
 import { snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
-import { progressBarState } from '../../utils/format-progress';
+import { formatEta, progressBarState } from '../../utils/format-progress';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
@@ -142,6 +142,11 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    *  parked at the slice floor during the count-less UMAP fit, the pair bounds
    *  the bar's shimmer zone. See ProgressEvent.overall_step_end. */
   readonly buildStepEnd = signal<number | null>(null);
+  /** Seconds the server estimates are left in the whole build, or ``null``
+   *  while it declines to guess. The tracker withholds one for the first few
+   *  seconds and throughout a count-less phase, so empty is the normal opening
+   *  state rather than a failure; see {@link buildEtaText}. */
+  readonly buildEta = signal<number | null>(null);
 
   /** `<vt-progress-bar>` inputs for the build state, preferring the whole-job
    *  ``overall`` fraction so the bar fills once across the build rather than
@@ -154,6 +159,15 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       overall_step_end: this.buildStepEnd(),
     }),
   );
+
+  /**
+   * The remaining-time estimate for the line beside the count, e.g.
+   * ``"About 10 min left"``. Rendered through the shared `formatEta` and never
+   * re-rounded here: the server already snaps the figure to a coarse sticky
+   * ladder so every consumer displays the same one. Empty string when there is
+   * no estimate, which the template drops.
+   */
+  readonly buildEtaText = computed(() => formatEta(this.buildEta()));
 
   /** Phase line under the bar: `"Step 2 of 3 · building pyramid"`. */
   readonly buildDetail = computed(() => {
@@ -1457,6 +1471,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.buildTotalSteps.set(meta?.total_steps ?? null);
     this.buildOverall.set(meta?.overall ?? null);
     this.buildStepEnd.set(meta?.overall_step_end ?? null);
+    this.buildEta.set(meta?.eta_seconds ?? null);
   }
 
   private loadProjection(): void {

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -155,6 +155,58 @@ describe('BrowseViewComponent (zoneless canary)', () => {
     expect(errEl!.textContent).toContain('projection exploded');
   });
 
+  // Issue #3500: the full-dataset build is the app's longest wait, so its
+  // status line must surface the server's remaining-time estimate the way the
+  // subset prep screen already does. The estimate is withheld for the first
+  // few seconds of a build and throughout the count-less UMAP fit, so the
+  // no-estimate opening state is normal and must render nothing rather than a
+  // placeholder.
+  it('renders the build ETA beside the count once the server offers one', async () => {
+    await settleZoneless(fixture);
+
+    const building = (extra: Partial<ProjectionMeta>): ProjectionMeta =>
+      ({
+        projection_id: 'p1',
+        bounds: [0, 0, 1, 1],
+        base_radius: 1,
+        tile_span: 1,
+        point_count: 0,
+        levels: [],
+        status: 'building',
+        current: 40,
+        total: 100,
+        message: 'binning',
+        step: 2,
+        total_steps: 3,
+        overall: 0.4,
+        ...extra,
+      }) as ProjectionMeta;
+
+    // Opening state: the tracker has not yet earned an estimate.
+    metaSubject.next(building({ eta_seconds: null }));
+    await settleZoneless(fixture);
+
+    const count = fixture.nativeElement.querySelector('.browse-status-count') as HTMLElement;
+    expect(count).not.toBeNull();
+    expect(count.textContent).toContain('40 / 100');
+    expect(count.querySelector('.browse-status-eta')).toBeNull();
+
+    // The estimate arrives on a later poll and joins the same line, rendered
+    // through the shared `formatEta` (no client-side re-rounding).
+    metaSubject.next(building({ current: 55, eta_seconds: 90 }));
+    await settleZoneless(fixture);
+
+    expect(fixture.nativeElement.querySelector('.browse-status-eta')!.textContent).toContain(
+      'About 1.5 min left',
+    );
+
+    // A phase that reports no estimate clears it rather than leaving the stale
+    // figure up.
+    metaSubject.next(building({ current: 70, eta_seconds: null }));
+    await settleZoneless(fixture);
+    expect(fixture.nativeElement.querySelector('.browse-status-eta')).toBeNull();
+  });
+
   it('covers the canvas until it reports its opening view is painted', async () => {
     await settleZoneless(fixture);
     const component = fixture.componentInstance;


### PR DESCRIPTION
The full-dataset UMAP build is the longest wait in the app and its "Building the map…" screen showed no ETA — even though the estimate has been reaching the client since #3497 backed `AsyncJob` with a `ProgressTracker`. `GET /api/projection/meta` carries `eta_seconds` on a `building` payload, `ProjectionMetaSchema` declares it and `ProjectionMeta` types it, but only the *subset* prep screen rendered it: `BrowseViewComponent.applyBuildProgress` mirrored every other progress field onto a signal and dropped this one.

## What changed

Wired through following the find-view precedent rather than inventing a placement:

- **`buildEta` signal** set in `applyBuildProgress`, so the `null` reset path (`enterBuilding`) clears it when a fresh build starts and a count-less phase clears it mid-build.
- **`buildEtaText` computed** running it through the shared `formatEta`. Not rounded, floored or re-smoothed client-side — the server already snaps the figure to a coarse sticky ladder so every consumer displays the same one.
- **Template**: a `<span class="browse-status-eta">` inside the existing reserved-height `.browse-status-count` line, `@if`-guarded exactly as `find-view.component.html` guards `browsePrep.eta()`.
- **SCSS**: the count line becomes a baseline flex row so the estimate sits beside the count with the standard `--space-sm` gap.

## Verification

Measured in Chromium against the shipped `.browse-status*` declarations: with and without the estimate, the count line is **19.59px** tall and the progress bar's top is at **281.906px** — **0.000px** shift, vertical and horizontal. The reserved height holds, which is the whole reason that line is shaped the way it is.

A Vitest spec drives three metas through the real poll path (`metaSubject` → `applyMeta`/`applyBuildMeta` → `applyBuildProgress`), asserting the opening no-estimate state renders nothing, an arriving estimate renders `About 1.5 min left` beside the count, and a later count-less phase clears it rather than leaving a stale figure up.

Full `./run-tests.sh`: 9748 passed, all gates green.

## One deviation from the issue

Step 3 suggested promoting `.find-wait-eta` to a shared rule. That rule is a **no-op**: it sets `color: var(--text-muted)`, which the span already inherits from `.find-wait-count` (also `--text-muted`). There is nothing worth promoting, and the style guide's rule-of-three would not call for it at two consumers anyway. So `.browse-status-eta` deliberately carries no rule of its own — it is a template/spec hook whose colour comes from the line — with a comment in the SCSS saying so, where someone would otherwise "fix" the omission by copying find-view's declaration. The redundant rule in find-view is left alone: it is an existing spec selector there, and removing it is unrelated churn.

Closes #3500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxhaBFFxJq3QbB3rk99Bff

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxhaBFFxJq3QbB3rk99Bff)_