### PR TITLE
fix(frontend): bump transitive qs to 6.16.0 to clear the npm audit gate

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7670,9 +7670,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
Closes #3529.

## The problem

`npm audit` was failing on `dev` itself, so **every** branch failed `./run-tests.sh` regardless of what it changed. Reproduced on a checkout with zero diff against `dev`:

```
qs  2.2.5 - 6.15.3
Severity: moderate
qs array-limit bypass via bracket-key comma parsing - GHSA-x5fp-wj9c-mxmx
qs: Denial of Service via Attacker Controlled isBuffer - GHSA-4mjr-xmp4-gh2g
1 moderate severity vulnerability
```
exit 1.

The lockfile pinned `qs` at exactly `6.15.3` — the top of the advisory range — as a dev-only transitive of `express` / `body-parser`. It became visible yesterday when #3439 removed `@angular-devkit/build-angular` and widened the audit gate off `--omit=dev`, which is the gate working as intended.

## The change

`npm audit fix` (no `--force`), which is a 3-line lockfile edit: `qs` 6.15.3 → 6.16.0. Both dependers already declare `^6`, so this is a semver-compatible patch bump and nothing else in the tree moves. Still `dev: true`; no runtime dependency changes.

## Verification

Full `./run-tests.sh` (not just the frontend group), green end to end:

- `npm audit` → `found 0 vulnerabilities`
- pytest: 9794 passed, 6 skipped, 2 xpassed
- pyright, pip-audit, vulture whitelist, `build:prod`, Vitest — all OK
- `RUN PASSED (all gates green)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAQpt9bcaNasBYfjS1Q1Vy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAQpt9bcaNasBYfjS1Q1Vy)_