### PR TITLE
docs(changelog): record the Autopilot retrain-mode entry fix (#3535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ not list every commit. Use `git log` for the full history.
   the dashboard and toasts read it as a red failure; both import paths now
   share one exception taxonomy and a cancel reads as `Cancelled` either side.
 
+- **Autopilot opens on the detector you already trained, instead of on its text
+  hint.** Whether a detector arrives already trained -- and so whether Autopilot
+  ranks with the model from its first screen instead of seeding from the text or
+  example hint -- was decided the instant the Autopilot panel mounted. On entry
+  to the Train window that instant is always two round trips before
+  `/api/votes` can answer (the window ends any live Find session before it reads
+  the votes), so the labelset counts it read were the not-yet-loaded zeroes and
+  the answer was always "untrained", however trained the detector was. Only the
+  Manual -> Autopilot tab switch, which rebuilds the panel with the counts
+  already loaded, ever got it right. The mount-time reading is now a guess that
+  the run's first *real* reading of the labelset corrects, and the ranking
+  follows that correction. It matters most for a detector trained on one dataset
+  and opened on another, where there are no votes to move the phase and so
+  nothing else would ever have corrected it. Two smaller things read the same
+  flag and were deciding from a value that was false for reasons of timing
+  rather than of fact: the re-sort prompt, and the sort mode Autopilot leaves
+  selected when you stop it.
+
 - **Find now calibrates each detector against the corpus it is searching, and
   scores each head the way that head was trained.** Two independent faults met
   in the cross-dataset Find route. A detector that is not loaded against the


### PR DESCRIPTION
**Stood down: #3543 already shipped the fix for #3535.** This PR originally carried a second implementation of it, written in parallel before that one merged. Rather than force my half in, I dropped it — what's left is one CHANGELOG entry.

### The shipped fix works — verified

Before standing down I checked #3543's fix in real chromium against the screenshot fixtures (`doc-demo`, 5 good / 4 bad, trained on `syn-imgs`, opened on a second SigLIP dataset):

```
      117ms POST /api/find/end-session
      119ms GET  /api/votes
      132ms GET  /api/votes
      438ms POST /api/learned-sort     <- exactly one, ~300ms after the votes land
```

Retrain mode engages, the phase correctly stays in *Find Initial Goods*, and there is no duplicate sort — the thing #3535 warned about. (A cold first run showed the ranking arriving ~6s after the votes instead of ~300ms; that reproduces only on the very first entry after a server start, while the dataset load is still blocking, and on no warm run.)

My implementation put the same decision in `LabelViewComponent` and dropped the seed sort unfired; `dev`'s puts it in `noteInitialLabelset` and lets the shared 300ms seed backstop replace whatever ranked first. Both reach the same end state and `dev`'s reuses the #3510 machinery, so there was nothing worth re-litigating.

### What is left here

One CHANGELOG entry. #3543 shipped without one, and the behaviour is user-visible: a detector trained on one dataset and opened on another now ranks with the model from its first screen instead of the text hint. Written to describe what shipped, not what I wrote.

The `fast-uri` duplicate-key fix this PR also carried has since landed on `dev` by another route, so it is no longer in the diff.

Full `./run-tests.sh` green (10274 passed).

Refs #3535 — fixed by #3543; this PR only records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137mRQD3N6aYpDR6CobLWLb