### PR TITLE
gridenv.sh: untrack the shadow shim, parameterise the venv and module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,12 @@ scratch/
 # belongs in history.
 slides/_build/
 slides/_out/
+
+# GRID editable-install shadow shim, created by `source gridenv.sh` (#2846).
+# A no-op `__editable___vtsearch_0_1_0_finder.py` that neutralises the venv's
+# editable-install finder, which would otherwise resolve `import vtscore` to the
+# MAIN checkout while PYTHONPATH looks correct. It is per-worktree venv glue,
+# named after one editable install's version -- generated, never committed. It
+# must stay untracked so gridenv.sh's creation block is the live mechanism:
+# tracking it made that block dead code (#3437).
+.shadow/

--- a/.shadow/__editable___vtsearch_0_1_0_finder.py
+++ b/.shadow/__editable___vtsearch_0_1_0_finder.py
@@ -1,2 +1,0 @@
-def install():
-    pass

--- a/gridenv.sh
+++ b/gridenv.sh
@@ -1,17 +1,30 @@
 # Source to run experiment code from THIS worktree (shadows main venv editable finder).
-# Self-locating: the path is derived from this file, not hardcoded to whichever
-# worktree happened to write it last.  A stale absolute path here silently puts
-# ANOTHER worktree's checkout on PYTHONPATH, which is how a run measures code you
-# did not commit.
-module load python/3.12.3
-source /exp/sgreenberg/projects/VTSearch/.venv/bin/activate
+# Self-locating: the *worktree* path is derived from this file, not hardcoded to
+# whichever worktree happened to write it last.  A stale absolute path there
+# silently puts ANOTHER worktree's checkout on PYTHONPATH, which is how a run
+# measures code you did not commit.
+#
+# The venv and the module are a different thing: they are shared machine state,
+# not per-worktree, so they are named rather than derived.  Both are overridable
+# for a different user, machine, or venv; the defaults are the GRID's current
+# ones.  Set VTS_PYTHON_MODULE= (empty) to skip `module load` on a host without
+# environment modules, and VTS_VENV= (empty) to skip venv activation entirely
+# (e.g. when the caller has already activated one).
+if [ -n "${VTS_PYTHON_MODULE-python/3.12.3}" ]; then
+  module load "${VTS_PYTHON_MODULE:-python/3.12.3}"
+fi
+if [ -n "${VTS_VENV-/exp/sgreenberg/projects/VTSearch/.venv}" ]; then
+  source "${VTS_VENV:-/exp/sgreenberg/projects/VTSearch/.venv}/bin/activate"
+fi
 _VTS_WT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # The no-op module that neutralises the venv's editable-install finder.  It is
 # untracked, so a *fresh* worktree does not have one -- and without it the finder
 # still resolves `import vtscore` to the MAIN checkout while PYTHONPATH looks
 # correct.  Create it here rather than writing it down: the failure is silent and
-# the remedy is two lines (#2846).
+# the remedy is two lines (#2846).  `.shadow/` is gitignored on purpose: it was
+# once committed, which made this block unreachable and left the prevention
+# resting on git tracking that nobody had written down (#3437).
 if [ ! -f "${_VTS_WT}/.shadow/__editable___vtsearch_0_1_0_finder.py" ]; then
   mkdir -p "${_VTS_WT}/.shadow"
   printf 'def install():\n    pass\n' > "${_VTS_WT}/.shadow/__editable___vtsearch_0_1_0_finder.py"


### PR DESCRIPTION
Closes #3437

`gridenv.sh` told two stories it did not keep. Both premises in the issue check out; one with a nuance, noted below.

## The shim was tracked, so the block guarding #2846 was dead

`.shadow/__editable___vtsearch_0_1_0_finder.py` was committed — via a merge (`6fbb45f2`), not a deliberate `git add` — so `[ ! -f … ]` could never be true in a fresh worktree. Every worktree got the shim from git, which means the prevention the 2026-08-07 lesson describes as *"code, not advice"* was actually resting on git tracking that nobody had written down. Meanwhile the comments in **both** `gridenv.sh` and `scripts/experiments/preflight.sh:271` still said the shim was untracked.

Of the two stories the issue offers, this takes the first: gitignore `.shadow/` and `git rm --cached` the shim. That

- restores the design the lesson documents, making the creation block the live mechanism again;
- makes both existing comments true with no comment edits (the other option would have required rewriting the one in `preflight.sh` too);
- self-heals a worktree whose `.shadow` gets cleaned away, which tracking does not;
- keeps venv glue — a file named after one editable install's version — out of version control.

Verified end to end: in a fresh directory under `set -euo pipefail`, sourcing the file now creates `.shadow/__editable___vtsearch_0_1_0_finder.py` and puts it first on `PYTHONPATH`.

## The venv and module are behind env vars

Three lines under a comment warning that a hardcoded absolute path is how a run measures the wrong checkout, the file hardcoded `module load python/3.12.3` and one user's venv.

The nuance: the "self-locating" comment was about the *worktree* path (`_VTS_WT`), which genuinely is derived — so the file was not quite self-contradictory. But the venv path did make it work for exactly one user on one machine, and the two kinds of path sat under one comment that read as covering both. Both now sit behind `VTS_PYTHON_MODULE` and `VTS_VENV` with the current GRID values as defaults — the `os.environ.get("VTS_REPO", …)` shape already used across `scripts/experiments/`. Setting either to the empty string skips that step, for a host without environment modules or a caller who already activated a venv. The header comment now separates the derived worktree path from the named machine paths.

Verified: unset → the GRID defaults; `VTS_VENV=/path` → that venv activates; `VTS_PYTHON_MODULE=` → `module load` is skipped.

## Testing

Full `./run-tests.sh`: `RUN PASSED`, 9748 passed / 6 skipped / 2 xpassed, all heavy gates green. The run needed `VTSEARCH_ALLOW_DELETIONS=1` for the deliberate `git rm --cached`; the phantom-base gate is otherwise clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoffRNX3FTjLvPg2YeYUKN

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoffRNX3FTjLvPg2YeYUKN)_