### PR TITLE
Standardize on one JSON error envelope

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,15 +153,14 @@ app.config["OPENAPI_JSON_PATH"] = "openapi.json"
 app.config["OPENAPI_SWAGGER_UI_PATH"] = "/docs"
 app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
 
-from flask_smorest import Api  # noqa: E402
-
+from vtsearch.errors import VTSearchApi  # noqa: E402
 from vtsearch.openapi_postprocess import (  # noqa: E402
     assign_operation_ids,
     collapse_nullable_refs,
     normalize_unprocessable_response,
 )
 
-api = Api(app)
+api = VTSearchApi(app)
 
 
 # flask-smorest / apispec doesn't populate ``operationId`` on its own, so

--- a/docs/API.md
+++ b/docs/API.md
@@ -84,11 +84,32 @@ both for any dataset- or detector-scoped call.
 | `X-Dataset-Id` / `X-Detector-Id` | [Context headers](#context-headers-x-dataset-id--x-detector-id) selecting the active dataset / detector |
 | Async endpoints | Return immediately; subscribe to the `dataset` channel on `GET /api/events` (SSE) for progress |
 
-**Common error shape:**
+**Common error shape.** Every JSON error the API returns — from a route, from
+a global handler, or from schema validation — carries the same envelope
+(`vtsearch/errors.py`, documented in the OpenAPI spec as the `Error` schema):
 
 ```json
-{"error": "Human-readable message"}
+{
+  "code": 404,
+  "status": "Not Found",
+  "message": "Human-readable message",
+  "request_id": "ab12cd34ef56"
+}
 ```
+
+`code` is the numeric HTTP status and `status` its name. `request_id` is
+present on every error raised inside a request (it also comes back in the
+`X-Request-Id` header), so a user can quote it in a bug report and an
+operator can grep the structured logs for it.
+
+Three optional fields appear when they apply, plus any endpoint-specific
+extras (e.g. `available`, `missing_fields`, `dataset_id`):
+
+| Field | When |
+|-------|------|
+| `errors` | Schema validation failed; maps location → field → messages (see the 422 example in [file-browser.md](api/file-browser.md)) |
+| `detail` | 500s; the exception type and its first line, e.g. `"RuntimeError: embedder X not loaded"` |
+| `error_code` | A machine-readable slug where the client branches on the *kind* of failure: `auth_required`, `dataset_not_loaded`, `detector_not_loaded` |
 
 Status codes follow standard HTTP semantics: 200 OK, 201 Created, 204 No
 Content, 400 Bad Request, 404 Not Found, 409 Conflict, 500 Internal Server

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -35,8 +35,8 @@ it shows a login screen at startup, otherwise it goes straight to the app.
 Whether the server actually *rejects* unauthenticated requests is governed by
 the provider's `enforce_auth()`, checked by a `before_request` hook: when it
 is true and `is_authenticated(request)` is false, any `/api/*` request is
-refused with **401** `{"error": "Authentication required", "code":
-"auth_required"}` before reaching a route handler. Exactly three paths are
+refused with **401** `{"message": "Authentication required", "error_code":
+"auth_required", ...}` before reaching a route handler. Exactly three paths are
 exempt — `/api/auth/status`, `/api/auth/login`, `/api/auth/logout` — so a
 client can always discover the auth mode and log in; everything else,
 including `/api/auth/huggingface/*`, sits behind the gate. Non-API paths
@@ -114,8 +114,8 @@ Only the `trivial` provider supports login.
 
 → **`trivial`**: sets the session username and returns the auth status dict
 (same shape as `GET /api/auth/status`, now `authenticated: true`).
-→ **`default` / `api_key`**: **400** `{"error": "Login/logout not supported by
-the active provider"}`.
+→ **`default` / `api_key`**: **400** `{"message": "Login/logout not supported by
+the active provider", ...}`.
 
 ### Logout
 
@@ -126,8 +126,8 @@ POST /api/auth/logout
 Only the `trivial` provider supports logout.
 
 → **`trivial`**: clears the session username and returns the auth status dict.
-→ **`default` / `api_key`**: **400** `{"error": "Login/logout not supported by
-the active provider"}`.
+→ **`default` / `api_key`**: **400** `{"message": "Login/logout not supported by
+the active provider", ...}`.
 
 ---
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -222,7 +222,7 @@ POST /api/dataset/cancel/{task_id}
 Cancels a specific loading task, with the same response shape and the same
 `409` contract when the task was not running or its worker is gone.
 
-→ `200 {"ok": true, ...}`, `409 {"ok": false, ...}`, or `{"error": "Task not found"}` (404)
+→ `200 {"ok": true, ...}`, `409 {"ok": false, ...}`, or `404 {"message": "Task not found", ...}`
 
 ---
 

--- a/docs/api/file-browser.md
+++ b/docs/api/file-browser.md
@@ -62,14 +62,9 @@ root.
 absolute paths — `"path": "/data/labels/labels.csv"`,
 `"current_path": "/data/labels"`.)
 
-400 if the path escapes the browse root (path traversal prevention) and
-403 if permission is denied reading the directory; both use the standard
-`{"message": "..."}` envelope.
-
-404 if the directory does not exist. This one is intercepted by the
-app-level `NotFound` handler, so it keeps the legacy shape
-`{"error": "Not Found", "request_id": "..."}` rather than the `message`
-envelope.
+400 if the path escapes the browse root (path traversal prevention), 403 if
+permission is denied reading the directory, and 404 if the directory does not
+exist; all three use the [standard error envelope](../API.md#conventions).
 
 422 if a query parameter fails schema validation, with the standard
 per-field `errors` envelope:

--- a/docs/plans/codebase-audit-2026-08.md
+++ b/docs/plans/codebase-audit-2026-08.md
@@ -28,7 +28,7 @@ the "Improvement proposals" section below.
 
 ---
 
-## Improvement proposals (40)
+## Improvement proposals (39)
 
 Design and architecture directions surfaced by the same review. These are
 deliberately **not** issues: each is a judgement call about direction rather than
@@ -39,12 +39,6 @@ ship on its own.
 ### Flask API layer
 
 <!-- item-sep -->
-
-- **Global NotFound handler discards every abort(404, message=...) body on /api/ routes** — `vtsearch/errors.py:43` (medium impact)
-
-  _handle_404 renders `error_response(exc.name, 404)`, i.e. always the literal 'Not Found', for every NotFound raised under /api/ — including flask-smorest `abort(404, message=...)` calls, whose message/extra kwargs ride on exc.data and are simply dropped. Routes across the codebase craft specific 404 messages that no client can ever see: `_abort_find(404, f"Dataset file missing for '{name}'")` (routes/detectors/find.py:183), 'Detector not found', 'File not found: <name>' (media/server.py:253), 'Job not found', etc. The learned-sort docstring (routes/sorting.py:486-492) even documents the message loss as a known quirk. The result is that any 404 with actionable detail (which dataset's pkl vanished, which of several filenames was missing) degrades to a generic banner. Benefit: one small change restores meaningful diagnostics to dozens of endpoints without touching them.
-
-  *Direction:* In _handle_404 (and _handle_405), prefer the smorest payload when present: `msg = (getattr(exc, 'data', None) or {}).get('message') or exc.description or exc.name; return error_response(msg, 404)`.
 
 <!-- item-sep -->
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3108,11 +3108,19 @@
         "type": "object"
       },
       "Error": {
-        "additionalProperties": false,
+        "additionalProperties": true,
         "properties": {
           "code": {
             "description": "Error code",
             "type": "integer"
+          },
+          "detail": {
+            "description": "Exception type and first line, on 500s",
+            "type": "string"
+          },
+          "error_code": {
+            "description": "Machine-readable slug, e.g. 'dataset_not_loaded'",
+            "type": "string"
           },
           "errors": {
             "additionalProperties": {},
@@ -3121,6 +3129,10 @@
           },
           "message": {
             "description": "Error message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Correlates the error with the server logs",
             "type": "string"
           },
           "status": {
@@ -9653,7 +9665,7 @@
     },
     "/api/dataset/detect-media-type": {
       "get": {
-        "description": "Powers the auto-detect hint in the import modal: rather than making\nthe user pick ``media_type`` blindly, the modal calls this after the\nuser selects a folder and pre-fills the dropdown with whichever type\nhas the most matching files in the first ``limit`` files of the tree.\n\nThe 404 returned when the source is unavailable on disk is\nintercepted by the app-level ``NotFound`` errorhandler and keeps the\nlegacy ``{\"error\": \"Not Found\", \"request_id\": ...}`` envelope.",
+        "description": "Powers the auto-detect hint in the import modal: rather than making\nthe user pick ``media_type`` blindly, the modal calls this after the\nuser selects a folder and pre-fills the dropdown with whichever type\nhas the most matching files in the first ``limit`` files of the tree.\n\nThe 404 returned when the source is unavailable on disk passes through\nthe app-level ``NotFound`` errorhandler (JSON rather than werkzeug's\nHTML page) with its ``message`` intact.",
         "operationId": "detect_media_type",
         "parameters": [
           {

--- a/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/combine-datasets-modal/combine-datasets-modal.component.spec.ts
@@ -142,7 +142,7 @@ describe('CombineDatasetsModalComponent', () => {
 
     component.submit();
     const req = httpMock.expectOne('/api/dataset/combine');
-    req.flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+    req.flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
 
     expect(started).toBe(false);
     expect(component.error()).toBe('boom');

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/dataset-importer-modal.component.spec.ts
@@ -564,7 +564,7 @@ describe('DatasetImporterModalComponent', () => {
     component.genericFormPicker().submit();
 
     httpMock.expectOne('/api/dataset/import/generic_form').flush(
-      { error: 'Not found' },
+      { message: 'Not found' },
       { status: 404, statusText: 'Not Found' },
     );
 
@@ -760,7 +760,7 @@ describe('DatasetImporterModalComponent', () => {
 
     httpMock.expectOne('/api/media-types').flush({ media_types: mockMediaTypes });
     httpMock.expectOne('/api/dataset/demo-list').flush(
-      { error: 'Server error' },
+      { message: 'Server error' },
       { status: 500, statusText: 'Internal Server Error' },
     );
 

--- a/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
+++ b/frontend/src/app/components/dashboard/dataset-importer-modal/pickers/generic-form/generic-form-picker.component.spec.ts
@@ -208,7 +208,7 @@ describe('GenericFormPickerComponent', () => {
     component.submit();
 
     httpMock.expectOne('/api/dataset/import/generic_form').flush(
-      { error: 'boom' },
+      { message: 'boom' },
       { status: 500, statusText: 'Internal Server Error' },
     );
 

--- a/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
+++ b/frontend/src/app/components/dashboard/new-detector-modal/new-detector-modal.component.spec.ts
@@ -221,7 +221,7 @@ describe('NewDetectorModalComponent', () => {
     component.submit();
 
     httpMock.expectOne('/api/detectors/registry').flush(
-      { error: 'Detector already exists' },
+      { message: 'Detector already exists' },
       { status: 409, statusText: 'Conflict' },
     );
 

--- a/frontend/src/app/components/folder-browser/folder-browser.component.spec.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.spec.ts
@@ -184,10 +184,10 @@ describe('FolderBrowserComponent', () => {
     expect(component.loading()).toBe(false);
   });
 
-  it('prefers error.message, then error.error, then a generic fallback', () => {
+  it('reads the envelope message, else a generic fallback', () => {
     const cases: [unknown, string][] = [
       [{ error: { message: 'from-message' } }, 'from-message'],
-      [{ error: { error: 'from-error' } }, 'from-error'],
+      [{ error: { code: 404, status: 'Not Found', message: 'gone' } }, 'gone'],
       [{ error: {} }, 'Could not browse this folder.'],
       [{ error: { message: 123 } }, 'Could not browse this folder.'],
     ];

--- a/frontend/src/app/components/folder-browser/folder-browser.component.ts
+++ b/frontend/src/app/components/folder-browser/folder-browser.component.ts
@@ -16,6 +16,7 @@ import { Observable, Subscription } from 'rxjs';
 
 import { IconComponent } from '../icon/icon.component';
 import { formatBytes } from '../../utils/format-metadata';
+import { apiErrorMessage } from '../../utils/api-error';
 
 export interface FolderBrowserDirEntry {
   name: string;
@@ -191,8 +192,7 @@ export class FolderBrowserComponent implements OnInit, OnDestroy, AfterViewInit 
         this.pathChange.emit({ path: this.currentPath(), rootPath: this.rootPath() });
       },
       error: (err) => {
-        const msg = (err && err.error && err.error.message) || (err && err.error && err.error.error) || 'Could not browse this folder.';
-        this.error.set(typeof msg === 'string' ? msg : 'Could not browse this folder.');
+        this.error.set(apiErrorMessage(err, 'Could not browse this folder.'));
         this.loading.set(false);
         this.rows.set([]);
       },

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -1058,7 +1058,7 @@ describe('LabelViewComponent', () => {
       startRunningJob();
       // 404 means the job was evicted or never existed; polling it forever
       // would just spin the panel.
-      resultPolls()[0].flush({ error: 'Not Found' }, { status: 404, statusText: 'Not Found' });
+      resultPolls()[0].flush({ message: 'Not Found' }, { status: 404, statusText: 'Not Found' });
 
       expect(component.sortState.sortBusy).toBe(false);
       expect(component.sortState.sortStatus).toBe('Training job expired');

--- a/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/dataset-stats-modal/dataset-stats-modal.component.spec.ts
@@ -165,7 +165,7 @@ describe('DatasetStatsModalComponent', () => {
   it('repaints the error text on a failed load (zoneless canary)', async () => {
     await fixture.whenStable();
     httpMock.expectOne('/api/datasets/registry/ds1/stats').flush(
-      { error: 'gone' },
+      { message: 'gone' },
       { status: 404, statusText: 'Not Found' },
     );
     await settleZoneless(fixture);

--- a/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/detector-stats-modal/detector-stats-modal.component.spec.ts
@@ -72,7 +72,7 @@ describe('DetectorStatsModalComponent', () => {
   it('repaints the error text on a failed load (zoneless canary)', async () => {
     await fixture.whenStable();
     httpMock.expectOne('/api/detectors/registry/det1/stats').flush(
-      { error: 'gone' },
+      { message: 'gone' },
       { status: 404, statusText: 'Not Found' },
     );
     await settleZoneless(fixture);

--- a/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/find-stats-modal/find-stats-modal.component.spec.ts
@@ -97,7 +97,7 @@ describe('FindStatsModalComponent', () => {
   it('repaints the error text on a failed load (zoneless canary)', async () => {
     await fixture.whenStable();
     httpMock.expectOne('/api/find/stats').flush(
-      { error: 'no find run' },
+      { message: 'no find run' },
       { status: 404, statusText: 'Not Found' },
     );
     httpMock.expectOne('/api/find/evidence-coverage').flush(mockEvidenceUnavailable);

--- a/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/label-importer-modal/label-importer-modal.component.spec.ts
@@ -108,7 +108,7 @@ describe('LabelImporterModalComponent', () => {
     component.submit();
 
     httpMock.expectOne('/api/label-importers/import/server_json_file').flush(
-      { error: 'File not found' },
+      { message: 'File not found' },
       { status: 404, statusText: 'Not Found' },
     );
 
@@ -218,7 +218,7 @@ describe('LabelImporterModalComponent', () => {
 
     component.submit();
     httpMock.expectOne('/api/label-importers/import/server_json_file').flush(
-      { error: 'Import blew up' },
+      { message: 'Import blew up' },
       { status: 500, statusText: 'Server Error' },
     );
     await settleZoneless(fixture);

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
@@ -94,7 +94,7 @@ describe('SettingsExporterModalComponent', () => {
 
     component.submit();
     httpMock.expectOne('/api/settings-exporters/export').flush(
-      { error: 'cannot write' },
+      { message: 'cannot write' },
       { status: 500, statusText: 'Server Error' },
     );
     await settleZoneless(fixture);

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
@@ -92,7 +92,7 @@ describe('SettingsImporterModalComponent', () => {
 
     component.submit();
     httpMock.expectOne('/api/settings-importers/import/server_json_file').flush(
-      { error: 'bad file' },
+      { message: 'bad file' },
       { status: 400, statusText: 'Bad Request' },
     );
     await settleZoneless(fixture);

--- a/frontend/src/app/interceptors/achievements-refresh.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/achievements-refresh.interceptor.spec.ts
@@ -51,7 +51,7 @@ describe('achievementsRefreshInterceptor', () => {
     http.post('/api/find-label', {}).subscribe({ error: () => {} });
     httpMock
       .expectOne('/api/find-label')
-      .flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
     expect(achievements.refresh).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/app/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/interceptors/error.interceptor.spec.ts
@@ -50,7 +50,7 @@ describe('errorInterceptor', () => {
     httpMock
       .expectOne('/api/foo')
       .flush(
-        { error: 'Boom', detail: 'more detail', request_id: 'req-1' },
+        { code: 500, status: 'Internal Server Error', message: 'Boom', detail: 'more detail', request_id: 'req-1' },
         { status: 500, statusText: 'Server Error' },
       );
 
@@ -72,7 +72,7 @@ describe('errorInterceptor', () => {
   it('enriches the error context with the active dataset/detector ids', () => {
     ctx.setActive('ds-9', 'mdl-3');
     http.get('/api/foo').subscribe({ error: () => {} });
-    httpMock.expectOne('/api/foo').flush({ error: 'x' }, { status: 400, statusText: 'Bad Request' });
+    httpMock.expectOne('/api/foo').flush({ message: 'x' }, { status: 400, statusText: 'Bad Request' });
 
     const arg = toast.error.mock.calls[0][0];
     expect(arg.errorContext.datasetId).toBe('ds-9');
@@ -84,7 +84,7 @@ describe('errorInterceptor', () => {
     httpMock
       .expectOne('/api/foo')
       .flush(
-        { error: 'x' },
+        { message: 'x' },
         { status: 500, statusText: 'err', headers: { 'X-Request-Id': 'hdr-1' } },
       );
 
@@ -95,8 +95,13 @@ describe('errorInterceptor', () => {
     http.get('/api/foo').subscribe({ error: () => {} });
     httpMock
       .expectOne('/api/foo')
-      .flush({ error: 'x', missing_fields: ['a', 'b'] }, { status: 422, statusText: 'err' });
+      .flush(
+        { code: 422, status: 'Unprocessable Content', message: 'x', missing_fields: ['a', 'b'] },
+        { status: 422, statusText: 'err' },
+      );
 
+    // ``code`` and ``status`` are envelope furniture the toast already
+    // renders from the HttpErrorResponse, so they stay out of ``extra``.
     expect(toast.error.mock.calls[0][0].errorContext.extra).toEqual({
       missing_fields: ['a', 'b'],
     });
@@ -118,7 +123,7 @@ describe('errorInterceptor', () => {
     http
       .get('/api/foo', { context: new HttpContext().set(SKIP_ERROR_TOAST, true) })
       .subscribe({ error: (e: HttpErrorResponse) => (caught = e) });
-    httpMock.expectOne('/api/foo').flush({ error: 'x' }, { status: 500, statusText: 'err' });
+    httpMock.expectOne('/api/foo').flush({ message: 'x' }, { status: 500, statusText: 'err' });
 
     expect(toast.error).not.toHaveBeenCalled();
     expect(caught?.status).toBe(500);

--- a/frontend/src/app/interceptors/error.interceptor.ts
+++ b/frontend/src/app/interceptors/error.interceptor.ts
@@ -142,16 +142,16 @@ function parseErrorBody(err: HttpErrorResponse): ParsedBody {
   }
   if (body && typeof body === 'object') {
     const obj = body as Record<string, unknown>;
-    // Standard {error, detail, request_id} shape from the backend.
-    const message =
-      pickString(obj, 'error') ||
-      pickString(obj, 'message') ||
-      undefined;
+    // The one backend error envelope (see vtsearch/errors.py):
+    // {code, status, message, request_id, errors?, detail?, ...extra}.
+    const message = pickString(obj, 'message');
     const detail = pickString(obj, 'detail');
     const requestId = pickString(obj, 'request_id');
-    // Surface any other top-level fields (e.g. missing_fields, available)
-    // so they show up in the "extra" section.
-    const known = new Set(['error', 'message', 'detail', 'request_id']);
+    // Surface any other top-level fields (e.g. missing_fields, available,
+    // error_code, errors) so they show up in the "extra" section. `code`
+    // and `status` are the numeric HTTP status and its name, which the
+    // toast already renders from the HttpErrorResponse itself.
+    const known = new Set(['code', 'status', 'message', 'detail', 'request_id']);
     const extra: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj)) {
       if (!known.has(k)) extra[k] = v;

--- a/frontend/src/app/services/achievements.service.spec.ts
+++ b/frontend/src/app/services/achievements.service.spec.ts
@@ -104,7 +104,7 @@ describe('AchievementsService', () => {
     service.state.subscribe();
     httpMock
       .expectOne('/api/achievements')
-      .flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
     expect(service.snapshot.achievements).toEqual([]);
   });
 
@@ -213,7 +213,7 @@ describe('AchievementsService', () => {
     service.checkPhrase('???').subscribe((r) => (result = r));
     httpMock
       .expectOne('/api/achievements/check-phrase')
-      .flush({ error: 'boom' }, { status: 500, statusText: 'Server Error' });
+      .flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
     expect(result).toEqual({ matched: false, doc_id: null, doc_name: null, already_read: false });
   });
 

--- a/frontend/src/app/services/browse-prep.service.ts
+++ b/frontend/src/app/services/browse-prep.service.ts
@@ -8,6 +8,7 @@ import { ProgressEventsService } from './progress-events.service';
 import { ProjectionApiService } from './projection-api.service';
 import { pollUntil, type PollHandle, type PollStep } from './poll-until';
 import { LoadingTask } from '../models/api.models';
+import { apiErrorMessage } from '../utils/api-error';
 import type { ProgressKind } from '../utils/format-progress';
 import type { ProjectionMeta } from '../models/projection.models';
 
@@ -325,8 +326,7 @@ export class BrowsePrepService {
 
   private errMessage(err: unknown, fallback: string): string {
     if (err instanceof HttpErrorResponse) {
-      const body = err.error as { message?: string; error?: string } | undefined;
-      return body?.message || body?.error || fallback;
+      return apiErrorMessage(err, fallback);
     }
     return fallback;
   }

--- a/frontend/src/app/utils/api-error.spec.ts
+++ b/frontend/src/app/utils/api-error.spec.ts
@@ -1,28 +1,23 @@
 import { apiErrorMessage } from './api-error';
 
 describe('apiErrorMessage', () => {
-  it('reads the error_response envelope ({error: ...})', () => {
-    expect(apiErrorMessage({ error: { error: 'No files uploaded' } }, 'fallback')).toBe(
-      'No files uploaded',
-    );
-  });
-
-  it('reads the flask_smorest envelope ({message: ...})', () => {
-    // Regression: inline handlers used to read only err.error?.error, so
-    // every abort(400, message=...) route degraded to the generic fallback.
+  it('reads the message key of the standard envelope', () => {
     expect(
       apiErrorMessage({ error: { code: 400, status: 'Bad Request', message: 'Missing field' } }, 'fallback'),
     ).toBe('Missing field');
   });
 
-  it('prefers the error key when both are present', () => {
-    expect(apiErrorMessage({ error: { error: 'specific', message: 'generic' } }, 'fb')).toBe(
-      'specific',
-    );
+  it('reads a global handler envelope carrying request_id and extras', () => {
+    expect(
+      apiErrorMessage(
+        { error: { code: 409, status: 'Conflict', message: 'Dataset is not loaded', request_id: 'r1', error_code: 'dataset_not_loaded' } },
+        'fallback',
+      ),
+    ).toBe('Dataset is not loaded');
   });
 
   it('falls back for empty, missing, or non-string payloads', () => {
-    expect(apiErrorMessage({ error: { error: '' } }, 'fb')).toBe('fb');
+    expect(apiErrorMessage({ error: { message: '' } }, 'fb')).toBe('fb');
     expect(apiErrorMessage({ error: {} }, 'fb')).toBe('fb');
     expect(apiErrorMessage({}, 'fb')).toBe('fb');
     expect(apiErrorMessage(null, 'fb')).toBe('fb');
@@ -31,5 +26,12 @@ describe('apiErrorMessage', () => {
     expect(apiErrorMessage({ error: { message: 42 } }, 'fb')).toBe('fb');
     // ProgressEvent bodies (network failure) have no keys at all.
     expect(apiErrorMessage({ error: new ProgressEvent('error') }, 'fb')).toBe('fb');
+  });
+
+  it('no longer reads the retired {error: ...} spelling', () => {
+    // Regression guard for the envelope unification: if a route ever
+    // reintroduces `{"error": ...}` the fallback fires loudly rather than
+    // the helper silently propping up a second envelope.
+    expect(apiErrorMessage({ error: { error: 'No files uploaded' } }, 'fb')).toBe('fb');
   });
 });

--- a/frontend/src/app/utils/api-error.ts
+++ b/frontend/src/app/utils/api-error.ts
@@ -1,21 +1,23 @@
 /**
  * Extract a human-readable message from an HTTP error response body.
  *
- * The backend deliberately emits two error envelope shapes:
+ * Every JSON error the backend emits carries one envelope
+ * (`vtsearch/errors.py`):
  *
- *  - `error_response()` (vtsearch/routes/_shared.py):
- *    `{ "error": ..., "detail": ..., "request_id": ... }`
- *  - `flask_smorest.abort()`:
- *    `{ "code", "status", "message", "errors" }`
+ * ```json
+ * { "code": 404, "status": "Not Found", "message": "...", "request_id": "..." }
+ * ```
  *
- * The global error toast interceptor already reads both keys; inline
- * component handlers must too, or every `abort(400, message=...)` route
- * degrades to the component's generic fallback string.  Funnel all inline
- * error-message extraction through here.
+ * This used to have to read two spellings: a hand-rolled `{error, detail,
+ * request_id}` envelope coexisted with flask-smorest's `{code, status,
+ * message, errors}`, so an inline handler that read only one key degraded
+ * every route on the other envelope to its generic fallback string. The
+ * backend now emits `message` everywhere, so this is a single key read --
+ * kept as a helper rather than inlined at each call site so the envelope
+ * stays named in one place if it ever moves again.
  */
 export function apiErrorMessage(err: unknown, fallback: string): string {
-  const body = (err as { error?: { error?: unknown; message?: unknown } } | null | undefined)
-    ?.error;
-  const message = body?.error ?? body?.message;
+  const body = (err as { error?: { message?: unknown } } | null | undefined)?.error;
+  const message = body?.message;
   return typeof message === 'string' && message ? message : fallback;
 }

--- a/tests/api/test_api_contracts.py
+++ b/tests/api/test_api_contracts.py
@@ -603,7 +603,9 @@ class TestErrorResponseFormat:
         resp = client.get("/api/medias/99999/audio")
         assert resp.status_code == 404
         data = resp.get_json()
-        assert "error" in data
+        assert data["message"] == "not found"
+        assert data["code"] == 404
+        assert "request_id" in data
 
     def test_400_sort_error_is_json(self, client):
         # The sort blueprint now returns flask-smorest's standard error
@@ -676,7 +678,8 @@ class TestErrorResponseFormat:
         )
         assert resp.status_code == 404
         data = resp.get_json()
-        assert "error" in data
+        assert "nonexistent_exporter" in data["message"]
+        assert "request_id" in data
 
     def test_400_missing_exporter_name_is_json(self, client):
         # Migrated to flask-smorest: schema-level validation surfaces

--- a/tests/api/test_auth_enforcement.py
+++ b/tests/api/test_auth_enforcement.py
@@ -65,8 +65,8 @@ class TestApiKeyEnforcement:
         resp = client.get("/api/medias/ids")
         assert resp.status_code == 401
         data = resp.get_json()
-        assert data["error"] == "Authentication required"
-        assert data["code"] == "auth_required"
+        assert data["message"] == "Authentication required"
+        assert data["error_code"] == "auth_required"
         assert resp.headers["WWW-Authenticate"] == "Bearer"
 
     def test_invalid_token_is_401(self, client, tmp_path):

--- a/tests/api/test_dashboard.py
+++ b/tests/api/test_dashboard.py
@@ -19,12 +19,7 @@ class TestDashboardDatasetInfo:
             resp = client.get("/api/dashboard/dataset-info")
             assert resp.status_code == 404
             data = resp.get_json()
-            # 404s are intercepted by the app-level ``NotFound``
-            # errorhandler in ``app.py`` (which always wins for 404
-            # because it matches a more specific exception subclass than
-            # flask-smorest's ``HTTPException`` handler), so the
-            # response carries ``error`` not ``message``.
-            assert "error" in data
+            assert data["message"] == "No dataset loaded"
         finally:
             medias.update(saved)
 

--- a/tests/api/test_embed.py
+++ b/tests/api/test_embed.py
@@ -96,8 +96,8 @@ class TestEmbedMediaUpload:
         )
         assert resp.status_code == 404
         body = resp.get_json()
-        assert "Unknown embedder 'nope'" in body["error"]
-        assert "Available:" in body["error"]
+        assert "Unknown embedder 'nope'" in body["message"]
+        assert "Available:" in body["message"]
 
     def test_missing_embedder_field_returns_400(self, client):
         resp = client.post(
@@ -106,7 +106,7 @@ class TestEmbedMediaUpload:
             content_type="multipart/form-data",
         )
         assert resp.status_code == 400
-        assert "embedder is required" in resp.get_json()["error"]
+        assert "embedder is required" in resp.get_json()["message"]
 
     def test_missing_file_returns_400(self, client, fake_image_embedder):
         resp = client.post(
@@ -115,7 +115,7 @@ class TestEmbedMediaUpload:
             content_type="multipart/form-data",
         )
         assert resp.status_code == 400
-        assert "file is required" in resp.get_json()["error"]
+        assert "file is required" in resp.get_json()["message"]
 
     def test_wrong_extension_returns_400(self, client, fake_image_embedder):
         """An audio file uploaded to an image embedder is rejected fast."""
@@ -148,7 +148,7 @@ class TestEmbedMediaUpload:
         )
         assert resp.status_code == 400
         body = resp.get_json()
-        assert "could not embed" in body["error"]
+        assert "could not embed" in body["message"]
         assert body["media_type"] == "image"
 
 
@@ -171,17 +171,17 @@ class TestEmbedTextJson:
     def test_unknown_embedder_returns_404(self, client):
         resp = client.post("/api/embed", json={"embedder": "nope", "text": "hi"})
         assert resp.status_code == 404
-        assert "Unknown embedder 'nope'" in resp.get_json()["error"]
+        assert "Unknown embedder 'nope'" in resp.get_json()["message"]
 
     def test_missing_embedder_returns_400(self, client):
         resp = client.post("/api/embed", json={"text": "hi"})
         assert resp.status_code == 400
-        assert "embedder is required" in resp.get_json()["error"]
+        assert "embedder is required" in resp.get_json()["message"]
 
     def test_missing_text_returns_400(self, client, fake_image_embedder):
         resp = client.post("/api/embed", json={"embedder": "fake_image"})
         assert resp.status_code == 400
-        assert "text is required" in resp.get_json()["error"]
+        assert "text is required" in resp.get_json()["message"]
 
     def test_non_text_embedder_returns_400(self, client, fake_image_embedder):
         fake_image_embedder._supports_text = False
@@ -192,7 +192,7 @@ class TestEmbedTextJson:
         assert resp.status_code == 400
         body = resp.get_json()
         assert body["supports_text"] is False
-        assert "does not support text" in body["error"]
+        assert "does not support text" in body["message"]
 
     def test_embedder_returns_none_yields_500(self, client, fake_image_embedder):
         fake_image_embedder.return_none_text = True
@@ -201,7 +201,7 @@ class TestEmbedTextJson:
             json={"embedder": "fake_image", "text": "a cat"},
         )
         assert resp.status_code == 500
-        assert "returned no vector" in resp.get_json()["error"]
+        assert "returned no vector" in resp.get_json()["message"]
 
     def test_invalid_json_returns_400(self, client):
         resp = client.post(

--- a/tests/api/test_error_envelope.py
+++ b/tests/api/test_error_envelope.py
@@ -1,7 +1,11 @@
-"""Tests for the standardized JSON error envelope.
+"""Tests for the single JSON error envelope.
 
-The ``{error, detail, request_id}`` shape is consumed by the frontend
-``ErrorService`` / global error banner; keep this contract stable.
+Every API error -- from a ``flask_smorest.abort()`` inside a route, from a
+global ``@app.errorhandler``, or from a route helper returning an error
+tuple -- renders the same ``{code, status, message, request_id, ...}`` shape
+(see :mod:`vtsearch.errors`). It is consumed by the frontend interceptor /
+``apiErrorMessage`` helper and documented in the OpenAPI spec; keep this
+contract stable.
 """
 
 from __future__ import annotations
@@ -12,6 +16,78 @@ import json
 class TestErrorEnvelope:
     """4xx responses from inline error returns include ``request_id``."""
 
+    def test_helper_and_abort_agree_on_the_envelope_keys(self, client):
+        """The two ways a route can fail must produce the same shape.
+
+        This is the whole point of the unification: ``error_response`` (used
+        by the global handlers) and ``flask_smorest.abort`` (used by ~350
+        route sites) used to emit ``{error, detail, request_id}`` and
+        ``{code, status, message, errors}`` respectively, so the client had
+        to read both spellings.
+        """
+        # error_response path (get_json_or_400 on /api/embed).
+        helper = json.loads(client.post("/api/embed", content_type="application/json").data)
+        # abort(404, message=...) path (server-media thumbnail).
+        aborted = json.loads(client.get("/api/server-media-files/nope.wav/thumbnail").data)
+
+        for body in (helper, aborted):
+            assert set(body) >= {"code", "status", "message", "request_id"}
+            assert isinstance(body["code"], int)
+            assert isinstance(body["status"], str)
+        assert helper["code"] == 400
+        assert aborted["code"] == 404
+
+    def test_abort_message_survives_the_global_404_handler(self, client):
+        """``abort(404, message=...)`` bodies are no longer discarded.
+
+        The app registers a ``NotFound`` handler so unknown ``/api/`` paths
+        render JSON rather than werkzeug's HTML page. Flask resolves the most
+        specific exception class first, so that handler used to take *every*
+        404 away from flask-smorest and render the literal 'Not Found' --
+        silently dropping the message from ~85 ``abort(404, message=...)``
+        sites. It now delegates the rendering back to flask-smorest.
+        """
+        resp = client.get("/api/server-media-files/nope.wav/thumbnail")
+        assert resp.status_code == 404
+        body = json.loads(resp.data)
+        assert body["message"] == "File not found: nope.wav"
+        assert "request_id" in body
+
+    def test_abort_extra_kwargs_ride_along(self, client):
+        """Unreserved ``abort()`` kwargs become top-level fields.
+
+        flask-smorest's own handler reads only ``message``/``errors``/
+        ``headers`` and drops the rest; the ``**extra`` support the retired
+        hand-rolled envelope had is preserved by the ``VTSearchApi`` override.
+        """
+        # ``eval_train_and_score_result`` aborts with two extras, and its
+        # 404 is exactly the case the global ``NotFound`` handler used to
+        # flatten.
+        resp = client.get("/api/eval/train-and-score/result?job_id=no-such-job")
+        assert resp.status_code == 404
+        body = json.loads(resp.data)
+        assert body["message"] == "Job not found"
+        assert body["job_id"] == "no-such-job"
+        assert body["job_status"] == "missing"
+        # The envelope's own fields win: an extra never overwrites one.
+        assert body["status"] == "Not Found"
+        assert "request_id" in body
+
+    def test_webargs_internals_never_reach_the_body(self, client):
+        """A 422 must not try to serialize webargs's ``schema`` kwarg.
+
+        webargs attaches the live marshmallow ``Schema`` and the
+        ``ValidationError`` to ``exc.data`` alongside ``messages``; a
+        pass-through that copied every unreserved key would 500 the error
+        handler itself on ``Object of type ... is not JSON serializable``.
+        """
+        resp = client.post("/api/medias/1/vote", json={"target": 123})
+        assert resp.status_code == 422
+        body = json.loads(resp.data)
+        assert "schema" not in body
+        assert "exc" not in body
+        assert body["errors"]
+
     def test_invalid_json_body_carries_request_id(self, client):
         # ``/api/embed`` is still on the legacy ``get_json_or_400``
         # helper (the dual-mode multipart-or-JSON dispatcher doesn't fit
@@ -21,7 +97,7 @@ class TestErrorEnvelope:
         resp = client.post("/api/embed", content_type="application/json")
         assert resp.status_code == 400
         body = json.loads(resp.data)
-        assert body["error"] == "Invalid request body"
+        assert body["message"] == "Invalid request body"
         assert "request_id" in body and len(body["request_id"]) >= 8
         # The header echoes the same id so the client can correlate logs.
         assert resp.headers.get("X-Request-Id") == body["request_id"]
@@ -42,7 +118,7 @@ class TestErrorEnvelope:
         # Exercise the helper directly so plugin discovery and route
         # wiring don't muddy the contract.
         from app import app as flask_app
-        from vtsearch.routes._shared import error_response
+        from vtsearch.errors import error_response
 
         with flask_app.test_request_context("/api/anything"):
             from flask import g
@@ -55,7 +131,9 @@ class TestErrorEnvelope:
             )
             assert status == 400
             body = resp.get_json()
-            assert body["error"] == "Missing required field(s): ['name']"
+            assert body["code"] == 400
+            assert body["status"] == "Bad Request"
+            assert body["message"] == "Missing required field(s): ['name']"
             assert body["missing_fields"] == ["name"]
             assert body["request_id"] == "abc123"
 
@@ -63,19 +141,25 @@ class TestErrorEnvelope:
         # Background-thread error paths have no g.request_id; the helper
         # should still produce a valid JSON envelope.
         from app import app as flask_app
-        from vtsearch.routes._shared import error_response
+        from vtsearch.errors import error_response
 
         with flask_app.app_context():
             resp, status = error_response("Something broke", 500)
             assert status == 500
             body = resp.get_json()
-            assert body == {"error": "Something broke"}
+            assert body == {
+                "code": 500,
+                "status": "Internal Server Error",
+                "message": "Something broke",
+            }
 
     def test_unknown_api_path_returns_json_404(self, client):
         resp = client.get("/api/this-route-does-not-exist")
         assert resp.status_code == 404
         body = json.loads(resp.data)
-        assert "error" in body
+        # No route aborted, so there is no message to preserve; the envelope
+        # falls back to the status name rather than omitting the key.
+        assert body["message"] == "Not Found"
         assert "request_id" in body
 
     def test_non_api_404_is_not_json(self, client):
@@ -128,7 +212,7 @@ class TestUncaughtExceptionHandler:
         resp = client.get(path)
         assert resp.status_code == 500
         body = json.loads(resp.data)
-        assert body["error"] == "Internal server error"
+        assert body["message"] == "Internal server error"
         assert "RuntimeError" in body.get("detail", "")
         assert "request_id" in body
 

--- a/tests/core/test_medias.py
+++ b/tests/core/test_medias.py
@@ -668,15 +668,14 @@ class TestMediaAudio:
             assert wf.getsampwidth() == 2
 
     def test_returns_404_for_invalid_id(self, client):
-        # The global 404 handler in ``app.py`` normalises NotFound
-        # exceptions on ``/api/`` paths to ``error_response(exc.name, 404)``
-        # (the JSON-for-SPA hook that overrides werkzeug's HTML 404).
-        # The flask-smorest message passed to ``abort()`` is dropped
-        # in favour of the canonical reason phrase.
+        # The global 404 handler renders JSON for ``/api/`` paths (the
+        # JSON-for-SPA hook that overrides werkzeug's HTML 404) but hands
+        # the rendering back to flask-smorest, so the route's own
+        # ``abort(404, message=...)`` text reaches the client.
         resp = client.get("/api/medias/9999/audio")
         assert resp.status_code == 404
         data = resp.get_json()
-        assert data["error"] == "Not Found"
+        assert data["message"] == "not found"
 
     def test_returns_404_for_zero_id(self, client):
         resp = client.get("/api/medias/0/audio")

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -90,11 +90,7 @@ class TestDatasetEndpoints:
         resp = client.get("/api/dataset/demo-categories/nonexistent_dataset_xyz")
         assert resp.status_code == 404
         data = resp.get_json()
-        # 404s are intercepted by the app-level ``NotFound`` errorhandler
-        # in ``app.py`` (it matches a more specific exception subclass
-        # than flask-smorest's ``HTTPException`` handler), so the
-        # response carries ``error`` not ``message``.
-        assert "error" in data
+        assert "nonexistent_dataset_xyz" in data["message"]
 
     def test_load_demo_accepts_merge_near_duplicates(self, client):
         """POST /api/dataset/load-demo accepts the ``merge_near_duplicates`` flag.
@@ -195,8 +191,7 @@ class TestDatasetEndpoints:
         resp = client.get("/api/browse-media-files?source=demo:nonexistent_xyz&path=")
         assert resp.status_code == 404
         data = resp.get_json()
-        # 404 → app-level NotFound handler wins; see above.
-        assert "error" in data
+        assert data["message"] == "Source not found or not available on disk"
 
     def test_browse_media_files_path_traversal_blocked(self, client):
         """GET /api/browse-media-files rejects path traversal."""

--- a/tests/datasets/test_request_context.py
+++ b/tests/datasets/test_request_context.py
@@ -121,7 +121,7 @@ class TestRequestScopedDataset:
         resp = client.get("/api/medias/ids", headers={"X-Dataset-Id": "nope"})
         assert resp.status_code == 409
         body = resp.get_json()
-        assert body["code"] == "dataset_not_loaded"
+        assert body["error_code"] == "dataset_not_loaded"
         assert body["dataset_id"] == "nope"
 
     def test_unloaded_header_does_not_block_routes_that_skip_proxies(self, client):
@@ -244,7 +244,7 @@ class TestRequestScopedModel:
         resp = client.get("/api/votes", headers={"X-Detector-Id": "nonexistent"})
         assert resp.status_code == 409
         body = resp.get_json()
-        assert body["code"] == "detector_not_loaded"
+        assert body["error_code"] == "detector_not_loaded"
         assert body["detector_id"] == "nonexistent"
 
     def test_header_resolves_correct_detector_in_request(self, client):

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -1393,7 +1393,7 @@ class TestLoadModelEndpoint:
             headers={"X-Dataset-Id": "not_a_loaded_dataset"},
         )
         assert res.status_code == 409
-        assert res.get_json().get("code") == "dataset_not_loaded"
+        assert res.get_json().get("error_code") == "dataset_not_loaded"
         # No task row was created, so the dashboard shows no stuck spinner.
         assert detector_loading_tasks.get_tracker(f"_detload_{detector_id}") is None
 
@@ -2961,7 +2961,7 @@ class TestRegisterModelFromLabelset:
             json={"name": "NoOrigin", "filepath": str(labels_path)},
         )
         assert res.status_code == 400
-        assert "media type" in res.get_json()["error"].lower()
+        assert "media type" in res.get_json()["message"].lower()
 
     def test_mixed_media_types_returns_400(self, client, tmp_path):
         """Labels with conflicting origin media types are rejected."""
@@ -2984,7 +2984,7 @@ class TestRegisterModelFromLabelset:
             json={"name": "Mixed", "filepath": str(labels_path)},
         )
         assert res.status_code == 400
-        err = res.get_json()["error"]
+        err = res.get_json()["message"]
         assert "audio" in err and "image" in err
 
     def test_unknown_importer_returns_404(self, client):
@@ -2993,7 +2993,7 @@ class TestRegisterModelFromLabelset:
             json={"name": "X"},
         )
         assert res.status_code == 404
-        assert "no_such_importer" in res.get_json()["error"]
+        assert "no_such_importer" in res.get_json()["message"]
 
     def test_duplicate_name_returns_409(self, client, tmp_path):
         """Name collision with an existing detector file."""

--- a/tests/detectors/test_labels_routes.py
+++ b/tests/detectors/test_labels_routes.py
@@ -76,7 +76,7 @@ class TestImportLabelsRoute:
         )
         assert res.status_code == 404
         body = res.get_json()
-        assert "not_a_real_importer" in body["error"]
+        assert "not_a_real_importer" in body["message"]
 
     def test_missing_filepath_returns_422(self, client):
         _write_seed_detector()
@@ -114,7 +114,7 @@ class TestImportLabelsRoute:
             json={"filepath": str(target)},
         )
         assert res.status_code == 400
-        assert "not found" in res.get_json()["error"].lower()
+        assert "not found" in res.get_json()["message"].lower()
 
     def test_happy_path_merges_labels(self, client, tmp_path, monkeypatch):
         """Successful import writes the entries into the on-disk labelset."""

--- a/tests/io/test_exporters.py
+++ b/tests/io/test_exporters.py
@@ -969,10 +969,10 @@ class TestExportEndpoint:
             json={"exporter_name": "unicorn", "results": SAMPLE_RESULTS},
         )
         assert res.status_code == 404
-        # The app-level ``NotFound`` errorhandler reformats 404s to
-        # ``{"error": "Not Found", ...}`` regardless of the
-        # ``message=`` passed to ``abort()``.
-        assert "error" in res.get_json()
+        # The app-level ``NotFound`` errorhandler renders JSON for /api/
+        # paths but hands the rendering back to flask-smorest, so the
+        # ``message=`` passed to ``abort()`` reaches the client.
+        assert "unicorn" in res.get_json()["message"]
 
     def test_gui_exporter_returns_success(self, client):
         res = client.post(

--- a/tests/io/test_label_import_endpoint.py
+++ b/tests/io/test_label_import_endpoint.py
@@ -28,7 +28,7 @@ class TestLabelImportEndpoint:
     def test_unknown_importer_returns_404(self, client):
         res = client.post("/api/label-importers/import/no_such_importer")
         assert res.status_code == 404
-        assert "no_such_importer" in res.get_json()["error"]
+        assert "no_such_importer" in res.get_json()["message"]
 
     def test_json_importer_applies_good_label(self, client, tmp_path):
         md5 = app_module.medias[1]["md5"]

--- a/vtsearch/errors.py
+++ b/vtsearch/errors.py
@@ -1,9 +1,36 @@
-"""Global JSON error handlers for the VTSearch app.
+"""Global JSON error handlers and the single API error envelope.
 
-Holds the ``@app.errorhandler`` functions that used to live inline in
-``app.py``: JSON 404/405 for ``/api/`` paths, the dataset/detector
-not-loaded → 409 mappings, the request-missing-context → 400 mapping, and
-the catch-all uncaught-exception → 500.
+Every JSON error the API emits -- whether it comes from a
+``flask_smorest.abort()`` inside a route, from one of the global
+``@app.errorhandler`` functions below, or from a route helper returning an
+error tuple -- carries **one** shape::
+
+    {
+      "code": 404,                     # int HTTP status (flask-smorest)
+      "status": "Not Found",           # HTTP status name  (flask-smorest)
+      "message": "Detector 'x' not found",
+      "request_id": "ab12cd34...",     # ours; correlates the error with the logs
+      "errors": {...},                 # marshmallow validation errors, when any
+      "detail": "RuntimeError: ...",   # ours, on 500s
+      "error_code": "dataset_not_loaded",   # ours, when a slug is useful
+      ...                              # any extra kwargs passed to abort()
+    }
+
+That was not always true.  A hand-rolled ``{"error", "detail", "request_id"}``
+envelope used to coexist with flask-smorest's ``{"code", "status", "message",
+"errors"}``, and a third flavour (a bare ``jsonify({"error": ...})``) carried no
+``request_id`` at all.  The Angular client had to read both spellings -- an
+``apiErrorMessage`` helper imported by seventeen components existed for no other
+reason -- while the ~350 ``abort()`` sites, the overwhelming majority of the
+API's errors, were the ones *without* a ``request_id``.
+:class:`VTSearchApi` folds our additions into flask-smorest's payload instead,
+so there is one envelope, documented once in the OpenAPI spec, and every API
+error is quotable in a bug report.
+
+The module also holds the ``@app.errorhandler`` functions that used to live
+inline in ``app.py``: JSON 404/405 for ``/api/`` paths, the dataset/detector
+not-loaded -> 409 mappings, the request-missing-context -> 400 mapping, and
+the catch-all uncaught-exception -> 500.
 
 ``app.py`` calls :func:`register_error_handlers` to wire them onto its
 module-level ``app``. Registration is explicit (rather than via
@@ -11,9 +38,17 @@ module-level ``app``. Registration is explicit (rather than via
 are registered in is preserved and obvious.
 """
 
-import logging
+from __future__ import annotations
 
-from werkzeug.exceptions import MethodNotAllowed, NotFound
+import logging
+from typing import Any
+
+import marshmallow as ma
+from flask import g, jsonify
+from flask_smorest import Api
+from flask_smorest.error_handler import ErrorSchema as _SmorestErrorSchema
+from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound
+from werkzeug.http import HTTP_STATUS_CODES
 
 from vtscore.state.core import (
     DatasetNotLoadedError,
@@ -21,39 +56,174 @@ from vtscore.state.core import (
     RequestMissingContextError,
 )
 
+#: ``abort()`` kwargs the framework consumes itself: the first four are read by
+#: flask-smorest's handler, and ``schema`` / ``exc`` are webargs internals it
+#: attaches on a validation failure (the live marshmallow ``Schema`` and the
+#: ``ValidationError``).  Everything else a route passes (``available=[...]``,
+#: ``dataset_id=...``) is surfaced verbatim as a top-level field -- what the
+#: hand-rolled envelope's ``**extra`` used to do.
+_SMOREST_RESERVED = frozenset({"message", "errors", "messages", "headers", "schema", "exc"})
+
+
+def _json_safe(value: Any) -> bool:
+    """True when *value* is a JSON primitive or a container built only of them.
+
+    A belt-and-braces guard on the ``abort()`` kwarg pass-through: a future
+    webargs/smorest release attaching a new non-serializable internal would
+    otherwise 500 the very handler meant to render the error.  Cheap because
+    it only ever runs on an error path.
+    """
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return True
+    if isinstance(value, (list, tuple)):
+        return all(_json_safe(v) for v in value)
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and _json_safe(v) for k, v in value.items())
+    return False
+
+
+class ErrorSchema(_SmorestErrorSchema):
+    """flask-smorest's error schema plus the fields VTSearch adds.
+
+    Documents the envelope in ``/api/openapi.json`` (as the ``Error``
+    component, keeping the name flask-smorest's own schema had) so the
+    generated client and the snapshot at ``frontend/openapi.json`` describe
+    what the app actually sends.  Like its base class it is never used to
+    *dump* a payload -- :meth:`VTSearchApi.handle_http_exception` and
+    :func:`error_payload` build the dict -- it exists purely for the spec.
+
+    ``unknown = INCLUDE`` renders as ``additionalProperties: true``, which is
+    the honest description: a route's ``abort()`` may add fields of its own
+    (``available``, ``missing_fields``, ``dataset_id``) that no fixed schema
+    can enumerate.
+    """
+
+    class Meta(_SmorestErrorSchema.Meta):
+        unknown = ma.INCLUDE
+
+    request_id = ma.fields.String(metadata={"description": "Correlates the error with the server logs"})
+    detail = ma.fields.String(metadata={"description": "Exception type and first line, on 500s"})
+    error_code = ma.fields.String(metadata={"description": "Machine-readable slug, e.g. 'dataset_not_loaded'"})
+
+
+class VTSearchApi(Api):
+    """``flask_smorest.Api`` whose error payload carries ``request_id``.
+
+    flask-smorest's own handler renders ``{code, status, message, errors}``
+    and drops every other ``abort()`` kwarg on the floor.  This override adds
+    the three things the retired hand-rolled envelope had and smorest's does
+    not:
+
+    * ``request_id``, pulled from :data:`flask.g` (set by ``before_request``),
+      so a user can quote it in a bug report and an operator can grep for it.
+    * a ``message`` fallback, so a bare ``abort(404)`` or a werkzeug-raised
+      ``NotFound`` still names the status instead of omitting the key.  That
+      is what lets :func:`_handle_404` delegate here and stop discarding every
+      ``abort(404, message=...)`` body.
+    * pass-through of unreserved ``abort()`` kwargs as top-level fields.
+    """
+
+    ERROR_SCHEMA = ErrorSchema
+
+    def handle_http_exception(self, error):
+        payload, code, headers = super().handle_http_exception(error)
+        if not payload.get("message"):
+            payload["message"] = error.name
+        rid = getattr(g, "request_id", None)
+        if rid:
+            payload["request_id"] = rid
+        for key, value in (getattr(error, "data", None) or {}).items():
+            if key not in _SMOREST_RESERVED and key not in payload and _json_safe(value):
+                payload[key] = value
+        return payload, code, headers
+
+
+def error_payload(message: str, status: int, detail: Any | None = None, **extra: Any) -> dict[str, Any]:
+    """Build the envelope described in this module's docstring, as a dict.
+
+    Used by the error handlers below -- which hold an exception rather than a
+    live request they could ``abort()`` out of -- and by the handful of route
+    helpers that return an error tuple.  Routes themselves should call
+    ``flask_smorest.abort(status, message=..., **extra)``; it lands on
+    :meth:`VTSearchApi.handle_http_exception` and produces the same shape.
+
+    ``request_id`` is omitted outside a request context (background threads),
+    where :data:`flask.g` has none.
+    """
+    body: dict[str, Any] = {
+        "code": status,
+        "status": HTTP_STATUS_CODES.get(status, "Unknown Error"),
+        "message": message,
+    }
+    rid = getattr(g, "request_id", None)
+    if rid:
+        body["request_id"] = rid
+    if detail is not None:
+        body["detail"] = detail
+    body.update(extra)
+    return body
+
+
+def error_response(message: str, status: int, detail: Any | None = None, **extra: Any):
+    """:func:`error_payload` as the ``(response, status)`` tuple a view returns."""
+    return jsonify(error_payload(message, status, detail, **extra)), status
+
+
+def _smorest_api(app):
+    """Return the app's :class:`VTSearchApi`, or ``None`` before it is wired.
+
+    The 404/405 handlers delegate to it rather than re-deriving the envelope,
+    so a ``NotFound`` raised by ``abort(404, message=...)`` renders exactly as
+    it would have without our more-specific handler in the way.
+    """
+    apis = (app.extensions.get("flask-smorest") or {}).get("apis") or {}
+    for entry in apis.values():
+        return entry.get("ext_obj")
+    return None
+
+
+def _delegate_to_smorest(exc):
+    """Render *exc* through the flask-smorest handler, falling back to ours."""
+    from flask import current_app
+
+    api = _smorest_api(current_app)
+    if api is not None:
+        return api.handle_http_exception(exc)
+    data = getattr(exc, "data", None) or {}
+    return error_response(data.get("message") or exc.name, exc.code or 500)
+
 
 def _handle_404(exc):
-    """JSON 404 for unknown ``/api/`` paths.
+    """JSON 404 for ``/api/`` paths, preserving the aborting route's message.
 
     Werkzeug's default 404 renders as HTML, which is awful for an SPA. The
     frontend ``ErrorService`` needs JSON to show a useful banner with the
     request_id. Non-API paths fall through to the SPA's catch-all route
     (which serves index.html for client-side routing).
 
-    Scoped to ``NotFound`` specifically so flask-smorest's own
-    ``HTTPException`` handler (which renders ``{message, errors}`` for
-    marshmallow validation failures and custom ``abort()`` calls) keeps
-    handling 400/422/etc.; Flask resolves the most specific exception
-    class first.
+    Flask resolves the most specific exception class first, so registering
+    anything for ``NotFound`` takes every 404 away from flask-smorest's
+    ``HTTPException`` handler -- including the ~85 ``abort(404, message=...)``
+    calls whose message rides on ``exc.data``.  This handler used to render
+    ``exc.name`` and nothing else, so every one of those messages ("Dataset
+    file missing for 'x'", "File not found: <name>", "Job not found") was
+    discarded before the client saw it.  It now decides only *whether* the
+    path is ours and hands the rendering back to smorest.
     """
     from flask import request as _req
 
-    from vtsearch.routes._shared import error_response
-
     if not _req.path.startswith("/api/"):
         return exc
-    return error_response(exc.name, 404)
+    return _delegate_to_smorest(exc)
 
 
 def _handle_405(exc):
     """JSON 405 for wrong-method requests on ``/api/`` paths. See _handle_404."""
     from flask import request as _req
 
-    from vtsearch.routes._shared import error_response
-
     if not _req.path.startswith("/api/"):
         return exc
-    return error_response(exc.name, 405)
+    return _delegate_to_smorest(exc)
 
 
 def _handle_dataset_not_loaded(exc):
@@ -63,28 +233,24 @@ def _handle_dataset_not_loaded(exc):
     dataset proxies and the header doesn't resolve to a loaded context.
     Replaces the silent fallback to the empty context that returned 200
     with stale data (logical-bug-audit H16). The frontend can
-    distinguish 409 + ``code="dataset_not_loaded"`` from a generic 500
-    and offer a load action.
+    distinguish 409 + ``error_code="dataset_not_loaded"`` from a generic
+    500 and offer a load action.
     """
-    from vtsearch.routes._shared import error_response
-
     return error_response(
         "Dataset is not loaded",
         409,
         dataset_id=exc.dataset_id,
-        code="dataset_not_loaded",
+        error_code="dataset_not_loaded",
     )
 
 
 def _handle_detector_not_loaded(exc):
     """Detector counterpart of :func:`_handle_dataset_not_loaded` (H16/H34)."""
-    from vtsearch.routes._shared import error_response
-
     return error_response(
         "Detector is not loaded",
         409,
         detector_id=exc.detector_id,
-        code="detector_not_loaded",
+        error_code="detector_not_loaded",
     )
 
 
@@ -101,8 +267,6 @@ def _handle_request_missing_context(exc):
     """
     from flask import request as _req
 
-    from vtsearch.routes._shared import error_response
-
     if not _req.path.startswith("/api/"):
         raise exc
     return error_response(str(exc), 400)
@@ -117,13 +281,11 @@ def _handle_uncaught_exception(exc):
     excluded so flask-smorest's own handler (and the 404/405 handlers
     above) keep their semantics.
     """
-    from werkzeug.exceptions import HTTPException as _HTTPException
-
-    if isinstance(exc, _HTTPException):
+    if isinstance(exc, HTTPException):
         return exc
     from flask import request as _req
 
-    from vtsearch.routes._shared import error_response, format_exception_detail
+    from vtsearch.routes._shared import format_exception_detail
 
     logging.getLogger(__name__).exception("Unhandled exception on %s %s", _req.method, _req.path)
     if not _req.path.startswith("/api/"):

--- a/vtsearch/hooks.py
+++ b/vtsearch/hooks.py
@@ -119,9 +119,9 @@ def _enforce_auth():
             return None
     except Exception:
         logging.getLogger(__name__).exception("Login provider auth check failed; rejecting request (fail closed)")
-    from vtsearch.routes._shared import error_response
+    from vtsearch.errors import error_response
 
-    body, status = error_response("Authentication required", 401, code="auth_required")
+    body, status = error_response("Authentication required", 401, error_code="auth_required")
     body.status_code = status
     try:
         challenge = provider.www_authenticate()

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
-from flask import g, jsonify, make_response, request, send_file
+from flask import make_response, request, send_file
 from flask_smorest import abort
 from marshmallow import ValidationError
 from werkzeug.exceptions import HTTPException
@@ -18,6 +18,7 @@ from vtscore.concurrency.progress import update_find_progress
 from vtscore.embedding.media_vectors import EMBEDDINGS_KEY
 from vtscore.utils.hashing import content_md5, new_md5
 from vtscore.utils.hits import hit_custom_metadata
+from vtsearch.errors import error_response
 
 if TYPE_CHECKING:
     from vtscore.plugins import PluginBase
@@ -214,28 +215,6 @@ def find_idle_on_crash(recorder: Any = None) -> Iterator[None]:
             recorder.finish(ok=False)
         find_idle()
         raise
-
-
-def error_response(error: str, status: int, detail: Any | None = None, **extra: Any):
-    """Build a standardized JSON error response.
-
-    Shape::
-
-        {"error": "<short message>", "detail": <optional>, "request_id": "<id>", ...extra}
-
-    ``request_id`` is pulled from ``flask.g`` when available, so clients can
-    quote it in bug reports and operators can correlate it with structured
-    logs. Additional keyword args become top-level fields (e.g.
-    ``missing_fields=[...]``).
-    """
-    body: dict[str, Any] = {"error": error}
-    if detail is not None:
-        body["detail"] = detail
-    rid = getattr(g, "request_id", None)
-    if rid:
-        body["request_id"] = rid
-    body.update(extra)
-    return jsonify(body), status
 
 
 def get_json_safe() -> dict:

--- a/vtsearch/routes/datasets/_helpers.py
+++ b/vtsearch/routes/datasets/_helpers.py
@@ -9,8 +9,9 @@ import json
 from pathlib import PurePosixPath
 from typing import Any
 
-from flask import jsonify, request
+from flask import request
 
+from vtsearch.errors import error_response
 from vtsearch.routes._shared import get_json_safe
 
 
@@ -42,14 +43,14 @@ def _extract_clipper_params(has_file_fields: bool) -> tuple[dict | None, Any]:
         try:
             parsed = json.loads(raw)
         except (ValueError, TypeError) as exc:
-            return None, (jsonify({"error": f"Invalid clipper_params: {exc}"}), 400)
+            return None, error_response(f"Invalid clipper_params: {exc}", 400)
     else:
         parsed = get_json_safe().get("clipper_params")
         if parsed is None or parsed == "":
             return None, None
 
     if not isinstance(parsed, dict):
-        return None, (jsonify({"error": "clipper_params must be a JSON object"}), 400)
+        return None, error_response("clipper_params must be a JSON object", 400)
     return parsed, None
 
 

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -7,10 +7,10 @@ Schema-level validation failures (missing required ``name`` on rename,
 missing or wrong-typed ``readers`` on the readers endpoint) surface as
 422 with the standard ``errors`` envelope; handler-level rejects (not
 loaded, not the creator) keep their HTTP codes (400 / 403 / 404 / 500)
-with the standard ``message`` envelope. 404s are intercepted by the
-app-level ``NotFound`` errorhandler in ``app.py`` and keep the legacy
-``{"error": "Not Found", "request_id": ...}`` shape regardless of the
-``message=`` kwarg passed to ``abort()``.
+with the standard ``message`` envelope. 404s pass through the app-level
+``NotFound`` errorhandler (which renders JSON for ``/api/`` paths rather
+than werkzeug's HTML page) and keep their ``abort(404, message=...)``
+text.
 
 Endpoints
 ---------

--- a/vtsearch/routes/datasets/ui.py
+++ b/vtsearch/routes/datasets/ui.py
@@ -399,9 +399,9 @@ def detect_media_type(query: dict):
     user selects a folder and pre-fills the dropdown with whichever type
     has the most matching files in the first ``limit`` files of the tree.
 
-    The 404 returned when the source is unavailable on disk is
-    intercepted by the app-level ``NotFound`` errorhandler and keeps the
-    legacy ``{"error": "Not Found", "request_id": ...}`` envelope.
+    The 404 returned when the source is unavailable on disk passes through
+    the app-level ``NotFound`` errorhandler (JSON rather than werkzeug's
+    HTML page) with its ``message`` intact.
     """
     from vtscore.datasets.media_type_detection import detect_media_types_in_folder
 

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -54,6 +54,7 @@ from vtscore.detectors.store import (
     _write_detector,
 )
 from vtscore.detectors.workflow import apply_and_retrain as _apply_and_retrain
+from vtsearch.errors import error_response
 from vtsearch.routes._shared import image_thumbnail_response, require_dataset_header, require_detector_header
 from vtsearch.schemas.detectors import (
     DetectorLabelsDetailResponseSchema,
@@ -322,7 +323,7 @@ def import_labels_into_detector(name: str, importer_name: str):
     path = _detector_path(name)
     data = _read_detector(path)
     if data is None:
-        return jsonify({"error": f"Detector '{name}' not found"}), 404
+        return error_response(f"Detector '{name}' not found", 404)
 
     from vtscore.labels.importers import get_label_importer, list_label_importers
     from vtsearch.routes._shared import (
@@ -342,14 +343,14 @@ def import_labels_into_detector(name: str, importer_name: str):
     if err:
         return err
     if not isinstance(label_entries, list):
-        return jsonify({"error": "Importer did not return a list of label dicts."}), 500
+        return error_response("Importer did not return a list of label dicts.", 500)
 
     # ------------------------------------------------------------------
     # 1) Merge into the persisted labelset (always, whether loaded or not)
     # ------------------------------------------------------------------
     merged = _merge_labels_into_detector_file(path, label_entries)
     if merged is None:
-        return jsonify({"error": f"Detector '{name}' not found"}), 404
+        return error_response(f"Detector '{name}' not found", 404)
     existing_ls, applied, skipped, new_entries = merged
 
     # Update the detector registry entry

--- a/vtsearch/routes/detectors/registry.py
+++ b/vtsearch/routes/detectors/registry.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from flask import jsonify
 from flask_smorest import Blueprint, abort
 
+from vtsearch.errors import error_response
 from vtsearch.auth import get_current_user
 from vtscore.detectors.embedder_type import detector_embedder_type_from_data
 from vtscore.detectors.store import (
@@ -369,7 +370,7 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
     if err:
         return err
     if not isinstance(label_entries, list):
-        return jsonify({"error": "Importer did not return a list of label dicts."}), 500
+        return error_response("Importer did not return a list of label dicts.", 500)
 
     elements: list[LabeledElement] = []
     detected_types: set[str] = set()
@@ -389,25 +390,19 @@ def register_detector_from_labelset(importer_name: str):  # noqa: C901
         applied += 1
 
     if not detected_types:
-        return jsonify(
-            {
-                "error": (
-                    "Could not infer media type from the imported labels; none of "
-                    "the entries carry origin information with a detectable type. "
-                    "Re-export the labels with origin metadata, or use a different "
-                    "importer."
-                ),
-            }
-        ), 400
+        return error_response(
+            "Could not infer media type from the imported labels; none of "
+            "the entries carry origin information with a detectable type. "
+            "Re-export the labels with origin metadata, or use a different "
+            "importer.",
+            400,
+        )
     if len(detected_types) > 1:
-        return jsonify(
-            {
-                "error": (
-                    f"Imported labels span multiple media types: {sorted(detected_types)}. "
-                    "A detector must be for a single media type."
-                ),
-            }
-        ), 400
+        return error_response(
+            f"Imported labels span multiple media types: {sorted(detected_types)}. "
+            "A detector must be for a single media type.",
+            400,
+        )
 
     media_type = next(iter(detected_types))
     labelset = LabelSet(elements)

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -340,7 +340,10 @@ def eval_train_and_score_result(query: dict):
 
     job = eval_jobs.get(job_id)
     if job is None:
-        abort(404, message="Job not found", job_id=job_id, status="missing")
+        # ``job_status``, not ``status``: the error envelope's own ``status``
+        # is the HTTP status name, and an extra kwarg never overwrites an
+        # envelope field (see ``VTSearchApi.handle_http_exception``).
+        abort(404, message="Job not found", job_id=job_id, job_status="missing")
 
     if job.status in ("running", "pending"):
         # Read progress from the job itself (not the global ``eval_progress``

--- a/vtsearch/routes/file_browser.py
+++ b/vtsearch/routes/file_browser.py
@@ -9,9 +9,9 @@ Migrated to ``flask_smorest`` so the route is described in
 failures (e.g. unparseable query params) surface as 422 with the
 standard ``errors`` envelope; handler-level rejects (path traversal,
 permission denied) keep their HTTP codes (400 / 403) with the standard
-``message`` envelope. 404s are intercepted by the app-level
-``NotFound`` errorhandler in ``app.py`` and keep the legacy
-``{"error": "Not Found", "request_id": ...}`` shape.
+``message`` envelope, as do 404s -- the app-level ``NotFound``
+errorhandler renders JSON for ``/api/`` paths rather than werkzeug's HTML
+page, but hands the rendering back to flask-smorest.
 
 Endpoints
 ---------

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -66,6 +66,7 @@ from flask_smorest import Blueprint
 logger = logging.getLogger(__name__)
 
 from vtscore.labels.importers import get_label_importer, list_label_importers
+from vtsearch.errors import error_response
 from vtsearch.routes._shared import (
     get_plugin_or_404,
     plugin_field_options,
@@ -281,7 +282,7 @@ def run_label_import(importer_name: str):  # noqa: C901
         return err
 
     if not isinstance(label_entries, list):
-        return jsonify({"error": "Importer did not return a list of label dicts."}), 500
+        return error_response("Importer did not return a list of label dicts.", 500)
 
     # Apply labels to global vote state
     origin_lookup, md5_lookup, name_lookup = cached_media_lookups()

--- a/vtsearch/routes/media/embed.py
+++ b/vtsearch/routes/media/embed.py
@@ -35,6 +35,7 @@ from flask_smorest import Blueprint
 from vtscore.config import DATA_DIR
 from vtscore.media import all_embedders, get_by_extension, get_embedder
 from vtscore.media.embedder import media_from_path
+from vtsearch.errors import error_response
 from vtsearch.routes._shared import get_json_or_400
 
 embed_bp = Blueprint(
@@ -51,10 +52,7 @@ logger = logging.getLogger(__name__)
 
 def _unknown_embedder_response(name: str):
     available = sorted(e.name for e in all_embedders())
-    return (
-        jsonify({"error": f"Unknown embedder '{name}'. Available: {available}"}),
-        404,
-    )
+    return error_response(f"Unknown embedder '{name}'. Available: {available}", 404, available=available)
 
 
 def _vector_response(vec, embedder):
@@ -98,7 +96,7 @@ def _embed_text_json():
 
     name = str(data.get("embedder") or "").strip()
     if not name:
-        return jsonify({"error": "embedder is required"}), 400
+        return error_response("embedder is required", 400)
 
     try:
         embedder = get_embedder(name)
@@ -107,28 +105,18 @@ def _embed_text_json():
 
     text = data.get("text")
     if not isinstance(text, str) or not text.strip():
-        return (
-            jsonify(
-                {
-                    "error": (
-                        "text is required for JSON input. "
-                        "To embed a media file instead, send a multipart/form-data "
-                        "request with a 'file' field."
-                    )
-                }
-            ),
+        return error_response(
+            "text is required for JSON input. "
+            "To embed a media file instead, send a multipart/form-data "
+            "request with a 'file' field.",
             400,
         )
 
     if not embedder.supports_text:
-        return (
-            jsonify(
-                {
-                    "error": f"Embedder '{embedder.name}' does not support text input.",
-                    "supports_text": False,
-                }
-            ),
+        return error_response(
+            f"Embedder '{embedder.name}' does not support text input.",
             400,
+            supports_text=False,
         )
 
     try:
@@ -136,10 +124,10 @@ def _embed_text_json():
         vec = embedder.embed_text(text)
     except Exception as exc:
         logger.exception("embed text failed for '%s'", name)
-        return jsonify({"error": f"Embedding failed: {exc}"}), 500
+        return error_response(f"Embedding failed: {exc}", 500)
 
     if vec is None:
-        return jsonify({"error": f"Embedder '{embedder.name}' returned no vector for the text"}), 500
+        return error_response(f"Embedder '{embedder.name}' returned no vector for the text", 500)
 
     return _vector_response(vec, embedder)
 
@@ -147,7 +135,7 @@ def _embed_text_json():
 def _embed_media_upload():
     name = str(request.form.get("embedder") or "").strip()
     if not name:
-        return jsonify({"error": "embedder is required"}), 400
+        return error_response("embedder is required", 400)
 
     try:
         embedder = get_embedder(name)
@@ -156,23 +144,17 @@ def _embed_media_upload():
 
     file = request.files.get("file")
     if file is None or not file.filename:
-        return jsonify({"error": "file is required"}), 400
+        return error_response("file is required", 400)
 
     suffix = Path(file.filename).suffix
     detected = get_by_extension(suffix.lower()) if suffix else None
     if detected is not None and detected.type_id != embedder.media_type_id:
-        return (
-            jsonify(
-                {
-                    "error": (
-                        f"Embedder '{embedder.name}' expects {embedder.media_type_id} files, "
-                        f"but the uploaded file looks like {detected.type_id} (extension '{suffix}')."
-                    ),
-                    "expected_media_type": embedder.media_type_id,
-                    "detected_media_type": detected.type_id,
-                }
-            ),
+        return error_response(
+            f"Embedder '{embedder.name}' expects {embedder.media_type_id} files, "
+            f"but the uploaded file looks like {detected.type_id} (extension '{suffix}').",
             400,
+            expected_media_type=embedder.media_type_id,
+            detected_media_type=detected.type_id,
         )
 
     DATA_DIR.mkdir(exist_ok=True)
@@ -184,20 +166,13 @@ def _embed_media_upload():
             vec = embedder.embed_media(media_from_path(temp_path))
         except Exception as exc:
             logger.exception("embed media failed for '%s'", name)
-            return jsonify({"error": f"Embedding failed: {exc}"}), 500
+            return error_response(f"Embedding failed: {exc}", 500)
 
         if vec is None:
-            return (
-                jsonify(
-                    {
-                        "error": (
-                            f"Embedder '{embedder.name}' (media_type={embedder.media_type_id}) "
-                            f"could not embed the uploaded file."
-                        ),
-                        "media_type": embedder.media_type_id,
-                    }
-                ),
+            return error_response(
+                f"Embedder '{embedder.name}' (media_type={embedder.media_type_id}) could not embed the uploaded file.",
                 400,
+                media_type=embedder.media_type_id,
             )
         return _vector_response(vec, embedder)
     finally:

--- a/vtsearch/routes/settings/io.py
+++ b/vtsearch/routes/settings/io.py
@@ -35,6 +35,7 @@ import logging
 from flask import jsonify
 from flask_smorest import Blueprint, abort
 
+from vtsearch.errors import error_response
 from vtsearch import settings
 from vtsearch.routes._shared import (
     get_plugin_or_404,
@@ -107,7 +108,7 @@ def run_settings_import(importer_name: str):
         return err
 
     if not isinstance(imported_settings, dict):
-        return jsonify({"error": "Importer did not return a valid settings dict"}), 500
+        return error_response("Importer did not return a valid settings dict", 500)
 
     # Apply imported settings through the settings API
     _apply_settings(imported_settings)

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -484,12 +484,6 @@ def learned_sort_result(query: dict):
 
     job = learned_sort_jobs.get(job_id)
     if job is None:
-        # 404s are intercepted by the app-level ``NotFound`` errorhandler
-        # in ``app.py`` and rendered with the legacy
-        # ``{"error": "Not Found", "request_id": "..."}`` envelope; the
-        # ``message`` kwarg and any extras (e.g. ``status="missing"``)
-        # are dropped. Frontends rely on the HTTP status code for the
-        # missing-job branch rather than a body field.
         abort(404, message="Job not found")
 
     if job.status in ("running", "pending"):


### PR DESCRIPTION
Two incompatible error envelopes coexisted: a hand-rolled `{error, detail, request_id}` (every global handler plus a dozen route sites) and flask-smorest's `{code, status, message, errors}` (~350 `abort()` calls). A third flavour, a bare `jsonify({"error": ...})` at 15 sites, carried no `request_id` at all.

## Why it was worth doing

The issue's framing — "the frontend pays for both" — undersells it. The interceptor's two-spelling lookup is three lines, but there is also a whole shared helper, `frontend/src/app/utils/api-error.ts`, imported by seventeen components *solely* to read both keys, plus two more hand-rolled copies of the same dual read (`folder-browser.component.ts`, `browse-prep.service.ts`).

The backend cost was larger and invisible from the frontend: `request_id` — the id a user quotes in a bug report and an operator greps the structured logs for — was present only on the *rarer* envelope. The overwhelming majority of API errors had none.

## What changed

Everything now renders flask-smorest's shape, with three additions folded in by a `VTSearchApi.handle_http_exception` override:

- `request_id`, from `flask.g`.
- A `message` fallback, so a bare `abort(404)` or a werkzeug-raised `NotFound` names its status rather than omitting the key.
- Pass-through of unreserved `abort()` kwargs as top-level fields — what the hand-rolled envelope's `**extra` did, and what smorest drops.

`error_response` survives as the builder the global handlers need (they hold an exception, not a request they can `abort()` out of), but moved to `vtsearch/errors.py` beside the one envelope it now emits. The 15 raw `jsonify({"error": ...})` sites go through it too, so they gain a `request_id` they never had.

## Also fixes the August audit's 404-message item

`Refs` in the issue said this unblocks it; it turned out to be the same change. The global `NotFound` handler exists so unknown `/api/` paths render JSON rather than werkzeug's HTML page, but Flask resolves the most specific exception class first — so it took *every* 404 away from flask-smorest and rendered the literal `"Not Found"`, silently discarding the message from ~85 `abort(404, message=...)` sites (`File not found: <name>`, `Dataset file missing for '<x>'`, `Job not found`). It now decides only whether the path is ours and hands the rendering back. Several tests pinned the loss as intended behaviour and now pin the message instead.

The proposal item is deleted from `docs/plans/codebase-audit-2026-08.md`.

## Contract changes

All internal (the SPA ships with the server), but worth naming:

| Was | Is | Why |
|---|---|---|
| `error` | `message` | One key for the human-readable message. |
| `code: "auth_required"` | `error_code: "auth_required"` | smorest's `code` is the numeric HTTP status; the slug needed a different key. Also `dataset_not_loaded`, `detector_not_loaded`. |
| `abort(..., status="missing")` | `job_status="missing"` | Same collision, in `eval_train_and_score_result`. It was never visible to a client before — the 404 handler dropped it. |

The OpenAPI `Error` schema gains `request_id` / `detail` / `error_code` and `additionalProperties: true` (routes add fields no fixed schema can enumerate); snapshot regenerated. The component keeps the name `Error`, so the generated TS client type is unchanged.

One sharp edge found by the tests: webargs attaches the live marshmallow `Schema` and the `ValidationError` to `exc.data` alongside `messages`, so a naive pass-through 500s the very handler meant to render a 422. Those keys are reserved, and the pass-through additionally skips anything not JSON-serializable.

## Testing

Full `./run-tests.sh`: 9752 passed, 6 skipped, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

Closes #3422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Yo1qXrZdKkHfDSucnUdn4

---
_Generated by [Claude Code](https://claude.ai/code/session_017Yo1qXrZdKkHfDSucnUdn4)_