### PR TITLE
#3257 evaluated unrun: the app reload path ships the anchored cut, not the conformal one

### DIFF
--- a/docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md
+++ b/docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md
@@ -395,9 +395,33 @@ places:
   re-derives a detector from saved origins, where there is no haystack to fuse
   against and *"the conformal cut ships alone"*.
 
-That second one is ordinary: every saved detector a user re-opens is thresholded
-this way. On region-voting detectors it is currently **0.063 ± 0.008 worse than
-what a freshly trained detector gets**, and roughly two-thirds of that gap
+> ### ⚠ Correction, 2026-09-02 (from #3257's pre-launch evaluation): the second site is not the app's reload
+>
+> `train_detector_from_origins` is the **library-tier** re-derivation entry
+> point and has **no in-app caller** — true on this run's tree
+> (`c39ce22e8`) as well as on today's `dev`. The app reloads a saved detector
+> through `POST /api/detectors/registry/load` → `train_from_labelset(...,
+> snap=snap)` → `train_and_threshold`, which gets the active dataset's medias
+> as a haystack and therefore fits the **fold-anchored** cut — measured
+> directly, not read off the source: after a real registry load the context
+> carries a fitted `FoldAnchoredCut` and ships `0.49600` where the pooled
+> conformal cut over the same fold orderings is `0.48519`. Pinned by
+> `tests/detectors/test_load_time_threshold_provenance.py`.
+>
+> **So "every saved detector a user re-opens is thresholded this way" is
+> false, and the −0.063 gap below does not apply to a reload.** The pooled
+> rule's real user-facing sites are the Inclusion re-cut named above and
+> **`vtsearch/routes/detectors/find.py:481`** — cold Find, which trains a
+> detector on the fly for a dataset it is not loaded against and calls
+> `train_and_threshold` *without* a snap, so its Good/Bad verdicts are cut by
+> the pooled conformal rule even though a haystack (`temp_medias`) is in hand.
+> That path, not the reload, is where this study's numbers land.
+>
+> → #3257 was closed unrun; the trajectory it wanted to measure does not exist.
+
+That second one is narrower than it reads: it is the library API, not the app's
+reload. On region-voting detectors the pooled rule is currently **0.063 ± 0.008
+worse than what a freshly trained detector gets**, and roughly two-thirds of that gap
 (−0.048 ± 0.007) is recoverable by changing nothing but the combine rule.
 
 ### The acquisition caveat does **not** apply here — measured, not assumed
@@ -478,12 +502,13 @@ Still: `vg_scale_any` inherits whatever `vg_scale` holds, and `build_pile.py
   The gate should be read as *"resolve above margin **and** the swept rule
   reaches the acquisition path"* — the second clause was implicit and should not
   have been.
-- **#3257 — the trajectory that *is* worth measuring: load-then-continue.** The conformal
-  cut is the **load-time** threshold, so a user who opens a saved detector and
-  then keeps voting starts the session on it, and that first threshold steers
-  everything after. This harness always trains fresh, so it never exercises that
-  path. That is a different experiment from an A/B of the rule, and it is the one
-  with real acquisition feedback in it.
+- **#3257 — load-then-continue. ~~The trajectory that *is* worth
+  measuring.~~ CLOSED UNRUN 2026-09-02: the premise is false.** This bullet
+  claimed that opening a saved detector starts the session on the conformal cut,
+  so that first threshold steers everything after. It does not: the app's reload
+  path fuses against the haystack like any other training pass and starts on the
+  fold-anchored cut (see the correction above). The conformal cut still never
+  reaches acquisition; what it does reach is cold Find's verdicts.
 - **#3258 — a mode-dependent combine for the conformal path.** The evidence points at
   quantile space for region and score space for binary. `threshold_from_fold_orderings`
   takes no voting-mode argument today, so this is a signature change, not a

--- a/tests/detectors/test_load_time_threshold_provenance.py
+++ b/tests/detectors/test_load_time_threshold_provenance.py
@@ -1,0 +1,80 @@
+"""Regression: reloading a saved detector lands on the **fold-anchored** cut.
+
+Issue #3257 proposed measuring a "load-then-continue" trajectory on the premise
+that a user who re-opens a saved detector starts the session on the *pooled
+conformal* cut - `train_detector_from_origins`, where "the conformal cut ships
+alone" - and that this worse starting threshold then steers acquisition.  The
+premise is wrong about the app: `train_detector_from_origins` is the
+**library-tier** re-derivation entry point and has no in-app caller.  The app's
+load path is `POST /api/detectors/registry/load` ->
+`vtscore.detectors.labelset_training.train_from_labelset(..., snap=snap)` ->
+`train_and_threshold`, which is handed the active dataset's medias as a
+haystack and therefore fits the fold-anchored population estimator - the same
+threshold a freshly trained detector gets.
+
+This test pins that, because the claim is otherwise only visible by following
+three call sites: what a resumed session starts on is what decides whether a
+whole class of "the load-time cut steers everything after" experiments has
+anything to measure.  It asserts the provenance directly (a fitted
+`FoldAnchoredCut` is parked on the context and the shipped threshold *is* its
+cut) and, so the assertion cannot pass vacuously, that the pooled conformal cut
+over the same fold orderings is a different number.
+
+Labels follow `test_find_inclusion_slide.py`: 6 good / 6 bad keeps the
+calibration folds non-separable, leaving ids 13-20 as the haystack the
+population estimator is fitted on.
+"""
+
+from __future__ import annotations
+
+from tests import load_detector_and_wait
+from tests.helpers import setup_trainable_model_in_registry
+from vtscore.state.core import get_detector_context
+from vtsearch.state import snapshot_medias
+
+_GOOD_IDS = [1, 2, 3, 4, 5, 6]
+_BAD_IDS = [7, 8, 9, 10, 11, 12]
+
+
+def _load_saved_detector(client, name: str):
+    """Write a detector to disk, load it through the real route, return its ctx."""
+    detector_id = setup_trainable_model_in_registry(
+        name,
+        good_ids=_GOOD_IDS,
+        bad_ids=_BAD_IDS,
+        snap=snapshot_medias(),
+    )
+    client.post("/api/inclusion", json={"inclusion": 0})
+    load_detector_and_wait(client, detector_id)
+    ctx = get_detector_context(detector_id)
+    assert ctx is not None
+    return ctx
+
+
+def test_reloaded_detector_starts_on_the_anchored_cut(client):
+    ctx = _load_saved_detector(client, "reload-anchored")
+
+    assert ctx.anchored_cut_cache is not None, (
+        "the registry load path must fit the fold-anchored population estimator; "
+        "without it a resumed session would start on the pooled conformal cut"
+    )
+    assert ctx.threshold == ctx.anchored_cut_cache.threshold_at(0)
+
+
+def test_reloaded_threshold_is_not_the_pooled_conformal_cut(client):
+    from vtscore.training.thresholds import threshold_from_fold_orderings
+
+    ctx = _load_saved_detector(client, "reload-not-conformal")
+
+    # The folds the conformal rule would cut over are cached on the context, so
+    # the counterfactual is computable here: it is what the load-time threshold
+    # would have been had no haystack reached `train_and_threshold`.
+    assert ctx.calibration_cache is not None
+    folds = ctx.calibration_cache[1]
+    assert folds.fallback is None and folds.orderings
+    pooled = threshold_from_fold_orderings(folds.orderings, 0)
+
+    assert ctx.threshold != pooled, (
+        "the anchored and pooled cuts coincide on this fixture, so the "
+        "provenance assertion above no longer distinguishes them"
+    )

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -5,8 +5,10 @@ by detector route handlers and test helpers.
 
 This module also holds the vote-aware detector training entry points -
 :func:`train_and_score` (online, called every time the user toggles a
-vote) and :func:`train_detector_from_origins` (load-time, called when
-re-deriving an MLP from a saved labelset). Both build on the generic
+vote) and :func:`train_detector_from_origins` (the **library-tier**
+re-derivation of an MLP from a saved labelset, for embedders driving
+``vtscore`` directly; the app does not call it - see that function's
+"Who calls this" note). Both build on the generic
 :mod:`vtscore.training` primitives but layer in the patch-region max-
 pool and origin-based file resolution that are detector-specific.
 """
@@ -1326,6 +1328,18 @@ def train_detector_from_origins(
     This is the load-time counterpart of file-based detector export: given
     the origin lists that were saved to disk, it re-derives the head weights
     by resolving the original media files, embedding them, and training.
+
+    **Who calls this: library consumers, not the app.**  Nothing in
+    ``vtsearch`` reaches here.  The app re-derives a saved detector through
+    ``POST /api/detectors/registry/load`` ->
+    :func:`vtscore.detectors.labelset_training.train_from_labelset` ->
+    :func:`train_and_threshold`, which is handed the active dataset's medias
+    as a haystack and therefore ships the **fold-anchored** cut, exactly as a
+    freshly trained detector does (pinned by
+    ``tests/detectors/test_load_time_threshold_provenance.py``).  So the plain
+    cross-calibration cut below is what a *library* caller with no haystack
+    gets - it is not the threshold a resumed VTSearch session starts on
+    (issue #3257, evaluated and closed unrun).
 
     Args:
         good_origins: Origin dicts for media labelled Good.

--- a/vtscore/docs/concepts.md
+++ b/vtscore/docs/concepts.md
@@ -327,7 +327,10 @@ detector lifecycle (load labelset → re-derive embeddings → train) lives
 in `vtscore.detectors.training.train_detector_from_origins`; the caller
 must pass `embedder_name` so re-derivation uses the same embedder the
 detector was trained with, not whatever the media type's current default
-happens to be.
+happens to be. That helper has **no haystack**, so its threshold is the
+plain cross-calibration cut; pass the population through
+`train_and_threshold` when you have one, which is what the VTSearch app
+does on its own detector-load path.
 
 ## 7. Context
 


### PR DESCRIPTION
Evaluation of experiment #3257 before launching it, plus the controls that stop its premise being re-derived. **No experiment was run** — the trajectory it wanted to measure does not exist in the app.

## The premise, and why it is false

#3257 proposed a "load-then-continue" study on the reading that a user who re-opens a saved detector starts the session on the pooled conformal cut (`train_detector_from_origins`, where *"the conformal cut ships alone"*), so that first threshold steers the first acquisition pick and everything after it.

- `train_detector_from_origins` has **no in-app caller** — it is the library-tier re-derivation entry point, documented for `vtscore` consumers. Its only non-test, non-docs references are its own definition and a `store.py` docstring pointer, and the CLI does not use it either. That was already true on #3115's tree (`c39ce22e8`), so the framing was inherited rather than outdated by later work.
- The app reloads a saved detector through `POST /api/detectors/registry/load` → `train_from_labelset(..., snap=snapshot_medias())` → `train_and_threshold`, which is handed the active dataset's medias as a haystack and therefore fits the **fold-anchored** population estimator — the same threshold a freshly trained detector gets.

Asserted through the real route rather than read off the source (fresh worktree at `dev` `4e2d4b54b`): after a registry load the context carries a fitted `FoldAnchoredCut` and ships `0.49600`, where the pooled conformal cut over the same fold orderings is `0.48519`. Not a coincidental tie — two different rules, two different numbers, and the anchored one is what shipped.

## What is in this PR

- **`tests/detectors/test_load_time_threshold_provenance.py`** — pins the provenance through the real load route: a fitted `FoldAnchoredCut` is parked on the context and the shipped threshold *is* its cut. A second test pins that the pooled cut over the same fold orderings is a *different* number, so the first cannot pass vacuously.
- **`vtscore/detectors/training.py`** — the module docstring and `train_detector_from_origins` now say **who calls this** (library consumers) and what the app does instead. Their bare "load-time" framing is what seeded the premise; no logic changes.
- **`vtscore/docs/concepts.md`** — the detector-lifecycle paragraph now says the origins helper has no haystack, and points at `train_and_threshold` for callers who have one.
- **`docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md`** — a dated correction block. The report's *"every saved detector a user re-opens is thresholded this way"* is false, and the **−0.063 ± 0.008** region gap does not apply to a reload. The correction names the pooled rule's real user-facing site instead.

## Follow-up filed

**#3516** — cold Find (`vtsearch/routes/detectors/find.py:481`) trains a head on the fly for a dataset the detector is not loaded against and calls `train_and_threshold` **without** a `snap`, so its Good/Bad verdicts are cut by the pooled conformal rule — while `_score_dataset` is holding `temp_medias` and has already built the embedding matrix for that space. That is where this study's numbers actually land. Code change with a cost question, not a sweep.

Refs #3257, refs #3115, refs #3258, refs #3516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6fD41dcw5NePj8NW7NS4h
