### PR TITLE
Extract the shared Browse audio-audition state machine

### DIFF
--- a/docs/plans/vtsbrowse-empirical-tuning.md
+++ b/docs/plans/vtsbrowse-empirical-tuning.md
@@ -149,6 +149,6 @@ the rework below exists.
 
 | Knob | Current value | Location |
 |------|---------------|----------|
-| Audio | `loop=true`, hard-cut on move | `playAudio` |
+| Audio | `loop=true`, hard-cut on move; `200` ms hover dwell | `BrowseAudioAudition` (`frontend/src/app/utils/browse-audio-audition.ts`) |
 | Text truncation | `300` chars | `loadText` |
 | Popup offset | `+16 / -8` px from cursor | `show` |

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.html
@@ -217,7 +217,4 @@
     }
   </div>
 
-  @if (mediaType() === 'audio') {
-    <audio #audioEl class="sr-only" [src]="audioSrc"></audio>
-  }
 </div>

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -17,10 +17,9 @@ import {
   binGridColumns,
   binGridRowSize,
 } from '../../utils/bin-grid-metrics';
-import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import { formatMetadataValue as formatMetadataValueUtil } from '../../utils/format-metadata';
-import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
+import { BrowseAudioAudition, type NowPlaying } from '../../utils/browse-audio-audition';
 import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
 
@@ -253,7 +252,6 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private readonly panelRef = viewChild<ElementRef<HTMLElement>>('panel');
   private readonly headerRef = viewChild<ElementRef<HTMLElement>>('header');
   private readonly grid = viewChild(BrowseBinMemberGridComponent);
-  private readonly audioRef = viewChild<ElementRef<HTMLAudioElement>>('audioEl');
 
   /**
    * Clamped on-screen position; starts at the anchor and is nudged inward.
@@ -357,22 +355,20 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     return this._previewId();
   }
 
-  /** Currently-playing hover audio source, so re-entering the same row is a no-op. */
-  private readonly _audioSrc = signal('');
-  get audioSrc(): string {
-    return this._audioSrc();
-  }
-  /** Media id of the clip currently auditioning, so the buffering listeners can
-   *  re-emit its now-playing state; ``null`` when silent. */
-  private nowPlayingId: number | null = null;
-  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the live
-   *  buffering state rather than forcing it back to ``false``. */
-  private nowPlayingLoading = false;
-  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
-   *  when the loop is stopped. */
-  private sweepRaf: number | null = null;
-  /** Whether the one-shot buffering listeners are wired onto the audio element. */
-  private audioListenersAttached = false;
+  /** The audition state machine shared with the canvas hover preview and the
+   *  selection panel, so every Browse surface drives the one now-playing
+   *  indicator identically.
+   *
+   *  ``dwellMs: 0`` is this surface's only divergence: opening a bin (or moving
+   *  onto a row of its member grid) is already a settled, deliberate gesture, so
+   *  there is no sweep of near-misses to debounce the way the canvas has. */
+  private readonly audition = new BrowseAudioAudition({
+    mediaUrl: (path) => this.activeContext.mediaUrl(path),
+    lookup: (id) => this.metadataCache.get(id),
+    ensureLoaded: (id) => this.metadataCache.ensureLoaded([id]),
+    emit: (state) => this.nowPlaying.emit(state),
+    dwellMs: 0,
+  });
 
   /** Ids whose full-res ``/image`` failed; the preview falls back to the
    *  thumbnail for these so it still shows something. Paired with a version
@@ -383,11 +379,9 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
 
   constructor() {
     // Keep the hover-to-hear preview element in step with the Browse toolbar's
-    // volume slider mid-playback; ``onEntryEnter`` also seeds it when a clip
-    // starts. Tracking the view query also re-seeds when the element mounts.
+    // volume slider mid-playback; starting a clip also seeds it.
     effect(() => {
-      const el = this.audioRef()?.nativeElement;
-      if (el) el.volume = this.volume();
+      this.audition.setVolume(this.volume());
     });
     // The input→state dispatch that used to live in ngOnChanges (signal inputs
     // don't fire it). Each effect tracks exactly the inputs its old ngOnChanges
@@ -413,7 +407,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
           return;
         }
         this._ids.set(next);
-        this.stopAudio();
+        this.audition.stop();
         // Open on the bin's representative (the centroid whose thumbnail the user
         // right-clicked) so the pane is never blank and the detail view starts on
         // the same image — not the 1-D list's first item, which differs.
@@ -553,7 +547,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     // Drop any in-flight metadata-divider drag listeners (destroyed mid-drag).
     document.removeEventListener('pointermove', this.boundMetaMove);
     document.removeEventListener('pointerup', this.boundMetaUp);
-    this.stopAudio();
+    this.audition.destroy();
   }
 
   private readonly gridSizeDict = signal<Record<string, string>>({});
@@ -1234,110 +1228,25 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * Audition ``id`` in the popup's audio element (audio media only), updating
-   * the shared now-playing indicator. Shared by the open-time autoplay and the
-   * grid-row hover; a no-op when the same clip is already playing so re-entering
-   * a row (or a redundant re-summon) doesn't restart it.
+   * Audition ``id`` on the shared now-playing indicator (audio media only).
+   * Shared by the open-time autoplay and the grid-row hover; a no-op when the
+   * same clip is already playing, so re-entering a row (or a redundant
+   * re-summon) doesn't restart it.
    */
   private playAudio(id: number): void {
     if (this.mediaType() !== 'audio') return;
-    const src = this.activeContext.mediaUrl(`/api/medias/${id}/audio`);
-    if (this.audioSrc === src) return;
-    this._audioSrc.set(src);
-    this.nowPlayingId = id;
-    // The autoplay-on-open path may fire before prefetchVisible has hydrated the
-    // representative's metadata, so make sure its clip extents are loading (the
-    // clip-window handlers read them lazily as they land).
-    this.metadataCache.ensureLoaded([id]);
-    // Starts loading: show the spinner on the now-playing widget until a
-    // ``playing``/``canplay`` event clears it.
-    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading: true, progress: null });
-    setTimeout(() => {
-      const el = this.audioRef()?.nativeElement;
-      if (!el) return;
-      this.attachBufferingListeners(el);
-      el.volume = this.volume();
-      // Windowed archive-member clips serve the whole file: seek to clip_start
-      // and loop within [clip_start, clip_end]. Metadata is read lazily inside
-      // the handlers regardless.
-      applyClipWindow(el, () => this.metadataCache.get(id));
-      el.load();
-      el.play().catch(() => {});
-      // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
-      this.startSweep();
-    });
-  }
-
-  /** Wire the buffering listeners onto the popup's audio element once (it lives
-   *  for the popup's lifetime, reused across summons). They flip the now-playing
-   *  widget's spinner on while the clip fetches/decodes or stalls to rebuffer,
-   *  and off once it's actually sounding. */
-  private attachBufferingListeners(el: HTMLAudioElement): void {
-    if (this.audioListenersAttached) return;
-    this.audioListenersAttached = true;
-    el.addEventListener('waiting', () => this.emitNowPlaying(true));
-    el.addEventListener('playing', () => this.emitNowPlaying(false));
-    el.addEventListener('canplay', () => this.emitNowPlaying(false));
-  }
-
-  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
-   *  playhead position. A no-op once nothing is auditioning, so events that fire
-   *  after a stop don't resurrect the widget. */
-  private emitNowPlaying(loading: boolean): void {
-    const id = this.nowPlayingId;
-    if (this.audioSrc === '' || id == null) return;
-    this.nowPlayingLoading = loading;
-    const el = this.audioRef()?.nativeElement;
-    const progress = el ? clipProgress(el, () => this.metadataCache.get(id)) : null;
-    this.nowPlaying.emit({ mediaId: id, waveUrl: this.thumbnailUrl(id), loading, progress });
-  }
-
-  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
-  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
-  // when the clip pauses or stops; idempotent while a loop is already live.
-  private startSweep(): void {
-    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
-    const tick = (): void => {
-      const el = this.audioRef()?.nativeElement;
-      if (this.nowPlayingId == null || !el || el.paused) {
-        this.sweepRaf = null;
-        return;
-      }
-      this.emitNowPlaying(this.nowPlayingLoading);
-      this.sweepRaf = requestAnimationFrame(tick);
-    };
-    this.sweepRaf = requestAnimationFrame(tick);
-  }
-
-  private stopSweep(): void {
-    if (this.sweepRaf !== null) {
-      cancelAnimationFrame(this.sweepRaf);
-      this.sweepRaf = null;
-    }
+    this.audition.hover(id);
   }
 
   /** Cursor left the grid: stop any hover audio and fall the preview back to the
    *  bin's representative so the pane stays populated. */
   onGridLeave(): void {
-    this.stopAudio();
+    this.audition.stop();
     // Fall the focus back to the bin's representative so the pane and metadata
     // column stay populated (every media type, matching the hover-follow above).
     this._previewId.set(this.representativeId());
   }
 
-  private stopAudio(): void {
-    const wasPlaying = this.audioSrc !== '';
-    this.stopSweep();
-    const el = this.audioRef()?.nativeElement;
-    if (el) {
-      clearClipWindow(el);
-      el.pause();
-      el.currentTime = 0;
-    }
-    this._audioSrc.set('');
-    this.nowPlayingId = null;
-    if (wasPlaying) this.nowPlaying.emit(null);
-  }
 
   // --- Names + thumbnails (mirrors the selection panel's treatment) ---------
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -4,7 +4,7 @@ import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BrowseBinPopupComponent } from './browse-bin-popup.component';
-import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
+import type { BrowseAudioAudition, NowPlaying } from '../../utils/browse-audio-audition';
 import { BrowseSelectionService } from '../../services/browse-selection.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
@@ -289,8 +289,11 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: true, progress: null });
 
     // The clip's audio element drives the buffering spinner: `playing` clears
-    // the loading flag, a `waiting` stall re-sets it.
-    const audioEl = fixture.nativeElement.querySelector('audio') as HTMLAudioElement;
+    // the loading flag, a `waiting` stall re-sets it. The element is owned by the
+    // shared audition machine and deliberately never mounted (browse audio is
+    // heard, not shown), so reach it there rather than through the DOM.
+    const audioEl = (fixture.componentInstance as unknown as { audition: BrowseAudioAudition })
+      .audition.element;
     audioEl.dispatchEvent(new Event('playing'));
     await settlePasses(fixture);
     expect(played.at(-1)).toEqual({ mediaId: 8, waveUrl: '/api/medias/8/thumbnail', loading: false, progress: null });

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.component.ts
@@ -2,32 +2,8 @@ import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, o
 
 import { ActiveContextService } from '../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
-import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
+import { BrowseAudioAudition, type NowPlaying } from '../../utils/browse-audio-audition';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
-
-/** A clip currently auditioning from a VTSBrowse hover (a canvas bin here, or a
- *  bin-popup member — see `browse-bin-popup.component.ts`), or ``null`` when
- *  nothing is playing. Drives the now-playing waveform anchored at the
- *  top-left of the canvas, alongside the volume control. */
-export interface NowPlaying {
-  mediaId: number;
-  /** The clip's waveform PNG — the same thumbnail painted on its tile. */
-  waveUrl: string;
-  /** ``true`` while the clip is still fetching/decoding and hasn't begun to
-   *  sound yet (or has stalled to rebuffer mid-play); drives the loading
-   *  spinner on the now-playing widget. Flips to ``false`` once playback is
-   *  actually audible. */
-  loading: boolean;
-  /** Playback position within the (possibly windowed) clip as a fraction in
-   *  ``[0, 1]``, or ``null`` before a finite duration is known. Drives the
-   *  sweeping playhead line on the now-playing waveform, updated ~60×/sec on a
-   *  requestAnimationFrame loop while the clip sounds. */
-  progress: number | null;
-}
-
-/** How long (ms) the cursor must rest on an audio bin before its clip starts
- *  auditioning, so sweeping across bins doesn't fire a burst of plays. */
-const AUDIO_DWELL_MS = 200;
 
 /**
  * The VTSBrowse hover preview.
@@ -62,18 +38,14 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
    *  ``null`` once the hover clears. */
   readonly nowPlaying = output<NowPlaying | null>();
 
-  /** Never mounted in the DOM — audio here is heard, not shown; the top-left
-   *  indicator is the only visual feedback that it's playing. */
-  private readonly audioEl = new Audio();
-  /** Waveform PNG of the clip currently auditioning, kept so the buffering
-   *  listeners below can re-emit the now-playing state without recomputing it. */
-  private nowPlayingWaveUrl = '';
-  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the
-   *  live buffering state rather than forcing it back to ``false``. */
-  private nowPlayingLoading = false;
-  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
-   *  when the loop is stopped. */
-  private sweepRaf: number | null = null;
+  /** The dwell debounce, buffering tri-state and playhead sweep, shared with the
+   *  selection panel and the bin popup. */
+  private readonly audition = new BrowseAudioAudition({
+    mediaUrl: (path) => this.activeContext.mediaUrl(path),
+    lookup: (id) => this.metadataCache.get(id),
+    ensureLoaded: (id) => this.metadataCache.ensureLoaded([id]),
+    emit: (state) => this.nowPlaying.emit(state),
+  });
 
   constructor() {
     // The hover input drives the whole preview: show over a cell, hide on
@@ -87,15 +59,8 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
     // Keep the live element's volume in sync when the toolbar slider moves
     // mid-playback; starting a clip also seeds it.
     effect(() => {
-      this.audioEl.volume = this.volume();
+      this.audition.setVolume(this.volume());
     });
-    // Buffering feedback: while the clip is fetching/decoding (or stalls to
-    // rebuffer), the widget shows a spinner; once it's actually sounding, the
-    // spinner clears. Listeners are attached once to the reused element and
-    // guarded by ``playingMediaId`` so stray events after a stop are ignored.
-    this.audioEl.addEventListener('waiting', () => this.emitNowPlaying(true));
-    this.audioEl.addEventListener('playing', () => this.emitNowPlaying(false));
-    this.audioEl.addEventListener('canplay', () => this.emitNowPlaying(false));
   }
 
   // --- Text / count popup (text + any other non-thumbnail type) --------------
@@ -108,15 +73,8 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
   readonly textContent = signal('');
   private textLoadAbort: AbortController | null = null;
 
-  // --- Audio audition state machine -------------------------------------------
-  private dwellTimer: ReturnType<typeof setTimeout> | null = null;
-  private pendingMediaId: number | null = null;
-  private playingMediaId: number | null = null;
-
   ngOnDestroy(): void {
-    this.cancelDwell();
-    this.stopSweep();
-    this.stopAudio();
+    this.audition.destroy();
     this.textLoadAbort?.abort();
   }
 
@@ -130,7 +88,7 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
     }
 
     if (mediaType === 'audio') {
-      this.scheduleAudio(event.cell.rep_id);
+      this.audition.hover(event.cell.rep_id);
       return;
     }
 
@@ -156,98 +114,7 @@ export class BrowseHoverPreviewComponent implements OnDestroy {
 
     // Audio: cancel a pending audition and stop anything already playing. There
     // is no panel to bridge the cursor onto, so hover-off silences it at once.
-    this.cancelDwell();
-    this.stopAudio();
-  }
-
-  // --- Audio audition state machine -------------------------------------------
-
-  private scheduleAudio(mediaId: number): void {
-    // Already auditioning this exact clip: keep it (don't restart).
-    if (this.playingMediaId === mediaId) return;
-
-    // Debounce: (re)arm the dwell so a sweep across bins keeps resetting it and
-    // only the bin the cursor settles on actually plays.
-    this.pendingMediaId = mediaId;
-    this.cancelDwell();
-    this.dwellTimer = setTimeout(() => {
-      this.dwellTimer = null;
-      const id = this.pendingMediaId;
-      this.pendingMediaId = null;
-      if (id != null) this.playAudio(id);
-    }, AUDIO_DWELL_MS);
-  }
-
-  private playAudio(mediaId: number): void {
-    this.playingMediaId = mediaId;
-    const waveUrl = this.activeContext.mediaUrl(`/api/medias/${mediaId}/thumbnail`);
-    this.nowPlayingWaveUrl = waveUrl;
-    // Hydrate clip extents (clip_start/clip_end) so windowed clips loop within
-    // their window; applyClipWindow reads them lazily as they land.
-    this.metadataCache.ensureLoaded([mediaId]);
-    this.audioEl.volume = this.volume();
-    applyClipWindow(this.audioEl, () => this.metadataCache.get(mediaId));
-    this.audioEl.src = this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`);
-    this.audioEl.load();
-    this.audioEl.play().catch(() => {});
-    // Starts loading: show the spinner until a ``playing``/``canplay`` event
-    // (wired in the constructor) clears it.
-    this.emitNowPlaying(true);
-    // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
-    this.startSweep();
-  }
-
-  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
-   *  playhead position, from the buffering listeners and the sweep loop. A no-op
-   *  once nothing is auditioning, so events that fire after a stop don't
-   *  resurrect the widget. */
-  private emitNowPlaying(loading: boolean): void {
-    const mediaId = this.playingMediaId;
-    if (mediaId == null) return;
-    this.nowPlayingLoading = loading;
-    const progress = clipProgress(this.audioEl, () => this.metadataCache.get(mediaId));
-    this.nowPlaying.emit({ mediaId, waveUrl: this.nowPlayingWaveUrl, loading, progress });
-  }
-
-  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
-  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
-  // when the clip pauses or stops; idempotent while a loop is already live.
-  private startSweep(): void {
-    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
-    const tick = (): void => {
-      if (this.playingMediaId == null || this.audioEl.paused) {
-        this.sweepRaf = null;
-        return;
-      }
-      this.emitNowPlaying(this.nowPlayingLoading);
-      this.sweepRaf = requestAnimationFrame(tick);
-    };
-    this.sweepRaf = requestAnimationFrame(tick);
-  }
-
-  private stopSweep(): void {
-    if (this.sweepRaf !== null) {
-      cancelAnimationFrame(this.sweepRaf);
-      this.sweepRaf = null;
-    }
-  }
-
-  private stopAudio(): void {
-    this.pendingMediaId = null;
-    if (this.playingMediaId == null) return;
-    this.playingMediaId = null;
-    this.stopSweep();
-    clearClipWindow(this.audioEl);
-    this.audioEl.pause();
-    this.audioEl.currentTime = 0;
-    this.nowPlaying.emit(null);
-  }
-
-  private cancelDwell(): void {
-    if (this.dwellTimer) {
-      clearTimeout(this.dwellTimer);
-      this.dwellTimer = null;
-    }
+    this.audition.stop();
   }
 
   private loadText(mediaId: number): void {

--- a/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-hover-preview/browse-hover-preview.zoneless.spec.ts
@@ -1,7 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 
-import { BrowseHoverPreviewComponent, NowPlaying } from './browse-hover-preview.component';
+import { BrowseHoverPreviewComponent } from './browse-hover-preview.component';
+import type { NowPlaying, BrowseAudioAudition } from '../../utils/browse-audio-audition';
 import { ActiveContextService } from '../../services/active-context.service';
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import type { HexHoverEvent } from '../browse-canvas/browse-canvas.component';
@@ -144,7 +145,8 @@ describe('BrowseHoverPreviewComponent (zoneless canary)', () => {
     expect(emitted).toEqual({ mediaId: 9, waveUrl: '/api/medias/9/thumbnail', loading: true, progress: null });
 
     // The reused (never-mounted) audio element drives the buffering listeners.
-    const audioEl = (fixture.componentInstance as unknown as { audioEl: HTMLAudioElement }).audioEl;
+    const audioEl = (fixture.componentInstance as unknown as { audition: BrowseAudioAudition }).audition
+      .element;
 
     // The element reports it's now playing → spinner clears.
     audioEl.dispatchEvent(new Event('playing'));

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.component.ts
@@ -11,18 +11,12 @@ import { ViewControlsComponent } from '../view-controls/view-controls.component'
 import { NoFocusStealDirective } from '../../directives/no-focus-steal.directive';
 import { IconComponent } from '../icon/icon.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
-import { applyClipWindow, clearClipWindow, clipProgress } from '../../utils/clip-window';
-import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
+import { BrowseAudioAudition, type NowPlaying } from '../../utils/browse-audio-audition';
 import { ListSortMode, SortableListEntry, sortListEntries } from '../../utils/sort-list-entries';
 
 /** Ordering for the selected-item list. No detector confidence in browse, so
  *  the choices are recency (selection order), name, and id. */
 type SelectionSortMode = Exclude<ListSortMode, 'confidence-desc' | 'confidence-asc'>;
-
-/** How long (ms) the cursor must rest on an audio entry before its clip starts
- *  auditioning, so sweeping down a large multi-select list doesn't fire a burst
- *  of plays. Matches the canvas hover-preview's dwell (`AUDIO_DWELL_MS`). */
-const AUDIO_DWELL_MS = 200;
 
 interface SelectionEntry extends SortableListEntry {
   id: number;
@@ -117,36 +111,22 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   private ids: number[] = [];
   private readonly thumbnailFailedUrls = new Set<string>();
 
-  // --- Audio audition state machine (mirrors browse-hover-preview) -----------
-  /** Never mounted in the DOM — audio here is heard, not shown; the top-left
-   *  now-playing indicator is the only visual feedback that it's playing. */
-  private readonly audioEl = new Audio();
-  /** Waveform PNG of the clip currently auditioning, kept so the buffering
-   *  listeners can re-emit the now-playing state without recomputing it. */
-  private nowPlayingWaveUrl = '';
-  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the
-   *  live buffering state rather than forcing it back to ``false``. */
-  private nowPlayingLoading = false;
-  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
-   *  when the loop is stopped. */
-  private sweepRaf: number | null = null;
-  private dwellTimer: ReturnType<typeof setTimeout> | null = null;
-  private pendingMediaId: number | null = null;
-  private playingMediaId: number | null = null;
+  /** The dwell debounce, buffering tri-state and playhead sweep, shared with the
+   *  canvas hover preview and the bin popup — so a hovered entry here sounds
+   *  exactly as a hovered bin does. */
+  private readonly audition = new BrowseAudioAudition({
+    mediaUrl: (path) => this.activeContext.mediaUrl(path),
+    lookup: (id) => this.metadataCache.get(id),
+    ensureLoaded: (id) => this.metadataCache.ensureLoaded([id]),
+    emit: (state) => this.nowPlaying.emit(state),
+  });
 
   constructor() {
     // Keep the live element's volume in sync when the toolbar slider moves
     // mid-playback; starting a clip also seeds it.
     effect(() => {
-      this.audioEl.volume = this.volume();
+      this.audition.setVolume(this.volume());
     });
-    // Buffering feedback: while the clip is fetching/decoding (or stalls to
-    // rebuffer), the widget shows a spinner; once it's actually sounding, the
-    // spinner clears. Listeners are attached once to the reused element and
-    // guarded by ``playingMediaId`` so stray events after a stop are ignored.
-    this.audioEl.addEventListener('waiting', () => this.emitNowPlaying(true));
-    this.audioEl.addEventListener('playing', () => this.emitNowPlaying(false));
-    this.audioEl.addEventListener('canplay', () => this.emitNowPlaying(false));
 
     // Rebuild the list whenever the selection changes. An effect on the signal
     // (rather than a `changed$` subscription) covers both the initial fill and
@@ -166,9 +146,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.cancelDwell();
-    this.stopSweep();
-    this.stopAudio();
+    this.audition.destroy();
   }
 
   private refreshSelection(): void {
@@ -238,7 +216,7 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
   onEntryClick(id: number): void {
     // The entry is about to leave the list (its element unmounts, so no
     // mouseleave will fire): silence it now if it's the one auditioning.
-    if (this.playingMediaId === id || this.pendingMediaId === id) this.stopAudio();
+    if (this.audition.isTargeting(id)) this.audition.stop();
     this.selection.remove(id);
   }
 
@@ -259,103 +237,14 @@ export class BrowseSelectionPanelComponent implements OnInit, OnDestroy {
    */
   onEntryEnter(id: number): void {
     if (this.mediaType() !== 'audio') return;
-    this.scheduleAudio(id);
+    this.audition.hover(id);
   }
 
   /** Cursor left an entry: cancel a pending audition and stop anything playing.
    *  There is no pane to bridge the cursor onto, so hover-off silences at once
    *  (the same as the canvas path). */
   onEntryLeave(): void {
-    this.cancelDwell();
-    this.stopAudio();
-  }
-
-  private scheduleAudio(mediaId: number): void {
-    // Already auditioning this exact clip: keep it (don't restart).
-    if (this.playingMediaId === mediaId) return;
-
-    // Debounce: (re)arm the dwell so a sweep down the list keeps resetting it and
-    // only the entry the cursor settles on actually plays.
-    this.pendingMediaId = mediaId;
-    this.cancelDwell();
-    this.dwellTimer = setTimeout(() => {
-      this.dwellTimer = null;
-      const id = this.pendingMediaId;
-      this.pendingMediaId = null;
-      if (id != null) this.playAudio(id);
-    }, AUDIO_DWELL_MS);
-  }
-
-  private playAudio(mediaId: number): void {
-    this.playingMediaId = mediaId;
-    const waveUrl = this.activeContext.mediaUrl(`/api/medias/${mediaId}/thumbnail`);
-    this.nowPlayingWaveUrl = waveUrl;
-    // Hydrate clip extents (clip_start/clip_end) so windowed clips loop within
-    // their window; applyClipWindow reads them lazily as they land.
-    this.metadataCache.ensureLoaded([mediaId]);
-    this.audioEl.volume = this.volume();
-    applyClipWindow(this.audioEl, () => this.metadataCache.get(mediaId));
-    this.audioEl.src = this.activeContext.mediaUrl(`/api/medias/${mediaId}/audio`);
-    this.audioEl.load();
-    this.audioEl.play().catch(() => {});
-    // Starts loading: show the spinner until a ``playing``/``canplay`` event
-    // (wired in the constructor) clears it.
-    this.emitNowPlaying(true);
-    // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
-    this.startSweep();
-  }
-
-  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
-   *  playhead position, from the buffering listeners and the sweep loop. A no-op
-   *  once nothing is auditioning, so events that fire after a stop don't
-   *  resurrect the widget. */
-  private emitNowPlaying(loading: boolean): void {
-    const mediaId = this.playingMediaId;
-    if (mediaId == null) return;
-    this.nowPlayingLoading = loading;
-    const progress = clipProgress(this.audioEl, () => this.metadataCache.get(mediaId));
-    this.nowPlaying.emit({ mediaId, waveUrl: this.nowPlayingWaveUrl, loading, progress });
-  }
-
-  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
-  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
-  // when the clip pauses or stops; idempotent while a loop is already live.
-  private startSweep(): void {
-    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
-    const tick = (): void => {
-      if (this.playingMediaId == null || this.audioEl.paused) {
-        this.sweepRaf = null;
-        return;
-      }
-      this.emitNowPlaying(this.nowPlayingLoading);
-      this.sweepRaf = requestAnimationFrame(tick);
-    };
-    this.sweepRaf = requestAnimationFrame(tick);
-  }
-
-  private stopSweep(): void {
-    if (this.sweepRaf !== null) {
-      cancelAnimationFrame(this.sweepRaf);
-      this.sweepRaf = null;
-    }
-  }
-
-  private stopAudio(): void {
-    this.pendingMediaId = null;
-    if (this.playingMediaId == null) return;
-    this.playingMediaId = null;
-    this.stopSweep();
-    clearClipWindow(this.audioEl);
-    this.audioEl.pause();
-    this.audioEl.currentTime = 0;
-    this.nowPlaying.emit(null);
-  }
-
-  private cancelDwell(): void {
-    if (this.dwellTimer) {
-      clearTimeout(this.dwellTimer);
-      this.dwellTimer = null;
-    }
+    this.audition.stop();
   }
 
   // --- Thumbnails (mirrors the Find label-list treatment) ------------------

--- a/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-selection-panel/browse-selection-panel.zoneless.spec.ts
@@ -6,7 +6,7 @@ import { BrowseSelectionService } from '../../services/browse-selection.service'
 import { MediaMetadataCacheService } from '../../services/media-metadata-cache.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
-import type { NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
+import type { NowPlaying } from '../../utils/browse-audio-audition';
 import { configureZoneless } from '../../testing/zoneless-testbed';
 import { makeActiveContextStub, makeSettingsStateStub } from '../../testing/mocks';
 import { settleZoneless } from '../../testing/settle-resource';

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -9,7 +9,8 @@ import {
   HexHoverEvent,
 } from '../browse-canvas/browse-canvas.component';
 import type { BrowseGraphicsMode } from '../browse-canvas/render-perf';
-import { BrowseHoverPreviewComponent, NowPlaying } from '../browse-hover-preview/browse-hover-preview.component';
+import { BrowseHoverPreviewComponent } from '../browse-hover-preview/browse-hover-preview.component';
+import type { NowPlaying } from '../../utils/browse-audio-audition';
 import { BrowseBinPopupComponent } from '../browse-bin-popup/browse-bin-popup.component';
 import { BrowseLegendComponent } from '../browse-legend/browse-legend.component';
 import { BrowseSelectionPanelComponent } from '../browse-selection-panel/browse-selection-panel.component';

--- a/frontend/src/app/utils/browse-audio-audition.spec.ts
+++ b/frontend/src/app/utils/browse-audio-audition.spec.ts
@@ -1,0 +1,172 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AUDIO_DWELL_MS, BrowseAudioAudition, type NowPlaying } from './browse-audio-audition';
+
+/**
+ * Unit coverage for the audition state machine the three Browse surfaces share
+ * (issue #3436): the dwell debounce, the stale-event guard, the stop edges and
+ * the `dwellMs: 0` variant the bin popup uses.
+ *
+ * **jsdom has no media pipeline**, so what is asserted here is the machine's
+ * bookkeeping — which emissions happen, on which edges, carrying what — never
+ * that sound actually came out. The parts that need a real pipeline (the rAF
+ * playhead sweep advancing a real `progress`, the buffering tri-state driven by
+ * real `waiting`/`playing` events, the clip window enforced against a real
+ * clock, and playback from an element that is never mounted) were verified in
+ * chromium against a served WAV; see the issue #3436 PR for that transcript.
+ */
+describe('BrowseAudioAudition', () => {
+  let emitted: (NowPlaying | null)[];
+
+  function make(dwellMs?: number): BrowseAudioAudition {
+    return new BrowseAudioAudition({
+      mediaUrl: (path) => `/ctx${path}`,
+      lookup: () => undefined,
+      ensureLoaded: () => {},
+      emit: (state) => emitted.push(state),
+      ...(dwellMs === undefined ? {} : { dwellMs }),
+    });
+  }
+
+  beforeEach(() => {
+    emitted = [];
+    vi.useFakeTimers();
+    // jsdom implements neither; the machine only needs them not to throw.
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue(undefined);
+    vi.spyOn(HTMLMediaElement.prototype, 'load').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('waits out the dwell before the first emission', () => {
+    const a = make();
+    a.hover(7);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS - 1);
+    expect(emitted).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    expect(emitted).toEqual([
+      { mediaId: 7, waveUrl: '/ctx/api/medias/7/thumbnail', loading: true, progress: null },
+    ]);
+    expect(a.element.src).toContain('/ctx/api/medias/7/audio');
+  });
+
+  it('re-arms the dwell on each hover, so only the settled item plays', () => {
+    const a = make();
+    a.hover(1);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS - 20);
+    a.hover(2);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS - 20);
+    a.hover(3);
+    expect(emitted).toEqual([]);
+
+    vi.advanceTimersByTime(AUDIO_DWELL_MS);
+    expect(emitted.map((e) => e?.mediaId)).toEqual([3]);
+    expect(a.isTargeting(3)).toBe(true);
+    expect(a.isTargeting(1)).toBe(false);
+  });
+
+  it('treats a re-hover of the auditioning clip as a no-op', () => {
+    const a = make();
+    a.hover(7);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS);
+    const after = emitted.length;
+
+    a.hover(7);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS * 2);
+    expect(emitted.length).toBe(after);
+  });
+
+  it('reports a media whose dwell is armed but not yet playing as targeted', () => {
+    const a = make();
+    a.hover(7);
+    expect(a.isTargeting(7)).toBe(true);
+    expect(emitted).toEqual([]);
+  });
+
+  it('flips the loading flag from the element buffering events', () => {
+    const a = make();
+    a.hover(7);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS);
+
+    a.element.dispatchEvent(new Event('playing'));
+    expect(emitted.at(-1)?.loading).toBe(false);
+
+    a.element.dispatchEvent(new Event('waiting'));
+    expect(emitted.at(-1)?.loading).toBe(true);
+
+    a.element.dispatchEvent(new Event('canplay'));
+    expect(emitted.at(-1)?.loading).toBe(false);
+  });
+
+  it('emits null exactly once on stop, and stays silent when stopped again', () => {
+    const a = make();
+    a.hover(7);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS);
+    emitted.length = 0;
+
+    a.stop();
+    expect(emitted).toEqual([null]);
+
+    a.stop();
+    expect(emitted).toEqual([null]);
+  });
+
+  it('emits nothing when stopping an audition that never started', () => {
+    const a = make();
+    a.hover(7);
+    a.stop();
+    vi.advanceTimersByTime(AUDIO_DWELL_MS * 2);
+    expect(emitted).toEqual([]);
+    expect(a.isTargeting(7)).toBe(false);
+  });
+
+  it('ignores buffering events that arrive after a stop', () => {
+    const a = make();
+    a.hover(7);
+    vi.advanceTimersByTime(AUDIO_DWELL_MS);
+    a.stop();
+    emitted.length = 0;
+
+    a.element.dispatchEvent(new Event('playing'));
+    a.element.dispatchEvent(new Event('waiting'));
+    expect(emitted).toEqual([]);
+  });
+
+  it('plays synchronously when the dwell is zero (the bin popup)', () => {
+    const a = make(0);
+    a.hover(42);
+    expect(emitted).toEqual([
+      { mediaId: 42, waveUrl: '/ctx/api/medias/42/thumbnail', loading: true, progress: null },
+    ]);
+  });
+
+  it('applies the volume to the element, and to a clip started later', () => {
+    const a = make(0);
+    a.setVolume(0.25);
+    expect(a.element.volume).toBe(0.25);
+
+    a.hover(7);
+    expect(a.element.volume).toBe(0.25);
+  });
+
+  it('emits the final null on destroy', () => {
+    const a = make(0);
+    a.hover(7);
+    emitted.length = 0;
+
+    a.destroy();
+    expect(emitted).toEqual([null]);
+    expect(a.element.paused).toBe(true);
+  });
+
+  it('keeps its element out of the document', () => {
+    const a = make(0);
+    a.hover(7);
+    expect(a.element.isConnected).toBe(false);
+    expect(document.querySelector('audio')).toBeNull();
+  });
+});

--- a/frontend/src/app/utils/browse-audio-audition.ts
+++ b/frontend/src/app/utils/browse-audio-audition.ts
@@ -1,0 +1,231 @@
+import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
+import { applyClipWindow, clearClipWindow, clipProgress } from './clip-window';
+
+/** A clip currently auditioning from a VTSBrowse hover — a canvas bin
+ *  (`browse-hover-preview.component.ts`), a selection-panel entry
+ *  (`browse-selection-panel.component.ts`), or a bin-popup member
+ *  (`browse-bin-popup.component.ts`) — or ``null`` when nothing is playing.
+ *  Drives the now-playing waveform anchored at the top-left of the canvas,
+ *  alongside the volume control. */
+export interface NowPlaying {
+  mediaId: number;
+  /** The clip's waveform PNG — the same thumbnail painted on its tile. */
+  waveUrl: string;
+  /** ``true`` while the clip is still fetching/decoding and hasn't begun to
+   *  sound yet (or has stalled to rebuffer mid-play); drives the loading
+   *  spinner on the now-playing widget. Flips to ``false`` once playback is
+   *  actually audible. */
+  loading: boolean;
+  /** Playback position within the (possibly windowed) clip as a fraction in
+   *  ``[0, 1]``, or ``null`` before a finite duration is known. Drives the
+   *  sweeping playhead line on the now-playing waveform, updated ~60×/sec on a
+   *  requestAnimationFrame loop while the clip sounds. */
+  progress: number | null;
+}
+
+/** How long (ms) the cursor must rest on an audio item before its clip starts
+ *  auditioning, so sweeping across bins (or down a long list) doesn't fire a
+ *  burst of plays. The default for hover-driven surfaces; the bin popup passes
+ *  ``0`` because opening it is already a deliberate, settled gesture. */
+export const AUDIO_DWELL_MS = 200;
+
+/** What the audition needs from its host component, as plain callbacks — this
+ *  file is `utils/`, so it takes no Angular DI. */
+export interface BrowseAudioAuditionOptions {
+  /** Resolve an API path against the active dataset — `ActiveContextService.mediaUrl`. */
+  mediaUrl: (path: string) => string;
+  /** The cached clip metadata for a media, if it has landed —
+   *  `MediaMetadataCacheService.get`. Read *lazily* (never captured), because
+   *  hydration may still be in flight when playback starts. */
+  lookup: (mediaId: number) => MediaBatchResponse | undefined;
+  /** Ask for a media's metadata to be hydrated — `MediaMetadataCacheService.ensureLoaded`. */
+  ensureLoaded: (mediaId: number) => void;
+  /** Push the now-playing state at the host's `nowPlaying` output. **This is the
+   *  zoneless notification path** (`docs/FRONTEND.md` §5): the indicator is
+   *  rendered by an ancestor, so an edge that fails to emit leaves the UI
+   *  showing stale playback state. */
+  emit: (state: NowPlaying | null) => void;
+  /** Dwell debounce before a hovered clip starts. Defaults to
+   *  {@link AUDIO_DWELL_MS}; ``0`` plays synchronously on {@link
+   *  BrowseAudioAudition.hover}. */
+  dwellMs?: number;
+}
+
+/**
+ * The VTSBrowse hover-audition state machine: dwell debounce, stale-event
+ * guard, buffering tri-state and playhead sweep, over an audio element it owns.
+ *
+ * Three Browse surfaces audition clips on hover — the canvas hover preview, the
+ * selection panel and the bin popup — and all three drive the *same* top-left
+ * now-playing indicator through the shared {@link NowPlaying} output. They used
+ * to carry a copy of this machine each; the copies diverged (issue #3436), so
+ * the machine lives here and the components keep only their output wiring.
+ *
+ * The element is created here and **never mounted in the DOM**: browse audio is
+ * heard, not shown — the top-left indicator is the only visual feedback — and a
+ * media element plays perfectly well detached. Owning it is what lets the
+ * source be set imperatively, which in turn is why starting a clip is
+ * synchronous rather than deferred behind a template binding.
+ *
+ * Every path that stops playback emits ``null`` exactly once, and every path
+ * that changes the buffering state or the playhead re-emits, so the indicator
+ * can never be left asserting a clip that is no longer sounding.
+ */
+export class BrowseAudioAudition {
+  /** The audition element. Detached from the document by design (see the class
+   *  docstring); exposed so specs can dispatch its buffering events. */
+  readonly element: HTMLAudioElement = new Audio();
+
+  private readonly dwellMs: number;
+  private dwellTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Media whose dwell is armed but has not yet started, or ``null``. */
+  private pendingMediaId: number | null = null;
+  /** Media currently auditioning, or ``null`` when silent. Doubles as the
+   *  stale-event guard: the buffering listeners below are attached once to the
+   *  reused element, so events that arrive after a stop must not resurrect the
+   *  widget. */
+  private playingMediaId: number | null = null;
+  /** Waveform PNG of the clip auditioning, kept so the buffering listeners can
+   *  re-emit without recomputing it. */
+  private waveUrl = '';
+  /** Last ``loading`` flag emitted, so the playhead sweep re-emits with the
+   *  live buffering state rather than forcing it back to ``false``. */
+  private loading = false;
+  /** Handle of the in-flight requestAnimationFrame playhead sweep, or ``null``
+   *  when the loop is stopped. */
+  private sweepRaf: number | null = null;
+  private volume = 1;
+
+  constructor(private readonly opts: BrowseAudioAuditionOptions) {
+    this.dwellMs = opts.dwellMs ?? AUDIO_DWELL_MS;
+    // Buffering feedback: while the clip is fetching/decoding (or stalls to
+    // rebuffer), the widget shows a spinner; once it's actually sounding, the
+    // spinner clears.
+    this.element.addEventListener('waiting', () => this.emitNowPlaying(true));
+    this.element.addEventListener('playing', () => this.emitNowPlaying(false));
+    this.element.addEventListener('canplay', () => this.emitNowPlaying(false));
+  }
+
+  /** Keep the element in step with the Browse toolbar's volume slider, including
+   *  mid-playback. Also seeds the volume a later {@link hover} starts at. */
+  setVolume(volume: number): void {
+    this.volume = volume;
+    this.element.volume = volume;
+  }
+
+  /** Whether `mediaId` is the clip auditioning, or the one whose dwell is armed.
+   *  Callers use it to silence an item that is about to leave the DOM (and so
+   *  will never fire its own mouseleave). */
+  isTargeting(mediaId: number): boolean {
+    return this.playingMediaId === mediaId || this.pendingMediaId === mediaId;
+  }
+
+  /**
+   * The cursor settled on `mediaId`: (re)arm the dwell so a sweep across items
+   * keeps resetting it and only the one the cursor rests on actually plays.
+   * Already auditioning this exact clip is a no-op, so re-entering an item (or
+   * a redundant re-summon) doesn't restart it.
+   */
+  hover(mediaId: number): void {
+    if (this.playingMediaId === mediaId) return;
+    this.pendingMediaId = mediaId;
+    this.cancelDwell();
+    if (this.dwellMs === 0) {
+      this.pendingMediaId = null;
+      this.play(mediaId);
+      return;
+    }
+    this.dwellTimer = setTimeout(() => {
+      this.dwellTimer = null;
+      const id = this.pendingMediaId;
+      this.pendingMediaId = null;
+      if (id != null) this.play(id);
+    }, this.dwellMs);
+  }
+
+  /**
+   * Silence the audition: cancel a pending dwell, stop anything playing and
+   * emit ``null`` so the indicator clears. Idempotent — a second call while
+   * already silent emits nothing.
+   *
+   * This is the single retreat edge: hover-off, an item leaving the list, a
+   * fresh bin replacing the one on show, and teardown all route through it.
+   */
+  stop(): void {
+    this.cancelDwell();
+    this.pendingMediaId = null;
+    if (this.playingMediaId == null) return;
+    this.playingMediaId = null;
+    this.stopSweep();
+    clearClipWindow(this.element);
+    this.element.pause();
+    this.element.currentTime = 0;
+    this.opts.emit(null);
+  }
+
+  /** Tear down with the host component. */
+  destroy(): void {
+    this.stop();
+    this.stopSweep();
+  }
+
+  private play(mediaId: number): void {
+    this.playingMediaId = mediaId;
+    this.waveUrl = this.opts.mediaUrl(`/api/medias/${mediaId}/thumbnail`);
+    // Hydrate clip extents (clip_start/clip_end) so windowed clips loop within
+    // their window; applyClipWindow reads them lazily as they land.
+    this.opts.ensureLoaded(mediaId);
+    this.element.volume = this.volume;
+    applyClipWindow(this.element, () => this.opts.lookup(mediaId));
+    this.element.src = this.opts.mediaUrl(`/api/medias/${mediaId}/audio`);
+    this.element.load();
+    this.element.play().catch(() => {});
+    // Starts loading: show the spinner until a ``playing``/``canplay`` event
+    // (wired in the constructor) clears it.
+    this.emitNowPlaying(true);
+    // Advance the playhead sweep while it sounds; self-cancels on pause/stop.
+    this.startSweep();
+  }
+
+  /** Re-emit the now-playing state with a fresh ``loading`` flag and the current
+   *  playhead position, from the buffering listeners and the sweep loop. A no-op
+   *  once nothing is auditioning, so events that fire after a stop don't
+   *  resurrect the widget. */
+  private emitNowPlaying(loading: boolean): void {
+    const mediaId = this.playingMediaId;
+    if (mediaId == null) return;
+    this.loading = loading;
+    const progress = clipProgress(this.element, () => this.opts.lookup(mediaId));
+    this.opts.emit({ mediaId, waveUrl: this.waveUrl, loading, progress });
+  }
+
+  // Re-emit the now-playing state ~60×/sec so the playhead sweeps smoothly:
+  // (timeupdate) fires only ~4×/sec, too coarse for a fluid line. Self-cancels
+  // when the clip pauses or stops; idempotent while a loop is already live.
+  private startSweep(): void {
+    if (this.sweepRaf !== null || typeof requestAnimationFrame !== 'function') return;
+    const tick = (): void => {
+      if (this.playingMediaId == null || this.element.paused) {
+        this.sweepRaf = null;
+        return;
+      }
+      this.emitNowPlaying(this.loading);
+      this.sweepRaf = requestAnimationFrame(tick);
+    };
+    this.sweepRaf = requestAnimationFrame(tick);
+  }
+
+  private stopSweep(): void {
+    if (this.sweepRaf !== null) {
+      cancelAnimationFrame(this.sweepRaf);
+      this.sweepRaf = null;
+    }
+  }
+
+  private cancelDwell(): void {
+    if (this.dwellTimer) {
+      clearTimeout(this.dwellTimer);
+      this.dwellTimer = null;
+    }
+  }
+}


### PR DESCRIPTION
Closes #3436.

## The premise, checked

Mostly right, with one correction worth stating because it changed the design.

**"Triplicated near-verbatim"** is true of *two* of the three. `browse-hover-preview` (160–249) and `browse-selection-panel` (299–394) are byte-identical apart from two comments ("a sweep across bins" vs "a sweep down the list"). That is the real duplication, and it is exactly the kind that rots: the dwell debounce, stale-event guard, rAF sweep and buffering tri-state were each fixed once and copied twice.

**`browse-bin-popup` is not a third copy.** It is a genuinely different machine that happens to emit the same interface, and reading it closely, it differs in only two substantive ways:

1. **No dwell.** It plays immediately on grid-row hover and on open.
2. **A mounted ``'&lt;audio #audioEl [src]&gt;'`` in the template** rather than an owned `new Audio()` — which is what forces its `setTimeout` deferral (the `[src]` binding has to land before `load()`), its `audioRef` viewChild, its lazy `attachBufferingListeners` latch, and its `audioSrc` signal standing in for "is playing".

Everything else — `emitNowPlaying`, `startSweep`/`stopSweep`, the buffering listeners, `applyClipWindow`/`clearClipWindow`, the stop edges, even the URL derivation — is the same logic with cosmetic differences.

## Where this deviates from the issue

The issue asks that "the extracted class must accommodate that difference rather than silently regress it back to a per-component element." **This PR does the opposite, deliberately.**

Accommodating it would mean a class carrying an `elementProvider` knob, a `deferStart` flag and `dwellMs` — three config dimensions to serve one caller, which is a worse artifact than the duplication it replaces. And the "pooled element" the issue treats as intentional does not appear to be: git history shows no decision behind it, the element is `sr-only` with no controls, and a media element does not need to be in the document to play. It reads as how the file happened to get written.

So the bin popup converges onto the owned element. That **deletes** the deferral, the viewChild, the latch and the `audioSrc` signal — a net simplification of the divergent component, not a knob added to the shared class. Its one real difference is the single `dwellMs: 0` option, documented at the call site with the reason (opening a bin is already a settled gesture; there is no sweep of near-misses to debounce).

The API is `hover(id)` / `stop()` / `destroy()` / `isTargeting(id)` rather than the suggested `hover` / `leave` / `stop`: every leave path — hover-off, an entry clicked out of the list, a fresh bin replacing the one on show, teardown — does the identical thing, so `leave()` and `stop()` would have been two names for one behaviour.

## Verification

**Real chromium, as the issue requires.** The dwell, the rAF sweep and the buffering tri-state depend on real timing and real media-element semantics, so the extracted class was driven headlessly against a served 4-second WAV (a windowed clip, `[0.5, 1.5]`) — 22 checks, all passing:

- Dwell debounce: nothing emitted mid-sweep, only the settled id plays, first emit lands at t=368ms.
- **The detached element really plays** — `currentTime` advances, `readyState` 4, `isConnected` false. This is the check that matters for the bin popup's migration.
- Real `canplay`/`playing` clear the loading flag; `progress` sweeps 0.000 → 1.000 at frame rate (33 emissions/500ms).
- Playback stays inside the clip window and wraps; native `loop` off for a windowed clip.
- `stop()` emits `null` exactly once, halts the sweep, rewinds, and is idempotent; stale buffering events afterwards cannot resurrect the widget; `destroy()` emits the final `null` and leaves no live sweep.
- `dwellMs: 0` emits synchronously and reaches real playback; re-hovering the live clip does not restart it.

Two findings from that run are worth recording because both looked like regressions and neither was:

- An apparent seek livelock (`seeking` stuck true, 30k emissions/sec from a `waiting` storm) was `python -m http.server` ignoring `Range:` — Chrome cannot seek without byte ranges. Serving with range support fixed it. Nothing to do with this change, but it is a good trap to know about when testing media locally.
- Playback overshoots `clip_end` by up to ~250ms. That is inherent to `applyClipWindow` wrapping on `timeupdate`, which Chrome fires only ~4×/sec — pre-existing, untouched, and not worth changing.

**Gated suites.** `./run-tests.sh` → `RUN PASSED`, all gates green (9748 Python tests, 2315 frontend tests, pyright, pip-audit, vulture whitelist, npm audit). Zero build warnings.

**New unit coverage.** The extraction turned private component fields into a plain DI-free class, so `utils/browse-audio-audition.spec.ts` now covers the machine directly (12 tests): dwell re-arming, `dwellMs: 0`, `isTargeting` on a pending clip, stop idempotence, the stale-event guard. It asserts bookkeeping only and says so in its header — jsdom has no media pipeline, which is precisely why the chromium pass above exists.

## On the zoneless risk

The issue flags the `nowPlaying` output as the notification path, and it is. Every path that stops playback emits `null` exactly once, and every buffering or playhead change re-emits; the `playingMediaId` guard makes a post-stop emission impossible. Both properties are asserted in chromium (edges 5, 6, 9) and in the unit spec. The three component `.zoneless.spec.ts` canaries are unchanged in substance and still pass — they now exercise the wiring rather than a private copy of the machine.

## Notes

- `NowPlaying` moves to the util beside the machine that emits it. It is the shared contract all three components emit, so living inside one of the three was the wrong home; importers updated.
- `docs/plans/vtsbrowse-empirical-tuning.md` cited a `playAudio` method that no longer exists — repointed, and the 200ms dwell added to the row since it is a tuning knob.

Net: 3 components, −320 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wnReBZixHrnrK8GcGexqs

---
_Generated by [Claude Code](https://claude.ai/code/session_018wnReBZixHrnrK8GcGexqs)_