### PR TITLE
Route the promote thread through spawn, and document the two background idioms

### DIFF
--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -90,7 +90,7 @@ care.
 
 ## Concurrency & progress
 
-- [ ] #3382 — Route the raw staging thread through `vtsearch.threading.spawn` (Haiku 4.5)
+- [x] #3382 — Route the raw staging thread through `vtsearch.threading.spawn` (Haiku 4.5)
 
 ## Layering & host seams
 

--- a/tests/integration/test_spawn.py
+++ b/tests/integration/test_spawn.py
@@ -136,3 +136,46 @@ class TestSpawnDatasetContext:
         _wait(done)
         thread.join(timeout=5)
         assert seen == [(1, "two", "extra")]
+
+
+class TestSpawnStartControl:
+    def teardown_method(self):
+        set_thread_user(None)
+
+    def test_start_false_returns_unstarted_thread(self):
+        # The ``loading_tasks.set_worker`` contract wants the thread in hand
+        # *before* it runs, so ``start=False`` must hand back a live-but-idle
+        # Thread rather than a started one.
+        ran = threading.Event()
+
+        def body():
+            ran.set()
+
+        thread = spawn(body, name="test-spawn-unstarted", start=False)
+        try:
+            assert not thread.is_alive()
+            assert not ran.is_set()
+        finally:
+            thread.start()
+        _wait(ran)
+        thread.join(timeout=5)
+
+    def test_start_false_snapshots_context_at_call_time(self):
+        # The snapshot is taken in ``spawn``, not in the thread body, so a
+        # caller that starts the thread later still gets the context that was
+        # active when it asked for the thread — not whatever the calling
+        # thread drifted to in between.
+        set_thread_user("alice")
+        captured: list[str] = []
+        done = threading.Event()
+
+        def body():
+            captured.append(get_current_user())
+            done.set()
+
+        thread = spawn(body, name="test-spawn-unstarted-ctx", start=False)
+        set_thread_user("bob")
+        thread.start()
+        _wait(done)
+        thread.join(timeout=5)
+        assert captured == ["alice"]

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -367,7 +367,12 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
 
     from vtsearch.threading import spawn
 
-    _loading_tasks.set_worker(task_id, spawn(load_task, name=f"ds-load-{dataset_id[:8]}"))
+    # Registered before the thread starts so a cancel arriving in the same
+    # instant can tell "not started yet" from "nothing here"; see
+    # ``LoadingTasksTracker.set_worker``.
+    worker = spawn(load_task, name=f"ds-load-{dataset_id[:8]}", start=False)
+    _loading_tasks.set_worker(task_id, worker)
+    worker.start()
     return {"ok": True, "message": "Loading started", "task_id": str(task_id) if task_id else ""}
 
 
@@ -453,7 +458,10 @@ def build_dataset_coverage_atlas(dataset_id: str):
 
     from vtsearch.threading import spawn
 
-    _loading_tasks.set_worker(task_id, spawn(build_task, name=f"atlas-{dataset_id[:8]}"))
+    # Registered before the thread starts; see ``LoadingTasksTracker.set_worker``.
+    worker = spawn(build_task, name=f"atlas-{dataset_id[:8]}", start=False)
+    _loading_tasks.set_worker(task_id, worker)
+    worker.start()
     return {"ok": True, "message": "Coverage atlas build started", "task_id": str(task_id)}
 
 

--- a/vtsearch/routes/datasets/staging.py
+++ b/vtsearch/routes/datasets/staging.py
@@ -18,7 +18,6 @@ in the plan doc.
 """
 
 import gc
-import threading
 import time
 import traceback
 from collections.abc import Callable
@@ -69,6 +68,7 @@ from vtsearch.schemas.datasets import (
     ImporterSuggestedNameResponseSchema,
 )
 from vtsearch.state import get_active_context, snapshot_medias
+from vtsearch.threading import spawn
 from vtscore.security.pickle import peek_pickle_dataset_summary
 
 datasets_staging_bp = Blueprint(
@@ -373,7 +373,14 @@ def _promote_in_background(
             gc.collect()
             loading_tasks.mark_finished(task_id)
 
-    worker = threading.Thread(target=task, daemon=True)
+    # ``spawn`` (not a bare ``threading.Thread``) so the task body inherits the
+    # request's user / dataset / detector thread-locals; ``created_by`` is
+    # re-asserted inside ``task`` because the promote is attributed to whoever
+    # asked for it, not to whichever thread happened to call this helper.
+    # Registered before the thread starts so a cancel arriving in the same
+    # instant can tell "not started yet" from "nothing here"; see
+    # ``LoadingTasksTracker.set_worker``.
+    worker = spawn(task, name=f"ds-promote-{task_id[-8:]}", start=False)
     loading_tasks.set_worker(task_id, worker)
     worker.start()
     return task_id

--- a/vtsearch/threading.py
+++ b/vtsearch/threading.py
@@ -14,6 +14,44 @@ Forgetting one silently writes to the wrong user file or no-ops against
 the empty fallback context.  This helper snapshots the calling thread's
 context at spawn time and re-installs it inside the new thread, so the
 plumbing is invisible to the caller.
+
+Which idiom to reach for
+------------------------
+
+App-tier background work runs under one of exactly two idioms, and they
+are chosen by *how the work is tracked*, not by how long it takes:
+
+``JobManager`` (:mod:`vtscore.concurrency.async_jobs`)
+    For work where only the **latest** request matters and a duplicate
+    request should coalesce rather than run twice: training, sorting,
+    eval.  One job runs at a time per manager, a second ``start()``
+    parks in a single coalescing pending slot, and results are cached by
+    signature so an unchanged re-request is free.  It owns its own
+    context propagation (``JobManager._run`` replays the requester's
+    user + dataset + detector the same way :func:`spawn` does), so code
+    reaching for a manager never calls ``spawn``.
+
+:func:`spawn` (this module)
+    For everything else: work that is genuinely per-invocation and may
+    run concurrently with siblings — loading a dataset, building a
+    coverage atlas, promoting a selection, re-embedding a detector,
+    ingesting a labelset.  ``spawn`` provides context replay and nothing
+    else; whatever progress or cancellation surface the job needs is
+    layered on by the caller.  In practice that is a
+    :class:`~vtscore.concurrency.progress.ProgressTracker` obtained from
+    the ``loading_tasks`` / ``detector_loading_tasks`` registries, whose
+    per-task entries feed the ``loading-tasks`` SSE channel and the
+    dashboard's Cancel button.  Callers that register a task that way
+    must pass ``start=False`` and start the thread themselves, so the
+    worker is registered before it runs — see the ``start`` parameter.
+
+There is no third idiom in the app tier.  A bare ``threading.Thread`` in
+``vtsearch/`` is a bug: it drops all three thread-locals, so the body
+writes to the wrong user's settings file and reads the empty fallback
+dataset.  (The library tier is different: ``vtscore`` cannot import this
+module, so its own background helpers replay context with the
+``vtscore.state.current_user`` / ``vtscore.state.core`` context managers
+directly.)
 """
 
 from __future__ import annotations
@@ -29,6 +67,7 @@ def spawn(
     *args: Any,
     name: str | None = None,
     daemon: bool = True,
+    start: bool = True,
     **kwargs: Any,
 ) -> threading.Thread:
     """Start *target* in a daemon thread with the current context replayed.
@@ -40,15 +79,26 @@ def spawn(
     code that depends on the active context resolving the same way it
     does on the calling thread.
 
-    Returns the started :class:`threading.Thread` so callers can join it
-    if they need to.  The thread is daemon by default so a forgotten
-    join doesn't keep the interpreter alive at shutdown.
+    Returns the :class:`threading.Thread` so callers can join it if they
+    need to.  The thread is daemon by default so a forgotten join
+    doesn't keep the interpreter alive at shutdown.
 
-    Long-running jobs that need cancellation / progress reporting should
-    keep using :class:`~vtscore.concurrency.async_jobs.JobManager`, which
-    already handles context propagation and exposes a richer
-    job-tracking surface; ``spawn`` is for the simpler fire-and-forget
-    cases.
+    Pass ``start=False`` to get the thread back *unstarted*; the
+    snapshot is still taken here, on the calling thread, so the caller
+    may start it later without losing the context.  This exists for the
+    one thing a caller has to do between construction and start:
+    register the worker with a
+    :class:`~vtscore.concurrency.progress.LoadingTasksTracker` via
+    ``set_worker``, which is documented to happen *before* the thread
+    runs so a cancel arriving in the same instant can tell "not started
+    yet" from "nothing here"::
+
+        worker = spawn(task, name="ds-promote-abc123", start=False)
+        loading_tasks.set_worker(task_id, worker)
+        worker.start()
+
+    See the module docstring for when to reach for ``spawn`` at all
+    versus :class:`~vtscore.concurrency.async_jobs.JobManager`.
     """
     user_snapshot = _snapshot_user()
     ds_snapshot, det_snapshot = _snapshot_state_contexts()
@@ -66,7 +116,8 @@ def spawn(
             _install_state_contexts(None, None)
 
     thread = threading.Thread(target=_runner, name=name, daemon=daemon)
-    thread.start()
+    if start:
+        thread.start()
     return thread
 
 


### PR DESCRIPTION
Closes #3382

## The premise, checked

Accurate. A repo-wide sweep for `threading.Thread(` confirms `routes/datasets/staging.py`'s promote task was the **only** bare thread left in the app tier (`vtsearch/`); every other hit is in `vtscore/`, which cannot import `vtsearch.threading` and correctly replays context with the library-tier context managers instead.

One correction to the issue's wording: the raw thread hand-rolled *half* the replay, not all of it. It wrapped its body in `with thread_user(created_by)` but set no dataset or detector context, so the promote task ran against the empty fallback contexts. Nothing in the body reads those proxies today (it works off a `subset` snapshot taken in the request thread), so this was latent rather than broken — which is exactly the failure mode `spawn` exists to make impossible.

## What changed

**`vtsearch/routes/datasets/staging.py`** — the promote task now goes through `spawn`, which replays all three thread-locals. `created_by` stays re-asserted inside the task body: the promote is attributed to whoever asked for it, not to whichever thread happened to call the helper (they coincide today, but `created_by` is a parameter, so the inner assertion is the authoritative one). Drops the now-unused `import threading`.

**`vtsearch/threading.py`** — `spawn` gains `start: bool = True`. This is what made the conversion honest rather than a lateral move: `LoadingTasksTracker.set_worker` is documented to run *before* the thread does, so that a cancel arriving in the same instant can tell "not started yet" from "nothing here" (otherwise `_park_unresponsive` marks a live task abandoned). `spawn` previously offered no way to get the thread back unstarted. The snapshot is still taken in `spawn`, on the calling thread, so a later `start()` cannot pick up drifted context — covered by a test.

**`vtsearch/routes/datasets/registry.py`** — the two existing `spawn` + `set_worker` call sites (dataset load, coverage-atlas build) registered the worker *after* starting it, silently violating that contract when they migrated to `spawn`. Both now use `start=False`. Same bug class, one line each; fixing them here is what stops the new knob from being the only correct call site.

**Docs** — `vtsearch/threading.py`'s module docstring now says when each of the two remaining idioms applies: `JobManager` for coalescing single-slot work where only the latest request matters (training, sorting, eval), `spawn` for per-invocation work that runs concurrently with siblings, with progress layered on by the caller via the `loading_tasks` / `detector_loading_tasks` trackers. It also states plainly that a bare `threading.Thread` in `vtsearch/` is a bug, and why the library tier legitimately differs.

## One consequence worth naming

`spawn` captures the active `DatasetContext`, so the promote thread now holds a reference to the source dataset for the duration of the job. If a user unloads that dataset mid-promote, its memory is freed when the promote finishes rather than immediately. The promote body never reads the context, so isolation from concurrent mutation is unaffected — only GC timing, on a job that already runs in seconds to minutes. Uniform context replay is worth that.

## Testing

Full `./run-tests.sh`: **RUN PASSED**, 9779 passed / 6 skipped, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

Two new tests in `tests/integration/test_spawn.py` cover `start=False`: that the returned thread is genuinely unstarted, and that the context snapshot is taken at call time rather than at `start()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEE2p6xvsesFt8avxBpquy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEE2p6xvsesFt8avxBpquy)_