### PR TITLE
refactor(cli): collapse the autodetect 2×2 behind one _autodetect()

### DIFF
--- a/tests/cli/test_cli_streaming.py
+++ b/tests/cli/test_cli_streaming.py
@@ -259,3 +259,82 @@ class TestStreamingExporterGuard:
                 keep_negatives=False,
                 empty_error="none",
             )
+
+
+class TestStreamingWholeDatasetVariants:
+    """``stream_results`` is accepted by the *whole* entry points too.
+
+    It used to be chunked-only, so a caller who did not want chunking had no
+    way to hand a streaming-capable exporter a lazy record iterator even
+    though ``_run_pipeline`` supported it.  A whole-dataset run holds all the
+    medias in RAM by construction, but streaming still keeps the *hits* from
+    accumulating - and, more to the point, the four entry points now differ
+    only in their source.
+    """
+
+    def test_whole_pickle_run_streams_positive_hits(self, client, tmp_path, _stub_split_training):
+        _write_pretrained_detector("stream-whole")
+        settings_path = _settings_file_with_detector(tmp_path, "stream-whole")
+        ds_path = tmp_path / "ds.pkl"
+        _write_pickle_dataset(ds_path, {i: _make_audio_media(i) for i in range(1, 6)})
+        out = tmp_path / "hits.ndjson"
+
+        from vtscore.cli import autodetect_main
+
+        autodetect_main(
+            str(ds_path),
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(out)},
+            stream_results=True,
+        )
+
+        meta, hits = _read_ndjson(out)
+        assert meta["format"] == "vtsearch-hits-ndjson/v1"
+        assert meta["keep_negatives"] is False
+        assert all(h["label"] == "good" for h in hits)
+        assert sorted(h["id"] for h in hits) == [1, 2, 3]
+
+    def test_whole_pickle_run_keeps_negatives(self, client, tmp_path, _stub_split_training):
+        _write_pretrained_detector("stream-whole-neg")
+        settings_path = _settings_file_with_detector(tmp_path, "stream-whole-neg")
+        ds_path = tmp_path / "ds.pkl"
+        _write_pickle_dataset(ds_path, {i: _make_audio_media(i) for i in range(1, 6)})
+        out = tmp_path / "hits.ndjson"
+
+        from vtscore.cli import autodetect_main
+
+        autodetect_main(
+            str(ds_path),
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(out)},
+            stream_results=True,
+            keep_negatives=True,
+        )
+
+        meta, hits = _read_ndjson(out)
+        assert meta["keep_negatives"] is True
+        assert sorted(h["id"] for h in hits if h["label"] == "good") == [1, 2, 3]
+        assert sorted(h["id"] for h in hits if h["label"] == "bad") == [4, 5]
+
+    def test_whole_run_dry_run_reports_streaming(self, client, tmp_path, capsys):
+        _write_pretrained_detector("stream-whole-dry")
+        settings_path = _settings_file_with_detector(tmp_path, "stream-whole-dry")
+        ds_path = tmp_path / "ds.pkl"
+        _write_pickle_dataset(ds_path, {i: _make_audio_media(i) for i in range(1, 6)})
+
+        from vtscore.cli import autodetect_main
+
+        autodetect_main(
+            str(ds_path),
+            settings_path=str(settings_path),
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": str(tmp_path / "out.ndjson")},
+            dry_run=True,
+            stream_results=True,
+        )
+
+        out = capsys.readouterr().out
+        assert "Chunk size: whole dataset" in out
+        assert "Streaming: yes" in out

--- a/tests_lib/cli/test_source_spec.py
+++ b/tests_lib/cli/test_source_spec.py
@@ -1,0 +1,92 @@
+"""Tests for ``vtscore.cli._SourceSpec``.
+
+The four public ``autodetect_*_main`` entry points are a 2x2 matrix
+(pickle/importer x whole/chunked) whose cells used to hand-copy three
+things apiece: the loader call, the ``--dry-run`` source description, and
+the "nothing loaded" error text.  They drifted (the chunked pair grew
+``stream_results``/``keep_negatives`` and the whole pair did not).
+``_SourceSpec`` owns all three, so these tests pin the mapping from a
+spec to each of them - the description in particular, since it is the
+part the CLI's ``--dry-run`` output is read from.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.cli import _SourceSpec
+
+
+class TestEmptyError:
+    def test_pickle_names_the_dataset(self):
+        spec = _SourceSpec(kind="pickle", dataset_path="/data/ds.pkl")
+        assert spec.empty_error == "No medias loaded from dataset: /data/ds.pkl"
+
+    def test_importer_names_the_importer(self):
+        spec = _SourceSpec(kind="importer", importer_name="server_folder")
+        assert spec.empty_error == "No medias loaded by importer 'server_folder'"
+
+
+class TestDescribe:
+    def test_pickle_whole(self):
+        spec = _SourceSpec(kind="pickle", dataset_path="/data/ds.pkl")
+        assert spec.describe(stream_results=False, keep_negatives=False) == {
+            "kind": "pickle",
+            "dataset": "/data/ds.pkl",
+            "chunk_size": None,
+            "stream_results": False,
+            "keep_negatives": False,
+        }
+
+    def test_pickle_chunked_carries_chunk_size_and_flags(self):
+        spec = _SourceSpec(kind="pickle", dataset_path="/data/ds.pkl", chunk_size=250)
+        assert spec.describe(stream_results=True, keep_negatives=True) == {
+            "kind": "pickle",
+            "dataset": "/data/ds.pkl",
+            "chunk_size": 250,
+            "stream_results": True,
+            "keep_negatives": True,
+        }
+
+    def test_importer_carries_params(self):
+        params = {"path": "/srv/sounds", "media_type": "audio"}
+        spec = _SourceSpec(kind="importer", importer_name="server_folder", field_values=params)
+        assert spec.describe(stream_results=False, keep_negatives=False) == {
+            "kind": "importer",
+            "importer": "server_folder",
+            "params": params,
+            "chunk_size": None,
+            "stream_results": False,
+            "keep_negatives": False,
+        }
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            _SourceSpec(kind="pickle", dataset_path="/data/ds.pkl"),
+            _SourceSpec(kind="pickle", dataset_path="/data/ds.pkl", chunk_size=10),
+            _SourceSpec(kind="importer", importer_name="server_folder"),
+            _SourceSpec(kind="importer", importer_name="server_folder", chunk_size=10),
+        ],
+    )
+    def test_every_cell_reports_the_streaming_flags(self, spec):
+        """All four cells describe streaming - the drift this class guards against."""
+        described = spec.describe(stream_results=True, keep_negatives=True)
+        assert described["stream_results"] is True
+        assert described["keep_negatives"] is True
+
+
+class TestLoad:
+    """``load()`` picks the loader; it must not consume the source eagerly."""
+
+    def test_missing_pickle_raises_only_on_iteration(self, tmp_path):
+        spec = _SourceSpec(kind="pickle", dataset_path=str(tmp_path / "nope.pkl"))
+        source = spec.load()  # generator: no I/O yet
+        with pytest.raises(FileNotFoundError):
+            next(iter(source))
+
+    def test_unknown_importer_raises_only_on_iteration(self):
+        spec = _SourceSpec(kind="importer", importer_name="definitely_not_an_importer")
+        source = spec.load()
+        with pytest.raises(ValueError, match="Unknown importer"):
+            next(iter(source))

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -10,6 +10,16 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **All four `autodetect_*_main` entry points accept `stream_results` and
+  `keep_negatives`** (issue #3432). The two keyword-only flags used to exist
+  only on the chunked pair, so a whole-dataset run had no way to hand a
+  streaming-capable exporter a lazy record iterator even though the pipeline
+  underneath supported it. Purely additive: the four names, their positional
+  parameters and their defaults are unchanged, and the flags default to
+  `False` (the previous behaviour). Internally the four are now thin shims
+  over one private `_autodetect(spec, ...)` driven by a `_SourceSpec`, which
+  is what let the matrix drift in the first place.
+
 - **`AsyncJob` is backed by a `ProgressTracker`** (issue #3380). Every job now
   owns one (`job.progress`) instead of carrying its own copy of the tracker's
   field set, so background jobs get the parts a hand-rolled copy never had: a

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import logging
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 
 from vtscore import cli_progress
@@ -761,7 +762,6 @@ def _load_importer_whole(importer_name: str, field_values: dict[str, Any]) -> It
 
     medias: dict[int, dict[str, Any]] = {}
     importer.run_cli(field_values, medias, thin=True)
-    apply_custom_metadata_md5(medias)
     if not medias:
         raise ValueError(f"No medias loaded by importer '{importer_name}'")
     yield medias
@@ -780,6 +780,54 @@ def _load_importer_chunked(
 
     importer.validate_cli_field_values(field_values)
     yield from _renumber_chunks(importer.run_chunked_cli(field_values, chunk_size, thin=True))
+
+
+@dataclass(frozen=True)
+class _SourceSpec:
+    """Where one autodetect run gets its medias: pickle/importer x whole/chunked.
+
+    The four public ``autodetect_*_main`` entry points used to hand-copy
+    three things per cell of that 2x2 - the loader call, the ``--dry-run``
+    source description, and the "nothing loaded" message - which is how the
+    matrix drifted (the chunked pair grew ``stream_results`` and the whole
+    pair did not).  Owning all three here means a new source variant is one
+    ``_SourceSpec`` construction, and the three can no longer disagree.
+    """
+
+    kind: Literal["pickle", "importer"]
+    dataset_path: str = ""
+    importer_name: str = ""
+    field_values: dict[str, Any] = field(default_factory=dict)
+    chunk_size: int | None = None
+
+    @property
+    def empty_error(self) -> str:
+        """The error text raised when the source yields no medias at all."""
+        if self.kind == "pickle":
+            return f"No medias loaded from dataset: {self.dataset_path}"
+        return f"No medias loaded by importer '{self.importer_name}'"
+
+    def load(self) -> Iterator[dict[int, dict[str, Any]]]:
+        """Open the media source, one dict per chunk (one chunk when whole)."""
+        if self.kind == "pickle":
+            if self.chunk_size:
+                return _load_pickle_chunked(self.dataset_path, self.chunk_size)
+            return _load_pickle_whole(self.dataset_path)
+        if self.chunk_size:
+            return _load_importer_chunked(self.importer_name, self.field_values, self.chunk_size)
+        return _load_importer_whole(self.importer_name, self.field_values)
+
+    def describe(self, *, stream_results: bool, keep_negatives: bool) -> dict[str, Any]:
+        """Build the ``source_description`` block reported by ``--dry-run``."""
+        common: dict[str, Any] = {
+            "kind": self.kind,
+            "chunk_size": self.chunk_size,
+            "stream_results": stream_results,
+            "keep_negatives": keep_negatives,
+        }
+        if self.kind == "pickle":
+            return {**common, "dataset": self.dataset_path}
+        return {**common, "importer": self.importer_name, "params": self.field_values}
 
 
 def _validate_dry_run_source(sd: dict[str, Any]) -> None:
@@ -1127,6 +1175,40 @@ def _run_pipeline(
     )
 
 
+def _autodetect(
+    spec: _SourceSpec,
+    *,
+    settings_path: str | None = None,
+    exporter_name: str | None = None,
+    exporter_field_values: dict[str, Any] | None = None,
+    dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
+) -> None:
+    """Shared body of the four public ``autodetect_*_main`` entry points.
+
+    Everything that used to be hand-copied across the 2x2 (pickle /
+    importer) x (whole / chunked) matrix lives here; *spec* supplies the
+    only parts that legitimately differ - the loader call, the dry-run
+    source description, and the "nothing loaded" message.
+    """
+    try:
+        _run_pipeline(
+            spec.load() if not dry_run else iter(()),
+            settings_path=settings_path,
+            exporter_name=exporter_name,
+            exporter_field_values=exporter_field_values,
+            empty_error=spec.empty_error,
+            dry_run=dry_run,
+            stream_results=stream_results,
+            keep_negatives=keep_negatives,
+            source_description=spec.describe(stream_results=stream_results, keep_negatives=keep_negatives),
+        )
+    except Exception as e:
+        cli_progress.emit_error(str(e))
+        sys.exit(1)
+
+
 def autodetect_main(
     dataset_path: str,
     settings_path: str | None = None,
@@ -1134,21 +1216,19 @@ def autodetect_main(
     exporter_field_values: dict[str, Any] | None = None,
     *,
     dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None:
     """CLI entry point: run autodetect with all Auto-Find detectors."""
-    try:
-        _run_pipeline(
-            _load_pickle_whole(dataset_path) if not dry_run else iter(()),
-            settings_path=settings_path,
-            exporter_name=exporter_name,
-            exporter_field_values=exporter_field_values,
-            empty_error=f"No medias loaded from dataset: {dataset_path}",
-            dry_run=dry_run,
-            source_description={"kind": "pickle", "dataset": dataset_path, "chunk_size": None},
-        )
-    except Exception as e:
-        cli_progress.emit_error(str(e))
-        sys.exit(1)
+    _autodetect(
+        _SourceSpec(kind="pickle", dataset_path=dataset_path),
+        settings_path=settings_path,
+        exporter_name=exporter_name,
+        exporter_field_values=exporter_field_values,
+        dry_run=dry_run,
+        stream_results=stream_results,
+        keep_negatives=keep_negatives,
+    )
 
 
 def autodetect_importer_main(
@@ -1159,26 +1239,19 @@ def autodetect_importer_main(
     exporter_field_values: dict[str, Any] | None = None,
     *,
     dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None:
     """CLI entry point: run autodetect with a named importer and output results."""
-    try:
-        _run_pipeline(
-            _load_importer_whole(importer_name, field_values) if not dry_run else iter(()),
-            settings_path=settings_path,
-            exporter_name=exporter_name,
-            exporter_field_values=exporter_field_values,
-            empty_error=f"No medias loaded by importer '{importer_name}'",
-            dry_run=dry_run,
-            source_description={
-                "kind": "importer",
-                "importer": importer_name,
-                "params": field_values,
-                "chunk_size": None,
-            },
-        )
-    except Exception as e:
-        cli_progress.emit_error(str(e))
-        sys.exit(1)
+    _autodetect(
+        _SourceSpec(kind="importer", importer_name=importer_name, field_values=field_values),
+        settings_path=settings_path,
+        exporter_name=exporter_name,
+        exporter_field_values=exporter_field_values,
+        dry_run=dry_run,
+        stream_results=stream_results,
+        keep_negatives=keep_negatives,
+    )
 
 
 def autodetect_main_chunked(
@@ -1193,27 +1266,15 @@ def autodetect_main_chunked(
     keep_negatives: bool = False,
 ) -> None:
     """CLI entry point: chunked autodetect on a pickle dataset."""
-    try:
-        _run_pipeline(
-            _load_pickle_chunked(dataset_path, chunk_size) if not dry_run else iter(()),
-            settings_path=settings_path,
-            exporter_name=exporter_name,
-            exporter_field_values=exporter_field_values,
-            empty_error=f"No medias loaded from dataset: {dataset_path}",
-            dry_run=dry_run,
-            stream_results=stream_results,
-            keep_negatives=keep_negatives,
-            source_description={
-                "kind": "pickle",
-                "dataset": dataset_path,
-                "chunk_size": chunk_size,
-                "stream_results": stream_results,
-                "keep_negatives": keep_negatives,
-            },
-        )
-    except Exception as e:
-        cli_progress.emit_error(str(e))
-        sys.exit(1)
+    _autodetect(
+        _SourceSpec(kind="pickle", dataset_path=dataset_path, chunk_size=chunk_size),
+        settings_path=settings_path,
+        exporter_name=exporter_name,
+        exporter_field_values=exporter_field_values,
+        dry_run=dry_run,
+        stream_results=stream_results,
+        keep_negatives=keep_negatives,
+    )
 
 
 def autodetect_importer_main_chunked(
@@ -1229,25 +1290,17 @@ def autodetect_importer_main_chunked(
     keep_negatives: bool = False,
 ) -> None:
     """CLI entry point: chunked autodetect with a named importer."""
-    try:
-        _run_pipeline(
-            _load_importer_chunked(importer_name, field_values, chunk_size) if not dry_run else iter(()),
-            settings_path=settings_path,
-            exporter_name=exporter_name,
-            exporter_field_values=exporter_field_values,
-            empty_error=f"No medias loaded by importer '{importer_name}'",
-            dry_run=dry_run,
-            stream_results=stream_results,
-            keep_negatives=keep_negatives,
-            source_description={
-                "kind": "importer",
-                "importer": importer_name,
-                "params": field_values,
-                "chunk_size": chunk_size,
-                "stream_results": stream_results,
-                "keep_negatives": keep_negatives,
-            },
-        )
-    except Exception as e:
-        cli_progress.emit_error(str(e))
-        sys.exit(1)
+    _autodetect(
+        _SourceSpec(
+            kind="importer",
+            importer_name=importer_name,
+            field_values=field_values,
+            chunk_size=chunk_size,
+        ),
+        settings_path=settings_path,
+        exporter_name=exporter_name,
+        exporter_field_values=exporter_field_values,
+        dry_run=dry_run,
+        stream_results=stream_results,
+        keep_negatives=keep_negatives,
+    )

--- a/vtscore/docs/packages/cli.md
+++ b/vtscore/docs/packages/cli.md
@@ -43,8 +43,10 @@ are accessible piece-by-piece from `vtscore.datasets`,
 
 ## `vtscore.cli` - autodetect entry points
 
-Four public entry points, all sharing the same internal `_run_pipeline`
-helper. Each variant differs only in how it produces media chunks:
+Four public entry points, all thin shims over one private
+`_autodetect(spec, ...)` (which in turn drives the shared
+`_run_pipeline`). Each variant differs only in the `_SourceSpec` it
+builds - i.e. in how it produces media chunks:
 
 | Function                              | Source         | Streaming?      |
 |---------------------------------------|----------------|-----------------|
@@ -54,7 +56,8 @@ helper. Each variant differs only in how it produces media chunks:
 | `autodetect_importer_main_chunked`    | Named importer | Chunked         |
 
 All four take optional `settings_path`, `exporter_name`,
-`exporter_field_values`, and the keyword-only `dry_run=False`. They
+`exporter_field_values`, and the keyword-only `dry_run=False`,
+`stream_results=False` and `keep_negatives=False`. They
 print errors via `cli_progress.emit_error()` and `sys.exit(1)` on
 failure - i.e. they're meant to be called from a `__main__`-style
 wrapper, not as well-behaved library functions. If you want the
@@ -68,7 +71,10 @@ def autodetect_main(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
-    *, dry_run: bool = False,
+    *,
+    dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None: ...                                                # vtscore/cli.py
 
 def autodetect_main_chunked(
@@ -77,7 +83,10 @@ def autodetect_main_chunked(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
-    *, dry_run: bool = False,
+    *,
+    dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None: ...                                                # vtscore/cli.py
 
 def autodetect_importer_main(
@@ -86,7 +95,10 @@ def autodetect_importer_main(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
-    *, dry_run: bool = False,
+    *,
+    dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None: ...                                                # vtscore/cli.py
 
 def autodetect_importer_main_chunked(
@@ -96,7 +108,10 @@ def autodetect_importer_main_chunked(
     settings_path: str | None = None,
     exporter_name: str | None = None,
     exporter_field_values: dict[str, Any] | None = None,
-    *, dry_run: bool = False,
+    *,
+    dry_run: bool = False,
+    stream_results: bool = False,
+    keep_negatives: bool = False,
 ) -> None: ...                                                # vtscore/cli.py
 ```
 
@@ -114,6 +129,15 @@ def autodetect_importer_main_chunked(
   exporter sees a single merged results dict at the end.
 - **Default exporter** is `"gui"` (prints to stdout) when
   `exporter_name` is `None`.
+- **`stream_results=True`** hands the (streaming-capable) exporter a
+  lazy record iterator instead of accumulating a merged results dict,
+  so nothing proportional to the hit count is held in RAM;
+  `keep_negatives=True` additionally streams below-threshold hits
+  (labelled `"bad"`). Both are accepted by all four entry points -
+  they pair naturally with the chunked variants, but a whole-dataset
+  run also benefits, since the hits need not accumulate even when the
+  medias already have. The `--stream-results` **CLI flag** is narrower:
+  it requires `--chunk-size N`.
 
 ```python
 from vtscore.cli import autodetect_main, autodetect_importer_main

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -17,6 +17,8 @@ import argparse
 import logging
 import os
 import sys
+from collections.abc import Callable
+from typing import Any
 
 from vtscore.media import set_progress_callback
 
@@ -733,64 +735,40 @@ def _dispatch_autodetect(
     keep_negatives,
 ) -> None:
     """Run the autodetect workflow via the importer- or pickle-file code path."""
+    from vtscore.cli import (
+        autodetect_importer_main,
+        autodetect_importer_main_chunked,
+        autodetect_main,
+        autodetect_main_chunked,
+    )
+
+    # Pick the entry point and its source-specific leading arguments; every
+    # other argument is identical across the four, so the call is written once.
+    entry_point: Callable[..., None]
+    source_args: tuple[Any, ...]
     if args.importer:
-        # Importer-based path
         field_values = {f.key: getattr(args, f.key, f.default) for f in importer.fields}
-
         if chunk_size:
-            from vtscore.cli import autodetect_importer_main_chunked
-
-            autodetect_importer_main_chunked(
-                args.importer,
-                field_values,
-                chunk_size,
-                settings_path,
-                args.exporter,
-                exporter_field_values,
-                dry_run=dry_run,
-                stream_results=stream_results,
-                keep_negatives=keep_negatives,
-            )
+            entry_point, source_args = autodetect_importer_main_chunked, (args.importer, field_values, chunk_size)
         else:
-            from vtscore.cli import autodetect_importer_main
-
-            autodetect_importer_main(
-                args.importer,
-                field_values,
-                settings_path,
-                args.exporter,
-                exporter_field_values,
-                dry_run=dry_run,
-            )
-
+            entry_point, source_args = autodetect_importer_main, (args.importer, field_values)
     elif args.dataset:
-        # Pickle-file path
         if chunk_size:
-            from vtscore.cli import autodetect_main_chunked
-
-            autodetect_main_chunked(
-                args.dataset,
-                chunk_size,
-                settings_path,
-                args.exporter,
-                exporter_field_values,
-                dry_run=dry_run,
-                stream_results=stream_results,
-                keep_negatives=keep_negatives,
-            )
+            entry_point, source_args = autodetect_main_chunked, (args.dataset, chunk_size)
         else:
-            from vtscore.cli import autodetect_main
-
-            autodetect_main(
-                args.dataset,
-                settings_path,
-                args.exporter,
-                exporter_field_values,
-                dry_run=dry_run,
-            )
-
+            entry_point, source_args = autodetect_main, (args.dataset,)
     else:
         parser.error("--autodetect requires either --dataset <file.pkl> or --importer <name>")
+
+    entry_point(
+        *source_args,
+        settings_path,
+        args.exporter,
+        exporter_field_values,
+        dry_run=dry_run,
+        stream_results=stream_results,
+        keep_negatives=keep_negatives,
+    )
 
 
 def _run_autodetect(args, parser, importer, exporter) -> None:


### PR DESCRIPTION
The four `autodetect_*_main` entry points (pickle/importer × whole/chunked) each hand-copied three things: the loader call, the `--dry-run` source description, and the "nothing loaded" error text. That is how the matrix drifted.

## What changed

- **`_SourceSpec`** (frozen dataclass in `vtscore/cli.py`) owns all three — `load()`, `describe()`, `empty_error` — so a source variant is one construction and the three can no longer disagree.
- **`_autodetect(spec, **opts)`** owns the shared body (the `try` / `emit_error` / `sys.exit(1)` wrapper around `_run_pipeline`).
- **All four public names stay exported as thin shims**, with their positional parameters, keyword-only flags and defaults unchanged. They are documented library API (`vtscore/docs/packages/cli.md`) and may have out-of-tree callers, so this was the acceptance criterion, not a nicety.
- **`stream_results` / `keep_negatives` are now accepted by all four** (previously chunked-only). Additive — both default to `False`, i.e. the previous behaviour. The `--stream-results` **CLI flag** is unchanged and still requires `--chunk-size N`; this only widens the library API, where a whole-dataset run can now hand a streaming-capable exporter a lazy record iterator instead of accumulating a merged results dict.
- **Dropped the redundant `apply_custom_metadata_md5` pass in `_load_importer_whole`.** `_run_pipeline` already applies it to every chunk, including this one. The second call was a provable no-op (the helper *pops* the key it reads), so this is dead-code removal, not a behaviour change.
- **`_dispatch_autodetect`** (`vtsearch/cli_main.py`) picks the entry point plus its source-specific leading arguments, then writes the shared 6-argument call once instead of four times.

## Tests

- `tests_lib/cli/test_source_spec.py` (new) — pins the spec → `describe()` / `empty_error` / `load()` mapping, including a parametrised case asserting all four cells report the streaming flags (the specific drift this guards against), and that `load()` stays lazy.
- `tests/cli/test_cli_streaming.py` — three cases for streaming on the *whole*-pickle entry point: positive hits, `keep_negatives`, and the `--dry-run` plan reporting `Chunk size: whole dataset` + `Streaming: yes`.

Full `./run-tests.sh` green: 9762 passed, 6 skipped, 1 xfailed; pyright, pip-audit, vulture whitelist, npm audit and Vitest all OK.

## Docs

`vtscore/docs/packages/cli.md` updated for the new signatures and the streaming-flag semantics; `vtscore/CHANGELOG.md` gets an Added entry, since this widens a public library surface.

Closes #3432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGetqpFSm2Nyfdqn6RSKHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGetqpFSm2Nyfdqn6RSKHQ)_