### PR TITLE
Bind the origin resolvers at import instead of auto-wiring them

### DIFF
--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -83,7 +83,7 @@ care.
 
 ## Library tier — dead code & unkept promises
 
-- [ ] #3397 — Keep the resolver extension point but delete its auto-wire dance and import-error mask (Sonnet 5)
+- [x] #3397 — Keep the resolver extension point but delete its auto-wire dance and import-error mask (Sonnet 5)
 - [ ] #3401 — Declare `image_response` on the `MediaType` ABC and document both undeclared hooks (Sonnet 5)
 - [ ] #3402 — Apply the sub-output disambiguators in the converted-demo emitter (Sonnet 5)
 - [ ] #3404 — Small vtscore batch: `JOB_MANAGERS` coverage, registry construction, `SAVED_DATASETS_DIR` (Haiku 4.5)

--- a/tests/detectors/test_resolver.py
+++ b/tests/detectors/test_resolver.py
@@ -1189,7 +1189,6 @@ class TestResolveFileContextLifetime:
             return src.resolve_path(origin_name, filename)
 
         monkeypatch.setattr(resolver_mod, "_source_resolver", _custom_source_resolver)
-        monkeypatch.setattr(resolver_mod, "_auto_wired", True)
 
         origin = {"importer": "fake", "params": {}}
         with resolver_mod.resolve_file_context(origin, origin_name="thing.txt") as path:
@@ -1233,7 +1232,6 @@ class TestResolveFileContextLifetime:
             return src.resolve_path(origin_name, filename)
 
         monkeypatch.setattr(resolver_mod, "_source_resolver", _custom_source_resolver)
-        monkeypatch.setattr(resolver_mod, "_auto_wired", True)
 
         _ = resolver_mod.resolve_file_from_origin({"importer": "fake"}, "x.txt")
         assert cleaned == [True], "wrapper exits its context immediately"

--- a/tests_lib/detectors/test_resolver_extension_point.py
+++ b/tests_lib/detectors/test_resolver_extension_point.py
@@ -65,6 +65,7 @@ class TestResolverRegistration:
 
         origin = {"importer": "server_folder", "params": {"path": str(folder)}}
         with resolver_mod.resolve_file_context(origin, origin_name="thing.txt") as path:
+            assert path is not None
             assert path == fake_file, "registered resolver must win over the default"
             assert path.read_bytes() == b"fake"
 

--- a/tests_lib/detectors/test_resolver_extension_point.py
+++ b/tests_lib/detectors/test_resolver_extension_point.py
@@ -70,9 +70,7 @@ class TestResolverRegistration:
 
         assert calls == [("thing.txt", "")]
 
-    def test_registered_source_resolver_may_defer_to_importer_dispatch(
-        self, tmp_path, restore_resolvers
-    ):
+    def test_registered_source_resolver_may_defer_to_importer_dispatch(self, tmp_path, restore_resolvers):
         """Returning ``None`` falls through to the importer resolver."""
         folder = tmp_path / "media"
         folder.mkdir()

--- a/tests_lib/detectors/test_resolver_extension_point.py
+++ b/tests_lib/detectors/test_resolver_extension_point.py
@@ -1,0 +1,131 @@
+"""The public resolver extension point must actually take effect.
+
+``register_source_resolver`` / ``register_importer_resolver`` are documented
+in ``vtscore/docs/packages/detectors.md`` for out-of-tree consumers, so this
+repo has no registrants of its own.  That is what a working extension point
+looks like — and it is also how the hooks could rot unnoticed.  These tests
+stand in for the absent in-repo caller: they register a fake resolver through
+the public function and assert it displaces the default that
+``vtscore.detectors.resolver`` installs at import time.
+"""
+
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vtscore.detectors import resolver as resolver_mod
+
+
+@pytest.fixture
+def restore_resolvers(monkeypatch):
+    """Undo whatever the test registers, without going through a public API.
+
+    There is deliberately no ``unregister_*`` function, so the defaults are
+    put back by re-binding the module globals to the values they currently
+    hold; ``monkeypatch`` restores them at teardown.
+    """
+    monkeypatch.setattr(resolver_mod, "_source_resolver", resolver_mod._source_resolver)
+    monkeypatch.setattr(resolver_mod, "_importer_resolver", resolver_mod._importer_resolver)
+
+
+class TestResolverRegistration:
+    def test_defaults_are_installed_at_import(self):
+        """No first-use auto-wiring: importing the module is enough."""
+        assert resolver_mod._source_resolver is resolver_mod._default_source_resolver
+        assert resolver_mod._importer_resolver is resolver_mod._default_importer_resolver
+
+    def test_registered_source_resolver_wins_over_default(self, tmp_path, restore_resolvers):
+        """A registered source resolver is consulted instead of the default.
+
+        The origin names ``server_folder`` with a path the default source
+        resolver would happily resolve, so a passing assertion means the fake
+        really displaced it rather than merely running first.
+        """
+        folder = tmp_path / "media"
+        folder.mkdir()
+        real = folder / "thing.txt"
+        real.write_bytes(b"real")
+        fake_file = tmp_path / "fake.txt"
+        fake_file.write_bytes(b"fake")
+
+        calls: list[tuple[str, str]] = []
+
+        def _fake_source_resolver(
+            stack: ExitStack,
+            origin: dict[str, Any],
+            origin_name: str,
+            filename: str,
+        ) -> Path | None:
+            calls.append((origin_name, filename))
+            return fake_file
+
+        resolver_mod.register_source_resolver(_fake_source_resolver)
+
+        origin = {"importer": "server_folder", "params": {"path": str(folder)}}
+        with resolver_mod.resolve_file_context(origin, origin_name="thing.txt") as path:
+            assert path == fake_file, "registered resolver must win over the default"
+            assert path.read_bytes() == b"fake"
+
+        assert calls == [("thing.txt", "")]
+
+    def test_registered_source_resolver_may_defer_to_importer_dispatch(
+        self, tmp_path, restore_resolvers
+    ):
+        """Returning ``None`` falls through to the importer resolver."""
+        folder = tmp_path / "media"
+        folder.mkdir()
+        (folder / "thing.txt").write_bytes(b"real")
+
+        importer_calls: list[str] = []
+
+        def _decline(
+            stack: ExitStack,
+            origin: dict[str, Any],
+            origin_name: str,
+            filename: str,
+        ) -> Path | None:
+            return None
+
+        def _fake_importer_resolver(
+            origin: dict[str, Any],
+            origin_name: str,
+            filename: str,
+        ) -> Path | None:
+            importer_calls.append(origin_name)
+            return folder / origin_name
+
+        resolver_mod.register_source_resolver(_decline)
+        resolver_mod.register_importer_resolver(_fake_importer_resolver)
+
+        origin = {"importer": "server_folder", "params": {"path": str(folder)}}
+        with resolver_mod.resolve_file_context(origin, origin_name="thing.txt") as path:
+            assert path == folder / "thing.txt"
+
+        assert importer_calls == ["thing.txt"], "importer resolver must be reached"
+
+    def test_registered_importer_resolver_wins_over_default(self, tmp_path, restore_resolvers):
+        """An importer-only origin routes through the registered hook."""
+        target = tmp_path / "from_importer.txt"
+        target.write_bytes(b"payload")
+
+        calls: list[str] = []
+
+        def _fake_importer_resolver(
+            origin: dict[str, Any],
+            origin_name: str,
+            filename: str,
+        ) -> Path | None:
+            calls.append(origin.get("importer", ""))
+            return target
+
+        resolver_mod.register_importer_resolver(_fake_importer_resolver)
+
+        # No media source backs this importer name, so source dispatch
+        # declines and the importer resolver is what answers.
+        origin = {"importer": "not_a_real_importer", "params": {}}
+        with resolver_mod.resolve_file_context(origin, origin_name="x.txt") as path:
+            assert path == target
+
+        assert calls == ["not_a_real_importer"]

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -77,6 +77,24 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **A broken `vtscore.datasets` install now fails loudly instead of silently
+  disabling origin resolution** (issue #3397).
+  `vtscore.detectors.resolver` used to defer its imports of
+  `vtscore.datasets.sources` / `vtscore.datasets.importers` into a first-use
+  auto-wire step wrapped in `except ImportError: pass`. Because both packages
+  ship in this same distribution, that `except` could only ever fire on a
+  genuinely broken install - and when it did, the module carried on with *no*
+  resolvers registered, so every label silently failed to resolve and the only
+  symptom was an "N of M labels resolved" warning. Both imports are now
+  module-level, and the defaults are bound at import time rather than on first
+  use, so the underlying `ImportError` reaches the caller with its real
+  traceback.
+
+  **For library consumers:** `register_source_resolver`,
+  `register_importer_resolver`, `SourceResolver` and `ImporterResolver` are
+  unchanged, and a registered resolver still replaces the default. The only
+  visible difference is *when* an already-fatal misconfiguration surfaces.
+
 - **`vtscore.config` is now a package, not a single module** (issue #3375). The
   933-line file is split into `paths`, `runtime`, `models`, `device`,
   `processor_backend` and `core_config`, layered so each reads only from the ones

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -92,6 +92,7 @@ class ImporterResolver(Protocol):
 # Pluggable resolver registry
 # ---------------------------------------------------------------------------
 
+
 def _default_source_resolver(
     stack: ExitStack,
     origin: dict[str, Any],

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -8,8 +8,8 @@ embeddings for training.  This module handles that resolution:
 2. Embed the file using the appropriate embedder for the media type.
 3. Return resolved embeddings with availability stats.
 
-File resolution is split into two pluggable resolvers, auto-wired on
-first use:
+File resolution is split into two resolvers, each installed with a
+default implementation at import time:
 
 - **Source resolver**: delegates to
   :func:`~vtscore.datasets.sources.get_source_for_origin` and calls
@@ -39,6 +39,9 @@ from pathlib import Path
 from typing import Any, Iterator, Protocol, runtime_checkable
 
 import numpy as np
+
+from vtscore.datasets.importers import get_importer
+from vtscore.datasets.sources import get_source_for_origin
 
 log = logging.getLogger(__name__)
 
@@ -89,13 +92,40 @@ class ImporterResolver(Protocol):
 # Pluggable resolver registry
 # ---------------------------------------------------------------------------
 
-_source_resolver: SourceResolver | None = None
-_importer_resolver: ImporterResolver | None = None
-_auto_wired = False
+def _default_source_resolver(
+    stack: ExitStack,
+    origin: dict[str, Any],
+    origin_name: str,
+    filename: str,
+) -> Path | None:
+    """Resolve *origin* through its :class:`MediaSource`, if it has one."""
+    source = get_source_for_origin(origin)
+    if source is None:
+        return None
+    # Keep the source alive (and its temp dir, if any) until the caller's
+    # resolve_file_context exits.
+    stack.callback(source.cleanup)
+    return source.resolve_path(origin_name, filename).path
+
+
+def _default_importer_resolver(
+    origin: dict[str, Any],
+    origin_name: str,
+    filename: str,
+) -> Path | None:
+    """Resolve *origin* through its dataset importer, if it is registered."""
+    importer = get_importer(origin.get("importer", ""))
+    if importer is not None:
+        return importer.resolve_file(origin, origin_name, filename)
+    return None
+
+
+_source_resolver: SourceResolver = _default_source_resolver
+_importer_resolver: ImporterResolver = _default_importer_resolver
 
 
 def register_source_resolver(fn: SourceResolver) -> None:
-    """Register a source-based file resolver.
+    """Register a source-based file resolver, replacing the default.
 
     The resolver is called with ``(stack, origin, origin_name, filename)``
     and should return a :class:`~pathlib.Path` or ``None``.  Register the
@@ -107,70 +137,13 @@ def register_source_resolver(fn: SourceResolver) -> None:
 
 
 def register_importer_resolver(fn: ImporterResolver) -> None:
-    """Register an importer-based file resolver.
+    """Register an importer-based file resolver, replacing the default.
 
     The resolver is called with ``(origin, origin_name, filename)`` and
     should return a :class:`~pathlib.Path` or ``None``.
     """
     global _importer_resolver
     _importer_resolver = fn
-
-
-def _auto_wire_resolvers() -> None:
-    """Auto-wire the default resolvers on first use.
-
-    Imports the datasets source and importer packages lazily and registers
-    them as the default resolvers.  This avoids hard-coding cross-package
-    imports throughout :func:`resolve_file_from_origin` while still
-    providing zero-config behaviour.
-    """
-    global _auto_wired
-    if _auto_wired:
-        return
-    _auto_wired = True
-
-    # Source-based resolver
-    if _source_resolver is None:
-        try:
-            from vtscore.datasets.sources import get_source_for_origin
-
-            def _default_source_resolver(
-                stack: ExitStack,
-                origin: dict[str, Any],
-                origin_name: str,
-                filename: str,
-            ) -> Path | None:
-                source = get_source_for_origin(origin)
-                if source is None:
-                    return None
-                # Keep the source alive (and its temp dir, if any) until
-                # the caller's resolve_file_context exits.
-                stack.callback(source.cleanup)
-                return source.resolve_path(origin_name, filename).path
-
-            register_source_resolver(_default_source_resolver)
-        except ImportError:
-            pass
-
-    # Importer-based resolver
-    if _importer_resolver is None:
-        try:
-            from vtscore.datasets.importers import get_importer
-
-            def _default_importer_resolver(
-                origin: dict[str, Any],
-                origin_name: str,
-                filename: str,
-            ) -> Path | None:
-                importer_name = origin.get("importer", "")
-                importer = get_importer(importer_name)
-                if importer is not None:
-                    return importer.resolve_file(origin, origin_name, filename)
-                return None
-
-            register_importer_resolver(_default_importer_resolver)
-        except ImportError:
-            pass
 
 
 @dataclass
@@ -298,35 +271,29 @@ def _resolve_with_stack(  # noqa: C901
 
     # -- Source-based dispatch (preferred) --
 
-    _auto_wire_resolvers()
-
-    if _source_resolver is not None:
-        result = _source_resolver(stack, origin, origin_name, filename)
-        if result is not None:
-            log.debug("resolve_file: source-based dispatch succeeded → %s", result)
-            return result
-        log.debug(
-            "resolve_file: source resolver returned None for origin_name=%r, filename=%r",
-            origin_name,
-            filename,
-        )
+    result = _source_resolver(stack, origin, origin_name, filename)
+    if result is not None:
+        log.debug("resolve_file: source-based dispatch succeeded → %s", result)
+        return result
+    log.debug(
+        "resolve_file: source resolver returned None for origin_name=%r, filename=%r",
+        origin_name,
+        filename,
+    )
 
     # -- Registry-based dispatch (fallback for importers without a source) --
 
-    if _importer_resolver is not None:
-        result = _importer_resolver(origin, origin_name, filename)
-        if result is not None:
-            log.debug("resolve_file: importer dispatch (%s) succeeded → %s", importer_name, result)
-            return result
-        log.debug(
-            "resolve_file: importer resolver returned None (importer=%r, origin_name=%r, filename=%r, params=%r)",
-            importer_name,
-            origin_name,
-            filename,
-            params,
-        )
-    else:
-        log.debug("resolve_file: no importer resolver registered")
+    result = _importer_resolver(origin, origin_name, filename)
+    if result is not None:
+        log.debug("resolve_file: importer dispatch (%s) succeeded → %s", importer_name, result)
+        return result
+    log.debug(
+        "resolve_file: importer resolver returned None (importer=%r, origin_name=%r, filename=%r, params=%r)",
+        importer_name,
+        origin_name,
+        filename,
+        params,
+    )
 
     # -- Generic fallback for unregistered origins with a path param --
     # Handles synthetic origins like "pdf" that store a direct file path.

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -341,15 +341,24 @@ class ImporterResolver(Protocol):
                  filename: str) -> Path | None: ...
 ```
 
-`register_source_resolver(fn)` and `register_importer_resolver(fn)`
-replace the default implementations. Library callers that want to
-extend resolution (e.g. fetch from a private CDN before falling
-through to importers) plug in here. On first use,
-`_auto_wire_resolvers` installs defaults that delegate to
+Both resolvers are bound to a default implementation at import time:
+`_default_source_resolver` delegates to
 `vtscore.datasets.sources.get_source_for_origin` (registering
-`source.cleanup` on the caller's `ExitStack`) and
-`vtscore.datasets.importers.get_importer` +
-`importer.resolve_file`.
+`source.cleanup` on the caller's `ExitStack`), and
+`_default_importer_resolver` delegates to
+`vtscore.datasets.importers.get_importer` + `importer.resolve_file`.
+Those two packages are imported directly at the top of the module, so a
+broken install fails loudly at import rather than degrading into "every
+label fails to resolve".
+
+`register_source_resolver(fn)` and `register_importer_resolver(fn)`
+replace those defaults, and may be called at any point — the dispatch
+reads the module global on every resolution. Library callers that want
+to extend resolution (e.g. fetch from a private CDN before falling
+through to importers) plug in here; returning `None` from a source
+resolver falls through to the importer resolver, and then to the
+generic `params["path"]` fallback. There is no `unregister_*`
+counterpart: a replacement is permanent for the life of the process.
 
 ### Public surface
 
@@ -366,10 +375,10 @@ with resolve_file_context(origin, origin_name, filename) as path:
 
 | Function                                                             | Behaviour                                                          |
 |----------------------------------------------------------------------|--------------------------------------------------------------------|
-| `resolve_file_context(origin, origin_name, filename)` (line 195)     | **Context manager** - must wrap any code that reads the file. Some sources (`http_archive` cache misses) materialise files in a tempdir they own; the `ExitStack` keeps that tempdir alive until the `with` block exits. |
-| `resolve_file_from_origin(origin, origin_name, filename)` (line 223) | One-shot convenience. Safe for `path.exists()` checks; unsafe for any call that may garbage-collect the source. |
+| `resolve_file_context(origin, origin_name, filename)` (line 169)     | **Context manager** - must wrap any code that reads the file. Some sources (`http_archive` cache misses) materialise files in a tempdir they own; the `ExitStack` keeps that tempdir alive until the `with` block exits. |
+| `resolve_file_from_origin(origin, origin_name, filename)` (line 196) | One-shot convenience. Safe for `path.exists()` checks; unsafe for any call that may garbage-collect the source. |
 | `embed_file(file_path, media_type, embedder_name="")` (line 376)     | Pick the embedder for the media type (named, else first registered) and call `embedder.embed_media(media_from_path(...))`. |
-| `resolve_label_embeddings(labels, media_type, progress_callback=None)` (line 691) | Batch entry point. Returns `ResolvedLabels`.            |
+| `resolve_label_embeddings(labels, media_type, progress_callback=None)` (line 793) | Batch entry point. Returns `ResolvedLabels`.            |
 
 `ResolvedLabels` is a dataclass with `embeddings`, `labels`,
 `resolved_count`, `total_count`, `missing_entries` plus the

--- a/vtscore/docs/packages/detectors.md
+++ b/vtscore/docs/packages/detectors.md
@@ -375,10 +375,10 @@ with resolve_file_context(origin, origin_name, filename) as path:
 
 | Function                                                             | Behaviour                                                          |
 |----------------------------------------------------------------------|--------------------------------------------------------------------|
-| `resolve_file_context(origin, origin_name, filename)` (line 169)     | **Context manager** - must wrap any code that reads the file. Some sources (`http_archive` cache misses) materialise files in a tempdir they own; the `ExitStack` keeps that tempdir alive until the `with` block exits. |
-| `resolve_file_from_origin(origin, origin_name, filename)` (line 196) | One-shot convenience. Safe for `path.exists()` checks; unsafe for any call that may garbage-collect the source. |
-| `embed_file(file_path, media_type, embedder_name="")` (line 376)     | Pick the embedder for the media type (named, else first registered) and call `embedder.embed_media(media_from_path(...))`. |
-| `resolve_label_embeddings(labels, media_type, progress_callback=None)` (line 793) | Batch entry point. Returns `ResolvedLabels`.            |
+| `resolve_file_context(origin, origin_name, filename)` (line 170)     | **Context manager** - must wrap any code that reads the file. Some sources (`http_archive` cache misses) materialise files in a tempdir they own; the `ExitStack` keeps that tempdir alive until the `with` block exits. |
+| `resolve_file_from_origin(origin, origin_name, filename)` (line 197) | One-shot convenience. Safe for `path.exists()` checks; unsafe for any call that may garbage-collect the source. |
+| `embed_file(file_path, media_type, embedder_name="")` (line 377)     | Pick the embedder for the media type (named, else first registered) and call `embedder.embed_media(media_from_path(...))`. |
+| `resolve_label_embeddings(labels, media_type, progress_callback=None)` (line 794) | Batch entry point. Returns `ResolvedLabels`.            |
 
 `ResolvedLabels` is a dataclass with `embeddings`, `labels`,
 `resolved_count`, `total_count`, `missing_entries` plus the


### PR DESCRIPTION
Closes #3397

## The defect

`vtscore/detectors/resolver.py` deferred its imports of `vtscore.datasets.sources` and `vtscore.datasets.importers` into a first-use `_auto_wire_resolvers()` step, each wrapped in `except ImportError: pass`.

Both packages ship in this same distribution, so that `except` could only ever fire on a genuinely broken install — and when it did, the module carried on with **no resolvers registered at all**. Every label then silently failed to resolve, and the only symptom was an "N of M labels resolved" warning plus a `log.debug("no importer resolver registered")` nobody was reading. A packaging failure was laundered into what looks like a data problem.

## What changed

- Import `get_source_for_origin` / `get_importer` directly at module scope; a real `ImportError` now reaches the caller with its traceback.
- `_default_source_resolver` / `_default_importer_resolver` are module-level functions bound to the globals at import time, replacing the ~55-line `_auto_wire_resolvers()` + `_auto_wired` flag.
- The two globals are non-`Optional` now, which drops two permanently-false `is not None` branches at the dispatch site.
- Removed the two `monkeypatch.setattr(resolver_mod, "_auto_wired", True)` lines in `tests/detectors/test_resolver.py` that the deletion made dead.

**No import cycle:** nothing under `vtscore/datasets/` imports `vtscore.detectors` at module level (the three references in `ingest.py` / `clipper_chain.py` are function-local). Verified empirically that `vtscore.detectors.resolver`, `vtscore.datasets`, `vtscore.datasets.sources`, `vtscore.datasets.ingest` and `app` all import cleanly in any order.

## The extension point stays

`register_source_resolver`, `register_importer_resolver`, `SourceResolver` and `ImporterResolver` are untouched — they are documented in `vtscore/docs/packages/detectors.md`, so zero in-repo registrants is what a *working* extension point looks like, not evidence of dead code. Registration still displaces the default, and now works at any point rather than racing the first-use wiring.

`tests_lib/detectors/test_resolver_extension_point.py` stands in for the absent in-repo caller: it registers a fake through the **public** function and asserts it wins over a default that would otherwise have resolved the same origin, covers the `None` → importer-dispatch fall-through, and asserts the defaults are bound at import. The existing tests only ever monkeypatched the private globals, so the public hooks had no coverage at all. Mutation-checked: no-op'ing the two register functions fails 3 of the 4.

## Docs

- `vtscore/docs/packages/detectors.md`: rewrote the resolver paragraph (no more `_auto_wire_resolvers`), documented the fall-through order and that there is no `unregister_*`. Also re-synced four stale `(line N)` references in the same table — three were already wrong before this change.
- `vtscore/CHANGELOG.md`: `[Unreleased] → Changed` entry. Not a deprecation — the public surface is unchanged; the only visible difference is *when* an already-fatal misconfiguration surfaces.

## Testing

Full `./run-tests.sh`: **9781 passed, 6 skipped**, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176dpRcPqX12raB3EEuY9HU

---
_Generated by [Claude Code](https://claude.ai/code/session_0176dpRcPqX12raB3EEuY9HU)_