### PR TITLE
Clear the media selection on a pair change, and seed the centre from the new pair's ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **Switching dataset or detector no longer leaves the previous pair's item in
+  the centre viewer.** Media ids are per-dataset, so the pair switch cleared the
+  ranking, the threshold and the vote cache but left the *selection* pointing at
+  an item that only existed under the pair you just left. Because the viewer
+  stamps the dataset id into the media URL when it builds it, the stranded item
+  kept loading from its own dataset and rendered normally -- so the grid showed
+  the new pair while the centre showed the old one, with nothing on screen
+  saying so. The selection is now dropped with the rest of the pair's state; the
+  centre reads "Select a media item to view" until the new pair's first pick
+  lands, exactly as it does on a fresh entry.
+
 - **The "arranging your items" wait now shows a remaining-time estimate.**
   Preparing a subset map from Find results renders an ETA chip beside the
   progress bar, but the projection build's status payload never carried an

--- a/frontend/src/app/components/label-view/label-view.component.ts
+++ b/frontend/src/app/components/label-view/label-view.component.ts
@@ -182,6 +182,11 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
   /** Armed on entry and on each pair reload; consumed once medias first render
    *  to snap both panels tight to the grid (see ``snapPanelsOnLoad``). */
   private pendingSnapOnLoad = false;
+  /** Armed on each pair reload; consumed by the first ranking that lands for
+   *  the new pair, which the centre viewer is then seeded from. See the effect
+   *  in the constructor for why the pair change cannot just auto-select itself.
+   */
+  private pendingSelectOnPairChange = false;
 
   constructor() {
     effect(() => {
@@ -259,6 +264,37 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
           this.autopilotMediaSortPending = false;
           this.triggerAutopilotMediaSort();
         }
+      });
+    });
+
+    // Seed the centre viewer for the new pair, once the pair change produces a
+    // ranking to seed it from.
+    //
+    // The pair change clears the selection, because a media id from the pair we
+    // left means nothing under the new one (`PairScopeService.clearPairState`,
+    // #3489). Something has to put an item back, and on this path nothing did:
+    // *entry* seeds the centre through Autopilot's activation sort
+    // (`triggerAutopilotTextSort` -> `onTextSort` -> `autoSelectNext`), which a
+    // switch never re-runs, and every re-rank a switch *does* fire passes
+    // `autoSelect: false` — correctly, since those same calls also run
+    // underneath a user who is mid-labelling, where moving them off the item
+    // they are looking at is the bug. So the seed is armed by the pair change
+    // itself and consumed here, once, by whichever re-rank happens to land
+    // first (the learned-sort rehydration below, an Autopilot phase change, a
+    // text sort).
+    //
+    // Deliberately silent when no ranking ever arrives: switching to a pair the
+    // detector has no labelset for leaves the centre on its placeholder, which
+    // is exactly where a fresh entry to that same pair leaves it.
+    effect(() => {
+      const order = this.sortState.sortOrder;
+      untracked(() => {
+        if (!this.pendingSelectOnPairChange) return;
+        if (!order || order.length === 0) return;
+        this.pendingSelectOnPairChange = false;
+        // A re-rank that auto-selected on its own (or a click that beat us to
+        // it) already owns the centre; never move the user off it.
+        if (this.mediaState.selectedId() === null) this.autoSelectNext();
       });
     });
 
@@ -370,6 +406,8 @@ export class LabelViewComponent implements OnInit, AfterViewInit, OnDestroy {
       this.pendingRehydrateLearned = false;
       // Read by the medias effect when the reload below lands.
       this.pendingSnapOnLoad = true;
+      // Read by the seed effect when the new pair's first ranking lands.
+      this.pendingSelectOnPairChange = true;
     });
     this.loadTrainingVotes();
 

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -927,6 +927,31 @@ describe('LabelViewComponent', () => {
       expect(component.sortState.sortOrder ?? []).toEqual([]);
     });
 
+    it('clears the centre viewer selection, and repaints, when the pair changes', () => {
+      const activeContext = seedPair();
+      flushInitialRequests();
+      flushDetectorRegistry();
+
+      // The user is looking at an item from pair 1.
+      component.mediaState.selectMedia(1);
+      TestBed.tick();
+      expect(fixture.nativeElement.querySelector('vt-center-panel .center-panel.empty')).toBeNull();
+
+      activeContext.setActivePair('ds2', 'det2');
+      flushDetectorRegistry();
+      TestBed.tick();
+
+      // Media ids are per-dataset, so the selection is pair-scoped state and
+      // has to go with the ranking (#3489). Asserting through the DOM rather
+      // than only on the signal is the point: the centre viewer stamps the
+      // dataset id into its `<img src>` and only rebuilds it when the media id
+      // changes, so a clear that does not notify under zoneless change
+      // detection would leave the stale pair-1 item painted (`docs/FRONTEND.md`
+      // §5) — which is the bug, not the fix.
+      expect(component.mediaState.selectedId()).toBeNull();
+      expect(fixture.nativeElement.querySelector('vt-center-panel .center-panel.empty')).not.toBeNull();
+    });
+
     it('stops polling a learned-sort job when the active pair changes', async () => {
       const activeContext = seedPair();
       flushInitialRequests();

--- a/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
+++ b/frontend/src/app/components/label-view/label-view.zoneless.spec.ts
@@ -927,10 +927,13 @@ describe('LabelViewComponent', () => {
       expect(component.sortState.sortOrder ?? []).toEqual([]);
     });
 
-    it('clears the centre viewer selection, and repaints, when the pair changes', () => {
+    it('clears the centre viewer selection, and repaints, when the pair changes', async () => {
       const activeContext = seedPair();
       flushInitialRequests();
       flushDetectorRegistry();
+      // The stub list rides `rxResource`, so `selectedMedia` cannot resolve id
+      // 1 into a media until the loader's value has landed.
+      await settleResource();
 
       // The user is looking at an item from pair 1.
       component.mediaState.selectMedia(1);
@@ -939,17 +942,31 @@ describe('LabelViewComponent', () => {
 
       activeContext.setActivePair('ds2', 'det2');
       flushDetectorRegistry();
+      // Answer the reset's own media reload with a list that *also* carries id
+      // 1. Ids restart at 1 in every dataset, so this collision is the common
+      // case, not a contrived one — and it is what makes the assertion below
+      // mean something: an uncleared selection resolves against the new list
+      // and keeps the viewer populated, rather than merely surviving the
+      // moment the resource is empty mid-reload.
       TestBed.tick();
+      httpMock.match('/api/medias/ids').forEach((req) =>
+        req.flush([
+          { id: 1, media_type: 'audio' },
+          { id: 2, media_type: 'audio' },
+        ]),
+      );
+      await settleResource();
+      expect(component.mediaState.mediasSignal().length).toBe(2);
 
       // Media ids are per-dataset, so the selection is pair-scoped state and
       // has to go with the ranking (#3489). Asserting through the DOM rather
       // than only on the signal is the point: the centre viewer stamps the
-      // dataset id into its `<img src>` and only rebuilds it when the media id
+      // dataset id into its media URL and only rebuilds it when the media id
       // changes, so a clear that does not notify under zoneless change
-      // detection would leave the stale pair-1 item painted (`docs/FRONTEND.md`
-      // §5) — which is the bug, not the fix.
-      expect(component.mediaState.selectedId()).toBeNull();
+      // detection would leave the stale pair-1 item painted
+      // (`docs/FRONTEND.md` §5) — which is the bug, not the fix.
       expect(fixture.nativeElement.querySelector('vt-center-panel .center-panel.empty')).not.toBeNull();
+      expect(component.mediaState.selectedId()).toBeNull();
     });
 
     it('stops polling a learned-sort job when the active pair changes', async () => {

--- a/frontend/src/app/services/media-state.service.spec.ts
+++ b/frontend/src/app/services/media-state.service.spec.ts
@@ -77,6 +77,22 @@ describe('MediaStateService', () => {
     expect(service.selectedId()).toBeNull();
   });
 
+  it('clearSelection should drop the selection but keep the loaded medias', async () => {
+    load();
+    await settleResource();
+    service.selectMedia(1);
+    expect(service.selectedMedia).not.toBeNull();
+
+    // The pair-change reset wants only this half: the stub list is re-fetched
+    // by `loadMedias()` rather than blanked, so the grid never flashes empty
+    // (issue #3489).
+    service.clearSelection();
+    TestBed.tick();
+    expect(service.selectedId()).toBeNull();
+    expect(service.selectedMedia).toBeNull();
+    expect(service.mediasSignal()).toEqual(mockMedias);
+  });
+
   it('loadMedias should restart an in-flight fetch instead of dropping the reload', async () => {
     // Pair switch A->B issues the first fetch (stamped with B's X-Dataset-Id)...
     service.loadMedias();

--- a/frontend/src/app/services/media-state.service.ts
+++ b/frontend/src/app/services/media-state.service.ts
@@ -89,6 +89,26 @@ export class MediaStateService {
     this.loadCount.update((n) => n + 1);
   }
 
+  /**
+   * Drop the selection without touching the stub list or the metadata cache.
+   *
+   * Media ids are *per-dataset*, so a selection is pair-scoped state: it is
+   * only meaningful against the pair that installed it. Carrying it across a
+   * pair change strands the centre viewer on an item from the pair we left —
+   * silently, because `ActiveContextService.mediaUrl` stamps the dataset id
+   * into the `<img src>` at build time and the viewers only rebuild that src
+   * when the media *id* changes (see `ImageViewerComponent.lastMediaId` and
+   * its four siblings). The stale item therefore keeps resolving against its
+   * own dataset and renders happily instead of 404-ing. See #3489.
+   *
+   * Separate from {@link clear} because the pair-change reset wants only this
+   * half: it re-fetches the stub list (rather than blanking it, which would
+   * flash the grid empty) and the metadata cache is already dataset-keyed.
+   */
+  clearSelection(): void {
+    this.selectedIdSignal.set(null);
+  }
+
   clear(): void {
     this.resource.set([]);
     this.selectedIdSignal.set(null);

--- a/frontend/src/app/services/pair-scope.service.spec.ts
+++ b/frontend/src/app/services/pair-scope.service.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { Subject } from 'rxjs';
 
+import { MediaStateService } from './media-state.service';
 import { PairScopeService } from './pair-scope.service';
 import { SortStateService } from './sort-state.service';
 import { VoteStateService } from './vote-state.service';
@@ -26,6 +27,7 @@ describe('PairScopeService', () => {
   let httpMock: HttpTestingController;
   let sortState: SortStateService;
   let voteState: VoteStateService;
+  let mediaState: MediaStateService;
 
   beforeEach(() => {
     configureZoneless({ imports: [HostComponent], providers: [...provideHttpTesting()] });
@@ -34,6 +36,7 @@ describe('PairScopeService', () => {
     httpMock = TestBed.inject(HttpTestingController);
     sortState = TestBed.inject(SortStateService);
     voteState = TestBed.inject(VoteStateService);
+    mediaState = TestBed.inject(MediaStateService);
   });
 
   afterEach(() => {
@@ -108,6 +111,34 @@ describe('PairScopeService', () => {
     // Reloads for the new pair went out.
     expect(httpMock.match('/api/dataset/status').length).toBe(1);
     expect(httpMock.match('/api/inclusion').length).toBe(1);
+  });
+
+  it('clears the selection too, so the centre viewer cannot outlive the pair', () => {
+    // Media ids are per-dataset, and `ActiveContextService.mediaUrl` stamps the
+    // dataset id into the `<img src>` at build time — so a selection that
+    // survives the switch keeps resolving against the pair we *left* and
+    // renders happily instead of 404-ing (#3489). Nothing else in the reset
+    // touches it: the ranking and the vote cache are cleared, everything
+    // derived from the selection goes with them, and the selection itself is
+    // the one piece of pair-scoped state left behind.
+    mediaState.selectMedia(7);
+    expect(mediaState.selectedId()).toBe(7);
+
+    service.resetForNewPair();
+
+    expect(mediaState.selectedId()).toBeNull();
+  });
+
+  it('clearPairState alone drops the selection, for find-view\'s entry path', () => {
+    // Dashboard -> Find enters against a possibly different dataset while the
+    // singleton `MediaStateService` still holds the previous session's pick.
+    // That entry path calls `clearPairState()` rather than the full reset, so
+    // the selection clear has to live there and not in `resetForNewPair`.
+    mediaState.selectMedia(7);
+
+    service.clearPairState();
+
+    expect(mediaState.selectedId()).toBeNull();
   });
 
   it('seedInclusion pushes the per-detector value into SortStateService', () => {

--- a/frontend/src/app/services/pair-scope.service.ts
+++ b/frontend/src/app/services/pair-scope.service.ts
@@ -104,12 +104,24 @@ export class PairScopeService implements OnDestroy {
    * applies the same clear on a fresh navigation (Find and Train share
    * singleton sub-view state, so a Dashboard → Find entry would otherwise
    * render the previous session's ranking against a possibly smaller dataset).
+   *
+   * The **selection** is part of that state, for the same reason the ranking
+   * is: media ids are per-dataset, so an id the old pair installed means
+   * nothing under the new one. Leaving it behind is the quiet half of the
+   * failure this service's header describes — the ranking and the vote cache
+   * get cleared, everything *derived* from the selection goes with them, and
+   * the selection itself survives, stranding the centre viewer on an item from
+   * the pair we just left (#3489). The viewer is then blank exactly as it is on
+   * a fresh entry, until whichever re-select the caller's tail owns lands: the
+   * boundary seed in find-view's `runFindLabel`, or `autoSelectNext` /
+   * `pendingSnapOnLoad` in label-view.
    */
   clearPairState(): void {
     this.sortState.setSortResults([], 0);
     this.sortState.setSortStatus('');
     this.sortState.setSortProgress(0, 0);
     this.voteState.clear();
+    this.mediaState.clearSelection();
   }
 
   /**


### PR DESCRIPTION
Closes #3489

## The bug, confirmed

`clearPairState` dropped every piece of pair-scoped state except the one the user is actually looking at. Media ids are per-dataset, so a selection installed by the pair we are leaving means nothing under the new one — and `ActiveContextService.mediaUrl` stamps the dataset id into the `<img src>` at build time while the viewers only rebuild that src when the media **id** changes (`ImageViewerComponent.lastMediaId` and its four siblings). The stranded item therefore keeps resolving against its own dataset and renders happily rather than 404-ing, so nothing on screen says it is stale.

Reproduced in real chromium on the pre-fix build, with the issue's delayed-`/api/dataset/status` race (fixtures from `scripts/screenshots/ensure-fixtures.mjs`):

```
B/before  Train on syn-imgs (status delayed 4s)
      header  = syn-imgs
      centre  = syn-imgs        <- correct
B/after   Train, raced back to syn-imgs
      header  = syn-imgs
      centre  = syn-patch       <- STALE: dataset_id of the pair we left
```

Two corrections to the issue's framing, both from running it:

- **The dataset pulldown is locked in Find** (`Dataset is fixed here — return to the Dashboard to switch`, `ContextPulldownComponent.updateLocked`), so the rapid switch the repro describes is only reachable in Train. The Train repro above is the one that reproduces.
- The failure is not confined to the raced switch. A media id that exists in both datasets resolves against the new list without rebuilding the src, so **an id collision reproduces it without any race** — and ids restart at 1 in every dataset, which makes that the common case rather than the exotic one.

## The fix

`MediaStateService.clearSelection()` drops the selection without touching the stub list or the metadata cache, and `PairScopeService.clearPairState` calls it alongside the sort and vote clears. It goes in `clearPairState` rather than `resetForNewPair` so find-view's entry path gets it too — that path already calls the clear on its own, for exactly this class of stale-id bug.

## The half the clear exposed

Clearing the selection left nobody to put an item back. Entry seeds the centre through Autopilot's activation sort (`triggerAutopilotTextSort` → `onTextSort` → `autoSelectNext`), which a switch never re-runs, and every re-rank a switch *does* fire passes `autoSelect: false` — correctly, since those same calls also run underneath a user who is mid-labelling, where moving them off their item is the bug. So `label-view` arms a one-shot seed on the pair change and consumes it from the first ranking that lands for the new pair, whichever path produced it, declining to override a selection that beat it there.

It is deliberately silent when no ranking arrives: switching to a pair the detector has no labelset for leaves the centre on its placeholder, which is exactly where a fresh entry to that same pair leaves it (verified — a fresh entry to `syn-patch`/`doc-demo` is blank too).

**Known limitation, filed as #3510:** a Train pair switch turns out to issue *no* sort request at all in the common walk, so a switch back to a pair that had a full ranking on entry now lands on the placeholder. That gap is pre-existing — the identical run on the pre-fix build issues the same zero sort requests — and was masked by the stranded selection painting an arbitrary item. Fixing #3510 populates the centre through the seed effect added here, with no further work in the viewer.

## Verification

- Real chromium, both builds, the issue's repro plus an unraced switch and a fresh-entry parity benchmark. Pre-fix: `centre = syn-patch` while the header says `syn-imgs`. Post-fix: no stale item in any case, and the centre follows the new pair wherever a ranking exists.
- Three new specs, each confirmed red before the fix and green after — including a `label-view` one that flushes the reload with a **colliding id** so the assertion means "the selection was cleared", not "the resource was momentarily empty", and asserts through the DOM so a clear that failed to notify under zoneless change detection would fail here.
- Full `./run-tests.sh`: `RUN PASSED`, 9748 passed / 6 skipped, every gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsJxcDSUUbzVr8ZxqpGmzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsJxcDSUUbzVr8ZxqpGmzJ)_