### PR TITLE
refactor(schemas): share the duplicated validator and passthrough hook, guard the PluginField mirror

### DIFF
--- a/tests/api/test_schema_plugin_drift.py
+++ b/tests/api/test_schema_plugin_drift.py
@@ -1,0 +1,152 @@
+"""Drift guards between plugin ``to_dict()`` payloads and their schemas.
+
+Several schemas in :mod:`vtsearch.schemas.datasets` hand-transcribe a plugin
+``to_dict()`` payload so the generated OpenAPI client carries a real typed
+model instead of ``any``.  Nothing tied the two together, and the failure
+mode is silent in the worst way: marshmallow **drops undeclared keys on
+dump**, so adding a key to a ``to_dict()`` removes it from the API response
+and from the generated TypeScript client without a single test going red.
+
+These tests close that loop.  They are deliberately one-directional except
+for :class:`~vtsearch.schemas.datasets.ImporterFieldSchema`: a key the wire
+emits but the schema does not declare is a bug (it vanishes), while a key
+the schema declares but no plugin currently emits is fine (routes annotate
+some payloads themselves — ``ImporterInfoSchema.enabled`` is added by the
+``/api/dataset/all-importers`` handler).
+
+The last two tests pin the two halves of the dump-side contract in
+:mod:`vtsearch.schemas.common`: opting in to the passthrough must let extras
+through, and *not* opting in must keep dropping them.  The strict default is
+a security boundary, not a formality — it is what keeps a media dict's
+embedding vectors out of an auto-detect response.
+"""
+
+from __future__ import annotations
+
+import pytest
+from marshmallow import Schema, fields
+
+from vtscore.converters import list_converters
+from vtscore.datasets import list_importers
+from vtscore.media import all_cleaners_dict, all_clippers_dict, all_embedders_dict, all_types_dict
+from vtscore.plugins import PluginField
+from vtsearch.schemas.common import PluginExtrasSchema
+from vtsearch.schemas.datasets import (
+    CleanerInfoSchema,
+    ClipperInfoSchema,
+    ConverterInfoSchema,
+    EmbedderInfoSchema,
+    ImporterFieldSchema,
+    ImporterInfoSchema,
+    MediaTypeInfoSchema,
+)
+
+
+def _wire_keys(schema: Schema) -> set[str]:
+    """The key names *schema* emits on dump (``data_key`` where declared)."""
+    return {f.data_key or name for name, f in schema.fields.items()}
+
+
+def test_importer_field_schema_matches_plugin_field_exactly():
+    """``ImporterFieldSchema`` is a hand-written mirror of ``PluginField.to_dict()``.
+
+    Unlike the other schemas here, this one is checked for *equality*:
+    ``PluginField`` is a dataclass whose ``to_dict`` emits all of its wire
+    fields unconditionally, so a key on one side and not the other is drift
+    in whichever direction it points.  ``PluginField`` itself is external
+    plugin API; only this transcript of it is ours to fix.
+    """
+    wire = set(PluginField(key="k", label="Label", field_type="text").to_dict())
+    declared = _wire_keys(ImporterFieldSchema())
+
+    assert wire == declared, (
+        "ImporterFieldSchema has drifted from PluginField.to_dict(). "
+        f"Emitted but not declared (silently dropped from every response): {sorted(wire - declared)}. "
+        f"Declared but never emitted: {sorted(declared - wire)}."
+    )
+
+
+@pytest.mark.parametrize(
+    ("schema", "payloads"),
+    [
+        pytest.param(MediaTypeInfoSchema, lambda: all_types_dict(), id="media_types"),
+        pytest.param(EmbedderInfoSchema, lambda: all_embedders_dict(), id="embedders"),
+        pytest.param(ConverterInfoSchema, lambda: [c.to_dict() for c in list_converters()], id="converters"),
+        pytest.param(ImporterInfoSchema, lambda: [i.to_dict() for i in list_importers()], id="importers"),
+    ],
+)
+def test_fixed_shape_schemas_declare_every_emitted_key(schema, payloads):
+    """Every key a registered plugin emits is declared by its schema.
+
+    These families have a fixed key set (no subclass overrides ``to_dict``
+    beyond the documented base), so an undeclared key is a plain bug: it is
+    dropped on dump and never reaches the client.
+    """
+    declared = _wire_keys(schema())
+    emitted: set[str] = set()
+    for payload in payloads():
+        emitted |= set(payload)
+
+    assert emitted, "no plugins registered — the check would pass vacuously"
+    assert emitted <= declared, (
+        f"{schema.__name__} does not declare every key its plugins emit; "
+        f"these are silently dropped on dump: {sorted(emitted - declared)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("schema", "payloads"),
+    [
+        pytest.param(ClipperInfoSchema, lambda: all_clippers_dict(), id="clippers"),
+        pytest.param(CleanerInfoSchema, lambda: all_cleaners_dict(), id="cleaners"),
+    ],
+)
+def test_open_shape_schemas_declare_the_fixed_base_keys(schema, payloads):
+    """Clippers and cleaners are the open families: extras pass through.
+
+    So the assertion is narrower than the fixed-shape one.  Every key that
+    *all* registered plugins in the family emit is a base key and must be
+    declared, since that is what gets a real type in the generated client; a
+    key only some of them emit is a concrete plugin's own resolved parameter
+    (``duration``, ``top_db``, ``box``, …) and reaches the client via
+    :class:`~vtsearch.schemas.common.PluginExtrasSchema` instead.
+    """
+    declared = _wire_keys(schema())
+    plugins = payloads()
+
+    assert len(plugins) > 1, "need at least two registered plugins to identify the shared base keys"
+    base_keys = set(plugins[0])
+    for payload in plugins[1:]:
+        base_keys &= set(payload)
+
+    assert base_keys <= declared, (
+        f"{schema.__name__} leaves base keys undeclared, so they lose their type in the "
+        f"generated client: {sorted(base_keys - declared)}"
+    )
+
+
+def test_plugin_extras_schema_passes_undeclared_keys_through_on_dump():
+    """The opt-in half: ``unknown = INCLUDE`` alone would not do this."""
+
+    class _Descriptor(PluginExtrasSchema):
+        name = fields.String()
+
+    dumped = _Descriptor().dump({"name": "blackout", "top_db": 30, "duration": 1.5})
+
+    assert dumped == {"name": "blackout", "top_db": 30, "duration": 1.5}
+
+
+def test_plain_schema_still_drops_undeclared_keys_on_dump():
+    """The default half, and the reason the passthrough must stay opt-in.
+
+    ``vtsearch.schemas.detectors._HitSchema`` relies on exactly this: a
+    strict dump is the last line of defence keeping a media dict's embedding
+    vectors out of an auto-detect response.
+    """
+
+    class _Strict(Schema):
+        name = fields.String()
+
+    dumped = _Strict().dump({"name": "blackout", "embedding": [0.1, 0.2, 0.3]})
+
+    assert dumped == {"name": "blackout"}

--- a/vtsearch/schemas/common.py
+++ b/vtsearch/schemas/common.py
@@ -1,0 +1,66 @@
+"""Validators and base schemas shared across :mod:`vtsearch.schemas`.
+
+Two things live here, both of which were previously copy-pasted between
+sibling schema modules:
+
+* :func:`list_of_strings` — the "reject non-``str`` list items at the schema
+  layer" validator, formerly duplicated byte-for-byte in ``datasets.py`` and
+  ``detectors.py``.
+* :class:`PluginExtrasSchema` — the ``unknown = INCLUDE`` + ``post_dump``
+  re-merge pair that lets a plugin descriptor's undeclared keys reach the
+  client, formerly written out three times.
+
+Deliberately *not* here: a shared base for ``unknown`` on its own.  That
+setting is a per-schema semantic decision rather than boilerplate — see the
+class docstring below for why making it a one-word inheritance choice would
+be a bad trade.
+"""
+
+from __future__ import annotations
+
+from marshmallow import INCLUDE, Schema, ValidationError, post_dump
+
+
+def list_of_strings(value: object) -> None:
+    """Validator: *value* must be a ``list`` whose every entry is a ``str``.
+
+    Used by the dataset- and detector-readers ACL endpoints so that numeric
+    or otherwise non-string items are rejected at the schema layer (422)
+    rather than silently coerced to strings by ``fields.String``'s
+    deserializer.
+    """
+    if not isinstance(value, list) or not all(isinstance(r, str) for r in value):
+        raise ValidationError("Must be a list of strings.")
+
+
+class PluginExtrasSchema(Schema):
+    """Base for a descriptor schema whose plugin may append keys of its own.
+
+    Enumerating the fixed base keys gives the generated OpenAPI client real
+    types; the ``unknown = INCLUDE`` / :meth:`_include_plugin_extras` pair
+    then lets a concrete plugin's own keys through on both load *and* dump.
+    Both halves are required: ``unknown`` is a **load-side** setting, and a
+    declared schema drops undeclared keys on ``dump`` no matter what it says.
+    The resulting ``additionalProperties: true`` is what gives the generated
+    model its index signature.
+
+    **Subclass this only for payloads whose extra keys are all safe to
+    serve.**  The strict-dump behaviour it opts out of is a security
+    boundary elsewhere in this package: it is the last line of defence
+    keeping a media dict's embedding vectors out of a response (see
+    ``vtsearch.schemas.detectors._HitSchema``, which documents in-place that
+    a passthrough must never be added there).  Reach for this base when the
+    payload is a plugin's own JSON-serialisable descriptor or outcome dict,
+    not when it wraps a media entry.
+    """
+
+    class Meta:
+        unknown = INCLUDE
+
+    @post_dump(pass_original=True)
+    def _include_plugin_extras(self, data: dict, original: object, **_: object) -> dict:
+        if isinstance(original, dict):
+            for key, value in original.items():
+                if key not in data:
+                    data[key] = value
+        return data

--- a/vtsearch/schemas/datasets.py
+++ b/vtsearch/schemas/datasets.py
@@ -18,18 +18,19 @@ plugin family can add keys of its own:
   key is a bug, and dropping it on dump is the correct signal.
 * **Clippers and cleaners** genuinely vary — concrete clippers append their
   own keys (``duration``, ``top_db``, ``box``, …) on top of the fixed base.
-  Their schemas enumerate the base and set ``unknown = INCLUDE`` plus a
-  :func:`~marshmallow.post_dump` passthrough, so the fixed fields get real
-  types while the plugin extras still reach the client verbatim.  The
-  generated model picks up an index signature from
+  Their schemas enumerate the base and inherit
+  :class:`~vtsearch.schemas.common.PluginExtrasSchema`, so the fixed fields
+  get real types while the plugin extras still reach the client verbatim.
+  The generated model picks up an index signature from
   ``additionalProperties: true``, which is exactly the shape the frontend
   used to hand-maintain.
 """
 
 from __future__ import annotations
 
-from marshmallow import INCLUDE, Schema, ValidationError, fields, post_dump, validate
+from marshmallow import Schema, fields, validate
 
+from vtsearch.schemas.common import PluginExtrasSchema, list_of_strings
 from vtsearch.schemas.file_browser import BrowseDirectoryEntrySchema, BrowseFileEntrySchema
 
 #: Upper bound on user-supplied dataset names, mirroring
@@ -38,17 +39,6 @@ from vtsearch.schemas.file_browser import BrowseDirectoryEntrySchema, BrowseFile
 #: ever reaching a filesystem path (and the uncaught ``OSError`` /
 #: absolute-path leak that would follow).
 MAX_NAME_LENGTH = 128
-
-
-def _list_of_strings(value):
-    """Validator: value must be a ``list`` whose every entry is a ``str``.
-
-    Used by the readers ACL endpoint so that numeric or other non-string
-    items are rejected at the schema layer (422) rather than silently
-    coerced to strings by ``fields.String``'s deserializer.
-    """
-    if not isinstance(value, list) or not all(isinstance(r, str) for r in value):
-        raise ValidationError("Must be a list of strings.")
 
 
 # ---------------------------------------------------------------------------
@@ -355,7 +345,7 @@ class ClipperParameterSchema(Schema):
     step = fields.Float()
 
 
-class ClipperInfoSchema(Schema):
+class ClipperInfoSchema(PluginExtrasSchema):
     """One ``MediaClipper.to_dict()`` payload (see ``vtscore/media/clipper.py``).
 
     The base key set is fixed, but concrete clippers append their own
@@ -364,9 +354,6 @@ class ClipperInfoSchema(Schema):
     module docstring for why that beats either an opaque ``fields.Dict()`` or
     a strict schema that would silently drop those keys.
     """
-
-    class Meta:
-        unknown = INCLUDE
 
     name = fields.String(required=True)
     media_type = fields.String(required=True)
@@ -390,17 +377,6 @@ class ClipperInfoSchema(Schema):
             )
         },
     )
-
-    @post_dump(pass_original=True)
-    def _include_plugin_extras(self, data: dict, original: dict, **_: object) -> dict:
-        # ``unknown = INCLUDE`` only affects ``load``; a declared schema drops
-        # undeclared keys on ``dump``.  Re-merge the concrete clipper's own
-        # keys so clients receive the full descriptor.
-        if isinstance(original, dict):
-            for k, v in original.items():
-                if k not in data:
-                    data[k] = v
-        return data
 
 
 class CleanerInfoSchema(ClipperInfoSchema):
@@ -1192,7 +1168,7 @@ class DatasetRegistryReadersRequestSchema(Schema):
 
     readers = fields.Raw(
         required=True,
-        validate=_list_of_strings,
+        validate=list_of_strings,
         metadata={
             "description": 'List of usernames; ``["*"]`` makes the dataset public.',
             "type": "array",

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -68,8 +68,9 @@ The labelset-element shape is shared with :mod:`vtsearch.schemas.labels`.
 
 from __future__ import annotations
 
-from marshmallow import INCLUDE, Schema, ValidationError, fields, post_dump, validate
+from marshmallow import Schema, fields, validate
 
+from vtsearch.schemas.common import PluginExtrasSchema, list_of_strings
 from vtsearch.schemas.labels import LabeledElementSchema
 from vtsearch.schemas.media import MediaEntrySchema, OriginSchema
 
@@ -81,16 +82,6 @@ from vtsearch.schemas.media import MediaEntrySchema, OriginSchema
 #: ``_slug`` truncation in ``vtscore.detectors.store`` is the filesystem-level
 #: backstop for names that reach the store by other paths.
 MAX_NAME_LENGTH = 128
-
-
-def _list_of_strings(value):
-    """Validator: *value* must be a ``list`` whose every entry is a ``str``.
-
-    Mirrors the dataset readers validator so non-string items are rejected at
-    the schema layer (422) rather than coerced.
-    """
-    if not isinstance(value, list) or not all(isinstance(r, str) for r in value):
-        raise ValidationError("Must be a list of strings.")
 
 
 class _ExampleSchema(Schema):
@@ -159,8 +150,11 @@ class DetectorDetailSchema(Schema):
     combined_from = fields.List(fields.String())
 
     class Meta:
-        # Detector files may carry transitional / extension fields; let
-        # them flow through on dump rather than silently dropping them.
+        # Detector files may carry transitional / extension fields; tolerate
+        # them on ``load`` instead of raising.  This is load-only: ``dump``
+        # emits the declared fields and nothing else, here and everywhere
+        # else a schema does not inherit
+        # :class:`~vtsearch.schemas.common.PluginExtrasSchema`.
         unknown = "include"
 
 
@@ -321,7 +315,8 @@ class DetectorRegistryEntrySchema(Schema):
 
     class Meta:
         # Registry entries may carry extension keys (e.g. future per-row
-        # status flags); let them flow through on dump.
+        # status flags); tolerate them on ``load`` rather than raising.
+        # Load-only — ``dump`` still emits only the declared fields.
         unknown = "include"
 
 
@@ -463,7 +458,7 @@ class DetectorRegistryReadersRequestSchema(Schema):
 
     readers = fields.Raw(
         required=True,
-        validate=_list_of_strings,
+        validate=list_of_strings,
         metadata={
             "description": 'List of usernames; ``["*"]`` makes the detector public.',
             "type": "array",
@@ -678,7 +673,7 @@ class _AutoDetectResultSchema(Schema):
     negative_hits = fields.List(fields.Nested(_HitSchema), required=True)
 
 
-class _AutoFindExportStatusSchema(Schema):
+class _AutoFindExportStatusSchema(PluginExtrasSchema):
     """Outcome of auto-exporting an Auto-Find run's results.
 
     Built by ``_run_autofind_export``: a fixed ``{exporter, success}`` base
@@ -702,21 +697,6 @@ class _AutoFindExportStatusSchema(Schema):
             )
         }
     )
-
-    class Meta:
-        unknown = INCLUDE
-
-    @post_dump(pass_original=True)
-    def _include_exporter_extras(self, data: dict, original: dict, **_: object) -> dict:
-        # ``unknown = INCLUDE`` only affects ``load``; a declared schema drops
-        # undeclared keys on ``dump``.  Safe to re-merge here: the values come
-        # from an exporter's own JSON-serialisable outcome dict, not a media
-        # dict, so there are no vectors or raw bytes to leak.
-        if isinstance(original, dict):
-            for k, v in original.items():
-                if k not in data:
-                    data[k] = v
-        return data
 
 
 class AutoDetectRequestSchema(Schema):

--- a/vtsearch/schemas/eval.py
+++ b/vtsearch/schemas/eval.py
@@ -25,15 +25,17 @@ of them.  Expressing that as an OpenAPI ``oneOf`` would mean hand-writing
 component ``$ref`` strings in field metadata, which silently rots the moment
 a schema class is renamed; the single client-side cast is the cheaper trade.
 
-The two train-and-score endpoints share a single response schema with
-``unknown = "include"``: the metric-specific data key
-(``error_cost`` / ``stability`` / ``diversity``) is computed at runtime
-and flows through without per-key declarations.
+The two train-and-score endpoints share a single response schema that
+declares every metric-specific data key (``error_cost`` / ``stability`` /
+``diversity``) and fills in whichever one the requested metric produced;
+its ``unknown = "include"`` only widens what the schema accepts on load.
 """
 
 from __future__ import annotations
 
-from marshmallow import Schema, fields, post_dump, validate
+from marshmallow import Schema, fields, validate
+
+from vtsearch.schemas.common import PluginExtrasSchema
 
 
 _METRIC_VALIDATOR = validate.OneOf(["smart", "stable", "diverse"])
@@ -104,31 +106,18 @@ class LabelingProgressResponseSchema(Schema):
 # ---------------------------------------------------------------------------
 
 
-class StatusIndicatorSchema(Schema):
+class StatusIndicatorSchema(PluginExtrasSchema):
     """One ``smart`` / ``stable`` / ``span`` indicator in the labeling-status
     response.  ``status`` is the red/yellow/green flag every indicator emits;
     ``reason`` is the human-readable explanation.  Metric-specific keys
     (``cost``, ``flips``, ``diversity_level``, ``avg_flip_rate``, …) flow
-    through unchanged via ``unknown = "include"`` plus :meth:`_include_extras`
-    the :mod:`vtscore.detectors.labeling_progress` analyzer remains the
+    through unchanged via
+    :class:`~vtsearch.schemas.common.PluginExtrasSchema`; the
+    :mod:`vtscore.detectors.labeling_progress` analyzer remains the
     source of truth for that shape."""
 
     status = fields.String(required=True)
     reason = fields.String()
-
-    class Meta:
-        unknown = "include"
-
-    @post_dump(pass_original=True)
-    def _include_extras(self, data: dict, original: dict, **_: object) -> dict:
-        # ``unknown = "include"`` only affects ``load``; declared schemas drop
-        # unknown keys on ``dump``.  Re-merge the original dict's metric-
-        # specific keys so callers receive the full indicator payload.
-        if isinstance(original, dict):
-            for k, v in original.items():
-                if k not in data:
-                    data[k] = v
-        return data
 
 
 class LabelingStatusResponseSchema(Schema):
@@ -234,8 +223,12 @@ class EvalTrainAndScoreResponseSchema(Schema):
     error = fields.String()
 
     class Meta:
-        # Future metrics may add new data keys; let them pass through
-        # without per-key declarations.
+        # A future metric's data key is tolerated on ``load`` rather than
+        # raising.  Load-only: ``dump`` emits the declared fields and
+        # nothing else, so a new metric still needs a field declared here
+        # (or this schema needs
+        # :class:`~vtsearch.schemas.common.PluginExtrasSchema`) before its
+        # data reaches the client.
         unknown = "include"
 
 


### PR DESCRIPTION
Closes #3425.

## What landed

**`vtsearch/schemas/common.py` (new).** Two things that were copy-pasted between sibling schema modules:

- **`list_of_strings`** — the "reject non-`str` list items at the schema layer" validator, previously byte-identical in `datasets.py:43` and `detectors.py:86`.
- **`PluginExtrasSchema`** — the `unknown = INCLUDE` + `post_dump` re-merge pair that lets a plugin descriptor's own keys reach the client. It was written out three times (`ClipperInfoSchema`, `_AutoFindExportStatusSchema`, `StatusIndicatorSchema`). The base carries the `Meta` *and* the hook together, because either half alone is inert — `unknown` is load-side, and a declared schema drops undeclared keys on dump regardless.

  Its docstring records that subclassing it is a security decision, not a style one: the strict-dump default it waives is what keeps a media dict's embedding vectors out of an auto-detect response, as `detectors._HitSchema` already documented in place.

**`tests/api/test_schema_plugin_drift.py` (new).** `ImporterFieldSchema` hand-transcribes `PluginField.to_dict()` with nothing tying the two together, and the failure mode is silent in the worst way: adding a key to `PluginField.to_dict()` would drop it from every API response *and* from the generated TS client without one test going red. The suite:

- pins that mirror for **equality** in both directions (the two sides are in sync today; verified by temporarily adding a key to `PluginField.to_dict()` and watching it fail);
- checks the fixed-shape families (media types, embedders, converters, importers) in the direction that matters — every key a registered plugin emits must be declared — while tolerating declared-but-unemitted keys, since routes annotate some payloads themselves (`ImporterInfoSchema.enabled` is added by the `/api/dataset/all-importers` handler);
- checks the open families (clippers, cleaners) more narrowly: keys emitted by *every* plugin in the family are base keys and must be declared; keys only some emit are a concrete plugin's resolved parameters and ride the passthrough;
- pins both halves of the dump contract — the passthrough passes extras through, a plain schema still drops them.

**Three corrected comments.** `DetectorDetailSchema`, `DetectorRegistryEntrySchema` and `EvalTrainAndScoreResponseSchema` each claimed `unknown = "include"` lets extension keys "flow through on dump". It does not — it is load-only, as the same files state correctly elsewhere. The comments were wrong, not the code; no behaviour change.

**No OpenAPI change.** The regenerated spec is byte-identical to `frontend/openapi.json`, so no snapshot or client regeneration is owed.

## What was declined, and why

**The `list_response(...)` factory.** The issue's Direction asked to replace the ~20 one-field list-response wrappers with a factory. Declined after review (confirmed with the owner). Each wrapper is three lines of pure declaration with a distinct field name, a distinct nested schema and a distinct route docstring — there is no *logic* duplicated, so a factory call is roughly the same line count while costing greppability and pyright typing, and it puts the generated component names behind a `type()` call for no gain.

**A shared base for `unknown` on its own.** The issue counted 20 `unknown = "include"` declarations (it is 14 `include` + 14 `exclude`) and proposed a shared base. That is the wrong consolidation: `unknown` is a per-schema semantic decision, and per `_HitSchema` the strict default is a security boundary. Making it a one-word inheritance choice makes that boundary one word away from being waived by accident. The pair that *does* repeat as code — include **plus** passthrough — is what got the base.

**`fields.Raw` / bare `fields.Dict()`.** Both counts check out (35 and 41), but they appear in the issue as evidence rather than in its Direction, and 22 of the 35 `Raw` are in `settings.py` where the values genuinely are heterogeneous. Tightening them is a separate, judgment-heavy change.

## Testing

Full `./run-tests.sh`: `RUN PASSED` — 9757 passed, 6 skipped, 1 xfailed, 1 xpassed; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PVdZVZ2c2dnwUCgMvXYa2

---
_Generated by [Claude Code](https://claude.ai/code/session_019PVdZVZ2c2dnwUCgMvXYa2)_