### PR TITLE
Finish the subscription-teardown sweep: takeUntilDestroyed() is now the only idiom

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -322,8 +322,7 @@ this codebase, and it is silent.
 
 - **Consumers use `effect()`, not `subscribe()`.** A constructor `effect()`
   reading a signal auto-disposes with the component, which is why the
-  `takeUntil(destroy$)` / `ngOnDestroy` plumbing has been dropped wherever it
-  was the last user.
+  teardown plumbing has been dropped wherever it was the last user.
 - **Where a subscription is still needed, tear it down with
   `takeUntilDestroyed()`** — see "Subscription teardown vs. cancellation"
   below for the one distinction that decides it.
@@ -581,12 +580,19 @@ Drop the explicit `destroyRef` argument only in an injection context (a field
 initializer or the constructor body); anywhere else — `ngOnInit`,
 `ngAfterViewInit`, an event handler — it must be passed. The point of the
 idiom is that teardown is *declared at the subscription*, so adding a
-subscription can never forget to add a matching `unsubscribe()`. Two older
-idioms survive in the tree and are converted opportunistically, never
-introduced: a hand-rolled `destroy$ = new Subject<void>()` fired from
-`ngOnDestroy`, and a `subs: Subscription[]` array drained in `ngOnDestroy`.
-Both are strictly worse — the bookkeeping is manual and the compiler does not
-check it.
+subscription can never forget to add a matching `unsubscribe()`. It is now the
+**only** teardown idiom in the SPA: the hand-rolled `destroy$ = new
+Subject<void>()` fired from `ngOnDestroy` and the `subs: Subscription[]` array
+drained in `ngOnDestroy` are both gone, and neither may be reintroduced. Both
+were strictly worse — the bookkeeping was manual and the compiler did not check
+it — and the subject form had a hazard the sanctioned idiom does not: RxJS
+`takeUntil` never fires on a pre-completed notifier, so a subscription armed
+*after* `ngOnDestroy` ran was never torn down at all. `takeUntilDestroyed`
+completes such a subscription immediately.
+
+Because teardown rides on the `DestroyRef`, a **spec drives it with
+`fixture.destroy()`**, never by calling `ngOnDestroy()` by hand — a bare hook
+call runs only what the hook itself still does.
 
 **Cancellation** — "stop the *previous* one because a newer one supersedes
 it." This is not teardown and `takeUntilDestroyed()` cannot express it; the

--- a/docs/plans/httpresource-migration.md
+++ b/docs/plans/httpresource-migration.md
@@ -100,7 +100,7 @@ conversions.
   kept — migrate caller and callee together (repo "no shims" rule).
 - **Consumer migration.** Every `x$.subscribe(v => …)` becomes a **constructor
   `effect()`** that reads the signal; effects auto-dispose with the component, so
-  the matching `takeUntil(destroy$)` / `destroy$` / `OnDestroy` plumbing is
+  the matching `takeUntilDestroyed()` / `DestroyRef` / `OnDestroy` plumbing is
   dropped where it was the last user. Synchronous getter reads become signal
   calls, including in templates.
 - **`inject()` over constructor params.** Resource field initializers reference

--- a/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
+++ b/frontend/src/app/components/achievement-unlock-host/achievement-unlock-host.component.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AchievementsService } from '../../services/achievements.service';
 import { ToastService } from '../../services/toast.service';
 
@@ -11,14 +10,14 @@ import { ToastService } from '../../services/toast.service';
   imports: [],
   template: '',
 })
-export class AchievementUnlockHostComponent implements OnInit, OnDestroy {
+export class AchievementUnlockHostComponent implements OnInit {
   private achievements = inject(AchievementsService);
   private toast = inject(ToastService);
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    this.achievements.unlocks.pipe(takeUntil(this.destroy$)).subscribe((p) => {
+    this.achievements.unlocks.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((p) => {
       this.toast.success({
         message: `${p.tier_name}: ${p.name}`,
         detail: `Milestone reached: ${p.threshold.toLocaleString()}`,
@@ -29,10 +28,5 @@ export class AchievementUnlockHostComponent implements OnInit, OnDestroy {
         },
       });
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
+++ b/frontend/src/app/components/achievements-tab/achievements-tab.component.ts
@@ -2,15 +2,14 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   effect,
   inject,
-  OnDestroy,
   OnInit,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { AchievementBadgeComponent } from '../achievement-badge/achievement-badge.component';
 import { ProgressBarComponent } from '../progress-bar/progress-bar.component';
 import { IconComponent } from '../icon/icon.component';
@@ -43,7 +42,7 @@ interface AchievementRow extends AchievementEntry {
   templateUrl: './achievements-tab.component.html',
   styleUrl: './achievements-tab.component.scss',
 })
-export class AchievementsTabComponent implements OnInit, OnDestroy {
+export class AchievementsTabComponent implements OnInit {
   private achievements = inject(AchievementsService);
   private settingsState = inject(SettingsStateService);
   private cdr = inject(ChangeDetectorRef);
@@ -64,7 +63,7 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   };
   submitting = false;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private disableAchievements = false;
   private lastState: AchievementState | null = null;
 
@@ -77,16 +76,11 @@ export class AchievementsTabComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.achievements.state.pipe(takeUntil(this.destroy$)).subscribe((state) => {
+    this.achievements.state.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((state) => {
       this.lastState = state;
       this.applyState(state);
     });
     this.achievements.refresh();
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   /** Whether *id*'s row supports an expandable detail panel. */

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, HostListener, inject, NgZone, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, ElementRef, HostListener, inject, NgZone, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import {
   BrowseCanvasComponent,
   BrowseContextMenuEvent,
@@ -382,7 +381,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    *  than spilling onto the side panel or past the canvas edges. */
   contextBounds: DOMRect | null = null;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   /** The in-flight build poll, or ``null`` when no build is being watched. */
   private poll: PollHandle | null = null;
 
@@ -478,7 +477,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
 
     this.datasetsRegistryApi
       .getStatus()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (status) => {
           this.mediaType.set(status.media_type || '');
@@ -501,7 +500,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // load; genuine later changes reload directly.
     if (!this.subset) {
       this.activeContext.pair$
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
           if (this.initialLoadStarted) {
             this.loadProjection();
@@ -513,8 +512,6 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
     this.stopPoll();
     document.removeEventListener('mousemove', this.boundPanelMove);
     document.removeEventListener('mouseup', this.boundPanelUp);
@@ -978,7 +975,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (!meta.has_labels) return;
     this.projectionApi
       .getLabels(this.subset)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (resp) => {
           // Guard against a stale response landing after the projection moved on.
@@ -1222,7 +1219,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     }
     this.enterBuilding();
     this.buildRequest()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (resp) => {
           if (resp.status === 'ready') {
@@ -1261,7 +1258,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     const request$ = this.subset
       ? this.projectionApi.reprojectSubset(this.subsetIds)
       : this.projectionApi.reproject();
-    request$.pipe(takeUntil(this.destroy$)).subscribe({
+    request$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (resp) => {
         if (resp.status === 'ready') {
           // Defensive: a forced build always re-fits, but re-read meta anyway.
@@ -1305,7 +1302,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (ids.length === 0) return;
     this.mediasApi
       .voteBulk(ids, target)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => this.dropFromBrowse(ids, target),
         error: () =>
@@ -1342,7 +1339,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     }
     this.projectionApi
       .subsetRemove(removedIds)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (meta) => {
           // Leave the viewport where the user had it; don't yank the camera to
@@ -1464,7 +1461,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     this.stopPoll();
     this.projectionApi
       .getMeta(this.subset)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (meta) => this.applyMeta(meta),
         error: (err) => {

--- a/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
+++ b/frontend/src/app/components/context-pulldown/context-pulldown.component.ts
@@ -1,9 +1,10 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, HostListener, inject, input, OnDestroy, OnInit, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, effect, ElementRef, HostListener, inject, input, OnInit, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TitleCasePipe } from '@angular/common';
 import { NavigationEnd, Router } from '@angular/router';
 
-import { Observable, Subject } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { DatasetStateService } from '../../services/dataset-state.service';
 import { ActiveContextService } from '../../services/active-context.service';
 import { ContextSwitchService } from '../../services/context-switch.service';
@@ -66,7 +67,7 @@ interface PulldownRow {
   templateUrl: './context-pulldown.component.html',
   styleUrl: './context-pulldown.component.scss',
 })
-export class ContextPulldownComponent implements OnInit, OnDestroy {
+export class ContextPulldownComponent implements OnInit {
   private host = inject<ElementRef<HTMLElement>>(ElementRef);
   private router = inject(Router);
   private datasetState = inject(DatasetStateService);
@@ -118,7 +119,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   private prevImporterOpen = false;
   private prevDetectorOpen = false;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   /** Live mirror of the Dashboard's sort for this pulldown's table. Kept
    *  in sync via a subscription in `ngOnInit`. */
@@ -146,32 +147,32 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.datasetState.datasets$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+    this.datasetState.datasets$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.rebuildRows();
       this.maybeAutoSelectNewDataset();
     });
-    this.datasetState.detectors$.pipe(takeUntil(this.destroy$)).subscribe(() => this.rebuildRows());
+    this.datasetState.detectors$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.rebuildRows());
     // Read intent (not active) so the pulldown highlight updates the
     // moment the user picks a row, rather than waiting for any
     // dataset/detector load to finish.
     this.activeContext.intentPair$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.rebuildRows());
-    this.datasetState.error$.pipe(takeUntil(this.destroy$)).subscribe((err) => {
+    this.datasetState.error$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((err) => {
       this.registryError = err;
       // Written from an async subscribe; notify the scheduler so the error row
       // repaints under zoneless.
       this.cdr.markForCheck();
     });
 
-    this.newThingFlows.created$.pipe(takeUntil(this.destroy$)).subscribe(({ kind, id }) => {
+    this.newThingFlows.created$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ kind, id }) => {
       if (kind !== this.kind() || !id || !this.awaitingNew) return;
       this.sawSuccessSignal = true;
       this.awaitingNew = false;
       this.switchToNewItem(id);
     });
     if (this.isDataset) {
-      this.newThingFlows.importStarted$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.newThingFlows.importStarted$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
         if (!this.awaitingNew) return;
         this.sawSuccessSignal = true;
         this.knownIdsAtAddStart = new Set(this.datasetState.datasets.map((d) => d.id));
@@ -180,13 +181,13 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     // Cancel the await if the user dismisses the underlying modal
     // without submitting. Without this, a later registry refresh from
     // an unrelated source would auto-select an unrelated dataset.
-    this.newThingFlows.importer$.pipe(takeUntil(this.destroy$)).subscribe((state) => {
+    this.newThingFlows.importer$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((state) => {
       const closing = this.prevImporterOpen && !state.open;
       this.prevImporterOpen = state.open;
       if (!closing || !this.isDataset) return;
       if (this.awaitingNew && !this.sawSuccessSignal) this.awaitingNew = false;
     });
-    this.newThingFlows.newDetector$.pipe(takeUntil(this.destroy$)).subscribe((state) => {
+    this.newThingFlows.newDetector$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((state) => {
       const closing = this.prevDetectorOpen && !state.open;
       this.prevDetectorOpen = state.open;
       if (!closing || this.isDataset) return;
@@ -195,7 +196,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
 
     this.pulldownControl
       .openSignal$(this.kind())
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.openMenu());
 
     // Mirror of the Dashboard table's sort. Read through
@@ -203,7 +204,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     // so this eager component doesn't pull the column-management code onto
     // the initial bundle.
     const sortState$: Observable<SortState> = this.dashboardSort.sort$(this.kind());
-    sortState$.pipe(takeUntil(this.destroy$)).subscribe((state) => {
+    sortState$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((state) => {
       this.sortState = state;
       this.rebuildRows();
     });
@@ -212,7 +213,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     // pair lights up the spinner glyph here. The service polls lazily;
     // it only fires HTTP traffic while at least one component is
     // subscribed.
-    this.runningJobs.busyPairs$.pipe(takeUntil(this.destroy$)).subscribe((pairs) => {
+    this.runningJobs.busyPairs$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((pairs) => {
       this.busyPairs = pairs;
       this.rebuildRows();
     });
@@ -224,7 +225,7 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     this.router.events
       .pipe(
         filter((e): e is NavigationEnd => e instanceof NavigationEnd),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((e) => this.updateLocked(e.urlAfterRedirects));
 
@@ -242,11 +243,6 @@ export class ContextPulldownComponent implements OnInit, OnDestroy {
     // Written from the router-events subscribe (async callback), so notify the
     // scheduler to repaint the trigger's disabled state under zoneless.
     this.cdr.markForCheck();
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   get isDataset(): boolean {

--- a/frontend/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/src/app/components/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, effect, HostListener, inject, OnDestroy, OnInit, Signal, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, HostListener, inject, OnDestroy, OnInit, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { NavigationCancel, NavigationEnd, NavigationError, Router } from '@angular/router';
 import { EMPTY, Subject, timer } from 'rxjs';
@@ -212,7 +213,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
   }
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private findPolling$ = new Subject<void>();
   /** Registry ids this mount has already seen, so `reconcileSelection` can
    *  tell "just appeared" from "was here when we arrived". Component state on
@@ -253,20 +254,20 @@ export class DashboardComponent implements OnInit, OnDestroy {
     // itself already lives in the service, so there is nothing to push.
     this.dashSelection.setDashboardVisible(true);
     this.authService.status$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((status) => {
         this.currentUser.set(status?.user || '');
         this.isDefaultLogin.set(status?.provider === 'default');
       });
     // Auto-select newly added items whenever the dataset/model lists change
     this.datasetState.datasets$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((datasets) => {
         this.reconcileSelection('dataset', datasets.map((d) => d.id));
         this.preloadSelectedEmbedders();
       });
     this.datasetState.detectors$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((models) => {
         this.reconcileSelection('detector', models.map((m) => m.id));
       });
@@ -284,7 +285,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     // guard, or errored). Without this, a guard redirect to /dashboard
     // would leave the icon waggling forever.
     this.router.events
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((e) => {
         if (
           e instanceof NavigationEnd ||
@@ -304,13 +305,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
    *  `AppComponent`; this component just reacts to their outcomes. */
   private subscribeNewThingFlows(): void {
     this.newThingFlows.importStarted$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.handleImportStarted());
     this.newThingFlows.demoSelected$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ demo }) => this.handleDemoSelected(demo));
     this.newThingFlows.created$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(({ kind, id }) => {
         if (kind === 'detector') this.handleDetectorCreated(id);
         else this.datasetState.refresh();
@@ -318,14 +319,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
     // Trigger the close-animation when the modal flips from open → closed.
     let importerWasOpen = false;
     this.newThingFlows.importer$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (importerWasOpen && !state.open) this.importerClosing.set(true);
         importerWasOpen = state.open;
       });
     let detectorWasOpen = false;
     this.newThingFlows.newDetector$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         if (detectorWasOpen && !state.open) {
           this.newDetectorClosing.set(true);
@@ -348,7 +349,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
         .pipe(
           filter((models) => models.some((m) => m.id === modelId)),
           take(1),
-          takeUntil(this.destroy$),
+          takeUntilDestroyed(this.destroyRef),
         )
         .subscribe(() => this.onLabel());
     }
@@ -357,7 +358,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private startDiskUsagePolling(): void {
     timer(0, 10000)
       .pipe(
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         switchMap(() => this.datasetsUiApi.getDiskUsage().pipe(catchError(() => EMPTY))),
       )
       .subscribe((usage) => {
@@ -368,7 +369,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private startRamUsagePolling(): void {
     timer(0, 10000)
       .pipe(
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         switchMap(() => this.datasetsUiApi.getRamUsage().pipe(catchError(() => EMPTY))),
       )
       .subscribe((usage) => {
@@ -399,8 +400,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
     // Off the Dashboard there are no tables to mirror; the pulldown reverts
     // to showing the active/loaded context.
     this.dashSelection.setDashboardVisible(false);
-    this.destroy$.next();
-    this.destroy$.complete();
     this.findPolling$.next();
     this.findPolling$.complete();
   }
@@ -944,7 +943,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
               return (!!t && (t.status === 'idle' || !!t.error)) || (!t && seenRunning);
             }),
             take(1),
-            takeUntil(this.destroy$),
+            takeUntilDestroyed(this.destroyRef),
           )
           .subscribe(() => {
             const failed = this.progressEvents.detectorLoadingTasks().some(
@@ -1356,7 +1355,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private startFindProgressPolling(): void {
     this.findPolling$.next(); // cancel previous
     this.progressEvents.find$
-      .pipe(takeUntil(this.findPolling$), takeUntil(this.destroy$))
+      .pipe(takeUntil(this.findPolling$), takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (progress: ProgressEvent) => {
           if (!progress || progress.status === 'idle') return;

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -1,7 +1,8 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, DestroyRef, effect, ElementRef, inject, NgZone, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { EMPTY, Subject, timer } from 'rxjs';
-import { catchError, finalize, switchMap, takeUntil } from 'rxjs/operators';
+import { catchError, finalize, switchMap } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -130,7 +131,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly RIGHT_MIN = 150;
   private readonly CENTER_MIN = 100;
   private readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   /**
    * Inclusion-slider values awaiting their `POST /api/inclusion`, funnelled
    * through a single debounced `switchMap` pipeline (wired in the constructor).
@@ -180,7 +181,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
             catchError(() => EMPTY),
           ),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((resp) => {
         if (resp.threshold != null && this.sortState.sortOrder) {
@@ -295,7 +296,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // loads + runFindLabel call above).
     let firstPair = true;
     this.activeContext.pair$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         if (firstPair) {
           firstPair = false;
@@ -322,8 +323,6 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnDestroy(): void {
     this.sortState.stopFindProgressTracking();
     // `pairScope` is component-provided, so Angular fires its scope on destroy.
-    this.destroy$.next();
-    this.destroy$.complete();
     this.inclusionRequests$.complete();
     this.voteState.setFindMode(false);
     this.voteState.stopPolling();
@@ -656,7 +655,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
         if (!ok) return;
         this.detectorsFindApi
           .addCorrectionsToDetector()
-          .pipe(takeUntil(this.destroy$))
+          .pipe(takeUntilDestroyed(this.destroyRef))
           .subscribe({
             next: (resp) => {
               if (resp.corrections_added === 0) {
@@ -792,7 +791,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
       if (!trimmed) return;
       this.datasetsCrudApi
         .promote(trimmed, ids)
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe({
           next: (res) => {
             this.loadingTasksSvc.startProgressPolling(res.task_id, () => {
@@ -810,7 +809,7 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
    *  a cancelled status via its progress channel and the finalize() in
    *  runFindLabel() takes care of clearing sortBusy. */
   onSortCancel(): void {
-    this.detectorsFindApi.cancelFind().pipe(takeUntil(this.destroy$)).subscribe();
+    this.detectorsFindApi.cancelFind().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 
   // --- Panel percentage helpers ---

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -1,8 +1,9 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, effect, ElementRef, inject, OnDestroy, OnInit, signal, untracked, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Subject, Subscription, of, pairwise, throwError } from 'rxjs';
-import { takeUntil, catchError, filter, take, tap } from 'rxjs/operators';
+import { Subscription, of, pairwise, throwError } from 'rxjs';
+import { catchError, filter, take, tap } from 'rxjs/operators';
 import { LeftPanelComponent } from '../left-panel/left-panel.component';
 import { CenterPanelComponent } from '../center-panel/center-panel.component';
 import { RightPanelComponent } from '../right-panel/right-panel.component';
@@ -153,10 +154,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly RIGHT_MIN = 150;
   readonly CENTER_MIN = 100;
   readonly DIVIDER_TOTAL = 16; // 2 × 8px dividers
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   // NOTE: a subscription started from `modelId$` (which emits *before*
-  // `pair$`) must stay on `destroy$`, or `reloadForNewPair`'s teardown would
-  // kill the request it just issued for the new pair.
+  // `pair$`) must stay on component teardown — `takeUntilDestroyed` — rather
+  // than the pair scope, or `reloadForNewPair`'s teardown would kill the
+  // request it just issued for the new pair.
   private statusPolling$: Subscription | null = null;
   private learnedSortPending = false;
   /** Active learned-sort job id while a training run is in flight. Set in
@@ -295,7 +297,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.pairScope.loadDatasetName();
 
     this.activeContext.modelId$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((modelId) => this.refreshTrainableModelName(modelId));
     this.refreshTrainableModelName(this.activeContext.modelId);
     this.pairScope.seedInclusion();
@@ -305,7 +307,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     // initial loads.
     let firstPair = true;
     this.activeContext.pair$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         if (firstPair) {
           firstPair = false;
@@ -315,7 +317,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       });
 
     this.autopilotStateService.state$
-      .pipe(pairwise(), takeUntil(this.destroy$))
+      .pipe(pairwise(), takeUntilDestroyed(this.destroyRef))
       .subscribe(([prev, curr]) => {
         if (prev.phase === curr.phase) return;
         this.autopilotExhausted.set(curr.phase === 'exhausted');
@@ -409,8 +411,6 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cancelSnapOnLoad();
     if (this.animatePopTimer) clearTimeout(this.animatePopTimer);
     // `pairScope` is component-provided, so Angular fires its scope on destroy.
-    this.destroy$.next();
-    this.destroy$.complete();
     this.voteState.stopPolling();
   }
 
@@ -607,7 +607,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       fastMs: 2000,
       slowMs: 10000,
     })
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (status) => {
           this.labelingStatus.set(status);
@@ -819,11 +819,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.currentLearnedSortJobId) {
       const jobId = this.currentLearnedSortJobId;
       this.currentLearnedSortJobId = null;
-      this.sortingApi.cancelLearnedSort(jobId).pipe(takeUntil(this.destroy$)).subscribe();
+      this.sortingApi.cancelLearnedSort(jobId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
       return;
     }
     if (this.sortState.sortMode === 'load') {
-      this.detectorsFindApi.cancelFind().pipe(takeUntil(this.destroy$)).subscribe();
+      this.detectorsFindApi.cancelFind().pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
     }
   }
 
@@ -1065,7 +1065,7 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       this.trainableModelName.set(null);
       return;
     }
-    this.detectorsRegistryApi.getRegistry().pipe(takeUntil(this.destroy$)).subscribe({
+    this.detectorsRegistryApi.getRegistry().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (resp) => {
         const entry = resp.detectors.find((m: DetectorRegistryEntry) => m.id === modelId);
         this.trainableModelName.set(entry?.name || null);

--- a/frontend/src/app/components/left-panel/media-list/media-list.component.ts
+++ b/frontend/src/app/components/left-panel/media-list/media-list.component.ts
@@ -1,8 +1,8 @@
-import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, effect, ElementRef, inject, input, NgZone, OnDestroy, OnInit, output, untracked, viewChild } from '@angular/core';
+import { AfterViewChecked, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, DestroyRef, effect, ElementRef, inject, input, NgZone, OnDestroy, OnInit, output, untracked, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ScrollingModule, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
-import { Subject, Subscription } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 import { MediaItemComponent } from '../media-item/media-item.component';
 import { Media } from '../../../models/api.models';
 import { MediaMetadataCacheService } from '../../../services/media-metadata-cache.service';
@@ -115,7 +115,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnDestroy {
   private selectedIdSeen = false;
   /** Previous ``gridGoalWidth`` value; ``null`` until the rebuild effect's first run. */
   private prevGridGoalWidth: number | null = null;
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   /** The viewport instance whose ``scrolledIndexChange`` is currently subscribed. */
   private scrollSubscribedViewport?: CdkVirtualScrollViewport;
   private scrollSub?: Subscription;
@@ -193,7 +193,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnDestroy {
     // When the cache hydrates new items, re-enrich the displayed rows so
     // visible items show their filename / score / metadata.
     this.metadataCache.version$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => this.rebuildOrderedItems());
   }
 
@@ -203,8 +203,6 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   ngOnDestroy(): void {
     this.resizeObserver?.disconnect();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   /**
@@ -395,7 +393,7 @@ export class MediaListComponent implements OnInit, AfterViewChecked, OnDestroy {
       this.scrollSubscribedViewport = virtualViewport;
       this.scrollSub?.unsubscribe();
       this.scrollSub = virtualViewport.scrolledIndexChange
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
           this.prefetchVisibleMetadata();
           this.maybeAutoLoadMore();

--- a/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
+++ b/frontend/src/app/components/modals/autodetect-results-modal/autodetect-results-modal.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, input, OnInit, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { ModalComponent } from '../../modal/modal.component';
 import {
   ClipboardColumn,
@@ -27,7 +26,7 @@ import { openExternalUrl, safeExternalUrl } from '../../../utils/external-url';
   templateUrl: './autodetect-results-modal.component.html',
   styleUrl: './autodetect-results-modal.component.scss',
 })
-export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
+export class AutoDetectResultsModalComponent implements OnInit {
   private exportersApi = inject(ExportersApiService);
   private templateVars = inject(PluginTemplateVarsService);
 
@@ -51,10 +50,10 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
     { key: 'origin', label: 'Origin' },
   ];
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    this.exportersApi.getExporters().pipe(takeUntil(this.destroy$)).subscribe({
+    this.exportersApi.getExporters().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (list) => {
         // Drop exporters the plugin author flagged hidden_from_picker, and
         // those that can't read a scored run - this picker's destination is
@@ -70,11 +69,6 @@ export class AutoDetectResultsModalComponent implements OnInit, OnDestroy {
         }
       },
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   /**

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -103,7 +103,7 @@ export class ExportModalComponent implements OnInit {
   // labels read is input-derived, so it waits for `ngOnInit` to set
   // `serverFilter` and flip `labelsReady`. All three wrap the generated-client
   // methods so the interceptor chain still applies, replacing the old
-  // `ngOnInit` subscribes + `destroy$` plumbing.
+  // `ngOnInit` subscribes + teardown plumbing.
   private readonly statusResource = rxResource({
     stream: () => this.datasetsRegistryApi.getStatus(),
   });

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.spec.ts
@@ -49,7 +49,11 @@ describe('ProgressModalComponent', () => {
   });
 
   afterEach(() => {
-    component.ngOnDestroy();
+    // `fixture.destroy()`, not a bare hook call: teardown here rides on the
+    // component's `DestroyRef`, which only fires when the fixture is
+    // destroyed. Destroy first, then verify — a cancelled request is not
+    // outstanding.
+    fixture.destroy();
     httpMock.verify();
   });
 
@@ -187,7 +191,7 @@ describe('ProgressModalComponent', () => {
 
   it('does not arm a poller when destroyed before the job envelope arrives', async () => {
     // Regression: destroying the modal while the train POST is in flight must
-    // not leave a poller running against an already-completed `destroy$`.
+    // not leave a poller running past the component's teardown.
     vi.useFakeTimers();
     try {
       fixture.componentRef.setInput('metric', 'diverse');
@@ -195,8 +199,8 @@ describe('ProgressModalComponent', () => {
       missCachedHistory('diverse');
 
       const trainReq = httpMock.expectOne('/api/eval/train-and-score');
-      component.ngOnDestroy();
-      // `takeUntil(destroy$)` unsubscribes from the in-flight POST, so the
+      fixture.destroy();
+      // `takeUntilDestroyed` unsubscribes from the in-flight POST, so the
       // request is cancelled: its `next` never runs, `pollEvalJob` is never
       // armed, and no result poll is issued.
       expect(trainReq.cancelled).toBe(true);
@@ -340,7 +344,7 @@ describe('ProgressModalComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('25%');
 
     // Drain the poller so `httpMock.verify()` sees no outstanding request.
-    component.ngOnDestroy();
+    fixture.destroy();
   });
 
   it('shows the empty state when a finished job yields no points', async () => {

--- a/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
+++ b/frontend/src/app/components/modals/progress-modal/progress-modal.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, OnDestroy, OnInit, output, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, ElementRef, inject, input, OnInit, output, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Subject, takeUntil, timer, switchMap, filter, take } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
@@ -24,7 +25,7 @@ export type ProgressMetric = 'smart' | 'stable' | 'diverse';
   templateUrl: './progress-modal.component.html',
   styleUrl: './progress-modal.component.scss',
 })
-export class ProgressModalComponent implements OnInit, OnDestroy {
+export class ProgressModalComponent implements OnInit {
   private sortingApi = inject(SortingApiService);
   private chartsService = inject(ChartsService);
   private settingsState = inject(SettingsStateService);
@@ -51,7 +52,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
    *  backend hands back a job envelope; consumed by ``onCancel``. */
   private currentJobId: string | null = null;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor() {
     // The canvas lives in the results `@else` branch, so it only exists one
@@ -86,16 +87,11 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     this.loadCachedHistory();
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
   private loadCachedHistory(): void {
     this.analyzing.set(true);
     this.sortingApi
       .getIndicatorScoreHistory(this.metric())
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
           // `complete: false` means the per-step cache is behind the label
@@ -127,12 +123,12 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     // dedicated notifier to stop watching once the bar reaches 100%: the
     // backend emits the `idle/Done` eval frame *inside* `_run`, before the
     // job flips to `done`, so this fires while the result poller is still
-    // polling. It must NOT tear down the poller — hence a separate subject
-    // rather than `this.destroy$.next()`, which would kill the poller too
-    // and leave `analyzing` hung forever.
+    // polling. It must NOT tear down the poller — hence a subject scoped to
+    // this one stream, rather than anything component-wide, which would kill
+    // the poller too and leave `analyzing` hung forever.
     const stopWatchingProgress$ = new Subject<void>();
     this.progressEvents.votingIterations$
-      .pipe(takeUntil(this.destroy$), takeUntil(stopWatchingProgress$))
+      .pipe(takeUntilDestroyed(this.destroyRef), takeUntil(stopWatchingProgress$))
       .subscribe({
         next: (res) => {
           if (res.total > 0) {
@@ -146,13 +142,17 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
       });
 
     // Request train-and-score; the new endpoint returns a job envelope.
-    // `takeUntil(destroy$)` guards the case where the modal is dismissed
-    // while the POST is in flight: without it, a late `next` would arm
-    // `pollEvalJob()` against an already-completed `destroy$` (RxJS
-    // `takeUntil` never fires on a pre-completed notifier), leaking a poller.
+    // Teardown here guards the case where the modal is dismissed while the
+    // POST is in flight: without it, a late `next` would arm `pollEvalJob()`
+    // on a dead component, leaking a poller. `takeUntilDestroyed` closes that
+    // from both ends — it stops this subscription at destroy, and a
+    // subscription armed *after* destroy completes immediately (its
+    // `destroyRef.destroyed` branch). A hand-rolled `takeUntil(destroy$)`
+    // could not do the second half: RxJS `takeUntil` never fires on a
+    // pre-completed notifier, so the poller would have run forever.
     this.sortingApi
       .trainAndScore(this.metric())
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
           if (res.status === 'done') {
@@ -173,7 +173,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
   private pollEvalJob(jobId: string): void {
     timer(200, 500)
       .pipe(
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         switchMap(() => this.sortingApi.getEvalTrainAndScoreResult(jobId)),
         filter((res) => res.status !== 'running'),
         take(1),
@@ -206,7 +206,7 @@ export class ProgressModalComponent implements OnInit, OnDestroy {
     const jobId = this.currentJobId;
     this.currentJobId = null;
     if (jobId) {
-      this.sortingApi.cancelEvalTrainAndScore(jobId).pipe(takeUntil(this.destroy$)).subscribe();
+      this.sortingApi.cancelEvalTrainAndScore(jobId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
     }
     this.analyzing.set(false);
     this.close();

--- a/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/auto-find/auto-find-settings.component.ts
@@ -1,8 +1,7 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, OnInit, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 import { IconComponent } from '../../../icon/icon.component';
 import { ImporterField } from '../../../../models/api.models';
@@ -40,7 +39,7 @@ export interface AutoFindExporterChange {
   templateUrl: './auto-find-settings.component.html',
   styleUrl: './auto-find-settings.component.scss',
 })
-export class AutoFindSettingsComponent implements OnInit, OnDestroy {
+export class AutoFindSettingsComponent implements OnInit {
   private exportersApi = inject(ExportersApiService);
 
   constructor() {
@@ -101,12 +100,12 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
    *  and the parent read) is re-derived from it on every commit. */
   private workingValues: Record<string, string> = {};
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
     this.exportersApi
       .getExporters()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (list) => {
           // Auto-Find runs its export on a scored run, so only exporters that
@@ -122,11 +121,6 @@ export class AutoFindSettingsComponent implements OnInit, OnDestroy {
           this.loadingExporters.set(false);
         },
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   // --- Results Exporter ----------------------------------------------------

--- a/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-modal/settings-modal.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input, OnDestroy, OnInit, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { FormsModule } from '@angular/forms';
-import { forkJoin, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { forkJoin } from 'rxjs';
 import { ModalComponent } from '../../modal/modal.component';
 import { IconComponent } from '../../icon/icon.component';
 import { SettingsImporterModalComponent } from '../settings-importer-modal/settings-importer-modal.component';
@@ -94,13 +94,11 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   readonly browserBlocksMotion = signal(browserPrefersReducedMotion());
   private reducedMotionCleanup: (() => void) | null = null;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnDestroy(): void {
     if (this.savedTimer !== null) clearTimeout(this.savedTimer);
     this.reducedMotionCleanup?.();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   ngOnInit(): void {
@@ -119,7 +117,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
       embedders: this.datasetsListingsApi.getEmbedders(),
       version: this.settingsApi.getVersion(),
     })
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
       next: (res) => {
         this.settings.set(res.settings);
@@ -614,7 +612,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     }
     this.settingsApi
       .getDefaults()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (defaults) => {
           this.settings.set(defaults);
@@ -635,7 +633,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
     // Reload settings from the server after import
     this.settingsApi
       .getSettings()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (s) => {
           this.settings.set(s);
@@ -653,7 +651,7 @@ export class SettingsModalComponent implements OnInit, OnDestroy {
   private save(): void {
     this.settingsState
       .update(this.settings())
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
           this.error.set('');

--- a/frontend/src/app/components/right-panel/right-panel.component.ts
+++ b/frontend/src/app/components/right-panel/right-panel.component.ts
@@ -1,7 +1,6 @@
-import { ChangeDetectionStrategy, Component, computed, effect, inject, input, OnDestroy, OnInit, output, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, input, OnDestroy, OnInit, output, signal, untracked } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { DetectorsRegistryApiService } from '../../services/detectors-registry-api.service';
 import type { DetectorLabelView } from '../../generated/api-client/models/detector-label-view';
 import { Media } from '../../models/api.models';
@@ -113,7 +112,7 @@ export class RightPanelComponent implements OnInit, OnDestroy {
     { fallback: 'M' },
   );
   readonly gridGoalWidth = computed(() => iconSizeToGoalWidth(this.gridIconSizeRight.value()));
-  private destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor() {
     // Track the active media type off the bound medias so the grid icon size
@@ -185,8 +184,6 @@ export class RightPanelComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.voteState.stopPolling();
     this.labelsetState.stopPolling();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   onSortModeChange(mode: LabelSortMode): void {
@@ -267,17 +264,17 @@ export class RightPanelComponent implements OnInit, OnDestroy {
 
   private subscribeToLabelset(): void {
     this.labelsetState.good$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((elements) => {
         this.goodElements.set(elements);
       });
     this.labelsetState.bad$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((elements) => {
         this.badElements.set(elements);
       });
     this.labelsetState.mediaType$
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((mt) => {
         if (this.useLabelset && mt && mt !== this.currentMediaType()) {
           this.currentMediaType.set(mt);

--- a/frontend/src/app/components/right-panel/right-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/right-panel/right-panel.zoneless.spec.ts
@@ -101,7 +101,9 @@ describe('RightPanelComponent', () => {
   });
 
   function cleanup(): void {
-    // Destroy component to cancel all subscriptions, then flush any outstanding
+    // Stops the two pollers the hook owns. The labelset subscriptions ride on
+    // the component's `DestroyRef` and outlive a bare hook call, so the
+    // discard below is what clears them out of `httpMock`.
     component.ngOnDestroy();
     const voteState = TestBed.inject(VoteStateService);
     voteState.stopPolling();

--- a/frontend/src/app/services/dataset-state.service.ts
+++ b/frontend/src/app/services/dataset-state.service.ts
@@ -1,14 +1,14 @@
-import { Injectable, OnDestroy, Signal, computed, inject, signal } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
+import { DestroyRef, Injectable, Signal, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { Subject, forkJoin, of } from 'rxjs';
-import { catchError, switchMap, takeUntil } from 'rxjs/operators';
+import { catchError, switchMap } from 'rxjs/operators';
 import { DatasetRegistryEntry } from '../models/api.models';
 import { DetectorRegistryEntry } from '../generated/api-client/models/detector-registry-entry';
 import { DatasetsRegistryApiService } from './datasets-registry-api.service';
 import { DetectorsRegistryApiService } from './detectors-registry-api.service';
 
 @Injectable({ providedIn: 'root' })
-export class DatasetStateService implements OnDestroy {
+export class DatasetStateService {
   private datasetsRegistryApi = inject(DatasetsRegistryApiService);
   private detectorsRegistryApi = inject(DetectorsRegistryApiService);
 
@@ -33,7 +33,7 @@ export class DatasetStateService implements OnDestroy {
    *  registry; on a deep-link cold start, the guard may run before the
    *  initial fetch lands. */
   private readonly _loaded = signal(false);
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   /** Emits whenever a refresh is requested; switchMap ensures only the latest response is used. */
   private readonly refreshTrigger$ = new Subject<void>();
 
@@ -57,7 +57,7 @@ export class DatasetStateService implements OnDestroy {
             detectors: this.detectorsRegistryApi.getRegistry(),
           }).pipe(catchError(() => of(null))),
         ),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: (res) => {
@@ -74,11 +74,6 @@ export class DatasetStateService implements OnDestroy {
           if (!this._loaded()) this._loaded.set(true);
         },
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   get datasets(): DatasetRegistryEntry[] {

--- a/frontend/src/app/services/labelset-state.service.ts
+++ b/frontend/src/app/services/labelset-state.service.ts
@@ -14,7 +14,6 @@ export class LabelsetStateService implements OnDestroy {
   private readonly badSubject = new BehaviorSubject<DetectorLabelView[]>([]);
   private readonly mediaTypeSubject = new BehaviorSubject<string>('');
   private readonly stopPolling$ = new Subject<void>();
-  private readonly destroy$ = new Subject<void>();
   private polling = false;
   private modelName: string | null = null;
 
@@ -24,8 +23,6 @@ export class LabelsetStateService implements OnDestroy {
 
   ngOnDestroy(): void {
     this.stopPolling();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   get good(): DetectorLabelView[] {

--- a/frontend/src/app/services/media-metadata-cache.service.ts
+++ b/frontend/src/app/services/media-metadata-cache.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, OnDestroy, inject, signal } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { DestroyRef, Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { BehaviorSubject } from 'rxjs';
 import type { MediaBatchResponse } from '../generated/api-client/models/media-batch-response';
 import { ActiveContextService } from './active-context.service';
 import { MediasApiService } from './medias-api.service';
@@ -40,7 +40,7 @@ export class MediaMetadataCacheService implements OnDestroy {
   private readonly cache = new Map<string, MediaBatchResponse>();
   private readonly pendingByDataset = new Map<string, Set<number>>();
   private batchTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
 
   /** Emits the current cache version (increments on every batch arrival). */
   private readonly versionSubject = new BehaviorSubject<number>(0);
@@ -61,8 +61,6 @@ export class MediaMetadataCacheService implements OnDestroy {
   readonly version = this.versionSignal.asReadonly();
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
     if (this.batchTimer) clearTimeout(this.batchTimer);
   }
 
@@ -172,7 +170,7 @@ export class MediaMetadataCacheService implements OnDestroy {
       const chunk = ids.slice(i, i + BATCH_SIZE);
       this.mediasApi
         .getMediasBatch(chunk)
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe({
           next: (items) => {
             for (const item of items) {

--- a/frontend/src/app/services/pair-scope.service.ts
+++ b/frontend/src/app/services/pair-scope.service.ts
@@ -17,8 +17,9 @@ import { VoteStateService } from './vote-state.service';
  *
  * Every request whose response writes *pair-scoped* state — the ranking, the
  * threshold, the inclusion slider, the dataset name, the vote cache — must be
- * piped through {@link scoped} rather than a `destroy$`, so the work started
- * for the pair we are leaving is torn down the instant the pair switches.
+ * piped through {@link scoped} rather than component teardown, so the work
+ * started for the pair we are leaving is torn down the instant the pair
+ * switches.
  *
  * Without it a scoring run — minutes long on a large dataset — outlives the
  * switch: whichever response lands last wins, so the *old* pair's ranking and
@@ -38,9 +39,9 @@ import { VoteStateService } from './vote-state.service';
  * need not) fire the scope by hand.
  *
  * NOTE for callers: a subscription started from `ActiveContextService.modelId$`
- * — which emits *before* `pair$` — must stay on the component's `destroy$`, or
- * {@link resetForNewPair}'s teardown would kill the request it just issued for
- * the *new* pair.
+ * — which emits *before* `pair$` — must stay on component teardown
+ * (`takeUntilDestroyed`), or {@link resetForNewPair}'s teardown would kill the
+ * request it just issued for the *new* pair.
  */
 @Injectable()
 export class PairScopeService implements OnDestroy {

--- a/frontend/src/app/services/running-jobs.service.ts
+++ b/frontend/src/app/services/running-jobs.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, OnDestroy, inject } from '@angular/core';
+import { DestroyRef, Injectable, OnDestroy, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HttpClient } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subject, timer } from 'rxjs';
 import { catchError, distinctUntilChanged, exhaustMap, map, takeUntil, timeout } from 'rxjs/operators';
@@ -49,13 +50,11 @@ export class RunningJobsService implements OnDestroy {
   private readonly requestTimeoutMs = 10000;
   private readonly busyPairsSubject = new BehaviorSubject<Map<string, string[]>>(new Map());
   private readonly stopPolling$ = new Subject<void>();
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private observerCount = 0;
   private polling = false;
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
     this.stopPolling$.next();
     this.stopPolling$.complete();
   }
@@ -101,7 +100,7 @@ export class RunningJobsService implements OnDestroy {
     timer(0, this.intervalMs)
       .pipe(
         takeUntil(this.stopPolling$),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         // exhaustMap (not switchMap): while one /api/jobs/active request
         // is in flight, ignore further ticks instead of aborting and
         // re-issuing. A slow or wedged backend then sees at most one poll

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { DestroyRef, Injectable, OnDestroy, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Observable, Subject } from 'rxjs';
 import { map, takeUntil, tap } from 'rxjs/operators';
 import type { MediaVoteResponse } from '../generated/api-client/models/media-vote-response';
@@ -72,7 +73,7 @@ export class VoteStateService implements OnDestroy {
   private readonly _labelsetBadCount = signal(0);
   private readonly _votesLoaded = signal(false);
   private readonly _goodRegionBoxes = signal<Record<string, number[]>>({});
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private readonly stopPolling$ = new Subject<void>();
   private polling = false;
   /**
@@ -139,8 +140,6 @@ export class VoteStateService implements OnDestroy {
   readonly toast$ = this.toastSubject.asObservable();
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
     this.stopPolling$.next();
     this.stopPolling$.complete();
   }
@@ -467,7 +466,7 @@ export class VoteStateService implements OnDestroy {
     const seq = ++this.votesSeq;
     this.sortingApi
       .getVotes()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((votes) => this.applyVotesFresh(votes, seq));
   }
 
@@ -494,7 +493,7 @@ export class VoteStateService implements OnDestroy {
         signature: ({ votes }) => JSON.stringify(votes),
       },
     )
-      .pipe(takeUntil(this.stopPolling$), takeUntil(this.destroy$))
+      .pipe(takeUntil(this.stopPolling$), takeUntilDestroyed(this.destroyRef))
       .subscribe(({ votes, seq }) => this.applyVotesFresh(votes, seq));
   }
 


### PR DESCRIPTION
Converts the remaining 18 `destroy$` + `takeUntil` files to `takeUntilDestroyed(this.destroyRef)`, finishing what #3471 started. The SPA now has exactly one teardown idiom.

Closes #3450

## The premise held, and it is slightly stronger than the issue priced it

The issue calls this "consistency work, not a bug fix", and audits it as leak-free. That is right — I found no leak either. But the two idioms are not merely stylistic variants:

```js
// @angular/core/rxjs-interop
const destroyed$ = new Observable(subscriber => {
  if (destroyRef.destroyed) { subscriber.next(); return; }   // ← no destroy$ equivalent
  const unregisterFn = destroyRef.onDestroy(subscriber.next.bind(subscriber));
  return unregisterFn;
});
```

A `Subject` that has already `complete()`d never emits, so `takeUntil(this.destroy$)` gives **zero** protection to a subscription created after `ngOnDestroy` has run — it runs forever. `takeUntilDestroyed` completes it immediately.

That is not hypothetical: `progress-modal.component.ts` carried a comment describing exactly this hazard ("RxJS `takeUntil` never fires on a pre-completed notifier"), and a defensive upstream `takeUntil` built to keep `pollEvalJob()` from ever being armed that late. The comment now records that the idiom handles it directly.

Two other premise details, checked against the tree:

- The counts are **18 / 8**, not 20 / 8 — three of the 20 files matched only in comments.
- All 18 subjects are teardown-only, fired solely from `ngOnDestroy`. Confirmed file by file, so every one was eligible, as the issue said.

## What changed

| | |
|---|---|
| Files converted | 18 (5 services, 13 components) |
| Call sites | ~90 |
| `ngOnDestroy` hooks deleted | 9 (teardown was all they did) |
| Net | 184 insertions, 223 deletions |

`LabelsetStateService`'s `destroy$` turned out to be **dead** — declared, fired from `ngOnDestroy`, never piped through a single `takeUntil` — so it is deleted rather than converted.

Commits are split so the heavy files review on their own: services, eight smaller components, then `context-pulldown` (11 sites), `browse-view` (8), `dashboard` (14), and `find-view` + `label-view`.

## What was deliberately left alone

Every cancellation idiom, per `docs/FRONTEND.md` §5 — these stop the *previous* operation on a component that is still alive, which `takeUntilDestroyed()` cannot express:

`pairScope` (`find-view`, `label-view`) · `findPolling$` (`dashboard`) · `stopWatchingProgress$` (`progress-modal`) · `stopPolling$` (`LabelsetState`, `RunningJobs`, `VoteState`) · every re-assigned `Subscription` field.

## A spec that stopped testing what it claimed

`progress-modal.component.spec.ts` drove teardown by calling `component.ngOnDestroy()` by hand. That no longer tears anything down — teardown rides on the `DestroyRef`, which fires on `fixture.destroy()`. Converted, matching what the `find-view` and `label-view` zoneless specs already do for the same reason. `docs/FRONTEND.md` now states the rule.

`right-panel.zoneless.spec.ts`'s `cleanup()` had a comment claiming a bare hook call "cancels all subscriptions"; corrected to say what it actually does.

## Verification

Full `./run-tests.sh`: **RUN PASSED** — 9748 passed, 6 skipped, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest 2303/2303).

The issue flags zoneless change-detection regression as the risk, and notes a jsdom stub is not a browser — so this was also driven in **real chromium** against a live app with the screenshot fixtures loaded:

- Dashboard registry tables paint; disk/RAM pollers both **deliver and repaint** (`RAM: 13.9 GB free of 15.7 GB`).
- Context pulldown repaints from `datasets$` / `detectors$` (11 converted subscriptions).
- Settings modal paints its `forkJoin` payload.
- Label view mounts and paints; `right-panel` present with its converted labelset subscriptions.
- **Teardown, measured:** poll request rate held flat at 4 per 12s across four label-view mount/unmount cycles. A leak would have compounded it.

No console errors on any step.

The realistic risk in this change was never reactivity — the conversion alters only the teardown notifier, not what is subscribed, when it emits, or what the callback writes — but a mechanical slip. Hence the per-file review of the cancellation subjects and the browser run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpZCuY3659sKLt2ZK6HzK2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpZCuY3659sKLt2ZK6HzK2)_