### PR TITLE
Mark cold vs warm runs on the generic timing recorder, and fit them apart (#3520)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -125,7 +125,7 @@ documented workarounds; this section describes the code as it stands.
 |----------|---------|-------------|
 | `VTSEARCH_TIMING_PROFILE` | unset | Path to a timing-profile JSON measured on this environment's hardware. Tells every instance how long each step of each long-running task takes here, so progress bars pace and predict against reality instead of the shipped defaults. See [Progress-bar timing profile](#progress-bar-timing-profile). |
 | `VTSEARCH_TIMING_RECORD` | unset | Path to a JSONL sink. When set, every long-running task — dataset imports included — appends one row per step as it finishes. This is how you gather the measurements the profile is fit from; leave it unset in steady state. |
-| `VTSEARCH_PROFILE_LOAD` | unset | Path to a second JSONL sink, written only by dataset imports and in more detail: it additionally splits cold from warm model loads, cold from cached downloads, and the finalize step into its sub-slots. Optional — imports already feed `VTSEARCH_TIMING_RECORD` above. Arm it as well when you are calibrating the load pipeline specifically; the fitter reads both files and both row shapes. |
+| `VTSEARCH_PROFILE_LOAD` | unset | Path to a second JSONL sink, written only by dataset imports and in more detail: it additionally splits cold from cached downloads and the finalize step into its sub-slots. (Both recorders mark cold vs warm model loads.) Optional — imports already feed `VTSEARCH_TIMING_RECORD` above. Arm it as well when you are calibrating the load pipeline specifically; the fitter reads both files and both row shapes. |
 
 ### Dataset-ingest concurrency
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5304,9 +5304,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "esbuild": "^0.28.1",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
+    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/tests_lib/core/test_timing_cold_warm.py
+++ b/tests_lib/core/test_timing_cold_warm.py
@@ -1,0 +1,257 @@
+"""Cold vs warm runs: the marker the recorder stamps and the fit that reads it.
+
+A once-per-process cost — downloading and instantiating an encoder — is paid by
+the first run in a process and by no other. Without a marker saying which run
+that was, its rows are unfittable: `dataset_load`'s model load measured
+``54.905, 0.000, 0.000, 0.000`` on rack7n06 and fitted to ``{"a": 0.0}``, giving
+0 % of a 412-image import's bar to a step that took most of a minute inside the
+very run it was fitted from (#3520, measured in
+``docs/experiments/2026-09-02-timing-r2-3345/REPORT.md``).
+
+These tests pin both halves: the recorder must label the branch, and the fitter
+must fit the two populations apart rather than medianing them together.
+"""
+
+import pytest
+
+from vtscore.concurrency.progress import PROGRESS_COMMON_EXTRAS, ProgressTracker
+from vtscore.timing import recorder as timing_recorder
+from vtscore.timing.fit import fit_profile, fit_step, load_rows, normalize_row
+from vtscore.timing.profile import StepCoeffs
+from vtscore.timing.recorder import RECORD_ENV_VAR, record_task
+from vtscore.timing.tasks import TASKS
+
+
+def _tracker() -> ProgressTracker:
+    return ProgressTracker(extra_fields=dict(PROGRESS_COMMON_EXTRAS))
+
+
+def _fit(samples: list[dict], *, byte_scaled: bool = False) -> StepCoeffs:
+    """``fit_step`` narrowed to non-``None`` (its no-samples return)."""
+    coeffs = fit_step(samples, byte_scaled)
+    assert coeffs is not None
+    return coeffs
+
+
+def _sample(n: float, seconds: float, *, cold: bool = False) -> dict:
+    return {"n": n, "size_mb": 0.0, "seconds": seconds, "cold": cold}
+
+
+@pytest.fixture
+def sink(tmp_path, monkeypatch):
+    """Arm the recorder at a temp JSONL and yield a reader for what it wrote."""
+    path = tmp_path / "timings.jsonl"
+    monkeypatch.setenv(RECORD_ENV_VAR, str(path))
+    timing_recorder.reset_seen_models_for_tests()
+
+    def read():
+        return load_rows([str(path)]) if path.exists() else []
+
+    return read
+
+
+def _run_text_sort(tracker, *, skip_model_load: bool = False) -> None:
+    if not skip_model_load:
+        tracker.update("sorting", "loading", 0, 0, step=1, total_steps=3)
+    tracker.update("sorting", "embedding", 0, 0, step=2, total_steps=3)
+    tracker.update("sorting", "scoring", 0, 0, step=3, total_steps=3)
+
+
+class TestRecorderMarksTheBranch:
+    def test_first_run_for_an_encoder_is_cold_and_the_next_is_warm(self, sink):
+        for skip in (False, True):
+            tracker = _tracker()
+            with record_task(tracker, "text_sort", media_type="image", embedder="siglip") as rec:
+                _run_text_sort(tracker, skip_model_load=skip)
+                rec.set_scale(n=1234)
+        rows = sink()
+        first = [r for r in rows if r["cold_model"]]
+        rest = [r for r in rows if not r["cold_model"]]
+        # One whole run per branch, not one row: the cold run's *other* steps
+        # carry the process warmup too, which is why the flag is per-run.
+        assert len(first) == 3 and len(rest) == 3
+
+    def test_the_ledger_is_keyed_by_media_type_and_embedder(self, sink):
+        # Keying on the embedder alone lets two blanks from different media
+        # types collide, and the second one's genuinely cold load is then
+        # written warm — the mislabel #3345 measured on the other recorder.
+        for media_type in ("image", "audio"):
+            tracker = _tracker()
+            with record_task(tracker, "text_sort", media_type=media_type) as rec:
+                _run_text_sort(tracker)
+                rec.set_scale(n=10)
+        rows = sink()
+        assert {r["media_type"] for r in rows if r["cold_model"]} == {"image", "audio"}
+
+    def test_a_task_that_loads_no_encoder_neither_claims_nor_carries_the_flag(self, sink):
+        # dataset_open reads a pkl. If it claimed (image, siglip), the genuinely
+        # cold text sort behind it would be stamped warm.
+        tracker = _tracker()
+        with record_task(tracker, "dataset_open", media_type="image", embedder="siglip") as rec:
+            tracker.update("loading", "items", 0, 0, step=1, total_steps=2)
+            tracker.update("loading", "coverage", 0, 0, step=2, total_steps=2)
+            rec.set_scale(n=500)
+        assert all("cold_model" not in r for r in sink())
+
+        tracker = _tracker()
+        with record_task(tracker, "text_sort", media_type="image", embedder="siglip") as rec:
+            _run_text_sort(tracker)
+            rec.set_scale(n=500)
+        assert any(r["cold_model"] for r in sink() if r["task"] == "text_sort")
+
+    def test_a_run_that_recorded_nothing_does_not_claim_the_key(self, sink):
+        # The key is claimed where the rows are written, not at construction: a
+        # run whose tracker never reached a step writes nothing, and claiming on
+        # its behalf would leave the next run — the first one anybody can fit —
+        # stamped warm.
+        tracker = _tracker()
+        with record_task(tracker, "text_sort", media_type="image", embedder="siglip"):
+            tracker.update("idle", "", 0, 0)
+        assert sink() == []
+
+        tracker = _tracker()
+        with record_task(tracker, "text_sort", media_type="image", embedder="siglip") as rec:
+            _run_text_sort(tracker)
+            rec.set_scale(n=10)
+        assert all(r["cold_model"] for r in sink())
+
+    def test_an_embedder_learned_late_still_decides_the_key(self, sink):
+        # A dataset load that lets the media type's default stand only resolves
+        # the encoder deep in the embed stage (#3345), so the key has to be read
+        # where the rows are written rather than at construction — otherwise the
+        # late-named run claims the blank key and the next one is stamped warm.
+        tracker = _tracker()
+        with record_task(tracker, "text_sort", media_type="image") as rec:
+            _run_text_sort(tracker)
+            rec.set_scale(n=10, embedder="siglip")
+        assert all(r["embedder"] == "siglip" and r["cold_model"] for r in sink())
+
+        tracker = _tracker()
+        with record_task(tracker, "text_sort", media_type="image", embedder="siglip") as rec:
+            _run_text_sort(tracker)
+            rec.set_scale(n=20)
+        assert not any(r["cold_model"] for r in sink() if r["n"] == 20)
+
+    def test_every_registered_task_declares_whether_it_loads_an_encoder(self):
+        # A new task defaults to False, which fits exactly as today; this pins
+        # the ones that were classified so a rename cannot silently drop one.
+        marked = {name for name, spec in TASKS.items() if spec.loads_encoder}
+        assert marked == {
+            "dataset_load",
+            "dataset_stage",
+            "detector_load",
+            "find",
+            "text_sort",
+            "train_and_score",
+        }
+
+
+class TestNormalizeCarriesTheFlag:
+    def test_generic_row(self):
+        row = normalize_row({"task": "text_sort", "step": "load_model", "seconds": 15.4, "cold_model": True})
+        assert row is not None and row["cold"] is True
+
+    def test_legacy_profiler_row(self):
+        # `_load_profiler` has stamped `cold_model` since long before the generic
+        # recorder did; the fitter simply never read it.
+        row = normalize_row({"phase": "model_load", "n": 412, "seconds": 54.9, "cold_model": True})
+        assert row is not None and row["task"] == "dataset_load" and row["cold"] is True
+
+    def test_a_row_without_the_marker_is_warm(self):
+        row = normalize_row({"task": "text_sort", "step": "score", "seconds": 1.8})
+        assert row is not None and row["cold"] is False
+
+
+class TestFittingTheTwoPopulationsApart:
+    def test_a_cold_row_among_warm_zeros_no_longer_fits_to_free(self):
+        # The measured rack7n06 rows for `dataset_load` · `load`: one cold load
+        # at 54.9 s and three warm runs that skipped the step outright.
+        measured = [_sample(412, 54.905, cold=True)] + [_sample(n, 0.0) for n in (245, 1000, 2954)]
+
+        unmarked = _fit([{**s, "cold": False} for s in measured])
+        assert unmarked.a == 0.0, "the bug: one population, median zero, a step priced free"
+
+        marked = _fit(measured)
+        assert marked.a > unmarked.a, "the coefficient must MOVE, not merely be finite"
+        assert marked.a == pytest.approx(0.5)
+
+    def test_a_step_the_warm_runs_really_do_pay_keeps_its_measured_cost(self):
+        # The floor is a guard against a confident zero, never a replacement for
+        # a measurement: a warm population with a real median keeps it.
+        coeffs = _fit([_sample(412, 9.0, cold=True)] + [_sample(n, 2.0) for n in (245, 1000, 2954)])
+        assert coeffs.a == pytest.approx(2.0)
+
+    def test_a_step_that_is_free_on_both_branches_stays_free(self):
+        coeffs = _fit([_sample(412, 0.0, cold=True)] + [_sample(n, 0.0) for n in (245, 1000)])
+        assert coeffs.a == 0.0
+
+    def test_the_cold_run_is_held_out_of_a_slope(self):
+        # #3062: one cold row at the smallest n pulled a finalize slope to less
+        # than half its warm value and collapsed the fit's r2. The cold row here
+        # is 20 s of process warmup on top of the same 0.01 s/item line.
+        warm = [_sample(float(n), 0.01 * n) for n in (200, 400, 600, 800)]
+        coeffs = _fit([_sample(100.0, 21.0, cold=True), *warm])
+        assert coeffs.b == pytest.approx(0.01)
+        assert coeffs.r2 == pytest.approx(1.0)
+
+        # Pooled, the same rows lose the line altogether: OLS comes back with a
+        # negative slope, `fit_step` refuses it, and the step ships as a flat
+        # 6 s median that is wrong at every size measured.
+        poisoned = _fit([{**s, "cold": False} for s in [_sample(100.0, 21.0, cold=True), *warm]])
+        assert poisoned.b == 0.0
+        assert poisoned.a == pytest.approx(6.0)
+
+    def test_the_holdout_never_costs_a_cell_its_only_line(self):
+        # A two-run sweep is the minimum `fit_profile` accepts, and its first
+        # run is always the cold one. Holding that row out would leave a single
+        # warm point, from which no slope is estimable — so the step would ship
+        # as a flat median and the profile would lose the scaling it measured.
+        two_run = [_sample(1_000.0, 1.0, cold=True), _sample(100_000.0, 100.0)]
+        assert _fit(two_run).b == pytest.approx(0.001)
+
+        # One more warm size and the holdout is affordable, so it applies.
+        three_run = [*two_run, _sample(50_000.0, 50.0)]
+        assert _fit(three_run).b == pytest.approx(0.001)
+        assert _fit([*three_run[:1], _sample(50_000.0, 5.0), _sample(100_000.0, 10.0)]).b == pytest.approx(0.0001)
+
+    def test_a_cell_that_only_ever_ran_cold_still_fits_its_cold_rows(self):
+        # One measurement of the expensive branch beats none — and it is all the
+        # legacy profiler ever writes, since a warm load emits no model row.
+        coeffs = _fit([_sample(float(n), 0.02 * n, cold=True) for n in (200, 400, 600)])
+        assert coeffs.b == pytest.approx(0.02)
+
+    def test_byte_scaled_steps_ignore_the_marker(self):
+        # `cold_model` says nothing about whether the archive was cached; the
+        # per-MB branch has its own filter for that.
+        rows = [
+            {"n": 400.0, "size_mb": 100.0, "seconds": 10.0, "cold": True},
+            {"n": 400.0, "size_mb": 100.0, "seconds": 10.0, "cold": False},
+        ]
+        assert _fit(rows, byte_scaled=True).per_mb == pytest.approx(0.1)
+
+
+class TestEndToEnd:
+    def test_a_sweep_that_saw_one_cold_load_prices_the_step_above_zero(self):
+        rows = []
+        for i, n in enumerate((412, 245, 1000, 2954)):
+            for step, seconds in (("load_model", 15.4 if i == 0 else 0.0), ("embed_query", 0.04), ("score", 0.001 * n)):
+                rows.append(
+                    {
+                        "task": "text_sort",
+                        "device": "cuda",
+                        "cuml": True,
+                        "media_type": "image",
+                        "embedder": "siglip",
+                        "n": n,
+                        "size_mb": 0.0,
+                        "step": step,
+                        "seconds": seconds,
+                        "ok": True,
+                        "complete": True,
+                        "cold_model": i == 0,
+                    }
+                )
+        cell = fit_profile(rows)["tasks"]["text_sort"]["cells"]["cuda+cuml|image|siglip"]
+        assert cell["steps"]["load_model"]["a"] > 0
+        # The step the sweep measured properly is untouched by the split.
+        assert cell["steps"]["score"]["b"] == pytest.approx(0.001)

--- a/tests_shared/state_reset.py
+++ b/tests_shared/state_reset.py
@@ -169,6 +169,13 @@ def reset_shared_state(medias_map, medias_snapshot) -> None:
 
     reset_mtime_cache_for_tests()
 
+    # Forget which encoders the timing recorder has seen loaded: the ledger is
+    # process-global and decides whether a recorded run is written cold or warm,
+    # so one test's run would otherwise label the next test's.
+    from vtscore.timing.recorder import reset_seen_models_for_tests
+
+    reset_seen_models_for_tests()
+
     # Reset CLI progress format so a test that flips it to "json" can't leak the
     # choice into the next test.
     from vtscore import cli_progress

--- a/vtscore/docs/packages/timing.md
+++ b/vtscore/docs/packages/timing.md
@@ -150,8 +150,18 @@ Each task wrapped in `record_task` then appends one row per step:
 ```json
 {"task": "text_sort", "device": "cuda", "cuml": true, "media_type": "image",
  "embedder": "siglip", "n": 12403, "size_mb": 0.0, "step": "score",
- "seconds": 1.83, "ok": true}
+ "seconds": 1.83, "ok": true, "cold_model": false}
 ```
+
+`cold_model` says whether this run was the first in the process to need
+its `(media_type, embedder)` encoder, and so the one that paid to
+download and instantiate it. Without it a once-per-process cost is
+unfittable: a text sort's model load measures 15 s once and 0 s on the
+next 47, and a fitter that cannot separate the two populations medians
+them into "free". Only tasks whose `TaskSpec` declares `loads_encoder`
+take part - a `dataset_open` reads a pkl and touches no encoder, so it
+neither carries the field nor claims a key that the genuinely cold sort
+behind it needs.
 
 Because the recorder sits behind an env var, an admin has two ways to
 gather data and both produce the same file:
@@ -170,12 +180,11 @@ of no-op method calls: no tracker subscription, no file handle.
 
 The dataset-load pipeline carries an older, richer recorder
 (`vtscore/datasets/stages/_load_profiler.py`) that additionally
-distinguishes cold from warm model loads, cold from cached downloads,
-and the sub-slots inside finalize. Both run on the same load. They
-answer different questions, are armed by different env vars, and write
-different files - and the fitter reads both row shapes, so a
-pre-existing dataset-load calibration sweep folds into a new profile
-rather than being re-measured.
+distinguishes cold from cached downloads and splits finalize into its
+sub-slots. Both run on the same load. They answer different questions,
+are armed by different env vars, and write different files - and the
+fitter reads both row shapes, so a pre-existing dataset-load calibration
+sweep folds into a new profile rather than being re-measured.
 
 ---
 
@@ -196,6 +205,16 @@ The fit is deliberately plain. Per `(task, cell, step)`:
 - **Everything else** gets ordinary least squares against `n`: the
   intercept is what the step costs at all (loading an encoder, opening a
   file) and the slope is what each additional item adds.
+- **Cold runs are held out** when the warm ones can carry the regression
+  alone. A cold run pays once-per-process costs no later run repeats -
+  the encoder download, the CUDA context, the first forward pass - and it
+  always lands at whichever `n` ran first, so it has enormous leverage on
+  the slope. The holdout stops short of costing a cell its only line:
+  below two distinct warm sizes no slope is estimable, and a two-run
+  sweep's first run is always the cold one. When the warm runs then
+  measure a step as *exactly* free while a cold one measured it as real,
+  the step is not free here but deferred, and it keeps a small floor
+  rather than 0 so the bar still shows a slice for it.
 - A fit with no spread in `n`, or one that comes back with a **negative**
   slope (noise beating signal on a short step), collapses to the median
   seconds with no slope. A confidently wrong slope extrapolates badly at

--- a/vtscore/timing/fit.py
+++ b/vtscore/timing/fit.py
@@ -24,6 +24,10 @@ The fit itself is deliberately plain. Per ``(task, cell, step)``:
   (noise beating signal on a short step), collapses to ``median seconds`` with
   no slope. A confidently wrong slope extrapolates badly at sizes the sweep
   never visited, and "we only know the average" is the honest answer there.
+- **Cold runs are held out** when the warm ones can carry the regression alone.
+  A cold run pays once-per-process costs no later run repeats, and it always
+  lands at whichever ``n`` happened to go first, so it has enormous leverage on
+  the slope. See :func:`fit_step`.
 
 Cells are emitted at three specificities — exact ``(device, media, embedder)``,
 then ``(device, media, *)``, then ``(device, *, *)``. The rollups are what make a
@@ -163,6 +167,11 @@ def normalize_row(raw: dict) -> Optional[dict]:
         "step": str(step),
         "slot": slot,
         "seconds": max(0.0, seconds),
+        # Both recorders spell this ``cold_model``. Absent means warm, which is
+        # what a row recorded before the marker existed — or one from a task
+        # that loads no encoder — should be treated as: it keeps every such
+        # sample in a single population and fits exactly as it did before.
+        "cold": bool(raw.get("cold_model", False)),
     }
 
 
@@ -208,6 +217,36 @@ def _r2_of(xs: list[float], ys: list[float], a: float, b: float) -> float:
     return 1.0 - ss_res / ss_tot
 
 
+#: Seconds a step keeps when its warm runs measured it as free but a cold run in
+#: the same cell measured it as real. Mirrors ``_WARM_MODEL_FLOOR_S`` in
+#: ``scripts/profiling/fit_load_weights.py``, whose warm model load gets the same
+#: value for the same reason; the two fitters have to agree, and ``vtscore``
+#: cannot import from ``scripts/``.
+_ONCE_PER_PROCESS_FLOOR_S = 0.5
+
+
+def _deferred_cost_floor(median_seconds: float, cold: list[dict]) -> float:
+    """Keep a skipped-because-warm step visible on the bar rather than free.
+
+    The generic recorder writes an explicit ``0.0`` for a step a run skipped, so
+    a cost paid once per process fits to a warm median of exactly zero — a true
+    statement about 47 of 48 text sorts and a useless one about the 48th, which
+    is the run somebody is watching. When a cold run in the same cell measured
+    the step as real, the step is not free here, it is *deferred*, and the bar
+    should keep a slice for it.
+
+    Deliberately a floor and not the cold cost. Pacing every run at the cold
+    price is as wrong as pacing it at zero, just in the other direction, and
+    most runs are warm — which is why ``fit_load_weights.py`` floors its warm
+    model load at the same value and carries the cold figure as a note. The
+    floor is a guard against a confident zero, not a cost model; measuring the
+    cold branch properly is the tuning driver's job (#3521).
+    """
+    if median_seconds > 0 or not any(s["seconds"] > 0 for s in cold):
+        return max(0.0, median_seconds)
+    return _ONCE_PER_PROCESS_FLOOR_S
+
+
 def fit_step(samples: list[dict], byte_scaled: bool) -> Optional[StepCoeffs]:
     """Fit one step's coefficients from its samples, or ``None`` if unusable."""
     if not samples:
@@ -222,8 +261,26 @@ def fit_step(samples: list[dict], byte_scaled: bool) -> Optional[StepCoeffs]:
             return StepCoeffs()
         return StepCoeffs(per_mb=statistics.median(rates))
 
-    xs = [s["n"] for s in samples]
-    ys = [s["seconds"] for s in samples]
+    # Fit the warm population. A cold run folds in costs paid once per *process*
+    # rather than once per job — the encoder download, the CUDA context, the
+    # first forward pass — and it always lands at whichever ``n`` ran first, so
+    # it has enormous leverage on the slope. #3062 measured a single cold row
+    # pulling a load's finalize slope to 0.0018 s/item from the warm 0.0040 and
+    # collapsing its r² from 0.999 to 0.08.
+    #
+    # The holdout stops short of costing a cell its only line. Below two
+    # distinct sizes no slope is estimable at all, and a minimal sweep is
+    # exactly that shape — its first run is always the cold one — so a strict
+    # holdout would turn every two-run sweep into a table of flat medians. There
+    # (and in a cell that only ever ran cold, which is all the legacy profiler
+    # ever writes for a model load) the cold rows stay in the regression and the
+    # floor below does what it can.
+    cold = [s for s in samples if s.get("cold")]
+    warm = [s for s in samples if not s.get("cold")]
+    fittable = warm if len({s["n"] for s in warm}) >= 2 else samples
+
+    xs = [s["n"] for s in fittable]
+    ys = [s["seconds"] for s in fittable]
     intercept, slope, r2 = affine_fit(xs, ys)
     if len({round(x, 6) for x in xs}) < _MIN_R2_POINTS:
         # A line through two points has ss_res == 0, so its r2 is 1.0 by
@@ -238,7 +295,7 @@ def fit_step(samples: list[dict], byte_scaled: bool) -> Optional[StepCoeffs]:
         # is deliberately NOT carried here: it describes a line this branch has
         # just declined to use, so reporting it would attach a goodness score to
         # coefficients that are a median.
-        return StepCoeffs(a=max(0.0, statistics.median(ys)))
+        return StepCoeffs(a=_deferred_cost_floor(statistics.median(ys), cold))
 
     a = max(0.0, intercept)
     if a != intercept:

--- a/vtscore/timing/recorder.py
+++ b/vtscore/timing/recorder.py
@@ -5,7 +5,7 @@ wraps its work in :func:`record_task` then appends one row per step::
 
     {"task": "text_sort", "device": "cuda", "cuml": true, "media_type": "image",
      "embedder": "siglip", "n": 12403, "size_mb": 0.0, "step": "score",
-     "seconds": 1.83, "ok": true}
+     "seconds": 1.83, "ok": true, "cold_model": false}
 
 ``scripts/profiling/tune_timing_profile.py`` fits those rows into the profile
 JSON that :mod:`vtscore.timing.profile` reads back. Because the recorder lives
@@ -22,14 +22,23 @@ gather data, and both produce the same file:
 When disarmed the cost is one ``os.environ`` lookup per task and a couple of
 no-op method calls; there is no tracker subscription and no file handle.
 
+**Cold vs warm.** Every row also carries ``cold_model``: whether this run was
+the first in the process to need its ``(media_type, embedder)`` encoder, and so
+the one that paid to download and instantiate it. Without that marker the rows
+for a once-per-process cost are unfittable — the model load of a text sort
+measures 15 s once and 0 s on the next 47, and a fitter that cannot tell the two
+populations apart medians them into "free" (#3520). Only tasks whose
+:class:`~vtscore.timing.tasks.TaskSpec` declares ``loads_encoder`` take part, so
+a task that never touches an encoder neither claims a key nor carries the field.
+
 The dataset-load pipeline *also* carries an older, richer recorder
 (:mod:`vtscore.datasets.stages._load_profiler`) that additionally distinguishes
-cold from warm model loads, cold from cached downloads, and the sub-slots inside
-finalize. The two run side by side on the same load: they answer different
-questions, are armed by different env vars, and write to different files. The
-tuning script's fitter reads both row shapes, so a pre-existing dataset-load
-calibration sweep still folds into a profile — but an admin who armed only
-``VTSEARCH_TIMING_RECORD`` gets import rows too, which for a while they did not.
+cold from cached downloads and splits finalize into its sub-slots. The two run
+side by side on the same load: they answer different questions, are armed by
+different env vars, and write to different files. The tuning script's fitter
+reads both row shapes, so a pre-existing dataset-load calibration sweep still
+folds into a profile — but an admin who armed only ``VTSEARCH_TIMING_RECORD``
+gets import rows too, which for a while they did not.
 
 Kept in ``vtscore`` (no Flask) so a plain CLI or library run records the same
 way a served request does.
@@ -51,6 +60,30 @@ logger = logging.getLogger(__name__)
 
 #: Environment variable naming the JSONL sink. Unset means "record nothing".
 RECORD_ENV_VAR = "VTSEARCH_TIMING_RECORD"
+
+#: ``(media_type, embedder)`` pairs whose encoder this process has already
+#: needed. The first run for a pair pays the cold load — downloading the weights
+#: and instantiating the model — and every later one finds it resident, which is
+#: why a warm text sort skips its ``load_model`` step entirely.
+#:
+#: Self-detecting residency is more robust than a caller-supplied flag, and lets
+#: one driven sweep measure both branches in a single process. The key pairs the
+#: media type in rather than keying on the embedder alone, because the name can
+#: legitimately arrive blank: two blanks from different media types would
+#: otherwise collide, and the second one's genuinely cold load would be written
+#: ``cold_model: false`` — the mislabel #3345 measured on the other recorder.
+_seen_models: set[tuple[str, str]] = set()
+_seen_lock = threading.Lock()
+
+
+def reset_seen_models_for_tests() -> None:
+    """Forget every encoder this process has recorded a load for.
+
+    Process-global, so one test's recorded run would otherwise decide whether
+    the next test's run is written cold or warm.
+    """
+    with _seen_lock:
+        _seen_models.clear()
 
 
 def recording_enabled() -> bool:
@@ -215,6 +248,27 @@ class TaskTimingRecorder:
         return None
 
     # -- emit ---------------------------------------------------------------
+    def _claim_encoder(self) -> Optional[bool]:
+        """Whether this run paid the cold encoder load, claiming the key if so.
+
+        ``None`` for a task that loads no encoder: it neither carries the field
+        nor claims a key, because the ledger is process-wide and a task that
+        never instantiates a model would otherwise mark one resident on behalf
+        of the task that actually loads it.
+
+        Read where the rows are written rather than at construction, for two
+        reasons: a run that learns its embedder partway through is then filed
+        under the encoder it really used, and a run that recorded nothing does
+        not claim a key on behalf of the next one.
+        """
+        if self._spec is None or not self._spec.loads_encoder:
+            return None
+        key = (self._media_type, self._embedder)
+        with _seen_lock:
+            cold = key not in _seen_models
+            _seen_models.add(key)
+        return cold
+
     def _emit(self) -> None:
         end = time.monotonic()
         if not self._path:
@@ -245,6 +299,9 @@ class TaskTimingRecorder:
             "ok": ok,
             "complete": complete,
         }
+        cold = self._claim_encoder()
+        if cold is not None:
+            base["cold_model"] = cold
         durations = {
             phase: max(0.0, (starts[order[i + 1]] if i + 1 < len(order) else end) - starts[phase])
             for i, phase in enumerate(order)

--- a/vtscore/timing/tasks.py
+++ b/vtscore/timing/tasks.py
@@ -59,6 +59,15 @@ class TaskSpec:
             regressing them against ``n``, because a 2 GB archive of 500 videos
             and a 20 MB archive of 500 texts take wildly different times to
             fetch for reasons ``n`` cannot see.
+        loads_encoder: Whether a run of this task can pay a **cold encoder
+            load** — the first time a process needs a given ``(media_type,
+            embedder)`` it downloads/instantiates the model, and every later run
+            finds it resident and pays nothing. Only tasks that declare this
+            participate in the recorder's residency ledger, because the ledger's
+            key is shared process-wide: a ``dataset_open`` that never touches an
+            encoder must not claim ``(image, siglip)`` and leave the genuinely
+            cold ``text_sort`` behind it stamped warm. Default ``False`` — the
+            safe direction, since an unmarked task simply fits as it does today.
     """
 
     name: str
@@ -68,6 +77,7 @@ class TaskSpec:
     scale: str
     default_terms: tuple[float, ...] = ()
     byte_scaled: tuple[str, ...] = ()
+    loads_encoder: bool = False
 
     def __post_init__(self) -> None:
         if len(self.step_index) != len(self.steps):
@@ -76,7 +86,14 @@ class TaskSpec:
             raise ValueError(f"{self.name}: default_terms must be parallel to steps")
 
 
-def _linear(name: str, steps: tuple[str, ...], scale: str, terms: tuple[float, ...]) -> TaskSpec:
+def _linear(
+    name: str,
+    steps: tuple[str, ...],
+    scale: str,
+    terms: tuple[float, ...],
+    *,
+    loads_encoder: bool = False,
+) -> TaskSpec:
     """Build a spec whose phases map 1:1 onto tracker steps (the common case)."""
     return TaskSpec(
         name=name,
@@ -85,6 +102,7 @@ def _linear(name: str, steps: tuple[str, ...], scale: str, terms: tuple[float, .
         tracker_steps=len(steps),
         scale=scale,
         default_terms=terms,
+        loads_encoder=loads_encoder,
     )
 
 
@@ -106,6 +124,7 @@ TASKS: dict[str, TaskSpec] = {
         tracker_steps=4,
         scale="media items embedded",
         byte_scaled=("download", "extract"),
+        loads_encoder=True,
     ),
     # Re-opening an already-imported dataset from its pkl. Step 1 (pickle read +
     # convert + the near-instant exact-dedup) is seconds at most; step 2 is the
@@ -138,6 +157,7 @@ TASKS: dict[str, TaskSpec] = {
         ("acquire", "embed", "serialize"),
         "media items staged",
         (0.30, 0.60, 0.10),
+        loads_encoder=True,
     ),
     # Loading a saved detector: read its labelset, pull the label examples back
     # into the active dataset, retrain the MLP. Training dominates; the other
@@ -147,6 +167,7 @@ TASKS: dict[str, TaskSpec] = {
         ("restore_labels", "seed_examples", "train"),
         "labels in the detector's labelset",
         (0.15, 0.15, 0.70),
+        loads_encoder=True,
     ),
     # Text search: load the embedder, embed the one-line query, score every
     # media by cosine similarity. The model load dominates on a cold start
@@ -157,6 +178,7 @@ TASKS: dict[str, TaskSpec] = {
         ("load_model", "embed_query", "score"),
         "medias scored",
         (0.75, 0.05, 0.20),
+        loads_encoder=True,
     ),
     # Running saved detectors across saved datasets. Scoring dominates; loading
     # datasets from pkl is moderate; preparing detector configs is quick.
@@ -165,6 +187,7 @@ TASKS: dict[str, TaskSpec] = {
         ("prepare", "load", "score"),
         "medias scored across all selected datasets",
         (0.10, 0.30, 0.60),
+        loads_encoder=True,
     ),
     # Train-and-score against the active dataset: resolve the detector, train
     # its MLP, score every media, apply the resulting labels. Train + score
@@ -174,6 +197,7 @@ TASKS: dict[str, TaskSpec] = {
         ("resolve", "train", "score", "apply"),
         "medias scored",
         (0.10, 0.45, 0.40, 0.05),
+        loads_encoder=True,
     ),
 }
 


### PR DESCRIPTION
Closes #3520

## The premise holds — with one number in it corrected

`vtscore/timing/recorder.py` records one row per step and says nothing about whether the encoder was already resident, so a once-per-process cost arrives as one expensive sample among many zeros and `fit_step` medians the two populations together. That is real, measured, and fixed here.

**But the issue's "Why it matters" overstates the gap, and the overstatement points at the wrong fix.** It says the fitted profile gives the model load `0.00` of a 412-image import's bar "where the shipped `LOAD_COST_MODEL` gives it **0.79**". The shipped table gives it **0.02**:

```
>>> cost_model_weights('cuda', 'image', 'siglip', 412, 131.0)
[0.666, 0.019, 0.208, 0.107]     # step 2 is the model load
```

which is exactly what [the #3345 report's §4 table](https://github.com/samggreenberg/VTSearch/blob/dev/docs/experiments/2026-09-02-timing-r2-3345/REPORT.md) records. The `0.7x` figure in that table belongs to `profile_resweep`, which prices the **cold** branch. So the issue's second bullet — "carry the cold cost as the intercept, which is what `fit_load_weights.py` already does" — is not what that script does and is not what the app ships: it floors the *warm* load at `_WARM_MODEL_FLOOR_S = 0.5` and carries the cold figure as a note, deliberately. Pacing every run at the cold price is as wrong as pacing it at zero, just in the other direction, and 47 of 48 sorts are warm.

That correction is load-bearing, because the literal prescription in the issue ("fit warm rows only") changes **nothing** on either headline case. Unlike `_load_profiler`, which emits *no* `model_load` row on a warm load, the generic recorder writes an explicit `0.0` — so warm-only is not "no data", it is "data saying zero", and the median is 0.00 either way. The value of the marker is elsewhere, and this PR goes after all three:

1. **Holding cold runs out of the *other* steps' regressions.** #3062 measured one cold row pulling a load's `finalize` slope to 0.0018 s/item from the warm 0.0040 and collapsing r² from 0.999 to 0.08. `fit_load_weights.py` excludes them; the generic fitter had no way to.
2. **Making the outcome deterministic.** A median over a mixed population lands warm only because the sweep happened to be mostly warm. Two cold and two warm samples — an entirely plausible small sweep — medians to ~27 s and mis-paces the bar catastrophically the other way.
3. **Distinguishing "free" from "deferred".** Only with the marker can the fitter tell a step that genuinely costs nothing here from one it only ever saw paid once. That is the report's own *"which branch did this sweep see?" is the question the profile most needs to answer and the only one it cannot*.

## What changed

- **`TaskSpec.loads_encoder`** — only a task that can pay a cold encoder load takes part in the residency ledger. The ledger is process-wide, so a `dataset_open` (reads a pkl, touches no encoder) would otherwise claim `(image, siglip)` and leave the genuinely cold sort behind it stamped warm. `dataset_open` and `dataset_promote` are out; the other six are in (`detector_load`, `find` and `train_and_score` all re-embed labels through `populate_label_embeddings`).
- **The recorder keeps that ledger**, keyed `(media_type, embedder)` — the same key `_load_profiler` uses, so two blank embedder names from different media types cannot collide. Every row of a participating task carries `cold_model`. Read where the rows are written, so a run that learned its embedder late (#3542's `set_scale(embedder=…)`) is filed under the encoder it really used, and a run that recorded nothing does not claim a key on the next run's behalf.
- **`fit_step` fits the warm population** — *when the warm rows can carry the regression on their own* (two distinct sizes). Below that a holdout would cost the cell its only line, and a two-run sweep's first run is always the cold one, so a strict holdout would turn every minimal sweep into a table of flat medians. There the cold rows stay in.
- **A deferred step keeps a floor.** When the warm runs measure a step as exactly free *and* a cold one measured it as real, it ships at the same 0.5 s `fit_load_weights.py` gives a warm model load — which is what takes the measured `54.905, 0.000, 0.000, 0.000` from `{"a": 0.0}` to the ~0.02 share the shipped table already assigns. It is a guard against a confident zero, not a cost model; measuring the cold branch properly is #3521's job.
- **`normalize_row` reads `cold_model` from both recorder shapes**, so the legacy profiler's flag — stamped since #3339, never read by *this* fitter — now steers the generic fit too. A row without the field is warm, so every pre-existing recording fits exactly as it did before.

Rebased onto `dev` after #3542 and #3545 landed. The split composes with both: #3542's r² guards score the line drawn through whichever population survives the split, and #3545's `_rollup_is_contradicted` fits each pooled group through `fit_step`, so it inherits the holdout without needing to know about it.

## Tests

`tests_lib/core/test_timing_cold_warm.py`, 17 tests. The one the issue asks for plants the measured rack7n06 rows and asserts the coefficient **moves**, not merely that it is finite:

```python
unmarked = _fit([{**s, "cold": False} for s in measured])
assert unmarked.a == 0.0, "the bug: one population, median zero, a step priced free"

marked = _fit(measured)
assert marked.a > unmarked.a, "the coefficient must MOVE, not merely be finite"
```

Plus: the per-run flag and its `(media_type, embedder)` key; an embedder learned late still deciding that key; a non-encoder task neither claiming nor carrying it; the cold run held out of a slope (and the same rows pooled losing the line entirely); the two-run guard in both directions; a cold-only cell still fitting; byte-scaled steps ignoring the marker; and an end-to-end `fit_profile` round trip.

`reset_seen_models_for_tests()` goes in `tests_shared/state_reset.py` so both suites reset the ledger, per CLAUDE.md.

Full `./run-tests.sh`: **9845 passed, 6 skipped**, all gates green.

## Second commit: `fast-uri` override

`npm audit` was failing on `dev` before this branch — four high-severity advisories against `fast-uri` 3.0.0–3.1.5, reached transitively through `@angular/cli` → `@angular-devkit/core` → `ajv`. Overridden to `^3.1.7`, which clears all four without leaving the major `ajv` asks for (`^3.0.1`). Unrelated to the timing change, fixed here because `run-tests.sh` gates on it and there is no CI backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRrxUCE3tC2NnYeoUzu5TQ