### PR TITLE
Finish the per-media-type settings-preference conversion, and close the refetch window that made its writes lossy

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -318,7 +318,20 @@ this codebase, and it is silent.
   own, instead of relying on some co-located `effect()` to dirty the view), and
   there is no mirror left to go stale when a key disappears server-side. The
   setter **merges**; a setter that replaced the dict would wipe every other
-  media type's preference. `LabelViewPanelStateService` is the reference use.
+  media type's preference. It takes a plain key, or a *signal* of a key where
+  the key itself varies (`vt-view-controls` picks `focus_mode_left` /
+  `_right` / `_popup` from its `side` input). `LabelViewPanelStateService` is
+  the reference use; `find-view`, `browse-view`, `browse-bin-popup` and
+  `view-controls` are the other consumers.
+
+  Two notes on where the seams are. **The Settings modal is deliberately not a
+  consumer**: it edits a *draft* settings signal across *every* media type via
+  a `typeId` loop, not "the current one", so the helper's shape does not fit.
+  And a preference whose control derives its next value from the current one —
+  the `vt-view-controls` size buttons, which also grey out at the ends of the
+  ladder — keeps a **local optimistic signal** written on click, with the
+  preference behind it; binding straight to the preference would make a rapid
+  second click read a pre-round-trip value.
 
 - **Consumers use `effect()`, not `subscribe()`.** A constructor `effect()`
   reading a signal auto-disposes with the component, which is why the

--- a/docs/plans/codebase-audit-2026-08.md
+++ b/docs/plans/codebase-audit-2026-08.md
@@ -264,11 +264,13 @@ ship on its own.
 
 <!-- item-sep -->
 
-- **Find-view duplicates label-view's per-media-type panel-preference machinery by hand** — `frontend/src/app/components/find-view/find-view.component.ts:87` (medium impact)
+- **Find-view duplicates label-view's panel drag/snap machinery by hand** — `frontend/src/app/components/find-view/find-view.component.ts` (medium impact)
 
-  Label-view extracted its per-media-type panel bookkeeping into LabelViewPanelStateService (grid-size dicts, focus-mode dicts, panel_pct_left/right persistence, applyPanelPx clamping) and uses PanelResizeDirective for divider drags, but find-view still carries a parallel hand-rolled copy: gridIconSizeLeftDict / focusModeLeftDict / focusModeRightDict / panelPxLeftDict / panelPxRightDict fields (lines 87-91), a near-identical settings-mirror effect (lines 137-177), applyPanelPx (line 821), savePanelPx (line 812), and duplicated divider-drag + grid-snap logic (lines 407-483). The two implementations have already drifted — find-view lacks the icon-size auto-pop and snap-on-load behaviors label-view gained — and every future panel fix must be made twice. Since the settings keys are shared between the views, drift produces user-visible inconsistency (e.g. a width saved and snapped in Label restores un-snapped in Find).
+  Label-view uses PanelResizeDirective for its divider drags and has icon-size auto-pop plus snap-on-load; find-view still carries its own divider-drag and grid-snap code and neither of those behaviours. Every future panel fix has to be made twice, and because the two views share the same settings keys the drift is user-visible — a width saved and snapped in Label restores un-snapped in Find.
 
-  *Direction:* Provide LabelViewPanelStateService (renamed to a view-agnostic PanelStateService) in find-view too, and reuse PanelResizeDirective for its dividers, deleting the duplicated dict/effect/drag code.
+  *Direction:* Reuse PanelResizeDirective for find-view's dividers and lift the auto-pop / snap-on-load behaviour alongside it, deleting the duplicated drag code.
+
+  *Background:* the settings half of this item is done — both views now resolve their per-media-type panel preferences through `SettingsStateService.perMediaType` (#3447), so the shadow dicts and the mirror effects are gone from find-view. What remains is the drag/snap duplication.
 
 <!-- item-sep -->
 

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.component.ts
@@ -9,6 +9,7 @@ import { IconComponent } from '../icon/icon.component';
 import { CopyDetailButtonComponent } from '../copy-detail-button/copy-detail-button.component';
 import { BrowseBinMemberGridComponent } from '../browse-bin-member-grid/browse-bin-member-grid.component';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
+import { coerceNonEmptyString, coercePx } from '../../utils/settings-coerce';
 import {
   COUNT_LABEL_HEIGHT,
   GRID_COLUMN_WIDTH,
@@ -20,7 +21,6 @@ import {
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import { formatMetadataValue as formatMetadataValueUtil } from '../../utils/format-metadata';
 import { BrowseAudioAudition, type NowPlaying } from '../../utils/browse-audio-audition';
-import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import type { MediaBatchResponse } from '../../generated/api-client/models/media-batch-response';
 
 /** Width (px) of the optional metadata column shown left of the preview pane. */
@@ -495,16 +495,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     effect(() => {
       const settings = this.settingsState.settingsSignal();
       // Track the two genuine triggers explicitly, then run the body untracked.
-      // The body now both reads and writes the view-pref signals (and `placed`),
-      // so a tracked body would re-arm itself on its own writes and spin; naming
-      // the triggers keeps the media-type re-place that the old implicit
-      // `mediaType()` read through `previewOverride` used to give us.
+      // The body both reads and writes view state (`_gridGoalWidth`,
+      // `metadataWidthPx`, `placed`), so a tracked body would re-arm itself on
+      // its own writes and spin. Settings and media type are between them every
+      // input the per-media preferences below resolve from, so naming the two
+      // still covers every case where a preference can change.
       this.mediaType();
       untracked(() => {
         if (!settings) return;
-        this.gridSizeDict.set((settings.grid_icon_size_popup as Record<string, string>) ?? {});
-        this.previewSizeDict.set((settings.popup_preview_size as Record<string, number>) ?? {});
-        this.metadataShownDict.set((settings.popup_metadata_shown as Record<string, boolean>) ?? {});
         // Mirror the docked metadata-column width (global). Skip mid-drag so a
         // settings round-trip can't reset the column while the user is dragging it.
         if (!this.draggingMeta && typeof settings.browse_details_metadata_width === 'number') {
@@ -520,14 +518,16 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
         // Re-place when the settings-driven size actually changed, OR when the popup
         // has mounted but not yet revealed (`placed` still false). The `!this.placed`
         // clause fixes the "first right-click shows nothing, second opens it" bug:
-        // {@link ngAfterViewInit} calls `settingsState.load()`, which bumps the
-        // settings resource's request and so momentarily resets `settingsSignal()` to
-        // null while it refetches. If `nudgeOnScreen`'s reveal gate (`settingsReady`)
-        // runs during that null window it holds `placed` false, and nothing else
-        // re-runs `place()` when settings land (the size didn't change) — so the popup
-        // strands hidden until the next summon. Re-placing on settings-arrival reveals
-        // it then, keeping the "wait for the real sizes" behaviour (no default-size
-        // flash) while dropping the spurious second click.
+        // {@link ngAfterViewInit} calls `settingsState.load()`, and until the very
+        // first response lands `settingsSignal()` is null. If `nudgeOnScreen`'s
+        // reveal gate (`settingsReady`) runs in that window it holds `placed`
+        // false, and nothing else re-runs `place()` when settings land (the size
+        // didn't change) — so the popup strands hidden until the next summon.
+        // Re-placing on settings-arrival reveals it then, keeping the "wait for the
+        // real sizes" behaviour (no default-size flash) while dropping the spurious
+        // second click. (A *re*fetch no longer opens that window at all —
+        // `SettingsStateService.load` reloads in place — but the first load still
+        // does.)
         if (override !== this.lastPreviewOverride || metaShown !== this.lastMetadataShown || !this.placed) {
           this.lastPreviewOverride = override;
           this.lastMetadataShown = metaShown;
@@ -550,17 +550,36 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
     this.audition.destroy();
   }
 
-  private readonly gridSizeDict = signal<Record<string, string>>({});
+  /**
+   * The three per-media-type popup preferences, keyed on {@link mediaType}
+   * through `SettingsStateService.perMediaType` (issue #3447): the member
+   * grid's thumbnail size, the detail-canvas size, and whether the metadata
+   * column is shown. `computed`s over the settings signal — the shadow dicts
+   * they replace were mirrored in by the settings effect, which meant every
+   * read below was one effect run behind the value it reported.
+   */
+  private readonly gridSizePref = this.settingsState.perMediaType<string>(
+    'grid_icon_size_popup',
+    this.mediaType,
+    { fallback: 'M', coerce: coerceNonEmptyString },
+  );
   /** Per-media-type detail-canvas size (px) the user has chosen via the popup's
    *  top-left buttons; absent entries fall back to the radius-derived default. */
-  private readonly previewSizeDict = signal<Record<string, number>>({});
+  private readonly previewSizePref = this.settingsState.perMediaType<number | null>(
+    'popup_preview_size',
+    this.mediaType,
+    { fallback: null, coerce: coercePx },
+  );
+  /** Whether the metadata column is shown for this media type. Absent entries
+   *  default to hidden, mirroring the Train/Find center panel's metadata tray. */
+  private readonly metadataShownPref = this.settingsState.perMediaType<boolean>(
+    'popup_metadata_shown',
+    this.mediaType,
+    { fallback: false, coerce: (raw) => (typeof raw === 'boolean' ? raw : undefined) },
+  );
   /** Last applied preview override, so the settings effect only re-clamps the
    *  popup when the detail-canvas size actually changed. */
   private lastPreviewOverride: number | null = null;
-  /** Per-media-type memory of whether the metadata column is shown, mirrored
-   *  from the ``popup_metadata_shown`` setting. Absent entries default to hidden
-   *  (mirroring the Train/Find center panel's metadata default). */
-  private readonly metadataShownDict = signal<Record<string, boolean>>({});
   /** Last applied column visibility, so the settings effect only re-clamps the
    *  popup when it actually toggled. */
   private lastMetadataShown: boolean | null = null;
@@ -604,9 +623,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  tray, which is collapsed by default so users judge the item itself
    *  rather than its notes. */
   get metadataShown(): boolean {
-    const mediaType = this.mediaType();
-    const value = mediaType ? this.metadataShownDict()[mediaType] : undefined;
-    return value === true;
+    return this.metadataShownPref.value();
   }
 
   /** Whether the metadata column actually renders: the metadata feature is
@@ -625,10 +642,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  future popups of this type — mirroring how the size buttons persist. The
    *  settings effect re-clamps the popup, since the width changed. */
   toggleMetadata(): void {
-    const mediaType = this.mediaType();
-    if (!mediaType) return;
-    const dict = { ...this.metadataShownDict(), [mediaType]: !this.metadataShown };
-    this.settingsState.update({ popup_metadata_shown: dict } as SettingsUpdate).subscribe();
+    this.metadataShownPref.set(!this.metadataShown)?.subscribe();
   }
 
   /** Cached metadata for the focused (displayed) item, or ``undefined`` before
@@ -677,9 +691,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   private applyViewPrefs(): void {
     const prevGoal = this.gridGoalWidth;
     const mediaType = this.mediaType();
-    this._gridGoalWidth.set(iconSizeToGoalWidth(
-      (mediaType && this.gridSizeDict()[mediaType]) || 'M',
-    ));
+    this._gridGoalWidth.set(iconSizeToGoalWidth(this.gridSizePref.value()));
     if (this.gridGoalWidth !== prevGoal) {
       this.rebuildRows();
       // The row stride changed, so the old scroll offset now points at a
@@ -778,9 +790,7 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
   /** The user's chosen detail-canvas size (px) for the active media type, or
    *  ``null`` when they haven't set one (and the radius-derived default is used). */
   get previewOverride(): number | null {
-    const mediaType = this.mediaType();
-    const value = mediaType ? this.previewSizeDict()[mediaType] : undefined;
-    return typeof value === 'number' ? value : null;
+    return this.previewSizePref.value();
   }
 
   /** Detail-canvas side (px) the popup opens at before any user override:
@@ -810,16 +820,14 @@ export class BrowseBinPopupComponent implements AfterViewInit, OnDestroy {
    *  type — mirroring how the grid thumbnail-size buttons persist. The settings
    *  effect re-clamps the popup so growing the canvas can't push it off-screen. */
   bumpPreview(delta: 1 | -1): void {
-    const mediaType = this.mediaType();
-    if (!this.hasPane || !mediaType) return;
+    if (!this.hasPane) return;
     const current = this.previewOverride ?? Math.round(this.previewDefault());
     const next =
       delta > 0
         ? (PREVIEW_SIZE_STEPS.find((s) => s > current) ?? PREVIEW_SIZE_STEPS[PREVIEW_SIZE_STEPS.length - 1])
         : ([...PREVIEW_SIZE_STEPS].reverse().find((s) => s < current) ?? PREVIEW_SIZE_STEPS[0]);
     if (next === this.previewOverride) return;
-    const dict = { ...this.previewSizeDict(), [mediaType]: next };
-    this.settingsState.update({ popup_preview_size: dict } as SettingsUpdate).subscribe();
+    this.previewSizePref.set(next)?.subscribe();
   }
 
   /** True when the detail canvas is already at the smallest ladder rung. */

--- a/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-bin-popup/browse-bin-popup.zoneless.spec.ts
@@ -10,7 +10,7 @@ import { MediaMetadataCacheService } from '../../services/media-metadata-cache.s
 import { ActiveContextService } from '../../services/active-context.service';
 import { SettingsStateService } from '../../services/settings-state.service';
 import { configureZoneless } from '../../testing/zoneless-testbed';
-import { makeActiveContextStub } from '../../testing/mocks';
+import { makeActiveContextStub, makeSettingsStateStub } from '../../testing/mocks';
 import { settleZoneless } from '../../testing/settle-resource';
 
 /**
@@ -58,11 +58,12 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
       ensureLoaded: () => {},
     };
     const activeContextStub = makeActiveContextStub();
-    const settingsStub: Partial<SettingsStateService> = {
+    // The popup's per-media preferences are built on the real `perMediaType`,
+    // which `makeSettingsStateStub` borrows from the prototype.
+    const { stub: settingsStub } = makeSettingsStateStub({
       settingsSignal: settings as unknown as SettingsStateService['settingsSignal'],
-      load: () => {},
       update: () => of({}) as ReturnType<SettingsStateService['update']>,
-    };
+    });
 
     TestBed.resetTestingModule();
     configureZoneless({
@@ -132,15 +133,20 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
   it('reveals once settings resolve after mount, with no re-summon (the two-right-click bug)', async () => {
     // Regression for "the first right-click shows nothing; the second opens it".
     //
-    // In the app the popup mounts while its settings-driven prefs are already known
-    // (settings loaded app-wide), but its own ngAfterViewInit `settingsState.load()`
-    // momentarily resets `settingsSignal()` to null while the resource refetches. So
-    // its first placement pass runs with `settingsReady` false and the reveal gate in
-    // nudgeOnScreen holds `placed` false. When settings land *again* the prefs are
-    // unchanged (same values), so the settings effect's size-change branch is a no-op
-    // — and before the fix nothing else re-ran `place()`, stranding the popup hidden
-    // until the next summon (the second right-click). The `!this.placed` clause makes
-    // the effect re-place on settings-arrival while still unrevealed.
+    // A popup summoned before settings have landed places itself with
+    // `settingsReady` false, and the reveal gate in nudgeOnScreen holds `placed`
+    // false. When settings then arrive the prefs may be unchanged from the
+    // defaults it already used, so the settings effect's size-change branch is a
+    // no-op — and before the fix nothing else re-ran `place()`, stranding the
+    // popup hidden until the next summon (the second right-click). The
+    // `!this.placed` clause makes the effect re-place on settings-arrival while
+    // still unrevealed.
+    //
+    // The original report reached this state through the popup's own
+    // ngAfterViewInit `settingsState.load()`, which used to blank
+    // `settingsSignal()` for the length of the refetch. `load()` reloads in place
+    // now (see `SettingsStateService.load`), so that route is closed — but a
+    // genuine first load still opens the same window, which is what this drives.
     //
     // Reproduce that state precisely: place with settings null (→ hidden, `placed`
     // false), then pre-seed the effect's "last seen prefs" to the values the arriving
@@ -168,8 +174,8 @@ describe('BrowseBinPopupComponent (zoneless positioning)', () => {
     comp.lastPreviewOverride = comp.previewOverride;
     comp.lastMetadataShown = comp.showMetadataColumn;
 
-    // Settings resolve (resource refetch completes). No new summon, and — with last*
-    // pre-seeded — no pref change, so only the unrevealed-re-place path is left.
+    // Settings resolve. No new summon, and — with last* pre-seeded — no pref
+    // change, so only the unrevealed-re-place path is left.
     settings.set({});
     await settlePasses(fixture);
 
@@ -360,11 +366,12 @@ describe('BrowseBinPopupComponent (docked presentation)', () => {
       ensureLoaded: () => {},
     };
     const activeContextStub = makeActiveContextStub();
-    const settingsStub: Partial<SettingsStateService> = {
+    // The popup's per-media preferences are built on the real `perMediaType`,
+    // which `makeSettingsStateStub` borrows from the prototype.
+    const { stub: settingsStub } = makeSettingsStateStub({
       settingsSignal: settings as unknown as SettingsStateService['settingsSignal'],
-      load: () => {},
       update: () => of({}) as ReturnType<SettingsStateService['update']>,
-    };
+    });
 
     TestBed.resetTestingModule();
     configureZoneless({

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -42,8 +42,11 @@ import { snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
 import { formatEta, progressBarState } from '../../utils/format-progress';
 import { shortcutsBlocked } from '../../utils/keyboard-shortcuts';
 import type { AppSettings } from '../../generated/api-client/models/app-settings';
-import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
 import { apiErrorMessage } from '../../utils/api-error';
+
+/** One of the named on-canvas thumbnail sizes (see
+ *  {@link BrowseViewComponent.ICON_SIZES}); the form the size is persisted in. */
+type BrowseIconSize = (typeof BrowseViewComponent.ICON_SIZES)[number];
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -210,8 +213,78 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   readonly thumbnailBorder = signal(DEFAULT_THUMBNAIL_BORDER);
 
   /** Last settings snapshot, kept so per-media browser prefs can be
-   *  re-resolved when the active media type becomes known after load. */
+   *  re-resolved when the active media type becomes known after load, and so a
+   *  refetch's momentary ``null`` can't reset them to defaults. Read-only: the
+   *  per-media dicts below are read through {@link SettingsStateService.perMediaType},
+   *  never out of this object. */
   private lastSettings: AppSettings | null = null;
+
+  /**
+   * The per-media browser preferences, each bound to {@link mediaType} through
+   * `SettingsStateService.perMediaType` so the read, the coerce and the
+   * merge-preserving write all live in one place instead of being spelled out
+   * at every site (issue #3447).
+   *
+   * They are read imperatively from {@link applyBrowsePrefsForMediaType} rather
+   * than bound in the template, because applying one of them is not a pure
+   * repaint: the icon size also re-seeds the canvas's overview granularity.
+   * Keeping that orchestration where it already was leaves the canvas's reframe
+   * timing untouched; only the plumbing underneath moved.
+   */
+  private readonly colormapPref = this.settingsState.perMediaType<BrowseColormapId>(
+    'browse_colormap',
+    this.mediaType,
+    {
+      fallback: 'auto',
+      coerce: (raw) =>
+        (BROWSE_COLORMAP_IDS as readonly unknown[]).includes(raw)
+          ? (raw as BrowseColormapId)
+          : undefined,
+    },
+  );
+  private readonly iconSizePref = this.settingsState.perMediaType<BrowseIconSize>(
+    'browse_icon_size',
+    this.mediaType,
+    {
+      fallback: 'M',
+      coerce: (raw) =>
+        (BrowseViewComponent.ICON_SIZES as readonly unknown[]).includes(raw)
+          ? (raw as BrowseIconSize)
+          : undefined,
+    },
+  );
+  private readonly thumbnailBorderPref = this.settingsState.perMediaType<number>(
+    'browse_thumbnail_border',
+    this.mediaType,
+    {
+      fallback: DEFAULT_THUMBNAIL_BORDER,
+      coerce: (raw) =>
+        typeof raw === 'number' && Number.isFinite(raw)
+          ? Math.max(0, Math.min(MAX_THUMBNAIL_BORDER, raw))
+          : undefined,
+    },
+  );
+  private readonly zoomsPerLevelPref = this.settingsState.perMediaType<number>(
+    'browse_mouse_zooms_per_level',
+    this.mediaType,
+    {
+      fallback: 2,
+      coerce: (raw) =>
+        typeof raw === 'number' && Number.isFinite(raw)
+          ? Math.max(1, Math.min(3, Math.round(raw)))
+          : undefined,
+    },
+  );
+  private readonly signpostsPref = this.settingsState.perMediaType<boolean>(
+    'browse_signposts',
+    this.mediaType,
+    { fallback: true, coerce: (raw) => (typeof raw === 'boolean' ? raw : undefined) },
+  );
+  private readonly binDetailsDockedPref = this.settingsState.perMediaType<boolean>(
+    'bin_details_docked',
+    this.mediaType,
+    { fallback: true, coerce: (raw) => (typeof raw === 'boolean' ? raw : undefined) },
+  );
 
   /**
    * Region-select mode: the GUI parallel to the Shift+drag hotkey. When on, a
@@ -639,7 +712,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     if (next === this.hexScaleIndex()) return;
     this.hexScaleIndex.set(next);
     this.canvas()?.setThumbnailRadius(this.thumbnailRadius, true);
-    this.persistBrowsePref('browse_icon_size', BrowseViewComponent.ICON_SIZES[next]);
+    this.iconSizePref.set(BrowseViewComponent.ICON_SIZES[next])?.subscribe();
   }
 
   /**
@@ -651,27 +724,24 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
    * by media type and reported by the projection meta.)
    */
   private applyBrowsePrefsForMediaType(): void {
+    // Gate on the sticky snapshot rather than the live settings signal: a
+    // refetch momentarily resets `settingsSignal()` to null, and resolving the
+    // prefs against an empty dict would reset every one of them to its default.
     const s = this.lastSettings;
     if (!s) return;
-    const mt = this.mediaType();
 
     // Thumbnail media (image/video) are pinned to grayscale so the colourful
     // density presets never tint real thumbnails; the saved per-type value is
     // ignored for them (the Settings UI hides the picker to match).
-    if (this.mediaTypeCaps.usesThumbnails(mt)) {
-      this.colormap.set('gray');
-    } else {
-      const cmap = mt ? this.perMediaValue(s.browse_colormap, mt) : '';
-      this.colormap.set(
-        cmap && (BROWSE_COLORMAP_IDS as readonly string[]).includes(cmap)
-          ? (cmap as BrowseColormapId)
-          : 'auto',
-      );
-    }
+    this.colormap.set(
+      this.mediaTypeCaps.usesThumbnails(this.mediaType())
+        ? 'gray'
+        : this.colormapPref.value(),
+    );
 
-    const sizeLabel = mt ? this.perMediaValue(s.browse_icon_size, mt) : '';
-    const sizeIdx = (BrowseViewComponent.ICON_SIZES as readonly string[]).indexOf(sizeLabel);
-    this.hexScaleIndex.set(sizeIdx >= 0 ? sizeIdx : 2);
+    this.hexScaleIndex.set(
+      BrowseViewComponent.ICON_SIZES.indexOf(this.iconSizePref.value()),
+    );
     // Seed the saved size as the overview granularity (no reframe): a settings
     // change re-bins at the current framing rather than zooming the viewport,
     // and on first load the initial fit picks the matching level. The query is
@@ -680,23 +750,9 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     // which the decorator @ViewChild it replaces never did.
     untracked(this.canvas)?.setThumbnailRadius(this.thumbnailRadius, false);
 
-    const borderMap = s.browse_thumbnail_border as { [key: string]: number } | undefined;
-    const rawBorder = mt && borderMap ? borderMap[mt] : undefined;
-    this.thumbnailBorder.set(
-      rawBorder == null
-        ? DEFAULT_THUMBNAIL_BORDER
-        : Math.max(0, Math.min(MAX_THUMBNAIL_BORDER, rawBorder)),
-    );
-
-    const zoomsMap = s.browse_mouse_zooms_per_level as { [key: string]: number } | undefined;
-    const rawZooms = mt && zoomsMap ? zoomsMap[mt] : undefined;
-    this.zoomsPerLevel.set(
-      rawZooms == null ? 2 : Math.max(1, Math.min(3, Math.round(rawZooms))),
-    );
-
-    const signMap = s.browse_signposts as { [key: string]: boolean } | undefined;
-    const rawSigns = mt && signMap ? signMap[mt] : undefined;
-    this.signposts.set(rawSigns == null ? true : rawSigns);
+    this.thumbnailBorder.set(this.thumbnailBorderPref.value());
+    this.zoomsPerLevel.set(this.zoomsPerLevelPref.value());
+    this.signposts.set(this.signpostsPref.value());
 
     // Global (not per-media): the client's rendering capability.
     const rawGraphics = s.browse_graphics;
@@ -704,32 +760,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
       rawGraphics === 'full' || rawGraphics === 'reduced' ? rawGraphics : 'auto',
     );
 
-    const dockMap = s.bin_details_docked as { [key: string]: boolean } | undefined;
-    const dockedValue = mt && dockMap ? dockMap[mt] : undefined;
-    this.detailsDocked.set(dockedValue === undefined ? true : dockedValue);
-  }
-
-  /** Read a ``{media_type: value}`` setting for *mt*, or ``''`` when unset. */
-  private perMediaValue(map: { [key: string]: string } | undefined, mt: string): string {
-    if (!map || !mt) return '';
-    return map[mt] ?? '';
-  }
-
-  /** Persist a per-media browser preference, merging into the current map so
-   *  other media types' choices are preserved, and update the local snapshot
-   *  so subsequent reads stay consistent before the PUT round-trips. */
-  private persistBrowsePref(
-    key: 'browse_colormap' | 'browse_icon_size',
-    value: string,
-  ): void {
-    const mt = this.mediaType();
-    if (!mt) return;
-    const existing = (this.lastSettings?.[key] as { [k: string]: string } | undefined) || {};
-    const next = { ...existing, [mt]: value };
-    if (this.lastSettings) {
-      (this.lastSettings as Record<string, unknown>)[key] = next;
-    }
-    this.settingsState.update({ [key]: next } as SettingsUpdate).subscribe();
+    this.detailsDocked.set(this.binDetailsDockedPref.value());
   }
 
   private clamp(value: number, lo: number, hi: number): number {
@@ -964,15 +995,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   toggleSignposts(): void {
     const next = !this.signposts();
     this.signposts.set(next);
-    const mt = this.mediaType();
-    if (!mt) return;
-    const existing =
-      (this.lastSettings?.browse_signposts as { [k: string]: boolean } | undefined) || {};
-    const map = { ...existing, [mt]: next };
-    if (this.lastSettings) {
-      (this.lastSettings as Record<string, unknown>)['browse_signposts'] = map;
-    }
-    this.settingsState.update({ browse_signposts: map } as SettingsUpdate).subscribe();
+    this.signpostsPref.set(next)?.subscribe();
   }
 
   /**
@@ -1200,16 +1223,13 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
   /** Persist the docked/floating choice per media type (``bin_details_docked``)
    *  and apply it locally, keeping the settings snapshot consistent. */
   private persistBinDetailsDocked(value: boolean): void {
-    const mt = this.mediaType();
-    if (!mt) return;
+    // `set` returns null when the media type is unknown, which is also the case
+    // where the local flip is withheld: the docked choice is per media type, so
+    // with nothing to key it on there is no preference to change.
+    const write = this.binDetailsDockedPref.set(value);
+    if (!write) return;
     this.detailsDocked.set(value);
-    const existing =
-      (this.lastSettings?.bin_details_docked as { [k: string]: boolean } | undefined) || {};
-    const map = { ...existing, [mt]: value };
-    if (this.lastSettings) {
-      (this.lastSettings as Record<string, unknown>)['bin_details_docked'] = map;
-    }
-    this.settingsState.update({ bin_details_docked: map } as SettingsUpdate).subscribe();
+    write.subscribe();
   }
 
   /**

--- a/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
+++ b/frontend/src/app/components/browse-view/browse-view.zoneless.spec.ts
@@ -18,7 +18,7 @@ import { VtDialogService } from '../../services/dialog.service';
 import { ToastService } from '../../services/toast.service';
 import type { ProjectionMeta } from '../../models/projection.models';
 import { configureZoneless } from '../../testing/zoneless-testbed';
-import { makeActiveContextStub } from '../../testing/mocks';
+import { makeActiveContextStub, makeSettingsStateStub } from '../../testing/mocks';
 import { settleZoneless } from '../../testing/settle-resource';
 
 /**
@@ -69,15 +69,16 @@ describe('BrowseViewComponent (zoneless canary)', () => {
           DetectorsRegistryApiService['releasePositivesBrowse']
         >,
     };
-    const settingsStub: Partial<SettingsStateService> = {
-      // Settings resolve (as they do in production): the browse view holds its
-      // first projection load until settings + media type are in, so it applies
-      // the saved per-media display prefs before the first canvas fit.
-      settingsSignal: signal({}) as unknown as SettingsStateService['settingsSignal'],
+    // Settings resolve (as they do in production): the browse view holds its
+    // first projection load until settings + media type are in, so it applies
+    // the saved per-media display prefs before the first canvas fit. The stub
+    // carries the real `perMediaType`, which the view's per-media prefs are
+    // built on (see `makeSettingsStateStub`).
+    const { stub: settingsStub, settings: settingsValue } = makeSettingsStateStub({
       error: signal(null) as unknown as SettingsStateService['error'],
-      load: noop,
       update: () => of({}) as ReturnType<SettingsStateService['update']>,
-    };
+    });
+    settingsValue.set({});
     const subsetStub: Partial<BrowseSubsetService> = {
       take: () => null,
       markReturningToFind: noop,

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -23,7 +23,10 @@ import { VoteStateService } from '../../services/vote-state.service';
 import { SortStateService, SortedItem } from '../../services/sort-state.service';
 import { SortingApiService } from '../../services/sorting-api.service';
 import { PairScopeService } from '../../services/pair-scope.service';
-import { SettingsStateService } from '../../services/settings-state.service';
+import {
+  SettingsStateService,
+  type PerMediaTypePref,
+} from '../../services/settings-state.service';
 import { BrowseSubsetService } from '../../services/browse-subset.service';
 import { BrowseSubsetPrepService } from '../../services/browse-subset-prep.service';
 import {
@@ -32,6 +35,12 @@ import {
   progressBarState,
 } from '../../utils/format-progress';
 import { iconSizeToGoalWidth, snapPanelWidthToGridColumns } from '../../utils/grid-icon-size';
+import {
+  coerceFocusMode,
+  coerceNonEmptyString,
+  coercePx,
+  type FocusMode,
+} from '../../utils/settings-coerce';
 
 /**
  * How long the Inclusion slider has to settle before its `POST /api/inclusion`
@@ -82,20 +91,62 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   readonly layoutRef = viewChild.required<ElementRef<HTMLElement>>('layout');
   readonly centerPanel = viewChild(CenterPanelComponent);
 
-  // Written from non-bound callbacks (HTTP status subscribe, the settings-mirror
-  // effect, the media-type effect) and read in the template, so under zoneless
-  // they must be signals — a plain-field write from those contexts would not
-  // schedule CD and the view would go stale (zoneless-migration.md, Phase 2.5,
-  // Recipe B & F).
-  readonly gridGoalWidthLeft = signal(80);
-  readonly focusModeLeft = signal<'click' | 'hover'>('click');
-  readonly focusModeRight = signal<'click' | 'hover'>('click');
-  private gridIconSizeLeftDict: Record<string, string> = {};
-  private focusModeLeftDict: Record<string, 'click' | 'hover'> = {};
-  private focusModeRightDict: Record<string, 'click' | 'hover'> = {};
-  private panelPxLeftDict: Record<string, number> = {};
-  private panelPxRightDict: Record<string, number> = {};
-  private currentMediaType = '';
+  /** The loaded medias' type, which every per-media panel preference is keyed
+   *  on. Written from the media-state effect and read by the `computed`s below,
+   *  so it has to be a signal for those to re-resolve on a switch. */
+  private readonly currentMediaType = signal('');
+
+  /**
+   * The five per-media-type panel preferences, bound to {@link currentMediaType}
+   * through `SettingsStateService.perMediaType` (issue #3447). Each is a
+   * `computed` over the settings signal, replacing the shadow `Record` + the
+   * effect that mirrored settings into it + the second re-derivation on a
+   * media-type switch that used to be spelled out here.
+   *
+   * Beyond brevity that kills a staleness bug: every shadow dict was hydrated
+   * behind an `if (dict && typeof dict === 'object')` guard, so a key that went
+   * absent server-side left the last-seen copy in place for the life of the
+   * view. A `computed` has no such state.
+   */
+  private readonly gridIconSizeLeftPref = this.settingsState.perMediaType<string>(
+    'grid_icon_size_left',
+    this.currentMediaType,
+    { fallback: 'M', coerce: coerceNonEmptyString },
+  );
+  private readonly focusPref: Record<'left' | 'right', PerMediaTypePref<FocusMode>> = {
+    left: this.settingsState.perMediaType<FocusMode>('focus_mode_left', this.currentMediaType, {
+      fallback: 'click',
+      coerce: coerceFocusMode,
+    }),
+    right: this.settingsState.perMediaType<FocusMode>('focus_mode_right', this.currentMediaType, {
+      fallback: 'click',
+      coerce: coerceFocusMode,
+    }),
+  };
+  private readonly panelPxPref: Record<'left' | 'right', PerMediaTypePref<number | null>> = {
+    left: this.settingsState.perMediaType<number | null>(
+      'panel_pct_left',
+      this.currentMediaType,
+      { fallback: null, coerce: coercePx },
+    ),
+    right: this.settingsState.perMediaType<number | null>(
+      'panel_pct_right',
+      this.currentMediaType,
+      { fallback: null, coerce: coercePx },
+    ),
+  };
+
+  /**
+   * Template-bound, and `computed` rather than mirrored: under zoneless a
+   * binding tracks these directly and repaints on its own (see
+   * `docs/FRONTEND.md` section 5), where the plain-field-plus-effect shape they
+   * replace needed the effect's write to schedule change detection.
+   */
+  readonly gridGoalWidthLeft = computed(() =>
+    iconSizeToGoalWidth(this.gridIconSizeLeftPref.value()),
+  );
+  readonly focusModeLeft = this.focusPref.left.value;
+  readonly focusModeRight = this.focusPref.right.value;
   leftWidth = 260;
   rightWidth = 300;
 
@@ -192,59 +243,22 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
         this.voteState.loadVotes();
       });
 
+    // The icon size and the two focus modes are `computed`s now, so nothing has
+    // to be re-derived here — but the saved panel widths are applied to plain
+    // fields and a CSS variable, so that write still needs a trigger. Reading
+    // the two resolved widths is it: they change when settings land and again
+    // on a media-type switch, which is exactly when the widths must be reapplied.
     effect(() => {
-      const settings = this.settingsState.settingsSignal();
-      if (!settings) return;
-      const sizeDict = settings.grid_icon_size_left;
-      if (sizeDict && typeof sizeDict === 'object') {
-        this.gridIconSizeLeftDict = sizeDict as Record<string, string>;
-        if (this.currentMediaType) {
-          this.gridGoalWidthLeft.set(
-            iconSizeToGoalWidth(this.gridIconSizeLeftDict[this.currentMediaType] ?? 'M'),
-          );
-        }
-      }
-      const fmLeft = settings.focus_mode_left;
-      if (fmLeft && typeof fmLeft === 'object') {
-        this.focusModeLeftDict = fmLeft as Record<string, 'click' | 'hover'>;
-        if (this.currentMediaType) {
-          this.focusModeLeft.set(this.focusModeLeftDict[this.currentMediaType] ?? 'click');
-        }
-      }
-      const fmRight = settings.focus_mode_right;
-      if (fmRight && typeof fmRight === 'object') {
-        this.focusModeRightDict = fmRight as Record<string, 'click' | 'hover'>;
-        if (this.currentMediaType) {
-          this.focusModeRight.set(this.focusModeRightDict[this.currentMediaType] ?? 'click');
-        }
-      }
-      const pplDict = settings.panel_pct_left;
-      if (pplDict && typeof pplDict === 'object') {
-        this.panelPxLeftDict = pplDict as Record<string, number>;
-        if (this.currentMediaType) {
-          this.applyPanelPx(this.currentMediaType);
-        }
-      }
-      const pprDict = settings.panel_pct_right;
-      if (pprDict && typeof pprDict === 'object') {
-        this.panelPxRightDict = pprDict as Record<string, number>;
-        if (this.currentMediaType) {
-          this.applyPanelPx(this.currentMediaType);
-        }
-      }
+      const left = this.panelPxPref.left.value();
+      const right = this.panelPxPref.right.value();
+      if (left == null && right == null) return;
+      this.applyPanelPx();
     });
 
     effect(() => {
       const medias = this.mediaState.mediasSignal();
       if (medias.length > 0) {
-        const newType = medias[0].media_type;
-        if (newType !== this.currentMediaType) {
-          this.currentMediaType = newType;
-          this.gridGoalWidthLeft.set(iconSizeToGoalWidth(this.gridIconSizeLeftDict[newType] ?? 'M'));
-          this.focusModeLeft.set(this.focusModeLeftDict[newType] ?? 'click');
-          this.focusModeRight.set(this.focusModeRightDict[newType] ?? 'click');
-          this.applyPanelPx(newType);
-        }
+        this.currentMediaType.set(medias[0].media_type);
       }
     });
   }
@@ -815,23 +829,19 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
   // --- Panel percentage helpers ---
 
   private savePanelPx(side: 'left' | 'right'): void {
-    if (!this.currentMediaType) return;
-    const px = side === 'left' ? this.leftWidth : this.rightWidth;
-    const key = side === 'left' ? 'panel_pct_left' : 'panel_pct_right';
-    const dict = side === 'left' ? this.panelPxLeftDict : this.panelPxRightDict;
-    dict[this.currentMediaType] = px;
-    this.settingsState.update({ [key]: { ...dict } }).subscribe();
+    this.panelPxPref[side].set(side === 'left' ? this.leftWidth : this.rightWidth)?.subscribe();
   }
 
-  private applyPanelPx(mediaType: string): void {
+  /** Apply the widths saved for the active media type, clamped to the layout. */
+  private applyPanelPx(): void {
     const layoutWidth = this.layoutRef().nativeElement.getBoundingClientRect().width || 1200;
-    const leftPx = this.panelPxLeftDict[mediaType];
+    const leftPx = this.panelPxPref.left.value();
     if (leftPx != null) {
       const leftMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.rightWidth;
       this.leftWidth = Math.max(this.LEFT_MIN, Math.min(leftMax, leftPx));
       this.layoutRef().nativeElement.style.setProperty('--left-width', `${this.leftWidth}px`);
     }
-    const rightPx = this.panelPxRightDict[mediaType];
+    const rightPx = this.panelPxPref.right.value();
     if (rightPx != null) {
       const rightMax = layoutWidth - this.DIVIDER_TOTAL - this.CENTER_MIN - this.leftWidth;
       this.rightWidth = Math.max(this.RIGHT_MIN, Math.min(rightMax, rightPx));

--- a/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
+++ b/frontend/src/app/components/find-view/find-view.zoneless.spec.ts
@@ -68,7 +68,7 @@ describe('FindViewComponent (zoneless canary)', () => {
       httpMock.match('/api/votes').forEach((req) =>
         req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
       );
-      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 0.8 }));
       httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
       httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
       httpMock.match('/api/embedders').forEach((req) => req.flush([]));
@@ -233,7 +233,7 @@ describe('FindViewComponent (pair-switch supersession)', () => {
       httpMock.match('/api/votes').forEach((req) =>
         req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
       );
-      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 0.8 }));
       httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
       httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
       httpMock.match('/api/embedders').forEach((req) => req.flush([]));
@@ -349,7 +349,7 @@ describe('FindViewComponent (inclusion supersession)', () => {
       httpMock.match('/api/votes').forEach((req) =>
         req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
       );
-      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 0.8 }));
       httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
       httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
       httpMock.match('/api/embedders').forEach((req) => req.flush([]));

--- a/frontend/src/app/components/label-view/label-view-panel-state.service.ts
+++ b/frontend/src/app/components/label-view/label-view-panel-state.service.ts
@@ -4,18 +4,7 @@ import {
   type PerMediaTypePref,
 } from '../../services/settings-state.service';
 import { iconSizeToGoalWidth } from '../../utils/grid-icon-size';
-
-type FocusMode = 'click' | 'hover';
-
-/** Accept only the two real focus modes; anything else falls back. */
-function coerceFocusMode(raw: unknown): FocusMode | undefined {
-  return raw === 'click' || raw === 'hover' ? raw : undefined;
-}
-
-/** Accept only a finite number of pixels; anything else falls back to "unset". */
-function coercePx(raw: unknown): number | undefined {
-  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
-}
+import { coerceFocusMode, coercePx, type FocusMode } from '../../utils/settings-coerce';
 
 /**
  * Per-media-type panel display preferences for `vt-label-view`.

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -78,7 +78,7 @@ describe('LabelViewComponent (zoneless dataset-name canary)', () => {
       httpMock.match('/api/votes').forEach((req) =>
         req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
       );
-      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 80 }));
+      httpMock.match('/api/settings').forEach((req) => req.flush({ volume: 0.8 }));
       httpMock.match('/api/inclusion').forEach((req) => req.flush({ inclusion: 0 }));
       httpMock.match('/api/media-types').forEach((req) => req.flush({ media_types: [] }));
       httpMock.match('/api/embedders').forEach((req) => req.flush([]));
@@ -167,9 +167,11 @@ describe('LabelViewComponent', () => {
     httpMock.match('/api/votes').forEach(req =>
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
     );
-    // /api/settings
+    // /api/settings. `volume` is a 0-1 fraction: the server clamps it to that
+    // range (`settings_models.py`), and the centre panel writes it straight
+    // onto `HTMLMediaElement.volume`, which throws on anything outside it.
     httpMock.match('/api/settings').forEach(req =>
-      req.flush({ volume: 80 }),
+      req.flush({ volume: 0.8 }),
     );
     // /api/dataset/status
     httpMock.match('/api/dataset/status').forEach(req =>
@@ -501,7 +503,7 @@ describe('LabelViewComponent', () => {
       req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
     );
     httpMock.match('/api/settings').forEach(req =>
-      req.flush({ volume: 80 }),
+      req.flush({ volume: 0.8 }),
     );
     httpMock.match('/api/dataset/status').forEach(req =>
       req.flush({ display_name: 'Test dataset' }),
@@ -552,7 +554,7 @@ describe('LabelViewComponent', () => {
       httpMock.match('/api/votes').forEach(req =>
         req.flush({ good: [], bad: [], click_times: {}, learned_scores: {} }),
       );
-      httpMock.match('/api/settings').forEach(req => req.flush({ volume: 80 }));
+      httpMock.match('/api/settings').forEach(req => req.flush({ volume: 0.8 }));
       httpMock.match('/api/dataset/status').forEach(req =>
         req.flush({ display_name: 'DINOv3 dataset' }),
       );

--- a/frontend/src/app/components/view-controls/view-controls.component.ts
+++ b/frontend/src/app/components/view-controls/view-controls.component.ts
@@ -1,12 +1,19 @@
 import { ChangeDetectionStrategy, Component, computed, effect, inject, input, OnChanges, OnInit, signal, SimpleChanges } from '@angular/core';
 
-import { SettingsStateService } from '../../services/settings-state.service';
-import type { AppSettings } from '../../generated/api-client/models/app-settings';
-import type { SettingsUpdate } from '../../generated/api-client/models/settings-update';
+import {
+  SettingsStateService,
+  type SettingsKey,
+} from '../../services/settings-state.service';
+import { coerceFocusMode, type FocusMode } from '../../utils/settings-coerce';
 import { IconComponent } from '../icon/icon.component';
 
 const ICON_SIZES = ['XS', 'S', 'M', 'L', 'XL'] as const;
 type IconSize = (typeof ICON_SIZES)[number];
+
+/** Accept only a size on this control's ladder; anything else falls back. */
+function coerceIconSize(raw: unknown): IconSize | undefined {
+  return (ICON_SIZES as readonly unknown[]).includes(raw) ? (raw as IconSize) : undefined;
+}
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -28,29 +35,48 @@ export class ViewControlsComponent implements OnInit, OnChanges {
    */
   readonly showFocus = input(true);
 
-  // These are signals (not plain fields) so the OnPush template re-renders when
-  // the constructor effect's `refresh()` updates them after a settings change.
-  // With plain fields the controls would not repaint until the next unrelated
-  // change-detection pass, which left the thumbnail-size buttons looking
-  // stuck-disabled.
-  readonly focusMode = signal<'click' | 'hover'>('click');
+  /**
+   * The two preferences this control edits, keyed on the active media type and
+   * on which panel it is mounted in (issue #3447). The key is a signal because
+   * `side` is an input: one component instance reads `focus_mode_left` or
+   * `focus_mode_popup` depending on where it was placed.
+   */
+  private readonly focusPref = this.settingsState.perMediaType<FocusMode>(
+    computed<SettingsKey>(() => `focus_mode_${this.side()}` as SettingsKey),
+    this.currentMediaType,
+    { fallback: 'click', coerce: coerceFocusMode },
+  );
+  private readonly sizePref = this.settingsState.perMediaType<IconSize>(
+    computed<SettingsKey>(() => `grid_icon_size_${this.side()}` as SettingsKey),
+    this.currentMediaType,
+    { fallback: 'M', coerce: coerceIconSize },
+  );
+
+  // Local, and written optimistically on click rather than bound straight to
+  // the preferences above: the buttons compute the next size from the current
+  // one and grey themselves out at the ends of the ladder, so waiting for the
+  // PUT to round-trip would make a rapid second click read a stale size and
+  // leave the control looking stuck. Signals (not plain fields) so the OnPush
+  // template repaints on a write from `refresh()`, which runs outside any bound
+  // handler.
+  readonly focusMode = signal<FocusMode>('click');
   readonly gridIconSize = signal<IconSize>('M');
 
-  private settings: AppSettings = { volume: 50 };
-
   constructor() {
-    effect(() => {
-      const settings = this.settingsState.settingsSignal();
-      if (!settings) return;
-      this.settings = settings;
-      this.refresh();
-    });
+    // `refresh()` reads both preferences, so this effect depends on them and
+    // re-runs whenever either resolves to something new: settings landing, a
+    // change made in the Settings modal or by the sibling control on the other
+    // panel, or a `side` / media-type switch.
+    effect(() => this.refresh());
   }
 
   ngOnInit(): void {
     this.settingsState.load();
   }
 
+  /** The constructor effect already re-resolves on a `side` / media-type
+   *  change; this keeps the update synchronous with the input write, as it was
+   *  before the preferences became signals. */
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['currentMediaType'] || changes['side']) {
       this.refresh();
@@ -58,25 +84,14 @@ export class ViewControlsComponent implements OnInit, OnChanges {
   }
 
   private refresh(): void {
-    const type = this.currentMediaType();
-    this.focusMode.set((this.getDict('focus_mode')[type] as 'click' | 'hover') ?? 'click');
-    const size = this.getDict('grid_icon_size')[type] as IconSize | undefined;
-    this.gridIconSize.set((size && ICON_SIZES.includes(size)) ? size : 'M');
+    this.focusMode.set(this.focusPref.value());
+    this.gridIconSize.set(this.sizePref.value());
   }
 
-  private key(prefix: 'focus_mode' | 'grid_icon_size'): keyof AppSettings {
-    return `${prefix}_${this.side()}` as keyof AppSettings;
-  }
-
-  private getDict(prefix: 'focus_mode' | 'grid_icon_size'): Record<string, string> {
-    const value = this.settings[this.key(prefix)];
-    return (value && typeof value === 'object') ? (value as Record<string, string>) : {};
-  }
-
-  setFocusMode(mode: 'click' | 'hover'): void {
+  setFocusMode(mode: FocusMode): void {
     if (!this.currentMediaType() || this.focusMode() === mode) return;
     this.focusMode.set(mode);
-    this.save('focus_mode', mode);
+    this.focusPref.set(mode)?.subscribe();
   }
 
   bumpSize(delta: 1 | -1): void {
@@ -85,16 +100,10 @@ export class ViewControlsComponent implements OnInit, OnChanges {
     const next = ICON_SIZES[Math.max(0, Math.min(ICON_SIZES.length - 1, idx + delta))];
     if (next === this.gridIconSize()) return;
     this.gridIconSize.set(next);
-    this.save('grid_icon_size', next);
+    this.sizePref.set(next)?.subscribe();
   }
 
   readonly atMaxSize = computed(() => this.gridIconSize() === ICON_SIZES[ICON_SIZES.length - 1]);
 
   readonly atMinSize = computed(() => this.gridIconSize() === ICON_SIZES[0]);
-
-  private save(prefix: 'focus_mode' | 'grid_icon_size', value: string): void {
-    const key = this.key(prefix);
-    const updated = { ...this.getDict(prefix), [this.currentMediaType()]: value };
-    this.settingsState.update({ [key]: updated } as SettingsUpdate).subscribe();
-  }
 }

--- a/frontend/src/app/services/settings-state.service.spec.ts
+++ b/frontend/src/app/services/settings-state.service.spec.ts
@@ -197,6 +197,69 @@ describe('SettingsStateService', () => {
       expect(pref.value()).toBe('M');
     });
 
+    /**
+     * A refetch must be invisible to a preference. `load()` reloads the
+     * resource in place rather than swapping its request, so the last value
+     * survives the round-trip; resolving through the old null window would
+     * flicker the value to its default, and merging through it would send a
+     * one-entry dict that the PUT *replaces* the stored one with, wiping every
+     * sibling media type. See `SettingsStateService.load`.
+     */
+    it('holds its value across an in-flight refetch', async () => {
+      const pref = service.perMediaType<string>('grid_icon_size_right', signal('audio'), {
+        fallback: 'M',
+      });
+      await loadDicts();
+      expect(pref.value()).toBe('L');
+
+      service.load();
+      TestBed.tick();
+      expect(service.isLoading()).toBe(true);
+      expect(service.settingsSignal()).not.toBeNull();
+      expect(pref.value()).toBe('L');
+
+      httpMock.expectOne('/api/settings').flush(withDicts);
+      await settleResource();
+      expect(pref.value()).toBe('L');
+    });
+
+    it('set() still merges when a refetch is in flight', async () => {
+      const pref = service.perMediaType<string>('grid_icon_size_right', signal('audio'), {
+        fallback: 'M',
+      });
+      await loadDicts();
+
+      service.load();
+      TestBed.tick();
+      const getReq = httpMock.expectOne((r) => r.method === 'GET');
+
+      pref.set('XL')?.subscribe();
+      const putReq = httpMock.expectOne((r) => r.method === 'PUT');
+      // `image: 'S'` MUST survive a write that races the refetch.
+      expect(putReq.request.body).toEqual({
+        grid_icon_size_right: { audio: 'XL', image: 'S' },
+      });
+      // Settle the refetch first: flushing the PUT installs its response as the
+      // resource's value, which aborts the GET still in flight.
+      getReq.flush(withDicts);
+      putReq.flush({ ...withDicts, grid_icon_size_right: { audio: 'XL', image: 'S' } });
+      await settleResource();
+      expect(pref.value()).toBe('XL');
+    });
+
+    it('clear() drops the value, so prefs fall back again', async () => {
+      const pref = service.perMediaType<string>('grid_icon_size_right', signal('audio'), {
+        fallback: 'M',
+      });
+      await loadDicts();
+      expect(pref.value()).toBe('L');
+
+      service.clear();
+      TestBed.tick();
+      expect(pref.value()).toBe('M');
+      expect(pref.dict()).toEqual({});
+    });
+
     it('ignores a non-dict value stored under the key', async () => {
       const pref = service.perMediaType<string>('grid_icon_size_right', signal('audio'), {
         fallback: 'M',

--- a/frontend/src/app/services/settings-state.service.ts
+++ b/frontend/src/app/services/settings-state.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Signal, computed, effect, inject, signal } from '@angular/core';
+import { Injectable, Signal, computed, effect, inject, isSignal, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -43,6 +43,9 @@ export interface PerMediaTypePref<T> {
    */
   set(next: T): Observable<AppSettings> | null;
 }
+
+/** A writable `AppSettings` key. */
+export type SettingsKey = keyof AppSettings & string;
 
 /** Options for {@link SettingsStateService.perMediaType}. */
 export interface PerMediaTypeOptions<T> {
@@ -156,19 +159,24 @@ export class SettingsStateService {
    *   went absent server-side left the last-seen copy in place forever. Reading
    *   through a `computed` has no such state.
    *
-   * @param key       the `AppSettings` key holding the dict.
+   * @param key       the `AppSettings` key holding the dict, or a signal of one
+   *                  where the key itself varies (`view-controls` picks
+   *                  `focus_mode_left` / `_right` / `_popup` from its `side`
+   *                  input).
    * @param mediaType signal carrying the active media type (`''` when unknown).
    * @param options   `fallback`, plus an optional `coerce` that rejects an
    *                  out-of-range or unrecognized stored value by returning
    *                  `undefined`.
    */
   perMediaType<T>(
-    key: keyof AppSettings & string,
+    key: SettingsKey | Signal<SettingsKey>,
     mediaType: Signal<string>,
     options: PerMediaTypeOptions<T>,
   ): PerMediaTypePref<T> {
+    const keySignal: Signal<SettingsKey> = isSignal(key) ? key : computed(() => key);
+
     const dict = computed<Record<string, T>>(() => {
-      const raw = this.settingsSignal()?.[key];
+      const raw = this.settingsSignal()?.[keySignal()];
       return raw && typeof raw === 'object' && !Array.isArray(raw)
         ? (raw as Record<string, T>)
         : {};
@@ -193,7 +201,7 @@ export class SettingsStateService {
         // Merge, never replace: dropping the other media types' entries here is
         // the one way this helper could silently destroy user data.
         const merged = { ...dict(), [mt]: next };
-        return this.update({ [key]: merged } as unknown as SettingsUpdate);
+        return this.update({ [keySignal()]: merged } as unknown as SettingsUpdate);
       },
     };
   }

--- a/frontend/src/app/services/settings-state.service.ts
+++ b/frontend/src/app/services/settings-state.service.ts
@@ -36,6 +36,10 @@ export interface PerMediaTypePref<T> {
   /**
    * Persist `next` for the active media type, preserving every other type's
    * entry. No-op when the media type is empty (nothing to key the write on).
+   *
+   * The merge is taken from the live dict, so it depends on the settings signal
+   * never reading as empty while the values are merely in flight — see
+   * {@link SettingsStateService.load}.
    */
   set(next: T): Observable<AppSettings> | null;
 }
@@ -58,8 +62,9 @@ export class SettingsStateService {
 
   // A monotonic load counter doubles as the resource request. `0` means
   // "not requested yet" -> `params()` returns `undefined` -> the resource stays
-  // idle (no fetch). Each `load()` bumps the counter, which changes the request
-  // and so re-runs the loader.
+  // idle (no fetch). The FIRST `load()` bumps the counter, which changes the
+  // request and so runs the loader; later ones reload in place instead, which
+  // keeps the last value while the refetch is in flight (see `load()`).
   private readonly loadCount = signal(0);
 
   private readonly resource = rxResource({
@@ -96,9 +101,32 @@ export class SettingsStateService {
     });
   }
 
-  /** Fetch (or refetch) settings from the server. No-op while a fetch is in flight. */
+  /**
+   * Fetch (or refetch) settings from the server. No-op while a fetch is in
+   * flight.
+   *
+   * A **refetch goes through `reload()`**, not through another bump of the
+   * request counter. Both re-run the loader, but changing the request throws
+   * the resource's stream away, so `value()` — and with it `settingsSignal()` —
+   * reverts to `null` for the length of the round-trip; `reload()` keeps the
+   * last value and only flips `isLoading()`. That window is not cosmetic:
+   * `load()` is called from half a dozen components' init hooks, so it lands
+   * regularly on a mounted view, and while it is open every consumer reads
+   * "no settings yet". Two things go wrong there.
+   *
+   * - **Values flicker.** A preference resolved through the null reports its
+   *   default and then snaps back — panel widths, thumbnail sizes, focus modes.
+   * - **A concurrent write destroys data.** A `{media_type: value}` write
+   *   merges into the dict it can see; against a null that merge yields
+   *   `{[mediaType]: value}` alone, and `PUT /api/settings` *replaces* the
+   *   stored dict — so every other media type's entry is silently dropped.
+   *   {@link perMediaType} is exactly this shape.
+   *
+   * The first load still bumps the counter: there is nothing to reload yet.
+   */
   load(): void {
     if (this.resource.isLoading()) return;
+    if (this.loadCount() > 0 && this.resource.reload()) return;
     this.loadCount.update((n) => n + 1);
   }
 

--- a/frontend/src/app/utils/settings-coerce.ts
+++ b/frontend/src/app/utils/settings-coerce.ts
@@ -1,0 +1,35 @@
+/**
+ * Coercers shared by the per-media-type settings preferences.
+ *
+ * `SettingsStateService.perMediaType`'s `coerce` hook is where a stored value is
+ * checked before it is trusted: a settings file is hand-editable and an older
+ * server can hold a shape the current app never writes, so a preference has to
+ * be able to say "that isn't one of mine" and fall back. The same three checks
+ * were being written out at each consumer; they live here so a fix lands once.
+ *
+ * Every coercer returns `undefined` to reject, which is what
+ * `perMediaType` reads as "use the fallback".
+ */
+
+/** The two focus modes a panel can be in: click-to-vote or hover-to-preview. */
+export type FocusMode = 'click' | 'hover';
+
+/** Accept only the two real focus modes; anything else falls back. */
+export function coerceFocusMode(raw: unknown): FocusMode | undefined {
+  return raw === 'click' || raw === 'hover' ? raw : undefined;
+}
+
+/** Accept only a finite number of pixels; anything else falls back to "unset". */
+export function coercePx(raw: unknown): number | undefined {
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+/**
+ * Accept a non-empty string. Used for the named icon sizes, whose ladders
+ * differ per surface (`XS…XL` in the panels, `XS…5XL` on the browse canvas) —
+ * `iconSizeToGoalWidth` already maps an unknown name onto the default, so the
+ * only value worth rejecting here is the empty one.
+ */
+export function coerceNonEmptyString(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw !== '' ? raw : undefined;
+}


### PR DESCRIPTION
Finishes #3447. #3474 added `SettingsStateService.perMediaType` and converted `LabelViewPanelStateService` plus the three `grid_icon_size_right` mirrors; this converts everything that was left, and fixes a real bug found on the way.

## The bug

`SettingsStateService.load()` refetched by bumping the resource's request. A new request throws the resource's stream away, so `settingsSignal()` reverted to `null` for the whole round-trip. `load()` is called from half a dozen components' init hooks, so that window opens regularly under a mounted view — and while it is open every consumer reads "no settings yet". Two things go wrong there:

- **Values flicker.** A preference resolved through the null reports its default and snaps back when the response lands — panel widths, thumbnail sizes, focus modes.
- **A concurrent write destroys data.** A `{media_type: value}` write merges into the dict it can see. Against the null that merge yields `{[mediaType]: value}` alone, and `PUT /api/settings` *replaces* the stored dict (`set_<key>` takes the whole value), so **every other media type's entry is silently dropped**. That is exactly the sibling-wipe the issue's constraints named, reachable through any per-media write that races a reload — the shipped `perMediaType` included.

`reload()` re-runs the same request and keeps the last value, flipping only `isLoading()`, so the window closes. The first load still bumps the counter (there is nothing to reload yet). Three specs pin it.

## The conversion

| Component | What went |
|---|---|
| `browse-view` | Six keys resolved longhand (colormap, icon size, thumbnail border, zooms-per-level, signposts, docked bin details), the `perMediaValue` helper, and three ad-hoc merge-writers. |
| `find-view` | Five shadow `Record`s, the effect mirroring settings into them, and the second re-derivation on a media-type switch. `gridGoalWidthLeft` / `focusModeLeft` / `focusModeRight` become `computed`s, so the template tracks them instead of depending on the mirror effect's write to schedule CD. |
| `view-controls` | `getDict` / `key` / `save`. Its key varies with the `side` input, so `perMediaType` now also accepts a *signal* of a key. |
| `browse-bin-popup` | Three dicts mirrored in by the settings effect; the reads no longer run one effect behind. |
| `label-view-panel-state` | Its private copies of the coercers, which move to `utils/settings-coerce.ts`. |

Each shadow dict was hydrated behind an `if (dict && typeof dict === 'object')` guard, so a key that went absent server-side left the last-seen copy in place for the life of the view. A `computed` has no such state.

**Two deliberate non-conversions**, now written down in `docs/FRONTEND.md`:

- The **Settings modal** stays hand-rolled: it edits a *draft* settings signal across *every* media type via a `typeId` loop, not "the current one".
- **`view-controls` keeps local optimistic signals** in front of its preferences. Its size buttons derive the next rung from the current one and grey out at the ends of the ladder, so binding straight to the preference would make a rapid second click read a pre-round-trip value.

`browse-view` is likewise conservative by design: its reads stay imperative inside `applyBrowsePrefsForMediaType()` rather than becoming bindings, because applying the icon size also re-seeds the canvas's overview granularity. Only the plumbing underneath moved, so the reframe timing is untouched.

## One spec fixture the `load()` fix uncovered

`label-view` / `find-view`'s zoneless specs flushed `{ volume: 80 }` from `/api/settings`. `volume` is a 0–1 fraction — `settings_models.py` clamps it, so no real server can return 80 — and the centre panel writes it straight onto `HTMLMediaElement.volume`, which throws `IndexSizeError` in jsdom outside that range. The bad fixture was unreachable only by accident: a second `load()` blanked the settings signal before the audio player could consume it. With the refetch keeping its value, the fixture's own invalidity surfaces. Fixed to `0.8`.

## On the issue's premise

The premise holds, with the two corrections #3474 already recorded (it is 9 files, not 14 components; nothing was *actually* wiping a sibling at the time). What the issue called a risk turned out to be a live defect after all, just one tier down — in the helper's own read path rather than at the call sites. Worth doing.

## Verification

Full `./run-tests.sh` green on the rebased branch: 9777 passed, plus pyright, pip-audit, vulture, npm audit and the 2323-test Vitest suite all OK.

Per the issue's constraint, also driven in **real chromium** against a running app, on a seeded settings file where every touched dict carries an `audio` sibling entry the views never show. Every check passed:

- **label + find, both panels** — thumbnail-size bump and focus toggle persist, the grid repaints (`--grid-goal-width` 80px → 130px), the toggle repaints to the pressed state, siblings survive.
- **label** — divider drag persists `panel_pct_left`, sibling survives.
- **browse** — icon-size bump persists and re-seeds the canvas; the read-only per-media prefs are untouched by unrelated writes.
- **bin popup** — reveals on the summoning right-click; detail-canvas size and metadata column persist and repaint; Dock → Pop out round-trips `bin_details_docked` and the docked panel mounts and releases.
- No console errors throughout.

Not exercised in the browser: `browse_signposts` (its toggle is gated on the projection having labels, which the synthetic fixture does not) and `grid_icon_size_popup` (the bins hit were singletons, which render no member grid). Both are covered by the unit suite.

No visual change is intended anywhere, so no screenshot reshoot is owed.

Closes #3447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zxyBMctxwYjdF9xbjD8Cy