### PR TITLE
refactor(tests): read state through the real imports, not an app alias shim

### DIFF
--- a/app.py
+++ b/app.py
@@ -186,30 +186,6 @@ api.spec.to_dict = _to_dict_with_operation_ids
 
 
 # ---------------------------------------------------------------------------
-# Test-time attributes
-# ---------------------------------------------------------------------------
-# ``tests/conftest.py`` attaches a handful of helpers and proxies to this
-# module so tests can use ``import app as app_module; app_module.medias`` etc.
-# Declaring them here in a ``TYPE_CHECKING`` block lets pyright resolve the
-# attribute accesses without changing runtime behaviour; the values are still
-# only set by conftest and are absent in production. Same pattern as
-# ``vtsearch/settings.py``'s dynamically generated accessors.
-from typing import TYPE_CHECKING  # noqa: E402
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any
-
-    NUM_MEDIAS: int
-    generate_wav: Callable[..., bytes]
-    train_and_score: Callable[..., Any]
-    medias: dict[int, dict[str, Any]]
-    good_votes: dict[int, None]
-    bad_votes: dict[int, None]
-    init_medias: Callable[[], None]
-
-
-# ---------------------------------------------------------------------------
 # Request-lifecycle hooks and global JSON error handlers
 # ---------------------------------------------------------------------------
 # Both live in their own modules (``vtsearch.hooks`` / ``vtsearch.errors``);

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest side effects)
 from vtscore.datasets.registry import register_dataset
 from vtscore.detectors.registry import register_detector
 from vtsearch.state import medias

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import patch
 
-import app as app_module  # noqa: F401  (triggers conftest side effects)
-
 
 class TestLiveness:
     """``GET /healthz`` is always 200 while the process is up."""

--- a/tests/api/test_jobs_active.py
+++ b/tests/api/test_jobs_active.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import threading
 
-import app as app_module  # noqa: F401  (triggers conftest side effects)
 from vtscore.concurrency.async_jobs import (
     AsyncJob,
     eval_jobs,

--- a/tests/api/test_openapi_snapshot.py
+++ b/tests/api/test_openapi_snapshot.py
@@ -11,7 +11,6 @@ version. These tests pin the canonical form so the drift guard is stable.
 
 from __future__ import annotations
 
-import app as app_module  # noqa: F401  (triggers conftest side effects)
 from vtsearch.openapi_postprocess import normalize_unprocessable_response
 
 

--- a/tests/api/test_projection.py
+++ b/tests/api/test_projection.py
@@ -18,7 +18,6 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-import app as app_module  # noqa: F401
 from vtscore.concurrency.async_jobs import projection_jobs
 from vtscore.projection import Projection, build_pyramid
 from vtscore.state.core import get_active_context

--- a/tests/cli/test_cli_detectors.py
+++ b/tests/cli/test_cli_detectors.py
@@ -13,10 +13,10 @@ from pathlib import Path
 
 import pytest
 
-import app as app_module
 from tests.helpers import make_dataset_file as _make_dataset_file
 from vtsearch.settings import get_detectors_dir
 from vtscore.media.audio.audio_generator import generate_wav
+from vtsearch.state import medias
 
 
 @pytest.fixture(autouse=True)
@@ -120,7 +120,7 @@ class TestAutofindDetectorsCLI:
         }
         _write_trainable_model("ds-a-detector", labelset)
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["ds-a-detector"])
         out_path = tmp_path / "hits.json"
 
@@ -185,7 +185,7 @@ class TestAutofindDetectorsCLI:
         # its scoring info records the clipper to re-apply.
         from vtscore.cli import _load_and_train_detectors
 
-        snap = dict(app_module.medias)
+        snap = dict(medias)
         trained = _load_and_train_detectors(["spec-mismatch"], "audio", snap)
 
         assert "spec-mismatch" in trained
@@ -232,7 +232,7 @@ class TestAutofindDetectorsCLI:
         # only mutate origin.params here, not the medias themselves.
         original_origins = {}
         try:
-            for mid, media in app_module.medias.items():
+            for mid, media in medias.items():
                 original_origins[mid] = media.get("origin")
                 media["origin"] = {
                     "importer": "test",
@@ -242,7 +242,7 @@ class TestAutofindDetectorsCLI:
                     },
                 }
 
-            dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+            dataset_path = _make_dataset_file(tmp_path, medias)
             settings_path = _settings_file_with_detectors(tmp_path, ["spec-matched"])
             out_path = tmp_path / "hits.json"
 
@@ -258,8 +258,8 @@ class TestAutofindDetectorsCLI:
             assert "spec-matched" in body.get("results", {})
         finally:
             for mid, origin in original_origins.items():
-                if mid in app_module.medias:
-                    app_module.medias[mid]["origin"] = origin
+                if mid in medias:
+                    medias[mid]["origin"] = origin
 
     def test_clear_error_when_origins_unresolvable(self, client, tmp_path, monkeypatch):
         """No origins resolve → ValueError with a CLI-friendly explanation."""
@@ -292,7 +292,7 @@ class TestAutofindDetectorsCLI:
         }
         _write_trainable_model("unreachable-tm", labelset)
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["unreachable-tm"])
 
         from vtscore.cli import _run_pipeline, _load_pickle_whole

--- a/tests/cli/test_cli_dry_run.py
+++ b/tests/cli/test_cli_dry_run.py
@@ -16,9 +16,9 @@ from pathlib import Path
 
 import pytest
 
-import app as app_module
 from tests.helpers import make_dataset_file as _make_dataset_file
 from vtsearch.settings import get_detectors_dir
+from vtsearch.state import medias
 
 
 @pytest.fixture(autouse=True)
@@ -81,7 +81,7 @@ def _make_labelset_with_two_audio_labels() -> dict:
 class TestDryRunPickle:
     def test_dry_run_pickle_prints_plan_and_writes_nothing(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
         out_path = tmp_path / "results.json"
 
@@ -111,7 +111,7 @@ class TestDryRunPickle:
 
     def test_dry_run_pickle_reports_chunk_size(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
 
         from vtscore.cli import autodetect_main_chunked
@@ -128,7 +128,7 @@ class TestDryRunPickle:
 
     def test_dry_run_reports_streaming(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
 
         from vtscore.cli import autodetect_main_chunked
@@ -149,7 +149,7 @@ class TestDryRunPickle:
 
     def test_dry_run_streaming_without_stream_results_has_no_streaming_line(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
 
         from vtscore.cli import autodetect_main_chunked
@@ -179,7 +179,7 @@ class TestDryRunPickle:
 
     def test_dry_run_missing_detector_flagged(self, client, tmp_path, capsys):
         # No detector JSON written for "ghost-tm".
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["ghost-tm"])
 
         from vtscore.cli import autodetect_main
@@ -191,7 +191,7 @@ class TestDryRunPickle:
         assert "MISSING" in out
 
     def test_dry_run_empty_autofind_list_calls_it_out(self, client, tmp_path, capsys):
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, [])
 
         from vtscore.cli import autodetect_main
@@ -260,7 +260,7 @@ class TestDryRunImporter:
 class TestDryRunExporterValidation:
     def test_dry_run_unknown_exporter_errors(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
 
         from vtscore.cli import autodetect_main
@@ -279,7 +279,7 @@ class TestDryRunExporterValidation:
 
     def test_dry_run_missing_required_exporter_field_errors(self, client, tmp_path, capsys):
         _write_trainable_model("dry-tm", _make_labelset_with_two_audio_labels())
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file_with_detectors(tmp_path, ["dry-tm"])
 
         from vtscore.cli import autodetect_main

--- a/tests/cli/test_cli_main_subprocess.py
+++ b/tests/cli/test_cli_main_subprocess.py
@@ -22,8 +22,8 @@ from pathlib import Path
 
 import pytest
 
-import app as app_module
 from tests.helpers import make_dataset_file as _make_dataset_file
+from vtsearch.state import medias
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -42,7 +42,7 @@ def _run_app(*args: str) -> subprocess.CompletedProcess:
 def test_app_autodetect_dry_run_via_subprocess(tmp_path):
     """``python app.py --autodetect --dataset ... --dry-run`` prints the plan
     and exits cleanly, with no exporter side effects."""
-    dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+    dataset_path = _make_dataset_file(tmp_path, medias)
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(json.dumps({"autofind_detectors": [], "detectors_dir": str(tmp_path / "det")}))
     out_path = tmp_path / "results.json"

--- a/tests/cli/test_cli_progress.py
+++ b/tests/cli/test_cli_progress.py
@@ -18,12 +18,12 @@ from pathlib import Path
 
 import pytest
 
-import app as app_module
 from tests.helpers import make_dataset_file as _make_dataset_file
 from vtscore import cli_progress
 
 from vtscore.media.audio.audio_generator import generate_wav
 from vtsearch.settings import get_detectors_dir
+from vtsearch.state import medias
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +306,7 @@ class TestAutodetectJsonOutput:
         _stub_resolve(monkeypatch, files)
         _write_detector("json-fmt-det", _audio_labelset())
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_with_detectors(tmp_path, ["json-fmt-det"])
         out_path = tmp_path / "hits.json"
 
@@ -338,7 +338,7 @@ class TestAutodetectJsonOutput:
         _stub_resolve(monkeypatch, files)
         _write_detector("text-fmt-det", _audio_labelset())
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_with_detectors(tmp_path, ["text-fmt-det"])
         out_path = tmp_path / "hits.json"
 

--- a/tests/cli/test_cli_routed_embedder.py
+++ b/tests/cli/test_cli_routed_embedder.py
@@ -19,7 +19,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-import app as app_module  # noqa: F401  (activates the default dataset context)
 from vtscore.cli import _score_direct_all
 
 DIM = 4

--- a/tests/cli/test_cli_score_geometry.py
+++ b/tests/cli/test_cli_score_geometry.py
@@ -22,7 +22,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-import app as app_module  # noqa: F401  (activates the default dataset context)
 from vtscore.cli import _score_direct_all, _score_one_detector
 from vtscore.detectors.training import _score_all_media, scoring_rows_for_snap
 from vtscore.embedding.matrix import media_score_rows

--- a/tests/cli/test_load_sort_window.py
+++ b/tests/cli/test_load_sort_window.py
@@ -16,8 +16,8 @@ import wave
 import numpy as np
 import pytest
 
-import app as app_module
 from vtsearch.state import medias
+from tests.fixtures.medias import NUM_MEDIAS
 
 
 class TestExampleSort:
@@ -54,7 +54,7 @@ class TestExampleSort:
         data = resp.get_json()
         assert "results" in data
         assert "threshold" in data
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
 
     def test_results_sorted_descending(self, client):
         wav_buf = self._make_wav_bytes()
@@ -94,7 +94,7 @@ class TestExampleSort:
         )
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
 
     def test_with_invalid_crop_params_falls_back_to_full(self, client):
         wav_buf = self._make_wav_bytes()
@@ -268,7 +268,7 @@ class TestExampleSortServer:
         data = resp.get_json()
         assert "results" in data
         assert "threshold" in data
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
 
     def test_multi_example_sort_returns_results(self, client):
         # Two examples rank the haystack against their embedding centroid.
@@ -280,7 +280,7 @@ class TestExampleSortServer:
         )
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
         assert "threshold" in data
 
     def test_multi_example_missing_one_returns_404(self, client):
@@ -330,7 +330,7 @@ class TestExampleSortServer:
         )
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
 
     def test_upload_with_crop_params_persists_cropped_bytes(self, client):
         # Upload a 1s WAV with crop_params; the saved file should be the
@@ -448,4 +448,4 @@ class TestExampleSortOrigin:
         data = resp.get_json()
         assert "results" in data
         assert "threshold" in data
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS

--- a/tests/cli/test_pipeline_file.py
+++ b/tests/cli/test_pipeline_file.py
@@ -14,10 +14,10 @@ from pathlib import Path
 import pytest
 import yaml
 
-import app as app_module
 from tests.helpers import make_dataset_file as _make_dataset_file
 from vtscore.media.audio.audio_generator import generate_wav
 from vtsearch.settings import get_detectors_dir
+from vtsearch.state import medias
 
 
 @pytest.fixture(autouse=True)
@@ -298,7 +298,7 @@ class TestRunPipelineFile:
 
         _write_detector("yaml-detector", _trained_labelset())
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file(tmp_path, ["yaml-detector"])
         out_path = tmp_path / "hits.json"
 
@@ -333,7 +333,7 @@ class TestRunPipelineFile:
         # The settings file points at a *different* detector that doesn't
         # exist on disk; if the override isn't honoured the run will fail.
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file(tmp_path, ["nonexistent-detector"])
         out_path = tmp_path / "hits.json"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,27 +35,16 @@ _patch_embed_audio.start()
 
 install_startup_contexts()
 
+# Importing ``app`` registers the Flask routes and builds the module-level
+# ``app_module.app`` the ``client`` fixture below serves.  Test modules do NOT
+# need to repeat this import: conftest is imported first, so ``app`` is already
+# in ``sys.modules`` (and its import side effects have already run) by the time
+# any test module is collected.
 import app as app_module
 
-# Import refactored modules and make them accessible through app_module
-from tests.fixtures.medias import NUM_MEDIAS, init_medias
-from vtscore.media.audio.audio_generator import generate_wav
+from tests.fixtures.medias import init_medias
 from vtscore.embedding import initialize_models
-from vtscore.detectors.training import train_and_score
-from vtsearch.state import (
-    bad_votes,
-    medias,
-    good_votes,
-)
-
-# Attach to app_module for backward compatibility with existing tests
-app_module.NUM_MEDIAS = NUM_MEDIAS
-app_module.generate_wav = generate_wav
-app_module.train_and_score = train_and_score
-app_module.medias = medias
-app_module.good_votes = good_votes
-app_module.bad_votes = bad_votes
-app_module.init_medias = init_medias  # legacy attribute used by some tests
+from vtsearch.state import medias
 
 # Initialize models and medias
 initialize_models()

--- a/tests/core/test_achievement_wiring.py
+++ b/tests/core/test_achievement_wiring.py
@@ -19,7 +19,6 @@ assumed.
 
 from __future__ import annotations
 
-import app as app_module  # noqa: F401  (triggers app startup + conftest media init)
 import pytest
 
 from vtsearch import achievements

--- a/tests/core/test_achievements.py
+++ b/tests/core/test_achievements.py
@@ -17,7 +17,6 @@ import pathlib
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import achievements, achievements_catalog
 from vtsearch import settings as settings_mod
 

--- a/tests/core/test_dataset_max_age.py
+++ b/tests/core/test_dataset_max_age.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
 

--- a/tests/core/test_eval_only_embedders.py
+++ b/tests/core/test_eval_only_embedders.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtscore.media import (
     all_embedders,
     all_embedders_dict,

--- a/tests/core/test_hidden_plugins.py
+++ b/tests/core/test_hidden_plugins.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 
 

--- a/tests/core/test_media_list_edge_paths.py
+++ b/tests/core/test_media_list_edge_paths.py
@@ -22,9 +22,9 @@ import numpy as np
 import pytest
 from PIL import Image
 
-import app as app_module
 from vtsearch.routes.media import list as media_list
 from vtsearch.state import medias
+from vtscore.media.audio.audio_generator import generate_wav
 
 # ---------------------------------------------------------------------------
 # Injection helpers
@@ -656,7 +656,7 @@ class TestAddToPileEdgePaths:
         # picks the first embedder registered for the media type.
         saved = self._single_audio_dataset("")
         try:
-            wav = app_module.generate_wav(4321, 0.2)
+            wav = generate_wav(4321, 0.2)
             resp = client.post(
                 "/api/medias/add-to-pile",
                 data={"label": "good", "file": (io.BytesIO(wav), "fresh.wav")},
@@ -673,7 +673,7 @@ class TestAddToPileEdgePaths:
         # handler still recovers via the media-type default embedder.
         saved = self._single_audio_dataset("no_such_embedder")
         try:
-            wav = app_module.generate_wav(4322, 0.2)
+            wav = generate_wav(4322, 0.2)
             resp = client.post(
                 "/api/medias/add-to-pile",
                 data={"label": "good", "file": (io.BytesIO(wav), "fresh2.wav")},
@@ -718,7 +718,7 @@ class TestAddToPileEdgePaths:
 
         audio_embedder = embedders_for_type("audio")[0]
         monkeypatch.setattr(audio_embedder, "embed_media", lambda *_a, **_k: None)
-        wav = app_module.generate_wav(4323, 0.2)
+        wav = generate_wav(4323, 0.2)
         resp = client.post(
             "/api/medias/add-to-pile",
             data={"label": "good", "file": (io.BytesIO(wav), "fresh3.wav")},
@@ -740,7 +740,7 @@ class TestAddToPileEdgePaths:
         # When the thumbnail generator yields nothing, the media is still
         # inserted -- just without thumbnail_bytes (the thumb-None branch).
         monkeypatch.setattr(media_list, "_make_pile_thumbnail", lambda *_a, **_k: None)
-        wav = app_module.generate_wav(4324, 0.2)
+        wav = generate_wav(4324, 0.2)
         resp = client.post(
             "/api/medias/add-to-pile",
             data={"label": "good", "file": (io.BytesIO(wav), "nothumb.wav")},

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -6,38 +6,41 @@ import numpy as np
 import app as app_module
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.utils.hashing import content_md5
+from tests.fixtures.medias import NUM_MEDIAS
+from vtscore.media.audio.audio_generator import generate_wav
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 class TestInitMedias:
     def test_creates_correct_number_of_medias(self):
-        assert len(app_module.medias) == app_module.NUM_MEDIAS
+        assert len(medias) == NUM_MEDIAS
 
     def test_media_ids_are_1_to_num_medias(self):
-        assert set(app_module.medias.keys()) == set(range(1, app_module.NUM_MEDIAS + 1))
+        assert set(medias.keys()) == set(range(1, NUM_MEDIAS + 1))
 
     def test_media_frequencies(self):
-        for i in range(1, app_module.NUM_MEDIAS + 1):
+        for i in range(1, NUM_MEDIAS + 1):
             expected_freq = 200 + (i - 1) * 50
-            assert app_module.medias[i]["frequency"] == expected_freq
+            assert medias[i]["frequency"] == expected_freq
 
     def test_media_durations(self):
-        for i in range(1, app_module.NUM_MEDIAS + 1):
+        for i in range(1, NUM_MEDIAS + 1):
             expected_dur = round(1.0 + (i % 5) * 0.5, 1)
-            assert app_module.medias[i]["duration"] == expected_dur
+            assert medias[i]["duration"] == expected_dur
 
     def test_media_has_embedding(self):
-        for media in app_module.medias.values():
+        for media in medias.values():
             emb = media_embedding(media)
             assert isinstance(emb, np.ndarray)
             assert len(emb) > 0
 
     def test_media_has_media_bytes(self):
-        for media in app_module.medias.values():
+        for media in medias.values():
             assert isinstance(media["media_bytes"], bytes)
             assert len(media["media_bytes"]) > 0
 
     def test_file_size_matches_media_bytes_length(self):
-        for media in app_module.medias.values():
+        for media in medias.values():
             assert media["file_size"] == len(media["media_bytes"])
 
     def test_deterministic_embeddings(self):
@@ -45,7 +48,7 @@ class TestInitMedias:
         from vtscore.config import DATA_DIR
         from vtscore.embedding import embed_audio_file
 
-        media = app_module.medias[1]
+        media = medias[1]
         # Re-embed the same WAV and verify the result matches
         temp_path = DATA_DIR / "temp_determ_test.wav"
         temp_path.write_bytes(media["media_bytes"])
@@ -57,21 +60,21 @@ class TestInitMedias:
 
 class TestMediaMD5:
     def test_media_has_md5(self):
-        for media in app_module.medias.values():
+        for media in medias.values():
             assert "md5" in media
             assert isinstance(media["md5"], str)
             assert len(media["md5"]) == 32  # MD5 hex string
 
     def test_md5_matches_media_bytes(self):
-        for media in app_module.medias.values():
+        for media in medias.values():
             expected_md5 = content_md5(media["media_bytes"])
             assert media["md5"] == expected_md5
 
     def test_md5_deterministic(self):
         """MD5 should be the same for the same media across re-generation."""
-        media = app_module.medias[1]
+        media = medias[1]
         # Regenerate the WAV with the same parameters and verify MD5
-        wav_bytes = app_module.generate_wav(media["frequency"], media["duration"])
+        wav_bytes = generate_wav(media["frequency"], media["duration"])
         assert content_md5(wav_bytes) == media["md5"]
 
 
@@ -310,7 +313,7 @@ class TestListMediaIds:
         resp = client.get("/api/medias/ids")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data) == app_module.NUM_MEDIAS
+        assert len(data) == NUM_MEDIAS
 
     def test_stub_fields_only(self, client):
         """Each stub carries id + media_type and (optionally) embedder(s); nothing else."""
@@ -400,7 +403,7 @@ class TestBatchMediasProvenance:
 
     @staticmethod
     def _set_origin(media_id, origin):
-        media = app_module.medias[media_id]
+        media = medias[media_id]
         saved = media.get("origin")
         media["origin"] = origin
         return saved
@@ -429,7 +432,7 @@ class TestBatchMediasProvenance:
         try:
             meta = self._metadata_for(client, 1)
         finally:
-            app_module.medias[1]["origin"] = saved
+            medias[1]["origin"] = saved
 
         assert meta["Source"] == "/data/videos/movie.mp4"
         assert meta["Derived Via"] == "Video → Images (n_clips=2)"
@@ -444,14 +447,14 @@ class TestBatchMediasProvenance:
         try:
             meta = self._metadata_for(client, 1)
         finally:
-            app_module.medias[1]["origin"] = saved
+            medias[1]["origin"] = saved
 
         assert meta["Imported Via"] == "Folder (path=/data/sounds)"
         assert "Source" not in meta
         assert "Derived Via" not in meta
 
     def test_importer_custom_metadata_wins_over_display_fields(self, client):
-        media = app_module.medias[1]
+        media = medias[1]
         saved_origin = self._set_origin(1, {"importer": "server_folder", "params": {"path": "/from-origin"}})
         media["custom_metadata"] = {"Imported Via": "hand-curated"}
         try:
@@ -467,19 +470,19 @@ class TestMediaThumbnailBytes:
     """Test medias have waveform thumbnail_bytes generated at init."""
 
     def test_all_medias_have_thumbnail_bytes(self):
-        for media in app_module.medias.values():
+        for media in medias.values():
             assert "thumbnail_bytes" in media
             assert isinstance(media["thumbnail_bytes"], bytes)
             assert len(media["thumbnail_bytes"]) > 0
 
     def test_thumbnail_bytes_is_valid_png(self):
-        media = app_module.medias[1]
+        media = medias[1]
         thumb = media["thumbnail_bytes"]
         # PNG magic number
         assert thumb[:8] == b"\x89PNG\r\n\x1a\n"
 
     def test_thumbnail_bytes_not_exposed_in_api(self, client):
-        resp = client.post("/api/medias/batch", json={"ids": list(range(1, app_module.NUM_MEDIAS + 1))})
+        resp = client.post("/api/medias/batch", json={"ids": list(range(1, NUM_MEDIAS + 1))})
         data = resp.get_json()
         for media in data:
             assert "thumbnail_bytes" not in media
@@ -511,7 +514,7 @@ class TestMediaImage:
 
     def test_fallback_generates_thumbnail_on_the_fly(self, client):
         """When thumbnail_bytes is missing, the endpoint generates it on the fly."""
-        media = app_module.medias[1]
+        media = medias[1]
         saved_thumb = media.pop("thumbnail_bytes", None)
         try:
             resp = client.get("/api/medias/1/image")
@@ -702,7 +705,7 @@ class TestAddToPile:
 
     def test_add_existing_media_to_good(self, client):
         """Uploading a file whose MD5 matches an existing media votes it good."""
-        media = app_module.medias[1]
+        media = medias[1]
         data = {"label": "good"}
         resp = client.post(
             "/api/medias/add-to-pile",
@@ -714,11 +717,11 @@ class TestAddToPile:
         assert result["ok"] is True
         assert result["is_new"] is False
         assert result["media_id"] == 1
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
     def test_add_existing_media_to_bad(self, client):
         """Uploading a file whose MD5 matches an existing media votes it bad."""
-        media = app_module.medias[2]
+        media = medias[2]
         data = {"label": "bad"}
         resp = client.post(
             "/api/medias/add-to-pile",
@@ -730,13 +733,13 @@ class TestAddToPile:
         assert result["ok"] is True
         assert result["is_new"] is False
         assert result["media_id"] == 2
-        assert 2 in app_module.bad_votes
+        assert 2 in bad_votes
 
     def test_add_new_media_to_good(self, client):
         """Uploading a file with new MD5 embeds it, inserts it, and votes good."""
         # Generate a unique WAV that doesn't match any existing media
-        wav_bytes = app_module.generate_wav(12345, 0.3)
-        initial_count = len(app_module.medias)
+        wav_bytes = generate_wav(12345, 0.3)
+        initial_count = len(medias)
         resp = client.post(
             "/api/medias/add-to-pile",
             data={"label": "good", "file": (io.BytesIO(wav_bytes), "new_sound.wav")},
@@ -747,11 +750,11 @@ class TestAddToPile:
         assert result["ok"] is True
         assert result["is_new"] is True
         new_id = result["media_id"]
-        assert new_id in app_module.medias
-        assert len(app_module.medias) == initial_count + 1
-        assert new_id in app_module.good_votes
+        assert new_id in medias
+        assert len(medias) == initial_count + 1
+        assert new_id in good_votes
         # Verify the new media has proper fields
-        new_media = app_module.medias[new_id]
+        new_media = medias[new_id]
         assert new_media["md5"] == content_md5(wav_bytes)
         assert new_media["filename"] == "new_sound.wav"
         assert new_media["origin"]["importer"] == "add_to_pile"
@@ -759,7 +762,7 @@ class TestAddToPile:
 
     def test_add_new_media_to_bad(self, client):
         """Uploading a new file and voting it bad."""
-        wav_bytes = app_module.generate_wav(54321, 0.2)
+        wav_bytes = generate_wav(54321, 0.2)
         resp = client.post(
             "/api/medias/add-to-pile",
             data={"label": "bad", "file": (io.BytesIO(wav_bytes), "bad_sound.wav")},
@@ -769,7 +772,7 @@ class TestAddToPile:
         result = resp.get_json()
         assert result["ok"] is True
         assert result["is_new"] is True
-        assert result["media_id"] in app_module.bad_votes
+        assert result["media_id"] in bad_votes
 
     def test_missing_file(self, client):
         resp = client.post(
@@ -784,7 +787,7 @@ class TestAddToPile:
         assert "No file" in resp.get_json()["message"]
 
     def test_missing_label(self, client):
-        wav_bytes = app_module.generate_wav(999, 0.1)
+        wav_bytes = generate_wav(999, 0.1)
         resp = client.post(
             "/api/medias/add-to-pile",
             data={"file": (io.BytesIO(wav_bytes), "test.wav")},
@@ -794,7 +797,7 @@ class TestAddToPile:
         assert "label" in resp.get_json()["message"]
 
     def test_invalid_label(self, client):
-        wav_bytes = app_module.generate_wav(999, 0.1)
+        wav_bytes = generate_wav(999, 0.1)
         resp = client.post(
             "/api/medias/add-to-pile",
             data={"label": "maybe", "file": (io.BytesIO(wav_bytes), "test.wav")},
@@ -814,10 +817,10 @@ class TestAddToPile:
 
     def test_no_dataset_loaded(self, client):
         """When no dataset is loaded, adding new media fails gracefully."""
-        saved = dict(app_module.medias)
-        app_module.medias.clear()
+        saved = dict(medias)
+        medias.clear()
         try:
-            wav_bytes = app_module.generate_wav(999, 0.1)
+            wav_bytes = generate_wav(999, 0.1)
             resp = client.post(
                 "/api/medias/add-to-pile",
                 data={"label": "good", "file": (io.BytesIO(wav_bytes), "test.wav")},
@@ -826,7 +829,7 @@ class TestAddToPile:
             assert resp.status_code == 400
             assert "No dataset" in resp.get_json()["message"]
         finally:
-            app_module.medias.update(saved)
+            medias.update(saved)
 
     def test_concurrent_uploads_same_md5_no_duplicate(self):
         """H32 regression: two concurrent uploads of identical bytes must
@@ -853,8 +856,8 @@ class TestAddToPile:
 
         audio_embedder = embedders_for_type("audio")[0]
 
-        wav_bytes = app_module.generate_wav(77777, 0.25)
-        initial_count = len(app_module.medias)
+        wav_bytes = generate_wav(77777, 0.25)
+        initial_count = len(medias)
 
         # Capture the test thread's contexts so the worker threads resolve
         # the same DatasetContext/DetectorContext when ``before_request``
@@ -917,8 +920,8 @@ class TestAddToPile:
         assert len(results) == 2
 
         # Exactly one new media inserted (the regression: was 2 before fix).
-        assert len(app_module.medias) == initial_count + 1, (
-            f"H32: duplicate insert; medias grew by {len(app_module.medias) - initial_count}, expected 1"
+        assert len(medias) == initial_count + 1, (
+            f"H32: duplicate insert; medias grew by {len(medias) - initial_count}, expected 1"
         )
 
         # Both requests succeed and report the same media id.
@@ -933,8 +936,8 @@ class TestAddToPile:
 
         # The single inserted media carries the uploaded bytes' md5.
         inserted_id = next(iter(media_ids))
-        assert app_module.medias[inserted_id]["md5"] == content_md5(wav_bytes)
-        assert inserted_id in app_module.good_votes
+        assert medias[inserted_id]["md5"] == content_md5(wav_bytes)
+        assert inserted_id in good_votes
 
     def _setup_loaded_detector(self, client, name="H33Detector"):
         """Register a detector, load it, and return its registry id."""
@@ -960,7 +963,7 @@ class TestAddToPile:
         from vtscore.datasets.labelset import LabelSet, element_key, media_element_key
         from vtscore.detectors.store import _detector_path, _read_detector
 
-        media = app_module.medias[1]
+        media = medias[1]
         _, name = self._setup_loaded_detector(client)
 
         resp = client.post(
@@ -989,7 +992,7 @@ class TestAddToPile:
         from vtscore.datasets.labelset import LabelSet
         from vtscore.detectors.store import _detector_path, _read_detector
 
-        wav_bytes = app_module.generate_wav(33333, 0.2)
+        wav_bytes = generate_wav(33333, 0.2)
         _, name = self._setup_loaded_detector(client)
 
         resp = client.post(
@@ -1026,7 +1029,7 @@ class TestAddToPile:
         from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
         from vtscore.state.core import get_active_detector_context
 
-        media = app_module.medias[2]
+        media = medias[2]
         self._setup_loaded_detector(client)
 
         resp = client.post(
@@ -1035,7 +1038,7 @@ class TestAddToPile:
             content_type="multipart/form-data",
         )
         assert resp.status_code == 200
-        assert 2 in app_module.good_votes
+        assert 2 in good_votes
 
         # Invalidate the detector context's caches and drop the in-memory
         # votes so the rehydrate hook must round-trip through the file.
@@ -1047,4 +1050,4 @@ class TestAddToPile:
         det_ctx.votes_dataset_id = ""
 
         ensure_votes_match_active_dataset()
-        assert 2 in app_module.good_votes, "label vanished on rehydration; H33 regressed"
+        assert 2 in good_votes, "label vanished on rehydration; H33 regressed"

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import json
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 from vtsearch import settings_store as settings_store_mod
 from vtsearch.auth import set_thread_user

--- a/tests/core/test_semantic_only.py
+++ b/tests/core/test_semantic_only.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -13,7 +13,6 @@ import json
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 
 

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
-
 # Flask API routes
 # ---------------------------------------------------------------------------
 

--- a/tests/core/test_settings_directories.py
+++ b/tests/core/test_settings_directories.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import json
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_solo_embedder.py
+++ b/tests/core/test_solo_embedder.py
@@ -14,7 +14,6 @@ import json
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 
 

--- a/tests/core/test_solo_media_type.py
+++ b/tests/core/test_solo_media_type.py
@@ -13,7 +13,6 @@ import json
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 
 

--- a/tests/core/test_support_email.py
+++ b/tests/core/test_support_email.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import pytest
 
-import app as app_module  # noqa: F401  (triggers conftest media init)
 from vtsearch import settings as settings_mod
 from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
 from vtsearch.settings_models import DEFAULT_SUPPORT_EMAIL

--- a/tests/core/test_votes.py
+++ b/tests/core/test_votes.py
@@ -1,4 +1,3 @@
-import app as app_module
 import vtscore.detectors.labeling_progress as labeling_progress
 from vtscore.detectors.labeling_progress import (
     _compute_stable_status,
@@ -7,12 +6,7 @@ from vtscore.detectors.labeling_progress import (
     invalidate_progress_cache_from,
 )
 from vtscore.embedding.media_vectors import media_embedding
-from vtsearch.state import (
-    build_coverage_atlas,
-    get_coverage_atlas,
-    medias,
-    label_history,
-)
+from vtsearch.state import bad_votes, build_coverage_atlas, get_coverage_atlas, good_votes, label_history, medias
 
 
 def _prog_cache():
@@ -30,26 +24,26 @@ class TestVoteClip:
         resp = client.post("/api/medias/1/vote", json={"target": "good"})
         assert resp.status_code == 200
         assert resp.get_json()["ok"] is True
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
     def test_vote_bad(self, client):
         resp = client.post("/api/medias/1/vote", json={"target": "bad"})
         assert resp.status_code == 200
-        assert 1 in app_module.bad_votes
+        assert 1 in bad_votes
 
     def test_unvote_good(self, client):
         """target=none removes a good vote."""
         client.post("/api/medias/1/vote", json={"target": "good"})
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
         client.post("/api/medias/1/vote", json={"target": "none"})
-        assert 1 not in app_module.good_votes
+        assert 1 not in good_votes
 
     def test_unvote_bad(self, client):
         """target=none removes a bad vote."""
         client.post("/api/medias/1/vote", json={"target": "bad"})
-        assert 1 in app_module.bad_votes
+        assert 1 in bad_votes
         client.post("/api/medias/1/vote", json={"target": "none"})
-        assert 1 not in app_module.bad_votes
+        assert 1 not in bad_votes
 
     def test_idempotent_re_vote_good(self, client):
         """Re-sending target=good on a good media is a no-op (H1 fix).
@@ -61,9 +55,8 @@ class TestVoteClip:
         assert r1.status_code == 200
         r2 = client.post("/api/medias/1/vote", json={"target": "good"})
         assert r2.status_code == 200
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
         # Idempotent: a single label_history entry, not two.
-        from vtsearch.state import label_history
 
         assert sum(1 for entry in label_history if entry[0] == 1) == 1
 
@@ -72,22 +65,21 @@ class TestVoteClip:
         assert r1.status_code == 200
         r2 = client.post("/api/medias/1/vote", json={"target": "bad"})
         assert r2.status_code == 200
-        assert 1 in app_module.bad_votes
-        from vtsearch.state import label_history
+        assert 1 in bad_votes
 
         assert sum(1 for entry in label_history if entry[0] == 1) == 1
 
     def test_switch_from_good_to_bad(self, client):
         client.post("/api/medias/1/vote", json={"target": "good"})
         client.post("/api/medias/1/vote", json={"target": "bad"})
-        assert 1 not in app_module.good_votes
-        assert 1 in app_module.bad_votes
+        assert 1 not in good_votes
+        assert 1 in bad_votes
 
     def test_switch_from_bad_to_good(self, client):
         client.post("/api/medias/1/vote", json={"target": "bad"})
         client.post("/api/medias/1/vote", json={"target": "good"})
-        assert 1 not in app_module.bad_votes
-        assert 1 in app_module.good_votes
+        assert 1 not in bad_votes
+        assert 1 in good_votes
 
     def test_invalid_target_value(self, client):
         # Marshmallow OneOf validator on ``target`` rejects non-{good,bad,none}
@@ -116,10 +108,10 @@ class TestVoteClip:
     def test_multiple_clips_independent_votes(self, client):
         client.post("/api/medias/1/vote", json={"target": "good"})
         client.post("/api/medias/2/vote", json={"target": "bad"})
-        assert 1 in app_module.good_votes
-        assert 2 in app_module.bad_votes
-        assert 1 not in app_module.bad_votes
-        assert 2 not in app_module.good_votes
+        assert 1 in good_votes
+        assert 2 in bad_votes
+        assert 1 not in bad_votes
+        assert 2 not in good_votes
 
 
 class TestVoteBulk:
@@ -138,25 +130,25 @@ class TestVoteBulk:
         assert data["ok"] is True
         assert data["changed"] == 2
         assert data["missing"] == []
-        assert 1 in app_module.bad_votes
-        assert 2 in app_module.bad_votes
-        assert 1 not in app_module.good_votes
-        assert 2 not in app_module.good_votes
+        assert 1 in bad_votes
+        assert 2 in bad_votes
+        assert 1 not in good_votes
+        assert 2 not in good_votes
 
     def test_bulk_idempotent_not_counted(self, client):
         client.post("/api/medias/1/vote", json={"target": "bad"})
         # 1 is already bad → no change; 2 transitions none→bad → one change.
         resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 2], "target": "bad"})
         assert resp.get_json()["changed"] == 1
-        assert 1 in app_module.bad_votes
-        assert 2 in app_module.bad_votes
+        assert 1 in bad_votes
+        assert 2 in bad_votes
 
     def test_bulk_reports_missing_ids(self, client):
         resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 9999], "target": "bad"})
         data = resp.get_json()
         assert data["missing"] == [9999]
         assert data["changed"] == 1
-        assert 1 in app_module.bad_votes
+        assert 1 in bad_votes
 
     def test_bulk_empty_ids_rejected(self, client):
         resp = client.post("/api/medias/vote-bulk", json={"ids": [], "target": "bad"})
@@ -179,20 +171,20 @@ class TestGetVotes:
         assert data["learned_scores"] == {}
 
     def test_returns_good_votes(self, client):
-        app_module.good_votes.update({k: None for k in [5, 1, 3]})
+        good_votes.update({k: None for k in [5, 1, 3]})
         resp = client.get("/api/votes")
         data = resp.get_json()
         assert data["good"] == [1, 3, 5]  # sorted regardless of insertion order
 
     def test_returns_bad_votes(self, client):
-        app_module.bad_votes.update({k: None for k in [4, 2]})
+        bad_votes.update({k: None for k in [4, 2]})
         resp = client.get("/api/votes")
         data = resp.get_json()
         assert data["bad"] == [2, 4]  # sorted regardless of insertion order
 
     def test_returns_both(self, client):
-        app_module.good_votes[1] = None
-        app_module.bad_votes[2] = None
+        good_votes[1] = None
+        bad_votes[2] = None
         resp = client.get("/api/votes")
         data = resp.get_json()
         assert data["good"] == [1]
@@ -212,14 +204,14 @@ class TestClearVotes:
         """POST /api/votes/clear should remove all votes."""
         client.post("/api/medias/1/vote", json={"target": "good"})
         client.post("/api/medias/2/vote", json={"target": "bad"})
-        assert 1 in app_module.good_votes
-        assert 2 in app_module.bad_votes
+        assert 1 in good_votes
+        assert 2 in bad_votes
 
         resp = client.post("/api/votes/clear")
         assert resp.status_code == 200
         assert resp.get_json()["ok"] is True
-        assert len(app_module.good_votes) == 0
-        assert len(app_module.bad_votes) == 0
+        assert len(good_votes) == 0
+        assert len(bad_votes) == 0
 
     def test_clear_votes_preserves_medias(self, client):
         """Clearing votes should not affect loaded medias."""
@@ -285,8 +277,8 @@ class TestLabelHistory:
         assert label_history[0][1] == "good"
         assert label_history[1][1] == "unlabel"
         assert label_history[2][1] == "bad"
-        assert 1 in app_module.bad_votes
-        assert 1 not in app_module.good_votes
+        assert 1 in bad_votes
+        assert 1 not in good_votes
 
 
 class TestProgressCacheWithLabelChanges:
@@ -894,14 +886,14 @@ class TestLiveModelReuse:
 
         clear_progress_cache()
 
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
 
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
 
         # A live model should have been injected for the current vote set
-        key = (frozenset(app_module.good_votes), frozenset(app_module.bad_votes))
+        key = (frozenset(good_votes), frozenset(bad_votes))
         assert key in _prog_cache().live_models, "learned-sort should inject the live model"
         model, threshold = _prog_cache().live_models[key]
         assert model is not None

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -5,6 +5,7 @@ import zipfile
 import pytest
 
 import app as app_module
+from vtsearch.state import medias
 
 
 class TestIndex:
@@ -454,14 +455,14 @@ class TestDatasetEndpoints:
             assert resp.status_code == 400
 
     def test_clear_dataset(self, client):
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             resp = client.post("/api/dataset/clear")
             assert resp.status_code == 200
             # After clearing, medias should be empty
-            assert len(app_module.medias) == 0
+            assert len(medias) == 0
         finally:
-            app_module.medias.update(saved)
+            medias.update(saved)
 
 
 class TestStartupState:
@@ -469,8 +470,8 @@ class TestStartupState:
 
     def test_status_loaded_false_when_clips_empty(self, client):
         """GET /api/dataset/status returns loaded=False when medias is cleared."""
-        saved = dict(app_module.medias)
-        app_module.medias.clear()
+        saved = dict(medias)
+        medias.clear()
         try:
             resp = client.get("/api/dataset/status")
             assert resp.status_code == 200
@@ -478,7 +479,7 @@ class TestStartupState:
             assert data["loaded"] is False
             assert data["num_medias"] == 0
         finally:
-            app_module.medias.update(saved)
+            medias.update(saved)
 
     def test_init_medias_not_called_automatically(self):
         """init_medias() exists for testing but is not called in production startup.
@@ -1615,7 +1616,7 @@ class TestLoadProgressRaceCondition:
         from tests.helpers import current_loading_progress
 
         # Register the current medias as a dataset entry so we can load it
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             # First, export current medias to a pkl for registration
             from vtscore.datasets.loader import export_dataset_to_file
@@ -1626,7 +1627,7 @@ class TestLoadProgressRaceCondition:
             pkl_path = str(ds_dir / "test_race.pkl")
             from pathlib import Path
 
-            Path(pkl_path).write_bytes(export_dataset_to_file(app_module.medias))
+            Path(pkl_path).write_bytes(export_dataset_to_file(medias))
 
             # Register in the dataset registry
             from vtscore.datasets.registry import register_dataset
@@ -1634,7 +1635,7 @@ class TestLoadProgressRaceCondition:
             entry = register_dataset(
                 name="test_race",
                 media_type="audio",
-                num_items=len(app_module.medias),
+                num_items=len(medias),
                 pkl_path=pkl_path,
             )
             dataset_id = entry["id"]
@@ -1656,8 +1657,8 @@ class TestLoadProgressRaceCondition:
                 if current_loading_progress()["status"] == "idle":
                     break
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
             # Clean up
             Path(pkl_path).unlink(missing_ok=True)
             from vtscore.datasets.registry import unregister_dataset
@@ -1686,18 +1687,18 @@ class TestLoadProgressRaceCondition:
         from vtscore.datasets.registry import register_dataset, unregister_dataset
         from vtsearch.settings import get_saved_datasets_dir
 
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         ds_dir = get_saved_datasets_dir()
         ds_dir.mkdir(parents=True, exist_ok=True)
         pkl_path = str(ds_dir / "test_idle_on_success.pkl")
         dataset_id = None
         try:
-            Path(pkl_path).write_bytes(export_dataset_to_file(app_module.medias))
+            Path(pkl_path).write_bytes(export_dataset_to_file(medias))
 
             entry = register_dataset(
                 name="test_idle_on_success",
                 media_type="audio",
-                num_items=len(app_module.medias),
+                num_items=len(medias),
                 pkl_path=pkl_path,
             )
             dataset_id = entry["id"]
@@ -1720,8 +1721,8 @@ class TestLoadProgressRaceCondition:
                 "load task must reach 'idle' on success instead of lingering at 'loading' until list_tasks() prunes it"
             )
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
             Path(pkl_path).unlink(missing_ok=True)
             if dataset_id:
                 unregister_dataset(dataset_id)
@@ -2017,7 +2018,7 @@ class TestCancelIngest:
         from tests.helpers import current_loading_progress
         from vtscore.concurrency.progress import resolve_progress_callback
 
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             started = threading.Event()
 
@@ -2061,8 +2062,8 @@ class TestCancelIngest:
             assert progress["status"] == "idle"
             assert progress["error"] == "Cancelled"
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
     def test_new_load_is_not_born_cancelled(self, client):
         """A cancelled load must not abort the *next* one.
@@ -2082,7 +2083,7 @@ class TestCancelIngest:
         cancelled.cancel()
         assert cancelled.is_cancelled
 
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             from vtscore.datasets.load_pipeline import _run_origin_load_in_background
 
@@ -2099,8 +2100,8 @@ class TestCancelIngest:
             # ...and the older cancel is still owed to the task it was aimed at.
             assert cancelled.is_cancelled
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
 
 class TestClearDatasetHeaderGuard:
@@ -2110,14 +2111,14 @@ class TestClearDatasetHeaderGuard:
     route now requires ``X-Dataset-Id`` and rejects loudly instead."""
 
     def test_headerless_clear_is_rejected(self, client):
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             resp = client.post("/api/dataset/clear", headers={"X-Dataset-Id": ""})
             assert resp.status_code == 400
             # Nothing was cleared or unregistered.
-            assert len(app_module.medias) == len(saved)
+            assert len(medias) == len(saved)
         finally:
-            app_module.medias.update(saved)
+            medias.update(saved)
 
 
 class TestDatasetRegistryStats:

--- a/tests/datasets/test_duplicates.py
+++ b/tests/datasets/test_duplicates.py
@@ -13,9 +13,8 @@ import copy
 
 import numpy as np
 
-import app as app_module
 from vtscore.datasets.labelset import LabelSet
-from vtsearch.state import collapse_duplicates, get_dupe_count
+from vtsearch.state import collapse_duplicates, get_dupe_count, good_votes, medias
 
 
 def _make_media(cid, md5="unique", origin_importer="test", filename=None, category="cat"):
@@ -197,16 +196,16 @@ class TestGetDupeCount:
         assert get_dupe_count(media_dict) == 1
 
     def test_uses_global_medias_by_default(self):
-        saved = copy.deepcopy(app_module.medias)
-        app_module.medias.clear()
+        saved = copy.deepcopy(medias)
+        medias.clear()
         try:
-            app_module.medias[1] = _make_media(1, md5="same")
-            app_module.medias[2] = _make_media(2, md5="same")
-            collapse_duplicates(app_module.medias)
+            medias[1] = _make_media(1, md5="same")
+            medias[2] = _make_media(2, md5="same")
+            collapse_duplicates(medias)
             assert get_dupe_count() == 1
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
 
 class TestDatasetStatusDupes:
@@ -219,19 +218,19 @@ class TestDatasetStatusDupes:
 
     def test_status_reports_dupes_after_collapse(self, client):
         # Temporarily create a dupe (deepcopy because collapse mutates in place)
-        saved = copy.deepcopy(app_module.medias)
-        app_module.medias[999] = copy.deepcopy(app_module.medias[1])
-        app_module.medias[999]["id"] = 999
-        app_module.medias[999]["filename"] = "dupe.wav"
+        saved = copy.deepcopy(medias)
+        medias[999] = copy.deepcopy(medias[1])
+        medias[999]["id"] = 999
+        medias[999]["filename"] = "dupe.wav"
         # Same MD5 => duplicate
-        collapse_duplicates(app_module.medias)
+        collapse_duplicates(medias)
         try:
             resp = client.get("/api/dataset/status")
             data = resp.get_json()
             assert data["num_dupes"] == 1
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
 
 class TestDatasetDuplicatesEndpoint:
@@ -301,8 +300,8 @@ class TestLabelExportExpandsDupes:
     def test_export_expands_dupe_set(self, client):
         """Voting on a dupe-set representative exports labels for all members."""
         # Set up a dupe-set representative
-        saved = dict(app_module.medias)
-        rep = copy.deepcopy(app_module.medias[1])
+        saved = dict(medias)
+        rep = copy.deepcopy(medias[1])
         rep["origin"] = {
             "importer": "dupe_set",
             "params": {"name": "a.wav"},
@@ -321,10 +320,10 @@ class TestLabelExportExpandsDupes:
                 },
             ],
         }
-        app_module.medias[1] = rep
+        medias[1] = rep
         try:
             # Vote on the representative
-            app_module.good_votes[1] = None
+            good_votes[1] = None
             resp = client.get("/api/labels/export")
             data = resp.get_json()
             labels = data["labels"]
@@ -336,12 +335,12 @@ class TestLabelExportExpandsDupes:
             # Both have the same label
             assert all(el["label"] == "good" for el in dupe_labels)
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
     def test_export_non_dupe_media_unchanged(self, client):
         """Normal (non-dupe) medias still export a single label entry."""
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert len(data["labels"]) == 1
@@ -349,10 +348,10 @@ class TestLabelExportExpandsDupes:
 
     def test_roundtrip_through_dupe_collapse(self, client):
         """Export from dupes, then import back into a dataset with dupes uncollapsed."""
-        saved = dict(app_module.medias)
+        saved = dict(medias)
 
         # Create dupe-set representative
-        rep = copy.deepcopy(app_module.medias[1])
+        rep = copy.deepcopy(medias[1])
         rep["origin"] = {
             "importer": "dupe_set",
             "params": {"name": "a.wav"},
@@ -371,8 +370,8 @@ class TestLabelExportExpandsDupes:
                 },
             ],
         }
-        app_module.medias[1] = rep
-        app_module.good_votes[1] = None
+        medias[1] = rep
+        good_votes[1] = None
 
         resp = client.get("/api/labels/export")
         exported = resp.get_json()
@@ -380,24 +379,24 @@ class TestLabelExportExpandsDupes:
 
         # Clear votes and import back; both entries share the same MD5,
         # so they should match the single representative.
-        app_module.good_votes.clear()
+        good_votes.clear()
         resp = client.post("/api/labels/import", json=exported)
         data = resp.get_json()
         # Both entries resolve to the same media (by MD5), so applied == 2
         assert data["applied"] == 2
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
-        app_module.medias.clear()
-        app_module.medias.update(saved)
+        medias.clear()
+        medias.update(saved)
 
 
 class TestLabelImportWithDupes:
     def test_import_matches_representative_by_md5(self, client):
         """Importing a label for any original dupe MD5 matches the representative."""
-        saved = dict(app_module.medias)
-        md5 = app_module.medias[1]["md5"]
+        saved = dict(medias)
+        md5 = medias[1]["md5"]
 
-        rep = copy.deepcopy(app_module.medias[1])
+        rep = copy.deepcopy(medias[1])
         rep["origin"] = {
             "importer": "dupe_set",
             "params": {"name": "a.wav"},
@@ -416,17 +415,17 @@ class TestLabelImportWithDupes:
                 },
             ],
         }
-        app_module.medias[1] = rep
+        medias[1] = rep
         try:
             # Import using the shared MD5
             labels = [{"md5": md5, "label": "good"}]
             resp = client.post("/api/labels/import", json={"labels": labels})
             data = resp.get_json()
             assert data["applied"] == 1
-            assert 1 in app_module.good_votes
+            assert 1 in good_votes
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
 
 class TestCollapseDuplicatesIntegration:

--- a/tests/datasets/test_memory_errors.py
+++ b/tests/datasets/test_memory_errors.py
@@ -6,11 +6,11 @@ from unittest import mock
 import numpy as np
 import pytest
 
-import app as app_module
 from vtscore.datasets.config import DEMO_DATASETS
 from vtsearch.state import medias
 from tests.helpers import current_loading_progress
 from vtsearch.state import clear_medias
+from tests.fixtures.medias import init_medias
 
 
 class TestClearClipsGarbageCollection:
@@ -26,7 +26,7 @@ class TestClearClipsGarbageCollection:
         clear_medias()
         assert len(medias) == 0
         # Restore test medias
-        app_module.init_medias()
+        init_medias()
 
 
 class TestPickleMemoryError:
@@ -241,7 +241,7 @@ class TestBackgroundImportMemoryError:
         assert progress["status"] == "idle"
 
         # Reinitialise medias for subsequent tests
-        app_module.init_medias()
+        init_medias()
 
     def test_demo_load_oom_reports_error(self, client):
         """When loading a demo dataset OOMs, the progress shows the error."""
@@ -272,4 +272,4 @@ class TestBackgroundImportMemoryError:
             assert "Out of memory" in progress["error"]
 
         # Reinitialise medias for subsequent tests
-        app_module.init_medias()
+        init_medias()

--- a/tests/datasets/test_origin_isolation.py
+++ b/tests/datasets/test_origin_isolation.py
@@ -19,7 +19,6 @@ import pickle
 from pathlib import Path
 from typing import Any
 
-import app as app_module  # noqa: F401  (sets up Flask test infra via conftest)
 from vtscore.datasets.importers.server_files import ServerFilesDatasetImporter
 from vtscore.datasets.ingest import _build_media_data
 from vtscore.datasets.load_pipeline import _tag_origins

--- a/tests/datasets/test_origin_labelset.py
+++ b/tests/datasets/test_origin_labelset.py
@@ -12,13 +12,9 @@ Covers:
 
 from __future__ import annotations
 
-import app as app_module
 from vtscore.datasets.labelset import LabelSet, LabeledElement
 from vtscore.datasets.origin import Origin
-from vtsearch.state import (
-    build_media_lookup,
-    resolve_media_ids,
-)
+from vtsearch.state import bad_votes, build_media_lookup, good_votes, medias, resolve_media_ids
 
 
 # ---------------------------------------------------------------------------
@@ -403,14 +399,14 @@ class TestBuildOrigin:
 class TestClipOrigins:
     def test_init_medias_have_origin(self):
         """Every media created by init_medias should have origin and origin_name."""
-        for cid, media in app_module.medias.items():
+        for cid, media in medias.items():
             assert "origin" in media, f"Clip {cid} missing origin"
             assert "origin_name" in media, f"Clip {cid} missing origin_name"
             assert media["origin"]["importer"] == "test"
             assert media["origin_name"] == media["filename"]
 
     def test_init_medias_have_filename(self):
-        for cid, media in app_module.medias.items():
+        for cid, media in medias.items():
             assert "filename" in media, f"Clip {cid} missing filename"
             assert media["filename"].startswith("test_media_")
 
@@ -422,7 +418,7 @@ class TestClipOrigins:
 
 class TestLabelExportOrigin:
     def test_export_includes_origin(self, client):
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert len(data["labels"]) == 1
@@ -435,8 +431,8 @@ class TestLabelExportOrigin:
 
     def test_export_roundtrip_with_origin(self, client):
         """Export labels with origin, re-import via legacy route, verify match."""
-        app_module.good_votes.update({k: None for k in [1, 3]})
-        app_module.bad_votes.update({k: None for k in [2]})
+        good_votes.update({k: None for k in [1, 3]})
+        bad_votes.update({k: None for k in [2]})
         resp = client.get("/api/labels/export")
         exported = resp.get_json()
 
@@ -445,17 +441,17 @@ class TestLabelExportOrigin:
             assert "origin" in entry
 
         # Clear and re-import
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        good_votes.clear()
+        bad_votes.clear()
         resp = client.post("/api/labels/import", json=exported)
         data = resp.get_json()
         assert data["applied"] == 3
-        assert set(app_module.good_votes) == {1, 3}
-        assert set(app_module.bad_votes) == {2}
+        assert set(good_votes) == {1, 3}
+        assert set(bad_votes) == {2}
 
     def test_export_backwards_compatible(self, client):
         """Exported labels still have md5 and label keys for legacy consumers."""
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         entry = data["labels"][0]

--- a/tests/detectors/test_auto_detect_multi_embedder.py
+++ b/tests/detectors/test_auto_detect_multi_embedder.py
@@ -18,7 +18,6 @@ import shutil
 import numpy as np
 import pytest
 
-import app as app_module  # noqa: F401  (ensures routes are registered)
 from vtsearch.settings import get_detectors_dir
 
 DIM = 4

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -10,6 +10,7 @@ from tests import wait_for_detector_task as _wait_for_detector_task
 from vtscore.embedding.media_vectors import media_embedding
 from vtsearch.settings import get_detectors_dir
 from vtscore.utils.hashing import content_md5
+from vtsearch.state import medias
 
 
 @pytest.fixture(autouse=True)
@@ -165,8 +166,6 @@ class TestExamplesBecomeLabels:
     @pytest.fixture(autouse=True)
     def _restore_medias(self):
         """Remove any media items inserted by example seeding after each test."""
-        from vtsearch.state import medias
-
         saved = dict(medias)
         yield
         medias.clear()
@@ -324,7 +323,6 @@ class TestExamplesBecomeLabels:
         in it (the vote sync must not reconcile the exemplar away)."""
         import vtscore.datasets.downloader as downloader_mod
         import vtscore.security.url_validation as url_mod
-        from vtsearch.state import medias
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -899,8 +897,6 @@ class TestSaveLabels:
 
     def test_save_labels_with_votes(self, client):
         """Save labels after casting votes: labelset should contain the voted medias."""
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded for this test")
 
@@ -940,7 +936,6 @@ class TestSaveLabels:
     def test_save_labels_captures_active_clipper_into_input_spec(self, client):
         """When the active dataset has a clipper, save_detector_labels stamps it onto input_spec."""
         from vtscore.detectors.store import _detector_path, _read_detector
-        from vtsearch.state import medias
 
         if not medias:
             pytest.skip("No medias loaded for this test")
@@ -1015,8 +1010,6 @@ class TestSaveLabels:
         """
         import copy
 
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded for this test")
 
@@ -1062,7 +1055,6 @@ class TestSaveLabels:
         merges non-destructively, mirroring the automatic post-vote sync.
         """
         from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
-        from vtsearch.state import medias
 
         if not medias:
             pytest.skip("No medias loaded for this test")
@@ -1108,11 +1100,7 @@ class TestLabelVoteIsolation:
         Simulates the Label-button flow: clear votes, then import a model's
         labels.  Without the clear, votes from a prior session leak in.
         """
-        from vtsearch.state import (
-            good_votes,
-            bad_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes, bad_votes
 
         ids = list(medias.keys())
         if len(ids) < 4:
@@ -1142,11 +1130,7 @@ class TestLabelVoteIsolation:
 
     def test_import_after_clear_only_has_model_labels(self, client):
         """After clearing + importing, only the target model's labels are active."""
-        from vtsearch.state import (
-            good_votes,
-            bad_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes, bad_votes
 
         ids = list(medias.keys())
         if len(ids) < 4:
@@ -1445,11 +1429,7 @@ class TestLoadModelEndpoint:
 
     def test_load_clears_previous_labels(self, client):
         """Loading model B must not carry over labels from model A."""
-        from vtsearch.state import (
-            bad_votes,
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import bad_votes, good_votes
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -1482,10 +1462,7 @@ class TestLoadModelEndpoint:
 
     def test_load_restores_saved_labels(self, client):
         """Loading a model that has a saved labelset should restore its labels."""
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -1521,14 +1498,7 @@ class TestLoadModelEndpoint:
         import numpy as np
 
         from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
-        from vtsearch.state import (
-            DatasetContext,
-            bad_votes,
-            good_votes,
-            medias,
-            register_context,
-            set_thread_dataset_context,
-        )
+        from vtsearch.state import DatasetContext, bad_votes, good_votes, register_context, set_thread_dataset_context
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -1596,12 +1566,7 @@ class TestLoadModelEndpoint:
 
         from vtscore.detectors.dataset_sync import ensure_votes_match_active_dataset
         from vtscore.state.core import get_active_detector_context
-        from vtsearch.state import (
-            DatasetContext,
-            medias,
-            register_context,
-            set_thread_dataset_context,
-        )
+        from vtsearch.state import DatasetContext, register_context, set_thread_dataset_context
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -1738,7 +1703,6 @@ class TestEmbedderMismatchInvalidatesStaleModel:
         from vtsearch.state import (
             DatasetContext,
             get_active_detector_context,
-            medias,
             register_context,
             set_thread_dataset_context,
         )
@@ -1820,8 +1784,6 @@ class TestValidatedVoteSnapshot:
 
         Returns ``(detector_id, good_cid, bad_cid)``.
         """
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded")
         ids = list(medias.keys())
@@ -1979,7 +1941,6 @@ class TestRequestMissingDatasetPreservesDetectorState:
             get_thread_dataset_context,
             set_thread_dataset_context,
         )
-        from vtsearch.state import medias
 
         if len(medias) < 2:
             pytest.skip("Need at least 2 medias")
@@ -2025,7 +1986,6 @@ class TestVoteSyncsToLoadedModel:
     def test_vote_updates_model_labels(self, client):
         """Casting a vote with a loaded model should persist labels and update registry stats."""
         from vtscore.detectors.registry import get_detector
-        from vtsearch.state import medias
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -2058,8 +2018,6 @@ class TestVoteSyncsToLoadedModel:
 
     def test_vote_toggle_off_updates_model(self, client):
         """Toggling a vote off should update the model labelset to reflect removal."""
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded")
 
@@ -2083,8 +2041,6 @@ class TestVoteSyncsToLoadedModel:
 
     def test_no_sync_without_loaded_model(self, client):
         """Voting with no loaded model should not create/update any model files."""
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded")
 
@@ -2103,7 +2059,6 @@ class TestVoteSyncsToLoadedModel:
     def test_label_import_syncs_to_loaded_model(self, client):
         """Importing labels with a loaded model should persist to the model."""
         from vtscore.detectors.registry import get_detector
-        from vtsearch.state import medias
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -2138,8 +2093,6 @@ class TestSeedVotesFromExamples:
     @pytest.fixture(autouse=True)
     def _restore_medias(self):
         """Remove any media items inserted by seeding after each test."""
-        from vtsearch.state import medias
-
         saved = dict(medias)
         yield
         # Remove items that were added, restore any that were modified
@@ -2160,10 +2113,7 @@ class TestSeedVotesFromExamples:
 
     def test_seed_endpoint_adds_good_votes(self, client):
         """Media examples whose MD5 matches a loaded media should become good votes."""
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -2214,8 +2164,6 @@ class TestSeedVotesFromExamples:
         """
         import json as _json
 
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded")
 
@@ -2240,10 +2188,7 @@ class TestSeedVotesFromExamples:
 
     def test_seed_unmatched_inserts_new_media(self, client):
         """A media example not in the dataset should be embedded and inserted as a new media."""
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         original_count = len(medias)
 
@@ -2274,8 +2219,6 @@ class TestSeedVotesFromExamples:
 
     def test_seed_preserves_original_origins(self, client):
         """Seeded medias should keep their original dataset origins."""
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded")
 
@@ -2296,8 +2239,6 @@ class TestSeedVotesFromExamples:
 
     def test_seed_appears_in_label_export(self, client):
         """Seeded good votes should appear in the label export."""
-        from vtsearch.state import medias
-
         if not medias:
             pytest.skip("No medias loaded")
 
@@ -2342,7 +2283,7 @@ class TestSeedVotesFromExamples:
     def test_seed_with_origin_stamps_real_origin(self, client, tmp_path):
         """An example carrying a datasource origin seeds a media that points
         back at its real source instead of the example_media sentinel."""
-        from vtsearch.state import good_votes, medias
+        from vtsearch.state import good_votes
 
         src = tmp_path / "novel_src.wav"
         src.write_bytes(b"origin-novel-bytes")
@@ -2368,7 +2309,6 @@ class TestSeedVotesFromExamples:
         """The stamped origin must resolve after the example_media/ file is gone."""
         from vtscore.detectors.resolver import resolve_file_from_origin
         from vtscore.security.path_validation import example_media_dir
-        from vtsearch.state import medias
 
         src = tmp_path / "resolvable.wav"
         src.write_bytes(b"resolvable-bytes")
@@ -2389,7 +2329,7 @@ class TestSeedVotesFromExamples:
     def test_seed_rederives_missing_cache_file_from_origin(self, client, tmp_path):
         """With the cache file gone entirely, seeding re-fetches from the origin."""
         from vtscore.utils.hashing import content_md5
-        from vtsearch.state import good_votes, medias
+        from vtsearch.state import good_votes
 
         src = tmp_path / "rederive.wav"
         src.write_bytes(b"rederive-bytes")
@@ -2411,8 +2351,6 @@ class TestSeedVotesFromExamples:
 
     def test_seed_url_origin_stamped(self, client):
         """A url_download origin is stored verbatim; origin_name is the URL."""
-        from vtsearch.state import medias
-
         fname = self._create_example_file(b"url-novel-bytes", "url_novel.wav")
         origin = {"importer": "url_download", "params": {"url": "https://x.test/bark.wav"}}
 
@@ -2429,7 +2367,6 @@ class TestSeedVotesFromExamples:
         """In multi-user mode an origin whose path escapes the user's dir is
         discarded: the media seeds via the example_media sentinel instead."""
         import vtscore.security.path_validation as paths_mod
-        from vtsearch.state import medias
 
         monkeypatch.setattr(paths_mod, "get_file_access_base_dir", lambda: tmp_path)
 
@@ -2468,7 +2405,7 @@ class TestSeedVotesFromExamples:
         the detector loads, and the seeded media carries the URL origin."""
         import vtscore.datasets.downloader as downloader_mod
         import vtscore.security.url_validation as url_mod
-        from vtsearch.state import good_votes, medias
+        from vtsearch.state import good_votes
 
         url = "https://x.test/roundtrip/bark.wav"
 
@@ -2503,11 +2440,7 @@ class TestSeedVotesFromExamples:
 
     def test_new_example_usable_in_training(self, client):
         """Inserted examples should have embeddings usable by learned-sort."""
-        from vtsearch.state import (
-            good_votes,
-            bad_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes, bad_votes
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -2539,10 +2472,7 @@ class TestSeedVotesFromExamples:
 
     def test_load_model_seeds_from_media_examples(self, client):
         """Loading a model with media examples should auto-seed good votes."""
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         if not medias:
             pytest.skip("No medias loaded")
@@ -2597,10 +2527,7 @@ class TestSeedVotesFromExamples:
         This tests the backend side: enough media examples seed enough
         good_votes that ``goodCount >= autopilot_top_greens``.
         """
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         ids = list(medias.keys())
         if len(ids) < 4:
@@ -2631,10 +2558,7 @@ class TestSeedVotesFromExamples:
 
     def test_load_model_seeds_novel_example(self, client):
         """Loading a model with a non-dataset example should embed and insert it."""
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         original_count = len(medias)
         fname = self._create_example_file(b"novel-load-bytes", "novel_load.wav")
@@ -2690,11 +2614,7 @@ class TestLoadModelCrossDatasetResolution:
         from vtscore.detectors.registry import register_detector, reset_for_tests
         from vtscore.detectors.store import _write_detector
         from vtsearch.settings import get_detectors_dir, set_detectors_dir
-        from vtsearch.state import (
-            good_votes,
-            bad_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes, bad_votes
 
         reset_for_tests()
 
@@ -2807,10 +2727,7 @@ class TestLoadModelCrossDatasetResolution:
         from vtscore.detectors.registry import register_detector, reset_for_tests
         from vtscore.detectors.store import _write_detector
         from vtsearch.settings import get_detectors_dir, set_detectors_dir
-        from vtsearch.state import (
-            good_votes,
-            medias,
-        )
+        from vtsearch.state import good_votes
 
         reset_for_tests()
 
@@ -2895,10 +2812,9 @@ class TestRegisterModelFromLabelset:
         return {"importer": "server_folder", "params": {"path": path, "media_type": "image"}}
 
     def test_creates_model_with_imported_labels(self, client, tmp_path):
-        import app as app_module
 
-        md5_good = app_module.medias[1]["md5"]
-        md5_bad = app_module.medias[2]["md5"]
+        md5_good = medias[1]["md5"]
+        md5_bad = medias[2]["md5"]
         origin = self._audio_origin()
         payload = json.dumps(
             {
@@ -2950,9 +2866,7 @@ class TestRegisterModelFromLabelset:
 
     def test_md5_only_labelset_returns_400(self, client, tmp_path):
         """Legacy md5-only labels have no origin; media type cannot be inferred."""
-        import app as app_module
-
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]})
         labels_path = tmp_path / "labels.json"
         labels_path.write_text(payload)
@@ -2965,10 +2879,8 @@ class TestRegisterModelFromLabelset:
 
     def test_mixed_media_types_returns_400(self, client, tmp_path):
         """Labels with conflicting origin media types are rejected."""
-        import app as app_module
-
-        md5_a = app_module.medias[1]["md5"]
-        md5_b = app_module.medias[2]["md5"]
+        md5_a = medias[1]["md5"]
+        md5_b = medias[2]["md5"]
         payload = json.dumps(
             {
                 "labels": [
@@ -2997,9 +2909,7 @@ class TestRegisterModelFromLabelset:
 
     def test_duplicate_name_returns_409(self, client, tmp_path):
         """Name collision with an existing detector file."""
-        import app as app_module
-
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps(
             {
                 "labels": [
@@ -3020,9 +2930,8 @@ class TestRegisterModelFromLabelset:
         assert res.status_code == 409
 
     def test_skips_invalid_label_values(self, client, tmp_path):
-        import app as app_module
 
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         origin = self._audio_origin()
         payload = json.dumps(
             {
@@ -3047,14 +2956,13 @@ class TestRegisterModelFromLabelset:
 
     def test_loading_after_creation_restores_labels(self, client, tmp_path):
         """Loading the newly-created model resolves labels into the active dataset."""
-        import app as app_module
         from vtsearch.state import (
             bad_votes,
             good_votes,
         )
 
-        md5_good = app_module.medias[1]["md5"]
-        md5_bad = app_module.medias[2]["md5"]
+        md5_good = medias[1]["md5"]
+        md5_bad = medias[2]["md5"]
         origin = self._audio_origin()
         payload = json.dumps(
             {

--- a/tests/detectors/test_find_cancel.py
+++ b/tests/detectors/test_find_cancel.py
@@ -16,7 +16,7 @@ from tests.helpers import setup_trainable_model_in_registry
 from vtscore.concurrency.progress import CancelledError, find_progress, get_find_progress
 from vtsearch.state import snapshot_medias
 
-import app as app_module  # noqa: F401  (ensures routes are registered)
+import app as app_module
 
 
 @pytest.fixture(autouse=True)

--- a/tests/detectors/test_find_end_session.py
+++ b/tests/detectors/test_find_end_session.py
@@ -10,11 +10,11 @@ entry; these tests pin what that does.
 
 from __future__ import annotations
 
-import app as app_module
 from tests import load_detector_and_wait
 from tests.helpers import setup_trainable_model_in_registry
 from vtscore.state.core import get_active_detector_context
 from vtsearch.state import snapshot_medias
+from tests.fixtures.medias import NUM_MEDIAS
 
 
 def _detector_with_votes(client):
@@ -38,7 +38,7 @@ class TestEndFindSession:
         assert resp.status_code == 200, resp.get_json()
         after_find = client.get("/api/votes").get_json()
         # Every media carries a presumption, and they are not the training votes.
-        assert len(after_find["good"]) + len(after_find["bad"]) == app_module.NUM_MEDIAS
+        assert len(after_find["good"]) + len(after_find["bad"]) == NUM_MEDIAS
         assert get_active_detector_context().find_mode is True
 
         ended = client.post("/api/find/end-session")

--- a/tests/detectors/test_find_label.py
+++ b/tests/detectors/test_find_label.py
@@ -7,10 +7,9 @@ labelset stored on disk.
 
 from __future__ import annotations
 
-import app as app_module
 import pytest
 from tests.helpers import setup_trainable_model_in_registry
-from vtsearch.state import snapshot_medias
+from vtsearch.state import medias, snapshot_medias
 
 
 class TestFindLabel:
@@ -29,7 +28,7 @@ class TestFindLabel:
         data = resp.get_json()
         assert data["ok"] is True
         total = data["good_count"] + data["bad_count"]
-        assert total == app_module.NUM_MEDIAS
+        assert total == NUM_MEDIAS
 
     def test_find_label_honors_active_detector_inclusion(self, client):
         """find-label trains at the active detector context's inclusion.
@@ -78,13 +77,13 @@ class TestFindLabel:
             bad_ids=[18, 19, 20],
             snap=snapshot_medias(),
         )
-        saved = dict(app_module.medias)
-        app_module.medias.clear()
+        saved = dict(medias)
+        medias.clear()
         try:
             resp = client.post("/api/find-label", json={"detector_id": detector_id})
             assert resp.status_code == 400
         finally:
-            app_module.medias.update(saved)
+            medias.update(saved)
 
     def test_find_label_body_dataset_id_is_rejected(self, client):
         """Regression for C5: the body must not carry a ``dataset_id`` field.
@@ -152,8 +151,8 @@ class TestFindLabelStructuralRerank:
         data = resp.get_json()
 
         assert captured["good_bad_labels"] == 6
-        assert captured["snap_len"] == app_module.NUM_MEDIAS
-        assert captured["n_results"] == app_module.NUM_MEDIAS
+        assert captured["snap_len"] == NUM_MEDIAS
+        assert captured["n_results"] == NUM_MEDIAS
         # The re-rank's threshold and re-ranked result set drive the labels.
         assert data["threshold"] == 0.5
         assert data["good_count"] == 1
@@ -177,7 +176,6 @@ class TestFindModeIsPerDetector:
     def test_find_label_on_one_detector_does_not_block_sync_on_another(self, client):
         from tests import load_detector_and_wait
         from vtscore.detectors.store import _detector_path, _read_detector
-        from vtsearch.state import medias
 
         if len(medias) < 5:
             pytest.skip("Need at least 5 medias")
@@ -245,7 +243,7 @@ class TestAutoDetect:
         result = data["results"]["auto-detect-model"]
         assert "hits" in result
         assert "negative_hits" in result
-        assert len(result["hits"]) + len(result["negative_hits"]) == app_module.NUM_MEDIAS
+        assert len(result["hits"]) + len(result["negative_hits"]) == NUM_MEDIAS
 
     def test_autofind_hits_carry_the_media_fields_the_table_renders(self, client):
         """Hits must carry the media fields the Auto-Find results table shows.
@@ -343,3 +341,6 @@ class TestAutoDetect:
         resp = client.post("/api/auto-detect", json={})
         assert resp.status_code == 400
         assert "gone-detector" in resp.get_json()["message"]
+
+
+from tests.fixtures.medias import NUM_MEDIAS

--- a/tests/detectors/test_find_progress_reset.py
+++ b/tests/detectors/test_find_progress_reset.py
@@ -21,7 +21,7 @@ from tests.helpers import setup_trainable_model_in_registry
 from vtscore.concurrency.progress import find_progress, get_find_progress
 from vtsearch.state import snapshot_medias
 
-import app as app_module  # noqa: F401  (ensures routes are registered)
+import app as app_module
 
 
 @pytest.fixture(autouse=True)

--- a/tests/detectors/test_find_routed_embedder.py
+++ b/tests/detectors/test_find_routed_embedder.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-import app as app_module  # noqa: F401  (ensures routes are registered)
+import app as app_module
 from vtsearch.routes.detectors import find as find_mod
 
 DIM = 4

--- a/tests/detectors/test_find_verification.py
+++ b/tests/detectors/test_find_verification.py
@@ -11,14 +11,21 @@ Covers:
 
 from __future__ import annotations
 
-import app as app_module
 from tests.helpers import setup_trainable_model_in_registry
 from tests import load_detector_and_wait
 from vtscore.detectors.dataset_sync import reset_mtime_cache_for_tests
 from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
 from vtscore.state.core import get_active_detector_context
 from vtscore.state.votes import rethreshold_unverified_find_items
-from vtsearch.state import set_find_initial_labels, set_find_scores, set_vote, snapshot_medias
+from vtsearch.state import (
+    bad_votes,
+    good_votes,
+    medias,
+    set_find_initial_labels,
+    set_find_scores,
+    set_vote,
+    snapshot_medias,
+)
 
 
 class TestMarkVerified:
@@ -68,7 +75,7 @@ class TestVotesVerifiedField:
         ctx = get_active_detector_context()
         ctx.find_mode = False
         ctx.verified_ids.clear()
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/votes")
         assert resp.get_json()["verified"] == []
 
@@ -79,8 +86,8 @@ class TestUnverifiedExport:
     def _setup(self):
         ctx = get_active_detector_context()
         # 1,2 unverified good; 3 verified good; 4 verified bad
-        app_module.good_votes.update({1: None, 2: None, 3: None})
-        app_module.bad_votes.update({4: None})
+        good_votes.update({1: None, 2: None, 3: None})
+        bad_votes.update({4: None})
         ctx.verified_ids.clear()
         ctx.verified_ids.update({3: None, 4: None})
 
@@ -88,7 +95,7 @@ class TestUnverifiedExport:
         self._setup()
         resp = client.get("/api/labels/export?label_filter=unverified")
         md5s = {e["md5"] for e in resp.get_json()["labels"]}
-        assert md5s == {app_module.medias[1]["md5"], app_module.medias[2]["md5"]}
+        assert md5s == {medias[1]["md5"], medias[2]["md5"]}
 
     def test_verified_filter(self, client):
         self._setup()
@@ -96,8 +103,8 @@ class TestUnverifiedExport:
         labels = resp.get_json()["labels"]
         by_md5 = {e["md5"]: e["label"] for e in labels}
         assert by_md5 == {
-            app_module.medias[3]["md5"]: "good",
-            app_module.medias[4]["md5"]: "bad",
+            medias[3]["md5"]: "good",
+            medias[4]["md5"]: "bad",
         }
 
 
@@ -110,10 +117,10 @@ class TestRethresholdUnverified:
         ctx.threshold = 0.5
         set_find_scores({1: 0.9, 2: 0.8, 3: 0.2, 4: 0.1})
         # Initial split at 0.5: 1,2 good; 3,4 bad.  Human verified id1 (good).
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
-        app_module.good_votes.update({1: None, 2: None})
-        app_module.bad_votes.update({3: None, 4: None})
+        good_votes.clear()
+        bad_votes.clear()
+        good_votes.update({1: None, 2: None})
+        bad_votes.update({3: None, 4: None})
         ctx.verified_ids.clear()
         ctx.verified_ids.update({1: None})
         return ctx
@@ -124,10 +131,10 @@ class TestRethresholdUnverified:
         rethreshold_unverified_find_items()
         # id1 verified-good stays good even though... it still clears 0.85 anyway;
         # id2 (0.8) is unverified and now below the line -> bad.
-        assert 1 in app_module.good_votes
-        assert 2 in app_module.bad_votes
-        assert 3 in app_module.bad_votes
-        assert 4 in app_module.bad_votes
+        assert 1 in good_votes
+        assert 2 in bad_votes
+        assert 3 in bad_votes
+        assert 4 in bad_votes
 
     def test_verified_item_holds_against_cutoff(self):
         ctx = self._setup()
@@ -136,15 +143,15 @@ class TestRethresholdUnverified:
         ctx.threshold = 0.85
         rethreshold_unverified_find_items()
         # id2 is verified-good; the cutoff must not demote it.
-        assert 2 in app_module.good_votes
-        assert 2 not in app_module.bad_votes
+        assert 2 in good_votes
+        assert 2 not in bad_votes
 
     def test_lower_cutoff_promotes_unverified(self):
         ctx = self._setup()
         ctx.threshold = 0.05  # everything clears it
         rethreshold_unverified_find_items()
         for cid in (1, 2, 3, 4):
-            assert cid in app_module.good_votes
+            assert cid in good_votes
 
     def test_noop_outside_find_mode(self):
         ctx = self._setup()
@@ -152,7 +159,7 @@ class TestRethresholdUnverified:
         ctx.threshold = 0.85
         rethreshold_unverified_find_items()
         # No re-split: the initial 0.5 assignment stands.
-        assert 2 in app_module.good_votes
+        assert 2 in good_votes
 
     def test_inclusion_post_returns_threshold(self, client):
         resp = client.post("/api/inclusion", json={"inclusion": 0})
@@ -173,8 +180,8 @@ class TestFindStats:
         set_find_initial_labels({1: "good", 2: "good", 3: "bad", 4: "bad"})
         # Human: confirm 1 good; cull 2 (false positive) to bad; rescue 4 to
         # good; leave 3 untouched (unverified bad).  Final adopted label set:
-        app_module.good_votes.update({1: None, 4: None})
-        app_module.bad_votes.update({2: None, 3: None})
+        good_votes.update({1: None, 4: None})
+        bad_votes.update({2: None, 3: None})
         ctx.verified_ids.clear()
         ctx.verified_ids.update({1: None, 2: None, 4: None})
 
@@ -209,8 +216,8 @@ class TestFindStats:
     def test_empty_when_no_votes(self, client):
         ctx = get_active_detector_context()
         ctx.verified_ids.clear()
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        good_votes.clear()
+        bad_votes.clear()
         data = client.get("/api/find/stats").get_json()
         assert data["total_good"] == 0
         assert data["total_bad"] == 0
@@ -293,8 +300,8 @@ class TestCorrectionsToDetector:
 
         labels = self._labelset_labels("corrections-model")
         by_md5 = {el["md5"]: el["label"] for el in labels}
-        assert by_md5[app_module.medias[good_item]["md5"]] == "bad"
-        assert by_md5[app_module.medias[bad_item]["md5"]] == "good"
+        assert by_md5[medias[good_item]["md5"]] == "bad"
+        assert by_md5[medias[bad_item]["md5"]] == "good"
         assert data["num_labels"] == len(labels)
 
     def test_session_frozen_and_marked_stale(self, client):
@@ -358,8 +365,8 @@ class TestCorrectionsToDetector:
 
         # Replace one media's entry with a stale, md5-only record of the same
         # bytes: same file, different provenance, so ``element_key`` differs.
-        stale_id = next(iter(app_module.medias))
-        stale_md5 = app_module.medias[stale_id]["md5"]
+        stale_id = next(iter(medias))
+        stale_md5 = medias[stale_id]["md5"]
         path = _detector_path("corrections-model")
         data = _read_detector(path)
         assert data is not None

--- a/tests/detectors/test_portable_detector_exporter.py
+++ b/tests/detectors/test_portable_detector_exporter.py
@@ -17,10 +17,10 @@ from pathlib import Path
 
 import pytest
 
-import app as app_module
 from tests.helpers import make_dataset_file as _make_dataset_file
 from vtsearch.settings import get_detectors_dir
 from vtscore.media.audio.audio_generator import generate_wav
+from vtsearch.state import medias
 
 
 @pytest.fixture(autouse=True)
@@ -120,7 +120,7 @@ class TestPortableDetectorCLI:
         _stub_resolve(monkeypatch, files)
         _write_trainable_model("cats", _labelset(good=["alpha.wav", "beta.wav"], bad=["gamma.wav"]))
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file(tmp_path, ["cats"])
         out_template = str(tmp_path / "{detector_name}-detector.zip")
 
@@ -147,7 +147,7 @@ class TestPortableDetectorCLI:
         _write_trainable_model("cats", ls)
         _write_trainable_model("dogs", ls)
 
-        dataset_path = _make_dataset_file(tmp_path, app_module.medias)
+        dataset_path = _make_dataset_file(tmp_path, medias)
         settings_path = _settings_file(tmp_path, ["cats", "dogs"])
         # No {detector_name} in the path: the exporter must insert the slug so
         # the two bundles don't overwrite each other.

--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -11,11 +11,10 @@ import io
 import json
 import zipfile
 
-import app as app_module
 import pytest
 from tests.fixtures.medias import DEFAULT_AUDIO_EMBEDDER
 from tests.helpers import setup_trainable_model_in_registry
-from vtsearch.state import snapshot_medias
+from vtsearch.state import medias, snapshot_medias
 
 
 def _export(client, detector_id):
@@ -97,12 +96,12 @@ class TestPortableExport:
             bad_ids=[18, 19, 20],
             snap=snapshot_medias(),
         )
-        saved = dict(app_module.medias)
-        app_module.medias.clear()
+        saved = dict(medias)
+        medias.clear()
         try:
             assert _export(client, detector_id).status_code == 400
         finally:
-            app_module.medias.update(saved)
+            medias.update(saved)
 
     def test_export_blocks_structural_detector(self, client, monkeypatch):
         """A structural detector is rejected (409) rather than silently mis-exported.

--- a/tests/io/test_corrections_export.py
+++ b/tests/io/test_corrections_export.py
@@ -9,11 +9,7 @@ Covers:
 
 from __future__ import annotations
 
-import app as app_module
-from vtsearch.state import (
-    get_find_initial_labels,
-    set_find_initial_labels,
-)
+from vtsearch.state import bad_votes, get_find_initial_labels, good_votes, medias, set_find_initial_labels
 
 
 class TestFindInitialLabelsState:
@@ -55,7 +51,7 @@ class TestIsCorrectionAnnotation:
 
     def test_no_corrections_without_find_labels(self, client):
         """When no find-label has run, is_correction should not be present."""
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert len(data["labels"]) == 1
@@ -64,8 +60,8 @@ class TestIsCorrectionAnnotation:
 
     def test_is_correction_false_when_unchanged(self, client):
         """Items that match the detector's original label are not corrections."""
-        app_module.good_votes.update({1: None, 2: None})
-        app_module.bad_votes.update({3: None})
+        good_votes.update({1: None, 2: None})
+        bad_votes.update({3: None})
         set_find_initial_labels({1: "good", 2: "good", 3: "bad"})
 
         resp = client.get("/api/labels/export")
@@ -78,8 +74,8 @@ class TestIsCorrectionAnnotation:
         # Detector initially said: 1=good, 2=bad
         set_find_initial_labels({1: "good", 2: "bad"})
         # User flipped both
-        app_module.bad_votes[1] = None  # was good, now bad
-        app_module.good_votes[2] = None  # was bad, now good
+        bad_votes[1] = None  # was good, now bad
+        good_votes[2] = None  # was bad, now good
 
         resp = client.get("/api/labels/export")
         data = resp.get_json()
@@ -92,15 +88,15 @@ class TestIsCorrectionAnnotation:
         set_find_initial_labels({1: "good", 2: "bad", 3: "good"})
         # 1 stays good (no correction), 2 flipped to good (correction),
         # 3 flipped to bad (correction)
-        app_module.good_votes.update({1: None, 2: None})
-        app_module.bad_votes[3] = None
+        good_votes.update({1: None, 2: None})
+        bad_votes[3] = None
 
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         corrections = {e["md5"]: e["is_correction"] for e in data["labels"]}
-        md5_1 = app_module.medias[1]["md5"]
-        md5_2 = app_module.medias[2]["md5"]
-        md5_3 = app_module.medias[3]["md5"]
+        md5_1 = medias[1]["md5"]
+        md5_2 = medias[2]["md5"]
+        md5_3 = medias[3]["md5"]
         assert corrections[md5_1] is False
         assert corrections[md5_2] is True
         assert corrections[md5_3] is True
@@ -112,22 +108,22 @@ class TestCorrectionsFilter:
     def test_corrections_filter_returns_only_changed(self, client):
         """label_filter=corrections returns only items the user changed."""
         set_find_initial_labels({1: "good", 2: "bad", 3: "good"})
-        app_module.good_votes.update({1: None, 2: None})  # 2 was bad -> correction
-        app_module.bad_votes[3] = None  # 3 was good -> correction
+        good_votes.update({1: None, 2: None})  # 2 was bad -> correction
+        bad_votes[3] = None  # 3 was good -> correction
 
         resp = client.get("/api/labels/export?label_filter=corrections")
         data = resp.get_json()
         assert len(data["labels"]) == 2
         md5s = {e["md5"] for e in data["labels"]}
-        assert app_module.medias[2]["md5"] in md5s
-        assert app_module.medias[3]["md5"] in md5s
+        assert medias[2]["md5"] in md5s
+        assert medias[3]["md5"] in md5s
         assert all(e["is_correction"] is True for e in data["labels"])
 
     def test_corrections_filter_empty_when_no_changes(self, client):
         """label_filter=corrections returns nothing if user didn't change any labels."""
         set_find_initial_labels({1: "good", 2: "bad"})
-        app_module.good_votes[1] = None
-        app_module.bad_votes[2] = None
+        good_votes[1] = None
+        bad_votes[2] = None
 
         resp = client.get("/api/labels/export?label_filter=corrections")
         data = resp.get_json()
@@ -135,8 +131,8 @@ class TestCorrectionsFilter:
 
     def test_corrections_filter_empty_without_find_labels(self, client):
         """label_filter=corrections returns all labels when no find-label has run."""
-        app_module.good_votes[1] = None
-        app_module.bad_votes[2] = None
+        good_votes[1] = None
+        bad_votes[2] = None
 
         resp = client.get("/api/labels/export?label_filter=corrections")
         data = resp.get_json()
@@ -147,8 +143,8 @@ class TestCorrectionsFilter:
     def test_other_filters_still_work(self, client):
         """Existing good/bad/both filters are unaffected by corrections feature."""
         set_find_initial_labels({1: "good", 2: "bad"})
-        app_module.good_votes[1] = None
-        app_module.bad_votes[2] = None
+        good_votes[1] = None
+        bad_votes[2] = None
 
         resp = client.get("/api/labels/export?label_filter=good")
         data = resp.get_json()

--- a/tests/io/test_csv_webhook_exporters.py
+++ b/tests/io/test_csv_webhook_exporters.py
@@ -7,7 +7,6 @@ from unittest import mock
 
 import pytest
 
-import app as app_module  # noqa: F401
 from vtscore.cli import _run_exporter
 
 

--- a/tests/io/test_export_options.py
+++ b/tests/io/test_export_options.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 import pytest
 
-import app as app_module
 from vtscore.embedding.media_vectors import media_embedding
+from vtsearch.state import bad_votes, good_votes
 
 SAMPLE_RESULTS = {
     "media_type": "audio",
@@ -104,8 +104,8 @@ class TestFillFromSortDryRun:
 
     def test_dry_run_excludes_already_voted(self, client):
         """Clips that already have votes should not be counted."""
-        app_module.good_votes.update({1: None, 2: None})
-        app_module.bad_votes.update({3: None})
+        good_votes.update({1: None, 2: None})
+        bad_votes.update({3: None})
         results = self._sort_results()
         resp = client.post(
             "/api/labels/fill-from-sort",
@@ -185,8 +185,8 @@ class TestFillFromSortConfirm:
         from vtsearch.state import medias
 
         assert total_applied == len(medias)  # all were unlabeled
-        assert len(app_module.good_votes) == data["good_applied"]
-        assert len(app_module.bad_votes) == data["bad_applied"]
+        assert len(good_votes) == data["good_applied"]
+        assert len(bad_votes) == data["bad_applied"]
 
     def test_confirm_returns_exporter_compatible_results(self, client):
         results = self._sort_results()
@@ -211,8 +211,8 @@ class TestFillFromSortConfirm:
 
     def test_confirm_does_not_relabel_already_voted(self, client):
         # Pre-label some medias
-        app_module.good_votes.update({1: None})
-        app_module.bad_votes.update({2: None})
+        good_votes.update({1: None})
+        bad_votes.update({2: None})
 
         results = self._sort_results()
         resp = client.post(
@@ -243,7 +243,7 @@ class TestFillFromSortConfirm:
         )
         data = resp.get_json()
         assert data["bad_applied"] == 0
-        assert len(app_module.bad_votes) == 0
+        assert len(bad_votes) == 0
 
     def test_confirm_bad_only(self, client):
         results = self._sort_results()
@@ -258,7 +258,7 @@ class TestFillFromSortConfirm:
         )
         data = resp.get_json()
         assert data["good_applied"] == 0
-        assert len(app_module.good_votes) == 0
+        assert len(good_votes) == 0
 
     def test_disk_sync_failure_surfaces_as_500(self, client, monkeypatch):
         """C11 regression: a sync failure must not be silently swallowed.
@@ -689,7 +689,7 @@ class TestAvailableColumnsNoDuplicates:
 
     def test_no_duplicate_category_column(self, client):
         """Category appears once in available_columns, not twice (lowercase + capitalized)."""
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export?enrich=true")
         assert resp.status_code == 200
         data = resp.get_json()

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -14,9 +14,9 @@ import json
 from unittest.mock import patch
 
 
-import app as app_module
 from tests import wait_for_detector_task
 from vtscore.utils.hashing import content_md5
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 # ---------------------------------------------------------------------------
@@ -31,7 +31,7 @@ class TestLabelImportEndpoint:
         assert "no_such_importer" in res.get_json()["error"]
 
     def test_json_importer_applies_good_label(self, client, tmp_path):
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -44,10 +44,10 @@ class TestLabelImportEndpoint:
         assert result["applied"] == 1
         assert result["skipped"] == 0
         assert result["missing_count"] == 0
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
     def test_json_importer_applies_bad_label(self, client, tmp_path):
-        md5 = app_module.medias[2]["md5"]
+        md5 = medias[2]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "bad"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -56,7 +56,7 @@ class TestLabelImportEndpoint:
             json={"filepath": str(p)},
         )
         assert res.status_code == 200
-        assert 2 in app_module.bad_votes
+        assert 2 in bad_votes
 
     def test_json_importer_reports_unknown_md5_as_missing(self, client, tmp_path):
         payload = json.dumps({"labels": [{"md5": "no_such_md5", "label": "good"}]})
@@ -75,7 +75,7 @@ class TestLabelImportEndpoint:
         assert snapshot["ingest_result"]["unresolved"] == 1
 
     def test_json_importer_skips_invalid_label_value(self, client, tmp_path):
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "meh"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -89,8 +89,8 @@ class TestLabelImportEndpoint:
         assert result["skipped"] == 1
 
     def test_csv_importer_applies_labels(self, client, tmp_path):
-        md5_1 = app_module.medias[1]["md5"]
-        md5_2 = app_module.medias[2]["md5"]
+        md5_1 = medias[1]["md5"]
+        md5_2 = medias[2]["md5"]
         csv_text = f"md5,label\n{md5_1},good\n{md5_2},bad\n"
         p = tmp_path / "labels.csv"
         p.write_text(csv_text)
@@ -101,8 +101,8 @@ class TestLabelImportEndpoint:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 2
-        assert 1 in app_module.good_votes
-        assert 2 in app_module.bad_votes
+        assert 1 in good_votes
+        assert 2 in bad_votes
 
     def test_csv_importer_reports_unknown_md5_as_missing(self, client, tmp_path):
         csv_text = "md5,label\nunknown_hash,good\n"
@@ -120,8 +120,8 @@ class TestLabelImportEndpoint:
         assert snapshot["ingest_result"]["unresolved"] == 1
 
     def test_import_overrides_existing_label(self, client, tmp_path):
-        app_module.good_votes[1] = None
-        md5 = app_module.medias[1]["md5"]
+        good_votes[1] = None
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "bad"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -129,8 +129,8 @@ class TestLabelImportEndpoint:
             "/api/label-importers/import/server_json_file",
             json={"filepath": str(p)},
         )
-        assert 1 not in app_module.good_votes
-        assert 1 in app_module.bad_votes
+        assert 1 not in good_votes
+        assert 1 in bad_votes
 
     def test_import_response_has_message(self, client, tmp_path):
         payload = json.dumps({"labels": []})
@@ -145,14 +145,14 @@ class TestLabelImportEndpoint:
 
     def test_json_roundtrip_via_importer(self, client, tmp_path):
         """Export labels via the old route and re-import via label importer endpoint."""
-        app_module.good_votes.update({k: None for k in [1, 3, 5]})
-        app_module.bad_votes.update({k: None for k in [2, 4]})
+        good_votes.update({k: None for k in [1, 3, 5]})
+        bad_votes.update({k: None for k in [2, 4]})
 
         export_res = client.get("/api/labels/export")
         exported = export_res.get_json()
 
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        good_votes.clear()
+        bad_votes.clear()
 
         p = tmp_path / "labels.json"
         p.write_text(json.dumps(exported))
@@ -162,17 +162,17 @@ class TestLabelImportEndpoint:
         )
         result = res.get_json()
         assert result["applied"] == 5
-        assert set(app_module.good_votes) == {1, 3, 5}
-        assert set(app_module.bad_votes) == {2, 4}
+        assert set(good_votes) == {1, 3, 5}
+        assert set(bad_votes) == {2, 4}
 
     def test_multiple_clips_via_csv(self, client, tmp_path):
         lines = ["md5,label"]
         good_ids = [1, 2, 3]
         bad_ids = [4, 5]
         for cid in good_ids:
-            lines.append(f"{app_module.medias[cid]['md5']},good")
+            lines.append(f"{medias[cid]['md5']},good")
         for cid in bad_ids:
-            lines.append(f"{app_module.medias[cid]['md5']},bad")
+            lines.append(f"{medias[cid]['md5']},bad")
         csv_text = "\n".join(lines)
         p = tmp_path / "labels.csv"
         p.write_text(csv_text)
@@ -182,8 +182,8 @@ class TestLabelImportEndpoint:
         )
         result = res.get_json()
         assert result["applied"] == 5
-        assert set(app_module.good_votes) == {1, 2, 3}
-        assert set(app_module.bad_votes) == {4, 5}
+        assert set(good_votes) == {1, 2, 3}
+        assert set(bad_votes) == {4, 5}
 
     def test_import_syncs_model_registry_num_training(self, client, tmp_path):
         """Importing labels should update the loaded model's num_training in the registry."""
@@ -223,7 +223,7 @@ class TestLabelImportEndpoint:
         set_thread_detector_context(det_ctx)
 
         # Import a label
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -271,8 +271,8 @@ class TestResolveClipIdsUnion:
         )
 
         # Entry with only md5, no origin; should match by md5
-        md5 = app_module.medias[1]["md5"]
-        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
+        md5 = medias[1]["md5"]
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
         entry = {"md5": md5, "label": "good"}
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert 1 in cids
@@ -283,8 +283,8 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
-        media = app_module.medias[1]
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
+        media = medias[1]
         entry = {"origin": media["origin"], "origin_name": media["origin_name"], "label": "good"}
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup)
         assert 1 in cids
@@ -297,11 +297,11 @@ class TestResolveClipIdsUnion:
         )
 
         # Give media 2 the same md5 as media 1 (simulate content-duplicate under different origin)
-        orig_md5 = app_module.medias[2]["md5"]
-        app_module.medias[2]["md5"] = app_module.medias[1]["md5"]
+        orig_md5 = medias[2]["md5"]
+        medias[2]["md5"] = medias[1]["md5"]
         try:
-            origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
-            clip1 = app_module.medias[1]
+            origin_lookup, md5_lookup, _ = build_media_lookup(medias)
+            clip1 = medias[1]
             # Entry: origin matches media 1, md5 also matches media 1 AND media 2
             entry = {
                 "md5": clip1["md5"],
@@ -313,7 +313,7 @@ class TestResolveClipIdsUnion:
             assert 1 in cids
             assert 2 in cids
         finally:
-            app_module.medias[2]["md5"] = orig_md5
+            medias[2]["md5"] = orig_md5
 
     def test_no_match_returns_empty(self):
         from vtsearch.state import (
@@ -321,7 +321,7 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
         entry = {
             "md5": "nonexistent",
             "origin": {"importer": "nope", "params": {}},
@@ -338,8 +338,8 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
-        origin_name = app_module.medias[1].get("origin_name", "")
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias)
+        origin_name = medias[1].get("origin_name", "")
         assert origin_name, "Test media 1 must have origin_name"
         entry = {"origin_name": origin_name, "label": "good"}
         # Without name_lookup; no match
@@ -356,8 +356,8 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
-        origin_name = app_module.medias[1].get("origin_name", "")
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias)
+        origin_name = medias[1].get("origin_name", "")
         assert origin_name
         entry = {"filename": origin_name, "label": "good"}
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
@@ -370,8 +370,8 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
-        md5 = app_module.medias[1]["md5"]
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias)
+        md5 = medias[1]["md5"]
         entry = {"md5": md5, "origin_name": "some_other_name", "label": "good"}
         cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
         assert 1 in cids
@@ -388,8 +388,8 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
-        origin_name = app_module.medias[1].get("origin_name", "")
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias)
+        origin_name = medias[1].get("origin_name", "")
         assert origin_name
         # md5 is present but doesn't match anything in this dataset (the
         # detector's labelset was built on a different dataset).  origin_name
@@ -408,8 +408,8 @@ class TestResolveClipIdsUnion:
             resolve_media_ids,
         )
 
-        origin_lookup, md5_lookup, name_lookup = build_media_lookup(app_module.medias)
-        origin_name = app_module.medias[1].get("origin_name", "")
+        origin_lookup, md5_lookup, name_lookup = build_media_lookup(medias)
+        origin_name = medias[1].get("origin_name", "")
         assert origin_name
         entry = {
             "origin": {"importer": "server_folder", "params": {"path": "/different/dataset"}},
@@ -432,8 +432,8 @@ class TestFindMissingEntries:
             find_missing_entries,
         )
 
-        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
-        entries = [{"md5": app_module.medias[i]["md5"], "label": "good"} for i in [1, 2, 3]]
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
+        entries = [{"md5": medias[i]["md5"], "label": "good"} for i in [1, 2, 3]]
         missing = find_missing_entries(entries, origin_lookup, md5_lookup)
         assert missing == []
 
@@ -443,9 +443,9 @@ class TestFindMissingEntries:
             find_missing_entries,
         )
 
-        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
         entries = [
-            {"md5": app_module.medias[1]["md5"], "label": "good"},
+            {"md5": medias[1]["md5"], "label": "good"},
             {"md5": "totally_unknown", "label": "bad"},
         ]
         missing = find_missing_entries(entries, origin_lookup, md5_lookup)
@@ -458,7 +458,7 @@ class TestFindMissingEntries:
             find_missing_entries,
         )
 
-        origin_lookup, md5_lookup, _ = build_media_lookup(app_module.medias)
+        origin_lookup, md5_lookup, _ = build_media_lookup(medias)
         entries = [
             {"md5": "unknown1", "label": "good"},
             {"md5": "unknown2", "label": "meh"},  # invalid label; excluded
@@ -481,7 +481,7 @@ class TestNextClipId:
     def test_returns_max_plus_one(self):
         from vtsearch.state import next_media_id
 
-        assert next_media_id(app_module.medias) == max(app_module.medias) + 1
+        assert next_media_id(medias) == max(medias) + 1
 
 
 # ---------------------------------------------------------------------------
@@ -492,7 +492,7 @@ class TestNextClipId:
 class TestLabelImportMissingElements:
     def test_response_includes_missing_entries(self, client, tmp_path):
         """Labels referencing unknown elements should appear in 'missing'."""
-        known_md5 = app_module.medias[1]["md5"]
+        known_md5 = medias[1]["md5"]
         payload = json.dumps(
             {
                 "labels": [
@@ -525,7 +525,7 @@ class TestLabelImportMissingElements:
         assert snapshot["ingest_result"]["unresolved"] == 1
 
     def test_no_missing_when_all_match(self, client, tmp_path):
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -541,7 +541,7 @@ class TestLabelImportMissingElements:
         """Missing elements are auto-resolved from their origin during import."""
 
         # Save/restore medias since auto-resolve adds new entries
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             # Create a text file that can be ingested
             text_dir = tmp_path / "texts"
@@ -552,7 +552,7 @@ class TestLabelImportMissingElements:
 
             origin = {"importer": "server_folder", "params": {"path": str(text_dir), "media_type": "text"}}
 
-            known_md5 = app_module.medias[1]["md5"]
+            known_md5 = medias[1]["md5"]
             payload = json.dumps(
                 {
                     "labels": [
@@ -585,16 +585,16 @@ class TestLabelImportMissingElements:
             snapshot = wait_for_detector_task(result["ingest_task_id"])
             assert snapshot["ingest_result"] == {"ingested": 1, "applied": 1, "unresolved": 0, "failed": 0}
             # The new media should be in the dataset and labeled
-            new_ids = [cid for cid, m in app_module.medias.items() if m.get("md5") == md5]
+            new_ids = [cid for cid, m in medias.items() if m.get("md5") == md5]
             assert len(new_ids) == 1
-            assert new_ids[0] in app_module.bad_votes
+            assert new_ids[0] in bad_votes
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)
 
     def test_auto_resolve_reports_unresolvable(self, client, tmp_path):
         """Elements that can't be resolved are reported in the response."""
-        known_md5 = app_module.medias[1]["md5"]
+        known_md5 = medias[1]["md5"]
         payload = json.dumps(
             {
                 "labels": [
@@ -642,15 +642,15 @@ class TestPartialFailure:
         importer should still apply the other labels and report the
         failed entry in ``failed``.
         """
-        md5_1 = app_module.medias[1]["md5"]
-        md5_2 = app_module.medias[2]["md5"]
-        md5_3 = app_module.medias[3]["md5"]
+        md5_1 = medias[1]["md5"]
+        md5_2 = medias[2]["md5"]
+        md5_3 = medias[3]["md5"]
 
         # Save & clear vote state so we can assert it precisely.
-        saved_good = dict(app_module.good_votes)
-        saved_bad = dict(app_module.bad_votes)
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        saved_good = dict(good_votes)
+        saved_bad = dict(bad_votes)
+        good_votes.clear()
+        bad_votes.clear()
         try:
             payload = json.dumps(
                 {
@@ -690,22 +690,22 @@ class TestPartialFailure:
             assert result["failed"][0]["entry"]["md5"] == md5_2
             assert "simulated downstream failure" in result["failed"][0]["error"]
             # The successful entries' votes actually landed.
-            assert 1 in app_module.good_votes
-            assert 3 in app_module.good_votes
-            assert 2 not in app_module.good_votes
+            assert 1 in good_votes
+            assert 3 in good_votes
+            assert 2 not in good_votes
             # Message advertises the failure.
             assert "failed to apply" in result["message"]
         finally:
-            app_module.good_votes.clear()
-            app_module.bad_votes.clear()
-            app_module.good_votes.update(saved_good)
-            app_module.bad_votes.update(saved_bad)
+            good_votes.clear()
+            bad_votes.clear()
+            good_votes.update(saved_good)
+            bad_votes.update(saved_bad)
 
     def test_clean_import_reports_zero_failed(self, client, tmp_path):
         """The new ``failed``/``failed_count`` fields are always present in the response,
         and read as 0 / [] on a clean import.
         """
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = json.dumps({"labels": [{"md5": md5, "label": "good"}]})
         p = tmp_path / "labels.json"
         p.write_text(payload)
@@ -741,13 +741,13 @@ class TestPartialFailure:
         def spy():
             sync_calls["count"] += 1
 
-        md5_1 = app_module.medias[1]["md5"]
-        md5_2 = app_module.medias[2]["md5"]
+        md5_1 = medias[1]["md5"]
+        md5_2 = medias[2]["md5"]
 
-        saved_good = dict(app_module.good_votes)
-        saved_bad = dict(app_module.bad_votes)
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        saved_good = dict(good_votes)
+        saved_bad = dict(bad_votes)
+        good_votes.clear()
+        bad_votes.clear()
         try:
             payload = json.dumps(
                 {
@@ -783,7 +783,7 @@ class TestPartialFailure:
             # Sync ran exactly once even though one entry failed mid-loop.
             assert sync_calls["count"] == 1
         finally:
-            app_module.good_votes.clear()
-            app_module.bad_votes.clear()
-            app_module.good_votes.update(saved_good)
-            app_module.bad_votes.update(saved_bad)
+            good_votes.clear()
+            bad_votes.clear()
+            good_votes.update(saved_good)
+            bad_votes.update(saved_bad)

--- a/tests/io/test_label_import_ingestion.py
+++ b/tests/io/test_label_import_ingestion.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.utils.hashing import content_md5
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 # ---------------------------------------------------------------------------
@@ -69,10 +70,8 @@ class TestIngestMissingEndpoint:
         importer route: a single bad entry must not abort the whole batch,
         and the response carries a ``failed`` list instead of bubbling a 500.
         """
-        import app as app_module
-
-        md5_1 = app_module.medias[1]["md5"]
-        md5_2 = app_module.medias[2]["md5"]
+        md5_1 = medias[1]["md5"]
+        md5_2 = medias[2]["md5"]
         entries = [
             {"md5": md5_1, "label": "good"},
             {"md5": md5_2, "label": "good"},
@@ -87,10 +86,10 @@ class TestIngestMissingEndpoint:
 
             inner(cid, label, **kwargs)
 
-        saved_good = dict(app_module.good_votes)
-        saved_bad = dict(app_module.bad_votes)
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        saved_good = dict(good_votes)
+        saved_bad = dict(bad_votes)
+        good_votes.clear()
+        bad_votes.clear()
         try:
             with patch.object(importers_module, "apply_label", side_effect=flaky_apply):
                 res = client.post(
@@ -104,10 +103,10 @@ class TestIngestMissingEndpoint:
             assert len(result["failed"]) == 1
             assert result["failed"][0]["entry"]["md5"] == md5_2
         finally:
-            app_module.good_votes.clear()
-            app_module.bad_votes.clear()
-            app_module.good_votes.update(saved_good)
-            app_module.bad_votes.update(saved_bad)
+            good_votes.clear()
+            bad_votes.clear()
+            good_votes.update(saved_good)
+            bad_votes.update(saved_bad)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/io/test_label_importers.py
+++ b/tests/io/test_label_importers.py
@@ -13,8 +13,8 @@ import json
 
 import pytest
 
-import app as app_module
 from tests import wait_for_detector_task
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 # ---------------------------------------------------------------------------
@@ -346,7 +346,7 @@ class TestServerJsonLabelImporter:
         assert result[0]["md5"] == "xyz"
 
     def test_api_route(self, client, tmp_path):
-        md5 = app_module.medias[1]["md5"]
+        md5 = medias[1]["md5"]
         payload = {"labels": [{"md5": md5, "label": "good"}]}
         p = tmp_path / "server_labels.json"
         p.write_text(json.dumps(payload))
@@ -357,7 +357,7 @@ class TestServerJsonLabelImporter:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 1
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
 
 # ---------------------------------------------------------------------------
@@ -409,8 +409,8 @@ class TestServerCsvLabelImporter:
         assert result[0]["md5"] == "xyz789"
 
     def test_api_route(self, client, tmp_path):
-        md5_1 = app_module.medias[1]["md5"]
-        md5_2 = app_module.medias[2]["md5"]
+        md5_1 = medias[1]["md5"]
+        md5_2 = medias[2]["md5"]
         p = tmp_path / "server_labels.csv"
         p.write_text(f"md5,label\n{md5_1},good\n{md5_2},bad\n")
         res = client.post(
@@ -420,8 +420,8 @@ class TestServerCsvLabelImporter:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 2
-        assert 1 in app_module.good_votes
-        assert 2 in app_module.bad_votes
+        assert 1 in good_votes
+        assert 2 in bad_votes
 
     def test_csv_importer_preserves_origin_name(self, tmp_path):
         """CSV importer reads origin_name/filename/category columns."""
@@ -468,8 +468,8 @@ class TestServerCsvLabelImporter:
         ingest the original media (via the resolver / ingest-missing flow)
         and have it matched by content hash.
         """
-        origin_name_1 = app_module.medias[1].get("origin_name", "")
-        origin_name_2 = app_module.medias[2].get("origin_name", "")
+        origin_name_1 = medias[1].get("origin_name", "")
+        origin_name_2 = medias[2].get("origin_name", "")
         assert origin_name_1, "Test media 1 must have an origin_name"
         csv_text = f"label,md5,origin_name\ngood,wrong_md5_1,{origin_name_1}\nbad,wrong_md5_2,{origin_name_2}\n"
         p = tmp_path / "cross_dataset.csv"
@@ -481,8 +481,8 @@ class TestServerCsvLabelImporter:
         assert res.status_code == 200
         result = res.get_json()
         assert result["applied"] == 0, "no labels should be applied via basename collision"
-        assert 1 not in app_module.good_votes
-        assert 2 not in app_module.bad_votes
+        assert 1 not in good_votes
+        assert 2 not in bad_votes
         # The rows are handed to the background auto-resolve pass (#2703),
         # which can't reach them either (no origin), so they stay unresolved.
         assert result["ingest_pending_count"] == 2

--- a/tests/io/test_labels.py
+++ b/tests/io/test_labels.py
@@ -2,8 +2,8 @@ import json
 
 import pytest
 
-import app as app_module
 from tests import load_detector_and_wait as _load_detector_and_wait
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 def _read_ndjson(resp):
@@ -20,38 +20,38 @@ class TestExportLabels:
         assert data == {"labels": []}
 
     def test_export_good_labels(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
+        good_votes.update({k: None for k in [1, 2]})
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert len(data["labels"]) == 2
         assert all(e["label"] == "good" for e in data["labels"])
 
     def test_export_bad_labels(self, client):
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert len(data["labels"]) == 2
         assert all(e["label"] == "bad" for e in data["labels"])
 
     def test_export_mixed_labels(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert len(data["labels"]) == 4
 
     def test_export_contains_md5_and_label(self, client):
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         entry = data["labels"][0]
         assert "md5" in entry
         assert "label" in entry
-        assert entry["md5"] == app_module.medias[1]["md5"]
+        assert entry["md5"] == medias[1]["md5"]
         assert entry["label"] == "good"
 
     def test_export_does_not_include_creation_info(self, client):
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export")
         data = resp.get_json()
         assert "dataset_creation_info" not in data
@@ -67,8 +67,8 @@ class TestExportLabelsNdjson:
         assert _read_ndjson(resp) == []
 
     def test_streams_one_line_per_label(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.get("/api/labels/export?format=ndjson")
         assert resp.mimetype == "application/x-ndjson"
         rows = _read_ndjson(resp)
@@ -77,16 +77,16 @@ class TestExportLabelsNdjson:
 
     def test_ndjson_matches_buffered_labels(self, client):
         """The streamed rows equal the buffered ``labels`` list, entry for entry."""
-        app_module.good_votes.update({k: None for k in [1, 3, 5]})
-        app_module.bad_votes.update({k: None for k in [2, 4]})
+        good_votes.update({k: None for k in [1, 3, 5]})
+        bad_votes.update({k: None for k in [2, 4]})
 
         buffered = client.get("/api/labels/export").get_json()["labels"]
         streamed = _read_ndjson(client.get("/api/labels/export?format=ndjson"))
         assert streamed == buffered
 
     def test_goods_only_filter(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.get("/api/labels/export?format=ndjson&goods_only=true")
         rows = _read_ndjson(resp)
         assert len(rows) == 2
@@ -96,25 +96,25 @@ class TestExportLabelsNdjson:
         from vtsearch.state import set_find_initial_labels
 
         set_find_initial_labels({1: "good", 2: "bad", 3: "good"})
-        app_module.good_votes.update({1: None, 2: None})  # 2 was bad -> correction
-        app_module.bad_votes[3] = None  # 3 was good -> correction
+        good_votes.update({1: None, 2: None})  # 2 was bad -> correction
+        bad_votes[3] = None  # 3 was good -> correction
 
         resp = client.get("/api/labels/export?format=ndjson&label_filter=corrections")
         rows = _read_ndjson(resp)
         assert len(rows) == 2
         assert all(r["is_correction"] is True for r in rows)
         md5s = {r["md5"] for r in rows}
-        assert app_module.medias[2]["md5"] in md5s
-        assert app_module.medias[3]["md5"] in md5s
+        assert medias[2]["md5"] in md5s
+        assert medias[3]["md5"] in md5s
 
     def test_corrections_filter_empty_without_find_labels(self, client):
-        app_module.good_votes[1] = None
-        app_module.bad_votes[2] = None
+        good_votes[1] = None
+        bad_votes[2] = None
         resp = client.get("/api/labels/export?format=ndjson&label_filter=corrections")
         assert _read_ndjson(resp) == []
 
     def test_enrich_attaches_custom_metadata_but_no_available_columns(self, client):
-        app_module.good_votes[1] = None
+        good_votes[1] = None
         resp = client.get("/api/labels/export?format=ndjson&enrich=true")
         rows = _read_ndjson(resp)
         assert len(rows) == 1
@@ -129,19 +129,19 @@ class TestExportLabelsNdjson:
 
 class TestImportLabels:
     def test_import_good_label(self, client):
-        labels = [{"md5": app_module.medias[1]["md5"], "label": "good"}]
+        labels = [{"md5": medias[1]["md5"], "label": "good"}]
         resp = client.post("/api/labels/import", json={"labels": labels})
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["applied"] == 1
         assert data["skipped"] == 0
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
     def test_import_bad_label(self, client):
-        labels = [{"md5": app_module.medias[1]["md5"], "label": "bad"}]
+        labels = [{"md5": medias[1]["md5"], "label": "bad"}]
         resp = client.post("/api/labels/import", json={"labels": labels})
         assert resp.status_code == 200
-        assert 1 in app_module.bad_votes
+        assert 1 in bad_votes
 
     def test_import_skips_unknown_md5(self, client):
         labels = [{"md5": "nonexistent_md5", "label": "good"}]
@@ -151,15 +151,15 @@ class TestImportLabels:
         assert data["skipped"] == 1
 
     def test_import_overrides_existing_label(self, client):
-        app_module.good_votes[1] = None
-        labels = [{"md5": app_module.medias[1]["md5"], "label": "bad"}]
+        good_votes[1] = None
+        labels = [{"md5": medias[1]["md5"], "label": "bad"}]
         client.post("/api/labels/import", json={"labels": labels})
-        assert 1 not in app_module.good_votes
-        assert 1 in app_module.bad_votes
+        assert 1 not in good_votes
+        assert 1 in bad_votes
 
     def test_import_mixed_known_and_unknown(self, client):
         labels = [
-            {"md5": app_module.medias[1]["md5"], "label": "good"},
+            {"md5": medias[1]["md5"], "label": "good"},
             {"md5": "unknown_md5", "label": "good"},
         ]
         resp = client.post("/api/labels/import", json={"labels": labels})
@@ -168,7 +168,7 @@ class TestImportLabels:
         assert data["skipped"] == 1
 
     def test_import_invalid_label_value(self, client):
-        labels = [{"md5": app_module.medias[1]["md5"], "label": "meh"}]
+        labels = [{"md5": medias[1]["md5"], "label": "meh"}]
         resp = client.post("/api/labels/import", json={"labels": labels})
         data = resp.get_json()
         assert data["applied"] == 0
@@ -186,35 +186,35 @@ class TestImportLabels:
     def test_import_multiple_labels(self, client):
         labels = []
         for cid in [1, 2, 3]:
-            labels.append({"md5": app_module.medias[cid]["md5"], "label": "good"})
+            labels.append({"md5": medias[cid]["md5"], "label": "good"})
         for cid in [4, 5]:
-            labels.append({"md5": app_module.medias[cid]["md5"], "label": "bad"})
+            labels.append({"md5": medias[cid]["md5"], "label": "bad"})
         resp = client.post("/api/labels/import", json={"labels": labels})
         data = resp.get_json()
         assert data["applied"] == 5
         assert data["skipped"] == 0
-        assert set(app_module.good_votes) == {1, 2, 3}
-        assert set(app_module.bad_votes) == {4, 5}
+        assert set(good_votes) == {1, 2, 3}
+        assert set(bad_votes) == {4, 5}
 
     def test_roundtrip_export_import(self, client):
         """Export labels, clear votes, import, and verify same state."""
-        app_module.good_votes.update({k: None for k in [1, 3, 5]})
-        app_module.bad_votes.update({k: None for k in [2, 4]})
+        good_votes.update({k: None for k in [1, 3, 5]})
+        bad_votes.update({k: None for k in [2, 4]})
         resp = client.get("/api/labels/export")
         exported = resp.get_json()
 
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
+        good_votes.clear()
+        bad_votes.clear()
 
         resp = client.post("/api/labels/import", json=exported)
         data = resp.get_json()
         assert data["applied"] == 5
-        assert set(app_module.good_votes) == {1, 3, 5}
-        assert set(app_module.bad_votes) == {2, 4}
+        assert set(good_votes) == {1, 3, 5}
+        assert set(bad_votes) == {2, 4}
 
     def test_import_matches_by_origin(self, client):
         """Labels with origin+origin_name match the correct media."""
-        media = app_module.medias[1]
+        media = medias[1]
         labels = [
             {
                 "md5": "wrong_md5_on_purpose",
@@ -226,24 +226,24 @@ class TestImportLabels:
         resp = client.post("/api/labels/import", json={"labels": labels})
         data = resp.get_json()
         assert data["applied"] == 1
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
 
     def test_import_duplicate_md5_labels_both_clips(self, client):
         """Two medias sharing the same MD5 should both receive the label."""
         # Temporarily give media 2 the same MD5 as media 1
-        original_md5 = app_module.medias[2]["md5"]
-        app_module.medias[2]["md5"] = app_module.medias[1]["md5"]
+        original_md5 = medias[2]["md5"]
+        medias[2]["md5"] = medias[1]["md5"]
         try:
-            shared_md5 = app_module.medias[1]["md5"]
+            shared_md5 = medias[1]["md5"]
             labels = [{"md5": shared_md5, "label": "good"}]
             resp = client.post("/api/labels/import", json={"labels": labels})
             data = resp.get_json()
             assert data["applied"] == 1
             # Both medias with the same MD5 should receive the label
-            assert 1 in app_module.good_votes
-            assert 2 in app_module.good_votes
+            assert 1 in good_votes
+            assert 2 in good_votes
         finally:
-            app_module.medias[2]["md5"] = original_md5
+            medias[2]["md5"] = original_md5
 
 
 class TestExportOriginOnlyFallback:
@@ -279,8 +279,6 @@ class TestExportOriginOnlyFallback:
 
         Returns ``(detector_id, good_cid, bad_cid)``.
         """
-        from vtsearch.state import medias
-
         if len(medias) < 2:
             pytest.skip("Need at least 2 medias")
         ids = list(medias.keys())
@@ -379,7 +377,6 @@ class TestExportOriginOnlyFallback:
         from vtscore.detectors.registry import get_detector
         from vtscore.detectors.store import _detector_path
         from vtscore.state.core import get_active_detector_context
-        from vtsearch.state import medias
 
         detector_id, good_cid, bad_cid = self._setup_detector(client)
         good_media = medias[good_cid]

--- a/tests/io/test_labelset_ingest_task.py
+++ b/tests/io/test_labelset_ingest_task.py
@@ -29,6 +29,7 @@ from vtscore.concurrency.progress import detector_loading_tasks
 from vtscore.datasets import ingest as ingest_module
 
 from tests import wait_for_detector_task
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 @pytest.fixture
@@ -174,10 +175,8 @@ class TestLabelImportIngestIsBackgrounded:
 
     def test_auto_resolve_applies_labels_and_publishes_counts(self, client, foreign_labels):
         """The backgrounded pass still lands the votes the inline one used to."""
-        import app as app_module
-
         labels_path, _ = foreign_labels
-        saved = dict(app_module.medias)
+        saved = dict(medias)
         try:
             res = client.post(
                 "/api/label-importers/import/server_json_file",
@@ -191,13 +190,11 @@ class TestLabelImportIngestIsBackgrounded:
                 "unresolved": 0,
                 "failed": 0,
             }
-            names = {m.get("origin_name") for m in app_module.medias.values()}
+            names = {m.get("origin_name") for m in medias.values()}
             assert {"task_1.wav", "task_2.wav"} <= names
-            voted = set(app_module.good_votes) | set(app_module.bad_votes)
-            ingested_ids = {
-                cid for cid, m in app_module.medias.items() if m.get("origin_name") in ("task_1.wav", "task_2.wav")
-            }
+            voted = set(good_votes) | set(bad_votes)
+            ingested_ids = {cid for cid, m in medias.items() if m.get("origin_name") in ("task_1.wav", "task_2.wav")}
             assert ingested_ids <= voted, "auto-resolved media must carry their labels"
         finally:
-            app_module.medias.clear()
-            app_module.medias.update(saved)
+            medias.clear()
+            medias.update(saved)

--- a/tests/sorting/test_label_sorting.py
+++ b/tests/sorting/test_label_sorting.py
@@ -7,15 +7,10 @@ from unittest.mock import patch
 
 import numpy as np
 
-import app as app_module
 import vtsearch.state as _state
 import vtscore.state.core as _core
 from vtscore.embedding.media_vectors import media_embedding
-from vtsearch.state import (
-    medias,
-    vote_click_times,
-    last_learned_scores,
-)
+from vtsearch.state import bad_votes, good_votes, last_learned_scores, medias, vote_click_times
 
 
 class TestClickTimeTracking:
@@ -57,14 +52,14 @@ class TestClickTimeTracking:
         # Switch from good to bad
         client.post("/api/medias/1/vote", json={"target": "bad"})
         assert vote_click_times[1] == 2
-        assert 1 in app_module.bad_votes
-        assert 1 not in app_module.good_votes
+        assert 1 in bad_votes
+        assert 1 not in good_votes
 
     def test_imported_labels_have_no_click_time(self, client):
         """Labels added via import should not receive a click time."""
-        labels = [{"md5": app_module.medias[1]["md5"], "label": "good"}]
+        labels = [{"md5": medias[1]["md5"], "label": "good"}]
         client.post("/api/labels/import", json={"labels": labels})
-        assert 1 in app_module.good_votes
+        assert 1 in good_votes
         assert 1 not in vote_click_times
 
 
@@ -99,8 +94,8 @@ class TestVotesEndpointEnriched:
     def test_learned_scores_populated_after_learned_sort(self, client):
         """After a learned-sort, /api/votes should include scores for all medias."""
         # Set up votes (need at least one good and one bad)
-        app_module.good_votes.update({1: None, 2: None})
-        app_module.bad_votes.update({3: None, 4: None})
+        good_votes.update({1: None, 2: None})
+        bad_votes.update({3: None, 4: None})
         # Trigger learned sort
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
@@ -112,7 +107,7 @@ class TestVotesEndpointEnriched:
         data = resp.get_json()
         assert len(data["learned_scores"]) > 0
         # Every media should have a score
-        for cid in app_module.medias:
+        for cid in medias:
             assert str(cid) in data["learned_scores"]
 
 

--- a/tests/sorting/test_sort_windowing.py
+++ b/tests/sorting/test_sort_windowing.py
@@ -8,8 +8,8 @@ still consumes the full ``results`` (windowed model lands separately).
 
 from __future__ import annotations
 
-import app as app_module
 import vtscore.state.sort_results_cache as sort_cache
+from tests.fixtures.medias import NUM_MEDIAS
 
 
 class TestSortResponseWindowMeta:
@@ -18,8 +18,8 @@ class TestSortResponseWindowMeta:
         assert resp.status_code == 200
         data = resp.get_json()
         # Full list still returned (additive change).
-        assert len(data["results"]) == app_module.NUM_MEDIAS
-        assert data["total"] == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
+        assert data["total"] == NUM_MEDIAS
         assert isinstance(data["sort_token"], str) and data["sort_token"]
         # above_threshold matches how many rows are >= the returned threshold.
         expected = sum(1 for r in data["results"] if r["similarity"] >= data["threshold"])
@@ -34,7 +34,7 @@ class TestSortResponseWindowMeta:
         # NUM_MEDIAS (20) < a high threshold → full list, no windowing.
         monkeypatch.setattr(sort_cache, "SORT_WINDOW_THRESHOLD", 1000)
         data = client.post("/api/sort", json={"text": "beep"}).get_json()
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
         assert data["has_more_below"] is False
 
 
@@ -50,10 +50,10 @@ class TestWindowedTransmission:
         self._shrink_window(monkeypatch)
         data = client.post("/api/sort", json={"text": "beep"}).get_json()
         above = data["above_threshold"]
-        expected = min(app_module.NUM_MEDIAS, min(above, 2) + 1)
-        assert data["total"] == app_module.NUM_MEDIAS
+        expected = min(NUM_MEDIAS, min(above, 2) + 1)
+        assert data["total"] == NUM_MEDIAS
         assert len(data["results"]) == expected
-        assert data["has_more_below"] is (expected < app_module.NUM_MEDIAS)
+        assert data["has_more_below"] is (expected < NUM_MEDIAS)
 
     def test_paging_reconstructs_the_full_ranking(self, client, monkeypatch):
         self._shrink_window(monkeypatch)
@@ -69,8 +69,8 @@ class TestWindowedTransmission:
             if not body["has_more"]:
                 break
             offset += 5
-        assert len(collected) == app_module.NUM_MEDIAS
-        assert len(set(collected)) == app_module.NUM_MEDIAS
+        assert len(collected) == NUM_MEDIAS
+        assert len(set(collected)) == NUM_MEDIAS
 
 
 class TestSortPage:
@@ -85,8 +85,8 @@ class TestSortPage:
         assert [r["id"] for r in body["results"]] == full_ids[1:3]
         assert body["offset"] == 1
         assert body["limit"] == 2
-        assert body["total"] == app_module.NUM_MEDIAS
-        assert body["has_more"] is (3 < app_module.NUM_MEDIAS)
+        assert body["total"] == NUM_MEDIAS
+        assert body["has_more"] is (3 < NUM_MEDIAS)
 
     def test_page_default_offset_and_limit(self, client):
         token = client.post("/api/sort", json={"text": "tone"}).get_json()["sort_token"]

--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -4,15 +4,13 @@ import unittest.mock
 import numpy as np
 import torch
 
-import app as app_module
-
 
 class TestSortClips:
     def test_returns_all_clips(self, client):
         resp = client.post("/api/sort", json={"text": "high pitched beep"})
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
         assert "threshold" in data
 
     def test_result_contains_id_and_similarity(self, client):
@@ -32,7 +30,7 @@ class TestSortClips:
         resp = client.post("/api/sort", json={"text": "sine wave"})
         data = resp.get_json()
         ids = {e["id"] for e in data["results"]}
-        assert ids == set(range(1, app_module.NUM_MEDIAS + 1))
+        assert ids == set(range(1, NUM_MEDIAS + 1))
 
     def test_similarity_values_in_range(self, client):
         resp = client.post("/api/sort", json={"text": "high pitch"})
@@ -59,44 +57,36 @@ class TestSortClips:
 
 class TestTrainAndScore:
     def test_returns_list_of_scored_clips(self):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
-        results, threshold, _model = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
-        assert len(results) == app_module.NUM_MEDIAS
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
+        results, threshold, _model = train_and_score(medias, good_votes, bad_votes)
+        assert len(results) == NUM_MEDIAS
         assert isinstance(threshold, float)
         for entry in results:
             assert "id" in entry
             assert "score" in entry
 
     def test_scores_between_zero_and_one(self):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
-        results, threshold, _model = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
+        results, threshold, _model = train_and_score(medias, good_votes, bad_votes)
         for entry in results:
             assert 0.0 <= entry["score"] <= 1.0
 
     def test_results_sorted_descending(self):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
-        results, threshold, _model = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
+        results, threshold, _model = train_and_score(medias, good_votes, bad_votes)
         scores = [e["score"] for e in results]
         assert scores == sorted(scores, reverse=True)
 
     def test_good_clips_scored_higher_than_bad(self):
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        results, threshold, _model = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
+        results, threshold, _model = train_and_score(medias, good_votes, bad_votes)
         score_map = {e["id"]: e["score"] for e in results}
-        avg_good = np.mean([score_map[i] for i in app_module.good_votes])
-        avg_bad = np.mean([score_map[i] for i in app_module.bad_votes])
+        avg_good = np.mean([score_map[i] for i in good_votes])
+        avg_bad = np.mean([score_map[i] for i in bad_votes])
         assert avg_good > avg_bad
 
     def test_trains_the_linear_head(self):
@@ -105,29 +95,23 @@ class TestTrainAndScore:
         Pins the #2790 swap on the pipeline users actually drive: a revert to
         ``_auto_hidden_dim`` would put back a ReLU and a second Linear here.
         """
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        _results, _threshold, model = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
+        _results, _threshold, model = train_and_score(medias, good_votes, bad_votes)
         assert model is not None
         assert [type(layer) for layer in model] == [torch.nn.Linear]
         assert set(model.state_dict()) == {"0.weight", "0.bias"}
 
     def test_order_changes_after_new_vote(self):
         """After adding a vote and retraining, the sort order should change."""
-        app_module.good_votes.update({k: None for k in [1, 2, 3, 4, 5]})
-        app_module.bad_votes.update({k: None for k in [16, 17, 18, 19, 20]})
-        results_before, _, _m = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
+        good_votes.update({k: None for k in [1, 2, 3, 4, 5]})
+        bad_votes.update({k: None for k in [16, 17, 18, 19, 20]})
+        results_before, _, _m = train_and_score(medias, good_votes, bad_votes)
         order_before = [e["id"] for e in results_before]
 
         # Add a new good vote on a media that was in the middle
-        app_module.good_votes[10] = None
-        results_after, _, _m = app_module.train_and_score(
-            app_module.medias, app_module.good_votes, app_module.bad_votes
-        )
+        good_votes[10] = None
+        results_after, _, _m = train_and_score(medias, good_votes, bad_votes)
         order_after = [e["id"] for e in results_after]
 
         assert order_before != order_after, "Sort order did not change after adding a new vote"
@@ -339,8 +323,8 @@ class TestCalibrationAtTinyLabelCounts:
         from vtscore.detectors import training as detector_training
         from vtscore.training.thresholds import conformal
 
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4, 5]})  # 5 labels < 6
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4, 5]})  # 5 labels < 6
 
         with unittest.mock.patch.object(
             conformal,
@@ -348,9 +332,9 @@ class TestCalibrationAtTinyLabelCounts:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             _, threshold, _model = detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
             )
         assert patched.call_count == 1
         assert 0.0 <= threshold <= 1.0
@@ -361,8 +345,8 @@ class TestCalibrationAtTinyLabelCounts:
         from vtscore.detectors import training as detector_training
         from vtscore.training.thresholds import conformal
 
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4, 5]})  # 5 labels < 6
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4, 5]})  # 5 labels < 6
 
         with unittest.mock.patch.object(
             conformal,
@@ -370,9 +354,9 @@ class TestCalibrationAtTinyLabelCounts:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
             )
         assert patched.call_count == 1
 
@@ -383,8 +367,8 @@ class TestCalibrationAtTinyLabelCounts:
         from vtscore.detectors import training as detector_training
         from vtscore.training.thresholds import conformal
 
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})  # 6 labels
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})  # 6 labels
 
         with unittest.mock.patch.object(
             conformal,
@@ -392,9 +376,9 @@ class TestCalibrationAtTinyLabelCounts:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
             )
         assert patched.call_count == 1
 
@@ -404,8 +388,8 @@ class TestCalibrationAtTinyLabelCounts:
         from vtscore.detectors import training as detector_training
         from vtscore.training.thresholds import conformal
 
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [17, 18, 19, 20]})  # 7 labels
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [17, 18, 19, 20]})  # 7 labels
 
         with unittest.mock.patch.object(
             conformal,
@@ -413,9 +397,9 @@ class TestCalibrationAtTinyLabelCounts:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
             )
         assert patched.call_count == 1
 
@@ -442,8 +426,8 @@ class TestCalibrationCache:
     def _seed_six_labels(self):
         # Six labels puts us above the ``< 6`` skip floor so calibration
         # actually runs (and can therefore be cached).
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
 
     def test_second_call_with_same_inputs_skips_calibration(self):
         from vtscore.detectors import training as detector_training
@@ -453,9 +437,9 @@ class TestCalibrationCache:
         det_ctx = self._det_ctx()
 
         detector_training.train_and_score(
-            app_module.medias,
-            app_module.good_votes,
-            app_module.bad_votes,
+            medias,
+            good_votes,
+            bad_votes,
             det_ctx=det_ctx,
         )
         assert det_ctx.calibration_cache is not None
@@ -466,9 +450,9 @@ class TestCalibrationCache:
             side_effect=AssertionError("fold orderings should be cached on repeat call"),
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
                 det_ctx=det_ctx,
             )
         patched.assert_not_called()
@@ -480,15 +464,15 @@ class TestCalibrationCache:
         det_ctx = self._det_ctx()
 
         _, t1, _ = detector_training.train_and_score(
-            app_module.medias,
-            app_module.good_votes,
-            app_module.bad_votes,
+            medias,
+            good_votes,
+            bad_votes,
             det_ctx=det_ctx,
         )
         _, t2, _ = detector_training.train_and_score(
-            app_module.medias,
-            app_module.good_votes,
-            app_module.bad_votes,
+            medias,
+            good_votes,
+            bad_votes,
             det_ctx=det_ctx,
         )
         assert t1 == t2
@@ -501,17 +485,17 @@ class TestCalibrationCache:
         det_ctx = self._det_ctx()
 
         detector_training.train_and_score(
-            app_module.medias,
-            app_module.good_votes,
-            app_module.bad_votes,
+            medias,
+            good_votes,
+            bad_votes,
             det_ctx=det_ctx,
         )
         assert det_ctx.calibration_cache is not None
         first_key = det_ctx.calibration_cache[0]
 
         # Flip one media's label; calibration must recompute.
-        app_module.good_votes.pop(3)
-        app_module.bad_votes[3] = None
+        good_votes.pop(3)
+        bad_votes[3] = None
 
         with unittest.mock.patch.object(
             conformal,
@@ -519,9 +503,9 @@ class TestCalibrationCache:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
                 det_ctx=det_ctx,
             )
         assert patched.call_count == 1
@@ -539,9 +523,9 @@ class TestCalibrationCache:
         det_ctx = self._det_ctx()
 
         detector_training.train_and_score(
-            app_module.medias,
-            app_module.good_votes,
-            app_module.bad_votes,
+            medias,
+            good_votes,
+            bad_votes,
             inclusion_value=0,
             det_ctx=det_ctx,
         )
@@ -554,9 +538,9 @@ class TestCalibrationCache:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
                 inclusion_value=2,
                 det_ctx=det_ctx,
             )
@@ -578,14 +562,14 @@ class TestCalibrationCache:
             wraps=conformal.compute_fold_orderings,
         ) as patched:
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
             )
             detector_training.train_and_score(
-                app_module.medias,
-                app_module.good_votes,
-                app_module.bad_votes,
+                medias,
+                good_votes,
+                bad_votes,
             )
         assert patched.call_count == 2
 
@@ -599,17 +583,17 @@ class TestCalibrationCache:
 
 class TestLearnedSort:
     def test_returns_all_clips(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         data = resp.get_json()
-        assert len(data["results"]) == app_module.NUM_MEDIAS
+        assert len(data["results"]) == NUM_MEDIAS
         assert "threshold" in data
 
     def test_result_fields(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         for entry in data["results"]:
@@ -617,20 +601,20 @@ class TestLearnedSort:
             assert "score" in entry
 
     def test_sorted_descending(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         scores = [e["score"] for e in data["results"]]
         assert scores == sorted(scores, reverse=True)
 
     def test_all_media_ids_present(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         ids = {e["id"] for e in data["results"]}
-        assert ids == set(range(1, app_module.NUM_MEDIAS + 1))
+        assert ids == set(range(1, NUM_MEDIAS + 1))
 
     def test_publishes_the_acquisition_cut_alongside_the_reporting_one(self, client):
         """Autopilot's Hard / New picks sample around a *different* cut.
@@ -640,8 +624,8 @@ class TestLearnedSort:
         coupled behaviour PR #2876 measured as costing 4.5x the positives - with
         nothing failing.
         """
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 200
         data = resp.get_json()
@@ -659,18 +643,18 @@ class TestLearnedSort:
         assert resp.get_json()["acq_threshold"] is None
 
     def test_only_good_votes_returns_400(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
+        good_votes.update({k: None for k in [1, 2]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_only_bad_votes_returns_400(self, client):
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         assert resp.status_code == 400
 
     def test_scores_in_valid_range(self, client):
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
         resp = client.post("/api/learned-sort", json={"wait": True})
         data = resp.get_json()
         for entry in data["results"]:
@@ -685,8 +669,8 @@ class TestLearnedSortAsync:
         from tests.conftest import _wait_for_job
         from vtscore.concurrency.async_jobs import learned_sort_jobs
 
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
 
         resp = client.post("/api/learned-sort", json={})
         assert resp.status_code == 200
@@ -708,8 +692,8 @@ class TestLearnedSortAsync:
         """The signature cache lets re-sorts skip training entirely."""
         from vtscore.concurrency.async_jobs import learned_sort_jobs
 
-        app_module.good_votes.update({k: None for k in [1, 2]})
-        app_module.bad_votes.update({k: None for k in [3, 4]})
+        good_votes.update({k: None for k in [1, 2]})
+        bad_votes.update({k: None for k in [3, 4]})
 
         first = client.post("/api/learned-sort", json={"wait": True}).get_json()
         assert first["status"] == "done"
@@ -723,7 +707,7 @@ class TestLearnedSortAsync:
         assert second["job_id"] == first_job_id
 
         # Cache invalidates when votes change.
-        app_module.bad_votes.update({5: None})
+        bad_votes.update({5: None})
         third = client.post("/api/learned-sort", json={"wait": True}).get_json()
         assert third["status"] == "done"
         assert third["job_id"] != first_job_id
@@ -760,9 +744,9 @@ class TestEvalTrainAndScoreAsync:
         # A handful of "good" votes are enough to exercise the smart metric.
         for cid, lbl in [(1, "good"), (2, "good"), (3, "bad"), (4, "bad")]:
             if lbl == "good":
-                app_module.good_votes[cid] = None
+                good_votes[cid] = None
             else:
-                app_module.bad_votes[cid] = None
+                bad_votes[cid] = None
             label_history.append((cid, lbl, 0.0))
 
     def test_wait_returns_metric_inline(self, client):
@@ -841,7 +825,7 @@ class TestEvalTrainAndScoreAsync:
 class TestExampleSort:
     def test_sort_with_audio_file(self, client):
         # Create a test WAV file in memory
-        wav_bytes = app_module.generate_wav(440.0, 1.0)
+        wav_bytes = generate_wav(440.0, 1.0)
         data = {"file": (io.BytesIO(wav_bytes), "test.wav")}
 
         resp = client.post("/api/example-sort", data=data, content_type="multipart/form-data")
@@ -849,10 +833,10 @@ class TestExampleSort:
         result_data = resp.get_json()
         assert "results" in result_data
         assert "threshold" in result_data
-        assert len(result_data["results"]) == app_module.NUM_MEDIAS
+        assert len(result_data["results"]) == NUM_MEDIAS
 
     def test_sort_results_sorted_descending(self, client):
-        wav_bytes = app_module.generate_wav(440.0, 1.0)
+        wav_bytes = generate_wav(440.0, 1.0)
         data = {"file": (io.BytesIO(wav_bytes), "test.wav")}
 
         resp = client.post("/api/example-sort", data=data, content_type="multipart/form-data")
@@ -861,7 +845,7 @@ class TestExampleSort:
         assert similarities == sorted(similarities, reverse=True)
 
     def test_sort_similarity_in_valid_range(self, client):
-        wav_bytes = app_module.generate_wav(440.0, 1.0)
+        wav_bytes = generate_wav(440.0, 1.0)
         data = {"file": (io.BytesIO(wav_bytes), "test.wav")}
 
         resp = client.post("/api/example-sort", data=data, content_type="multipart/form-data")
@@ -1021,17 +1005,17 @@ class TestLearnedSortVoteSnapshot:
         from vtscore.detectors import learned_sort as ls_mod
 
         learned_sort_jobs.reset_for_tests()
-        app_module.good_votes.clear()
-        app_module.bad_votes.clear()
-        app_module.good_votes.update({1: None, 2: None})
-        app_module.bad_votes.update({3: None})
+        good_votes.clear()
+        bad_votes.clear()
+        good_votes.update({1: None, 2: None})
+        bad_votes.update({3: None})
 
         captured: dict[str, dict] = {}
 
         def fake_run(*, good, bad, **_kwargs):
             # Simulate a vote landing after the request computed its signature
             # but before/while the job runs: mutate the live proxy.
-            app_module.good_votes[99] = None
+            good_votes[99] = None
             captured["good"] = dict(good)
             captured["bad"] = dict(bad)
             return [], 0.5
@@ -1046,3 +1030,9 @@ class TestLearnedSortVoteSnapshot:
         assert captured["good"] == {1: None, 2: None}
         assert 99 not in captured["good"]
         assert captured["bad"] == {3: None}
+
+
+from tests.fixtures.medias import NUM_MEDIAS
+from vtscore.detectors.training import train_and_score
+from vtscore.media.audio.audio_generator import generate_wav
+from vtsearch.state import bad_votes, good_votes, medias

--- a/tests/sorting/test_threshold_settings.py
+++ b/tests/sorting/test_threshold_settings.py
@@ -15,7 +15,6 @@ Covers:
 import numpy as np
 import pytest
 
-import app as app_module
 from vtscore.detectors.training import train_and_score
 from vtscore.training.thresholds import (
     NO_GOOD_THRESHOLD,
@@ -23,6 +22,7 @@ from vtscore.training.thresholds import (
     calculate_gmm_threshold,
     calculate_safe_threshold,
 )
+from vtsearch.state import bad_votes, good_votes, medias
 
 
 class TestCalculateSafeThreshold:
@@ -126,19 +126,19 @@ class TestTrainAndScoreFusesUnconditionally:
         assert "safe_thresholds" not in inspect.signature(train_and_score).parameters
 
     def test_returns_a_valid_threshold(self):
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        results, threshold, _model = train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
+        results, threshold, _model = train_and_score(medias, good_votes, bad_votes)
         assert 0.0 <= threshold <= 1.0
-        assert len(results) == len(app_module.medias)
+        assert len(results) == len(medias)
 
     def test_threshold_is_realizable_on_the_haystack_distribution(self):
         """The shipped cut is realized as a quantile of the scores it will be
         compared against, so it always lands inside their range - which the raw
         conformal quantile, measured on fold-model scores, need not."""
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
-        results, threshold, _model = train_and_score(app_module.medias, app_module.good_votes, app_module.bad_votes)
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
+        results, threshold, _model = train_and_score(medias, good_votes, bad_votes)
         scores = [r["score"] for r in results]
         assert min(scores) <= threshold <= max(scores)
 
@@ -293,15 +293,15 @@ class TestCalibrationFractionTrainAndScore:
         assert default is None
 
     def test_custom_fraction_returns_valid_results(self):
-        app_module.good_votes.update({k: None for k in [1, 2, 3]})
-        app_module.bad_votes.update({k: None for k in [18, 19, 20]})
+        good_votes.update({k: None for k in [1, 2, 3]})
+        bad_votes.update({k: None for k in [18, 19, 20]})
         results, threshold, _model = train_and_score(
-            app_module.medias,
-            app_module.good_votes,
-            app_module.bad_votes,
+            medias,
+            good_votes,
+            bad_votes,
             calibration_fraction=0.2,
         )
-        assert len(results) == len(app_module.medias)
+        assert len(results) == len(medias)
         # threshold can be inf if the split is too extreme for 6 labels
         assert isinstance(threshold, float)
 


### PR DESCRIPTION
Closes #3426.

`tests/conftest.py` monkeypatched seven names onto the `app` module "for backward compatibility" — `medias`, `good_votes`, `bad_votes`, `NUM_MEDIAS`, `generate_wav`, `train_and_score`, `init_medias` — and ~520 assertions across 30 files read global state through that alias layer instead of the import surface the app itself uses.

The shim had already leaked out of the test tier: `app.py` carried a `TYPE_CHECKING` block declaring all seven names purely so pyright could resolve attribute accesses that only ever exist under pytest. Production source describing test infrastructure is the concrete cost that made this worth fixing rather than leaving alone.

## What changed

Codemod `app_module.<name>` → the real import, in every test:

| Name | Now imported from |
|---|---|
| `medias`, `good_votes`, `bad_votes` | `vtsearch.state` |
| `NUM_MEDIAS`, `init_medias` | `tests.fixtures.medias` |
| `generate_wav` | `vtscore.media.audio.audio_generator` |
| `train_and_score` | `vtscore.detectors.training` |

Then:

* Deleted the alias block from `tests/conftest.py` and the `TYPE_CHECKING` block from `app.py`.
* Deleted 23 `import app as app_module  # noqa: F401` lines whose comments claimed a side effect that does not exist — conftest imports `app` at module scope and is loaded before any test module, so a repeat import in a test file is a `sys.modules` hit that triggers nothing. The conftest import now carries a comment saying why it is the one that matters.
* Stripped the stale `# noqa: F401` from the three files where `app_module` *is* used (for `app_module.app`, the genuine module attribute — those references stay).
* Dropped function-local `from vtsearch.state import ...` imports made redundant by the new module-level ones. Several files had both idioms; `tests/detectors/test_detectors.py` had one function importing `app` for `app_module.medias` and `vtsearch.state` for `good_votes` in the same body.

## Why the rewrite is safe

* **Identity is preserved.** `medias` / `good_votes` / `bad_votes` are singleton proxy instances built once in `vtsearch/state_proxies.py` from `_PROXY_SPECS` and never rebound, so `app_module.good_votes` and `from vtsearch.state import good_votes` always named the same object. The conftest assignments were pure aliasing, not indirection.
* **No shadowing.** An AST pass over every rewritten site checked whether its enclosing function scope binds the same name (several files do have local `medias = {}` / `good_votes = {...}` in *other* functions). Zero conflicts.
* **Nothing patched through the alias.** No `patch("app.medias")`, `setattr(app_module, ...)`, or equivalent — so no test depended on the app module being the lookup site.

Net −180 lines. Full `./run-tests.sh`: 9748 passed, 6 skipped, 2 xfailed; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeVTGqK9btbrYpc9zhW91V

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeVTGqK9btbrYpc9zhW91V)_