### PR TITLE
Collapse the six admin-override knobs into one declarative registry

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,7 @@ api.spec.to_dict = _to_dict_with_operation_ids
 # module exposes a ``register_*`` function that wires its handlers on in the
 # original order.
 
+from vtsearch import admin_overrides  # noqa: E402
 from vtsearch.errors import register_error_handlers  # noqa: E402
 from vtsearch.hooks import register_hooks  # noqa: E402
 
@@ -257,76 +258,61 @@ app.register_blueprint(hf_auth_bp)
 # ---------------------------------------------------------------------------
 
 
-def _apply_env_dataset_max_age() -> None:
-    """Honour ``VTSEARCH_DATASET_MAX_AGE_DAYS`` when no CLI flag was passed.
+def _report_admin_overrides() -> None:
+    """Print every process-level admin restriction actually in force.
 
-    The gunicorn-launched images never parse ``--dataset-max-age-days`` (the
-    argparse path only runs under ``python app.py``), so the same override is
-    reachable from the environment. An explicit CLI flag always wins. Like the
-    flag, this applies to every user for the lifetime of the process and is not
-    editable via the settings API.
+    Walks :data:`vtsearch.admin_overrides.OVERRIDES` and reports each knob
+    whose effective value is not the "nothing set" one, naming where it came
+    from -- the flag, the env var, or (when neither was given and the persisted
+    setting is doing the work) the settings key. An operator can then confirm
+    from the startup log that the restriction they configured is live, however
+    they configured it.
     """
-    from vtsearch.settings import get_cli_dataset_max_age_days, set_cli_dataset_max_age_days
+    from vtsearch import settings as _settings
 
-    if get_cli_dataset_max_age_days() is not None:
-        return
-    raw = os.environ.get("VTSEARCH_DATASET_MAX_AGE_DAYS")
-    if not raw:
-        return
-    try:
-        days = int(raw)
-    except ValueError:
-        days = 0
-    if days >= 1:
-        set_cli_dataset_max_age_days(days)
-        print(f"\U0001f5d3️  Dataset max age: {days}d (from VTSEARCH_DATASET_MAX_AGE_DAYS)", flush=True)
-    else:
+    for override in admin_overrides.OVERRIDES.values():
+        effective = _settings.get_effective_override(override.name)
+        if not effective:
+            continue
+        source = admin_overrides.override_source(override.name) or f"the {override.name} setting"
         print(
-            f"⚠️  Ignoring VTSEARCH_DATASET_MAX_AGE_DAYS={raw!r} (want a positive integer number of days)",
+            f"{_OVERRIDE_ICONS.get(override.name, '⚙️')}  "
+            f"{_OVERRIDE_LABELS.get(override.name, override.name)}: "
+            f"{_format_override(effective)} (from {source})",
             flush=True,
         )
 
 
-def _apply_env_support_email() -> None:
-    """Honour ``VTSEARCH_SUPPORT_EMAIL`` when no CLI flag was passed.
+#: Startup-banner icon and label per override, purely cosmetic.
+_OVERRIDE_ICONS = {
+    "solo_media_type": "\U0001f3af",
+    "solo_embedders": "\U0001f3af",
+    "hidden_plugins": "\U0001f648",
+    "dataset_max_age_days": "\U0001f5d3️",
+    "support_email": "\U0001f4e7",
+    "semantic_only": "\U0001f512",
+}
 
-    Same rationale as :func:`_apply_env_dataset_max_age`: the gunicorn images
-    never parse ``--support-email``. An explicit CLI flag always wins.
-    """
-    from vtsearch.settings import get_cli_support_email, set_cli_support_email
-
-    if get_cli_support_email() is not None:
-        return
-    email = (os.environ.get("VTSEARCH_SUPPORT_EMAIL") or "").strip()
-    if email:
-        set_cli_support_email(email)
-        print(f"\U0001f4e7 Support email: {email} (from VTSEARCH_SUPPORT_EMAIL)", flush=True)
+_OVERRIDE_LABELS = {
+    "solo_media_type": "Solo mediaType",
+    "solo_embedders": "Solo mediaEmbedders",
+    "hidden_plugins": "Hidden plugins",
+    "dataset_max_age_days": "Dataset max age",
+    "support_email": "Support email",
+    "semantic_only": "Semantic embedders only",
+}
 
 
-def _apply_env_semantic_only() -> None:
-    """Honour ``VTSEARCH_SEMANTIC_ONLY`` when no CLI flag was passed.
-
-    Same rationale as the two helpers above (gunicorn never parses
-    ``--semantic-only``); any of ``1``/``true``/``yes``/``on`` enables the
-    lock. Reports the lock however it arrived - flag, env var, or the persisted
-    ``semantic_only`` setting - so an operator can confirm from the startup log
-    that the prototype embedder types are off.
-    """
-    from vtsearch.settings import (
-        get_cli_semantic_only,
-        get_effective_semantic_only,
-        set_cli_semantic_only,
-    )
-
-    source = "--semantic-only"
-    if get_cli_semantic_only() is None:
-        if (os.environ.get("VTSEARCH_SEMANTIC_ONLY") or "").strip().lower() in ("1", "true", "yes", "on"):
-            set_cli_semantic_only(True)
-            source = "VTSEARCH_SEMANTIC_ONLY"
-        else:
-            source = "the semantic_only server setting"
-    if get_effective_semantic_only():
-        print(f"\U0001f512 Semantic embedders only (from {source})", flush=True)
+def _format_override(value) -> str:
+    """Render an override value for the startup banner."""
+    if isinstance(value, dict):
+        return ", ".join(
+            f"{key}={','.join(sorted(item))}" if isinstance(item, (set, frozenset)) else f"{key}={item}"
+            for key, item in sorted(value.items())
+        )
+    if value is True:
+        return "on"
+    return str(value)
 
 
 def initialize_server(mode_label: str = "PRODUCTION") -> None:
@@ -344,30 +330,23 @@ def initialize_server(mode_label: str = "PRODUCTION") -> None:
     """
     print(f"\U0001f680 Running in {mode_label} mode", flush=True)
 
-    # Deployment-level overrides that the gunicorn-launched images can only
-    # reach through the environment (they never parse argv).
-    _apply_env_dataset_max_age()
-    _apply_env_support_email()
-    _apply_env_semantic_only()
+    # Deployment-level overrides the gunicorn-launched images can only reach
+    # through the environment (they never parse argv). An explicit flag wins.
+    admin_overrides.apply_env_overrides()
+    _report_admin_overrides()
 
     print("\U0001f4da Loading ML libraries...", flush=True)
     initialize_models(on_progress=lambda *a, **k: None)
-    # The solo-mediaType restriction (``--solo-media-type`` or the persisted
+    # The solo-mediaType restriction (the flag, the env var, or the persisted
     # server setting) tells us which mediaType's default embedder to warm even
     # if no datasets or detectors are registered yet. It is server-tier, so it
     # resolves without a current user at startup.
-    from vtsearch.settings import get_cli_solo_embedders, get_cli_solo_media_type, get_effective_solo_media_type
+    from vtsearch.settings import get_cli_solo_embedders, get_effective_solo_media_type
 
     solo = get_effective_solo_media_type()
     extra_types = [solo] if solo else None
-    if solo:
-        origin = "--solo-media-type" if get_cli_solo_media_type() else "the solo_media_type setting"
-        print(f"\U0001f3af Solo mediaType: {solo} (from {origin})", flush=True)
     cli_solo_embedders = get_cli_solo_embedders()
     extra_embedders = list(cli_solo_embedders.values()) if cli_solo_embedders else None
-    if cli_solo_embedders:
-        pretty = ", ".join(f"{mt}={emb}" for mt, emb in cli_solo_embedders.items())
-        print(f"\U0001f3af Solo mediaEmbedders: {pretty} (from --solo-embedder)", flush=True)
     preloaded = preload_predicted_embedders(
         extra_media_types=extra_types,
         extra_embedders=extra_embedders,

--- a/app.py
+++ b/app.py
@@ -262,17 +262,23 @@ def _report_admin_overrides() -> None:
     """Print every process-level admin restriction actually in force.
 
     Walks :data:`vtsearch.admin_overrides.OVERRIDES` and reports each knob
-    whose effective value is not the "nothing set" one, naming where it came
-    from -- the flag, the env var, or (when neither was given and the persisted
+    whose effective value is an actual restriction, naming where it came from
+    -- the flag, the env var, or (when neither was given and the persisted
     setting is doing the work) the settings key. An operator can then confirm
     from the startup log that the restriction they configured is live, however
     they configured it.
+
+    A knob still sitting at its shipped default is *not* reported: the banner
+    is a list of what makes this deployment unusual, so printing the built-in
+    support address on every boot would be noise.
     """
     from vtsearch import settings as _settings
+    from vtsearch.settings_models import ServerSettings, UserSettings
 
+    defaults = {**UserSettings().model_dump(), **ServerSettings().model_dump()}
     for override in admin_overrides.OVERRIDES.values():
         effective = _settings.get_effective_override(override.name)
-        if not effective:
+        if not effective or effective == defaults.get(override.persisted_getter.removeprefix("get_")):
             continue
         source = admin_overrides.override_source(override.name) or f"the {override.name} setting"
         print(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -380,6 +380,11 @@ VTSearch/
 │   ├── settings_store.py           Two-tier persistence engine (file locking, caches) for settings.py
 │   ├── settings_models.py          Pydantic ServerSettings / UserSettings models; the source of
 │   │                               truth for setting types, defaults, ranges, and enums
+│   ├── admin_overrides.py          Declarative registry of the process-level admin overrides
+│   │                               (solo mediaType / embedder locks, plugin hides, dataset
+│   │                               retention, support email, Semantic-only): one descriptor
+│   │                               per knob carrying its CLI flag, env var, shared validator,
+│   │                               resolution rule, and /api/settings key
 │   ├── threading.py                Context-carrying thread helper (user + dataset + detector locals)
 │   ├── achievements.py             Achievement state management
 │   ├── autorun_processors.py       autorun_extractors / autorun_localizers CRUD
@@ -882,6 +887,18 @@ field lists — this document names the tiers and the shape, not every key.
   `panel_pct_*`, `autopilot_*`, `settings_source`, `achievement_state`, and the
   **Auto-Find** keys `autofind_detectors`, `autofind_exporter`,
   `autofind_exporter_field_values`.
+
+Six of those server-tier keys double as **admin overrides**: an operator can
+pin `solo_media_type`, `solo_embedder_per_media_type`, `hidden_plugins`,
+`dataset_max_age_days`, `support_email` and `semantic_only` at startup, for
+every user and for the life of the process, without the settings file. Each is
+declared once in `vtsearch/admin_overrides.py` — a descriptor carrying its CLI
+flag, its env-var equivalent (so the gunicorn images, which never parse `argv`,
+can set it too), the validator both entry paths share, how it combines with the
+persisted value, and the key `/api/settings` publishes the result under. The
+argparse arguments, the env fallbacks, the `get_effective_*` resolvers in
+`settings.py` and the response overlay all derive from that registry rather
+than being re-plumbed per knob.
 
 Both models set `extra = "allow"`, so free-form sub-objects
 (`achievement_state`, `settings_source`) round-trip alongside the typed keys.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -504,7 +504,10 @@ shows it read-only), and `PUT /api/settings` refuses to touch it. The
 flag is a process-level override of the server-tier `solo_media_type`
 key, so an operator can also set it persistently by writing
 `"solo_media_type": "image"` into `data/settings.json`; the flag wins
-for the lifetime of the process.
+for the lifetime of the process. The gunicorn-launched Docker images
+never parse `argv`, so the same restriction is settable there as
+`VTSEARCH_SOLO_MEDIA_TYPE=image` — an explicit flag wins over the
+variable, and both run the same validation.
 
 **Solo mediaEmbedder** (`--solo-embedder`): lock the embedding model
 for one or more mediaTypes so the dataset-importer modal hides its
@@ -521,7 +524,9 @@ each locked embedder at startup even when no datasets or detectors are
 registered yet. Unlike `--solo-media-type`, this one is a per-process
 **fallback** over a per-user setting: any user can override it
 per-mediaType via the Settings dialog ("Ask each time" is the opt-out),
-and their choice persists across restarts.
+and their choice persists across restarts. Under Docker, set the same
+locks as a comma-separated `VTSEARCH_SOLO_EMBEDDERS=image=siglip,audio=clap`;
+an explicit flag wins.
 
 **Hidden plugins** (`--hide-plugin family:name`, repeatable): drop a
 plugin from picker / listing API responses for this deployment without
@@ -545,8 +550,12 @@ not a security boundary. The CLI flag merges with the persisted
 `hidden_plugins` key in the server settings file (`data/settings.json`
 or whatever path `--settings` points at), where a deployment can set
 `{"hidden_plugins": {"converters": ["audio2image"]}}` and pick it up on
-every restart. Use `--list-plugins --format names` to discover the
-available `family:name` pairs.
+every restart. The merge is a **union**: either source can add a hide,
+and neither can un-hide what the other hid. Under Docker, pass the same
+pairs comma-separated as
+`VTSEARCH_HIDE_PLUGINS=converters:audio2image,embedders:e5`; an explicit
+flag wins. Use `--list-plugins --format names` to discover the available
+`family:name` pairs.
 
 **Dataset retention** (`--dataset-max-age-days DAYS`): stamp every
 dataset created by this server process with an expiry `DAYS` days after

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -118,6 +118,9 @@ documented workarounds; this section describes the code as it stands.
 | `VTSEARCH_SUPPORT_EMAIL` | built-in project address | Recipient for the Help modal's "Email us" link. Overrides the persisted `support_email` setting for the process lifetime (all users; not editable via the API). Equivalent to the `--support-email` CLI flag, for the gunicorn images that never parse `argv`; an explicit flag wins. |
 | `VTSEARCH_SEMANTIC_ONLY` | unset | Set to `1`/`true`/`yes`/`on` to lock the deployment to **Semantic** embedders, hiding the prototype Patch Semantic and Structural types from every picker and rejecting them at the dataset-load / detector-create routes. Env-var equivalent of `--semantic-only`, for the gunicorn images; an explicit flag wins, and either beats the persisted `semantic_only` server setting. |
 | `VTSEARCH_DATASET_MAX_AGE_DAYS` | unset (datasets never expire) | Stamps every newly created dataset with an expiry this many days out. Positive integers only; anything else is ignored with a warning on stdout. Env-var equivalent of `--dataset-max-age-days`, for the gunicorn images; an explicit flag wins. |
+| `VTSEARCH_SOLO_MEDIA_TYPE` | unset | Lock the whole instance to one mediaType: the importer and new-detector flows hide their mediaType pickers, converter offerings are filtered to converters that output this type, and that type's default embedder is preloaded at startup. Must be a registered media-type id (`audio`, `image`, `video`, `text`, `document`). Env-var equivalent of `--solo-media-type`, for the gunicorn images; an explicit flag wins, and either beats the persisted `solo_media_type` server setting. |
+| `VTSEARCH_SOLO_EMBEDDERS` | unset | Comma-separated `TYPE=EMBEDDER` pairs (e.g. `image=siglip,audio=clap`) locking the embedder for those mediaTypes, so the importer modal hides its embedder picker for each. A per-process *fallback*: any user who picks their own embedder in the settings UI overrides it for themselves. Env-var equivalent of the repeatable `--solo-embedder`; an explicit flag wins. |
+| `VTSEARCH_HIDE_PLUGINS` | unset | Comma-separated `FAMILY:NAME` pairs (e.g. `embedders:e5,importers:synthetic`) hidden from picker and listing API responses. Hidden plugins stay importable and callable by name — this declutters the UI, it is not a security boundary. Env-var equivalent of the repeatable `--hide-plugin`; an explicit flag wins, and the result is *unioned* with the persisted `hidden_plugins` setting (either source can add a hide; neither can un-hide). |
 
 ### Progress-bar timing
 
@@ -625,8 +628,10 @@ working.
   (`"converters"`, `"embedders"`, `"importers"`, … — the keys used by
   `vtscore.plugins.inventory`) to a list of plugin names to omit from picker
   and listing responses. Merged at read time with any `--hide-plugin
-  family:name` CLI flags. This is a UI-declutter setting, **not a security
-  boundary**: hidden plugins remain importable and callable by name.
+  family:name` flags / `VTSEARCH_HIDE_PLUGINS` entries — the merge is a union,
+  so either source can add a hide and neither can un-hide. This is a
+  UI-declutter setting, **not a security boundary**: hidden plugins remain
+  importable and callable by name.
 - `dataset_max_age_days`: stamps new datasets with an expiry this many days
   out. `null` (the default) means datasets never expire. Also settable with
   `--dataset-max-age-days` / `VTSEARCH_DATASET_MAX_AGE_DAYS`, either of which
@@ -645,7 +650,8 @@ working.
   and new-detector flows hide their media-type pickers and lock to it, the
   converter picker filters to converters that output it, and media-type steps
   in tabbed UIs are skipped. `null` shows everything. Users cannot change it;
-  also settable with `--solo-media-type`.
+  also settable with `--solo-media-type` / `VTSEARCH_SOLO_MEDIA_TYPE`, either of
+  which wins for the process lifetime.
 - `projection_n_neighbors`, `projection_min_dist`: UMAP knobs for the VTSBrowse
   map. The persisted projection is keyed on these, so changing one forces a
   recompute rather than serving a layout fit under the old params. Clamped to

--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -99,7 +99,6 @@ care.
 ## App tier — settings
 
 - [ ] #3413 — Delete the settings migration shims for old persisted formats (Sonnet 5)
-- [ ] #3415 — Collapse the six CLI-override knobs into one declarative `AdminOverride` descriptor (Sonnet 5)
 - [ ] #3416 — Give `inclusion` one owner and one clamp (Sonnet 5)
 
 ## App tier — routes, schemas, facades

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5304,9 +5304,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -18,40 +18,23 @@ import sys
 
 import pytest
 
+from vtsearch import admin_overrides
 from vtsearch import cli_main
 from vtsearch import settings as settings_mod
 
 
 @pytest.fixture(autouse=True)
 def _restore_cli_overrides():
-    """Snapshot and restore the process-level CLI override globals.
+    """Snapshot and restore the process-level admin-override store.
 
     ``settings.reset()`` (run by ``isolated_settings`` around each test)
     does *not* clear these, so a test that applies a valid
     ``--solo-media-type`` / ``--hide-plugin`` / etc. would otherwise leak
     the value into later tests.
     """
-    saved = (
-        settings_mod._cli_solo_media_type,
-        dict(settings_mod._cli_hidden_plugins),
-        dict(settings_mod._cli_solo_embedders),
-        settings_mod._cli_dataset_max_age_days,
-        settings_mod._cli_support_email,
-        settings_mod._cli_semantic_only,
-    )
+    saved = admin_overrides.snapshot()
     yield
-    (
-        settings_mod._cli_solo_media_type,
-        hidden,
-        solo_emb,
-        settings_mod._cli_dataset_max_age_days,
-        settings_mod._cli_support_email,
-        settings_mod._cli_semantic_only,
-    ) = saved
-    settings_mod._cli_hidden_plugins.clear()
-    settings_mod._cli_hidden_plugins.update(hidden)
-    settings_mod._cli_solo_embedders.clear()
-    settings_mod._cli_solo_embedders.update(solo_emb)
+    admin_overrides.restore(saved)
 
 
 def _run_main(monkeypatch, argv, app=None, initialize_server=None):
@@ -98,8 +81,8 @@ class TestBuildParser:
         assert args.progress_format == "text"
         assert args.output_format == "plain"
         assert args.label_importer == "server_json_file"
-        assert args.hide_plugin == []
-        assert args.solo_embedders is None
+        assert args.hidden_plugins == []
+        assert args.solo_embedders == []
         assert args.dry_run is False
         assert args.list_plugins is False
 
@@ -137,7 +120,7 @@ class TestBuildParser:
         args = parser.parse_args(
             ["--hide-plugin", "importers:a", "--hide-plugin", "exporters:b", "--solo-embedder", "image=x"]
         )
-        assert args.hide_plugin == ["importers:a", "exporters:b"]
+        assert args.hidden_plugins == ["importers:a", "exporters:b"]
         assert args.solo_embedders == ["image=x"]
 
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -631,7 +631,7 @@ class TestApplyOverrides:
     def test_hide_plugin_valid_is_stashed(self, monkeypatch):
         monkeypatch.setattr(cli_main, "_run_server", lambda *a: None)
         _run_main(monkeypatch, ["--hide-plugin", "importers:server_folder"])
-        assert "server_folder" in settings_mod._cli_hidden_plugins.get("importers", set())
+        assert "server_folder" in settings_mod.get_cli_hidden_plugins().get("importers", set())
 
     def test_hide_plugin_empty_half_errors(self, monkeypatch, capsys):
         with pytest.raises(SystemExit) as exc:

--- a/tests/core/test_admin_overrides.py
+++ b/tests/core/test_admin_overrides.py
@@ -1,0 +1,196 @@
+"""Tests for the declarative admin-override registry.
+
+The registry (:mod:`vtsearch.admin_overrides`) is what stops the six
+process-level admin knobs from drifting apart the way they had: before it,
+each was hand-plumbed through argparse, the environment, the settings
+resolvers and the ``/api/settings`` overlay separately, and only three of the
+six ever got an env var -- so which restrictions a Docker deployment could set
+was arbitrary.
+
+The first class below is the guard against that recurring: it asserts
+*structurally* that every registered override is reachable from a flag, from
+the environment, and from the settings payload. A seventh knob that forgets one
+of the three fails here rather than being discovered by an operator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtsearch import admin_overrides
+from vtsearch import cli_main
+from vtsearch import settings as settings_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_overrides():
+    """Snapshot and restore the process-level override store around each test."""
+    saved = admin_overrides.snapshot()
+    admin_overrides.reset_overrides()
+    yield
+    admin_overrides.restore(saved)
+
+
+class TestRegistryCoverage:
+    """Every override must be reachable from all four consumers."""
+
+    def test_every_override_declares_a_flag_and_an_env_var(self):
+        for name, override in admin_overrides.OVERRIDES.items():
+            assert override.flag.startswith("--"), name
+            assert override.env.startswith("VTSEARCH_"), name
+            assert override.effective_key, name
+            assert override.help, name
+
+    def test_flags_and_env_names_are_unique(self):
+        flags = [ov.flag for ov in admin_overrides.OVERRIDES.values()]
+        envs = [ov.env for ov in admin_overrides.OVERRIDES.values()]
+        assert len(set(flags)) == len(flags)
+        assert len(set(envs)) == len(envs)
+
+    def test_persisted_getter_exists_on_settings(self):
+        for name, override in admin_overrides.OVERRIDES.items():
+            getter = getattr(settings_mod, override.persisted_getter, None)
+            assert callable(getter), f"{name}: no settings.{override.persisted_getter}"
+
+    def test_every_override_is_registered_on_the_parser(self):
+        parser = cli_main._build_parser()
+        registered = {opt for action in parser._actions for opt in action.option_strings}
+        for name, override in admin_overrides.OVERRIDES.items():
+            assert override.flag in registered, name
+
+    def test_value_and_append_overrides_carry_a_parser(self):
+        """Only ``switch`` knobs may omit ``parse``; ``append`` needs ``fold`` too."""
+        for name, override in admin_overrides.OVERRIDES.items():
+            if override.kind == "switch":
+                continue
+            assert override.parse is not None, name
+            if override.kind == "append":
+                assert override.fold is not None, name
+
+    def test_settings_resolves_every_override(self):
+        """``get_effective_override`` works for every name, with nothing set."""
+        for name in admin_overrides.OVERRIDES:
+            settings_mod.get_effective_override(name)
+
+
+class TestEnvOverrides:
+    """The env form of each knob -- the half that used to be missing."""
+
+    def test_solo_media_type_from_env(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_SOLO_MEDIA_TYPE", "image")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_effective_solo_media_type() == "image"
+        assert admin_overrides.override_source("solo_media_type") == "VTSEARCH_SOLO_MEDIA_TYPE"
+
+    def test_hide_plugins_from_env_is_comma_separated(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_HIDE_PLUGINS", "embedders:clap, importers:synthetic")
+        admin_overrides.apply_env_overrides()
+        hidden = settings_mod.get_effective_hidden_plugins()
+        assert hidden["embedders"] == {"clap"}
+        assert hidden["importers"] == {"synthetic"}
+
+    def test_solo_embedders_from_env_is_comma_separated(self, monkeypatch):
+        from vtscore.media import all_type_ids, embedders_for_type
+
+        pair = next(
+            ((mt, embs[0].name) for mt in all_type_ids() if (embs := embedders_for_type(mt))),
+            None,
+        )
+        assert pair is not None, "no embedders registered"
+        mt, emb = pair
+        monkeypatch.setenv("VTSEARCH_SOLO_EMBEDDERS", f"{mt}={emb}")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_cli_solo_embedders()[mt] == emb
+
+    def test_dataset_max_age_from_env(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_DATASET_MAX_AGE_DAYS", "30")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_effective_dataset_max_age_days() == 30
+
+    def test_support_email_from_env(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_SUPPORT_EMAIL", "ops@example.org")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_effective_support_email() == "ops@example.org"
+
+    def test_semantic_only_from_env_accepts_truthy_words(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_SEMANTIC_ONLY", "yes")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_effective_semantic_only() is True
+
+    def test_semantic_only_env_zero_does_not_loosen(self, monkeypatch):
+        """The switch can only enable; ``0`` leaves the persisted setting in charge."""
+        monkeypatch.setenv("VTSEARCH_SEMANTIC_ONLY", "0")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_cli_semantic_only() is None
+
+    def test_an_explicit_flag_wins_over_the_env(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_SUPPORT_EMAIL", "env@example.org")
+        admin_overrides.set_override("support_email", "flag@example.org", source="--support-email")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_effective_support_email() == "flag@example.org"
+
+    def test_a_blank_env_var_sets_nothing(self, monkeypatch):
+        monkeypatch.setenv("VTSEARCH_SUPPORT_EMAIL", "   ")
+        admin_overrides.apply_env_overrides()
+        assert settings_mod.get_cli_support_email() is None
+
+
+class TestSharedValidation:
+    """A value the flag rejects is rejected the same way from the environment."""
+
+    def test_env_and_flag_run_the_same_validator(self, monkeypatch):
+        warnings: list[str] = []
+        monkeypatch.setenv("VTSEARCH_DATASET_MAX_AGE_DAYS", "0")
+        admin_overrides.apply_env_overrides(warn=warnings.append)
+        assert settings_mod.get_cli_dataset_max_age_days() is None
+        assert warnings and "must be a positive integer" in warnings[0]
+
+    def test_a_bad_env_value_names_the_variable_not_the_flag(self, monkeypatch):
+        warnings: list[str] = []
+        monkeypatch.setenv("VTSEARCH_SOLO_MEDIA_TYPE", "not_a_type")
+        admin_overrides.apply_env_overrides(warn=warnings.append)
+        assert warnings
+        assert "VTSEARCH_SOLO_MEDIA_TYPE" in warnings[0]
+        assert "--solo-media-type" not in warnings[0]
+
+    def test_a_bad_env_value_leaves_the_server_bootable(self, monkeypatch):
+        """Unlike the CLI, the env path warns rather than exiting."""
+        monkeypatch.setenv("VTSEARCH_HIDE_PLUGINS", "no-colon-here")
+        admin_overrides.apply_env_overrides(warn=lambda _msg: None)
+        assert settings_mod.get_cli_hidden_plugins() == {}
+
+    def test_non_numeric_dataset_max_age_flag_is_our_error(self):
+        """``type=str`` on the flag means the descriptor writes the message."""
+        with pytest.raises(admin_overrides.OverrideValueError, match="positive integer"):
+            admin_overrides.OVERRIDES["dataset_max_age_days"].parse_token("abc", source="--dataset-max-age-days")
+
+
+class TestStore:
+    """The process-level store itself."""
+
+    def test_get_override_returns_a_defensive_copy(self):
+        settings_mod.add_cli_hidden_plugin("embedders", "clap")
+        got = admin_overrides.get_override("hidden_plugins")
+        got.setdefault("embedders", set()).add("mutated")
+        assert admin_overrides.get_override("hidden_plugins")["embedders"] == {"clap"}
+
+    def test_clearing_an_override_clears_its_source(self):
+        admin_overrides.set_override("support_email", "a@b.c", source="--support-email")
+        settings_mod.set_cli_support_email(None)
+        assert admin_overrides.override_source("support_email") is None
+
+    def test_reset_clears_everything(self):
+        settings_mod.set_cli_support_email("a@b.c")
+        settings_mod.add_cli_hidden_plugin("embedders", "clap")
+        admin_overrides.reset_overrides()
+        assert settings_mod.get_cli_support_email() is None
+        assert settings_mod.get_cli_hidden_plugins() == {}
+
+
+class TestSettingsPayload:
+    """``/api/settings`` publishes the effective value of every override."""
+
+    def test_every_effective_key_is_present(self, client):
+        body = client.get("/api/settings").get_json()
+        for name, override in admin_overrides.OVERRIDES.items():
+            assert override.effective_key in body, f"{name} missing from /api/settings"

--- a/tests/core/test_solo_embedder.py
+++ b/tests/core/test_solo_embedder.py
@@ -14,6 +14,7 @@ import json
 
 import pytest
 
+from vtsearch import admin_overrides
 from vtsearch import settings as settings_mod
 
 
@@ -37,10 +38,10 @@ def _first_audio_embedder() -> str:
 
 @pytest.fixture(autouse=True)
 def _reset_cli_solo_embedders():
-    """The CLI fallback is process-global; clear it around each test."""
-    settings_mod._cli_solo_embedders.clear()
+    """The startup fallback is process-global; clear it around each test."""
+    admin_overrides.set_override("solo_embedders", None)
     yield
-    settings_mod._cli_solo_embedders.clear()
+    admin_overrides.set_override("solo_embedders", None)
 
 
 class TestSoloEmbedderSettings:

--- a/vtsearch/admin_overrides.py
+++ b/vtsearch/admin_overrides.py
@@ -1,0 +1,637 @@
+"""Declarative registry of the process-level **admin override** knobs.
+
+An *admin override* is a server-wide restriction an operator sets at startup:
+it applies to every user, is fixed for the lifetime of the process, and is not
+editable through ``PUT /api/settings``. Six exist today -- the solo mediaType
+lock, the per-mediaType solo-embedder locks, the plugin hide list, the dataset
+retention window, the support-email address, and the Semantic-only embedder
+lock.
+
+Each one used to be spelled out four times: a ``set_cli_X`` / ``get_cli_X`` /
+``get_effective_X`` triad in :mod:`vtsearch.settings`, an ``_apply_X`` argparse
+hook in :mod:`vtsearch.cli_main`, an ``_apply_env_X`` startup hook in
+``app.py``, and a line in the ``/api/settings`` effective-value overlay. Nothing
+tied the four together, so the set drifted: only three of the six were reachable
+from the environment, which meant the gunicorn-launched Docker images (which
+never parse ``argv``) could set *some* admin restrictions and not others, for no
+reason a reader could recover. The env path also re-implemented validation --
+``--dataset-max-age-days 0`` was an argparse error while
+``VTSEARCH_DATASET_MAX_AGE_DAYS=0`` warned and carried on.
+
+This module is the single source of truth instead. One :class:`AdminOverride`
+descriptor per knob carries the flag spelling and help text, the env-var name,
+the parser/validator both entry paths share, the rule for combining the
+override with the persisted setting, and the key it surfaces under at
+``/api/settings``. Everything else derives from the registry:
+
+* :func:`register_override_flags` builds the argparse arguments.
+* :func:`apply_flag_values` validates and stores what argparse parsed.
+* :func:`apply_env_overrides` does the same for the environment, honouring an
+  explicit flag first.
+* ``vtsearch.settings.get_effective_override`` resolves one against its
+  persisted value, and the named ``get_effective_X`` wrappers delegate to it.
+* ``vtsearch.routes.settings.api._with_effective`` loops the registry to build
+  the read-only overlay.
+
+Adding a seventh knob is therefore one :class:`AdminOverride` entry, and
+``tests/core/test_admin_overrides.py`` fails if it does not carry a flag, an env
+var, and an overlay key -- the coverage can no longer go arbitrary by accident.
+
+This module deliberately imports nothing from :mod:`vtsearch.settings` (the
+dependency runs the other way) and touches the plugin/media registries only
+lazily, inside the validators, so importing it is free.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+#: Env-var values accepted as "on" for a switch-shaped override.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+class OverrideValueError(ValueError):
+    """A flag or env value failed its override's validator.
+
+    Carries a message written for an operator (it names the flag or variable
+    and the valid values). :mod:`vtsearch.cli_main` turns it into
+    ``parser.error`` (exit 2); the env path prints it as a warning and leaves
+    the override unset, because a bad variable should not stop a container from
+    booting.
+    """
+
+
+@dataclass(frozen=True)
+class AdminOverride:
+    """One process-level admin knob, described once for all four consumers.
+
+    :param name: Stable id; also the ``settings.py`` accessor stem
+        (``support_email`` → ``set_cli_support_email``).
+    :param flag: Long option spelling, e.g. ``--support-email``.
+    :param env: Environment variable the gunicorn images use instead.
+    :param kind: ``"value"`` (single argument), ``"append"`` (repeatable, one
+        entry per occurrence; the env form is a comma-separated list) or
+        ``"switch"`` (``store_true``; can only *enable*, never loosen).
+    :param persisted_getter: Name of the :mod:`vtsearch.settings` getter for
+        the setting this overrides. Resolved lazily by
+        ``settings.get_effective_override`` so this module never imports it.
+    :param effective_key: Key the resolved value is published under in the
+        ``/api/settings`` payload.
+    :param parse: ``str -> value`` for one token, raising
+        :class:`OverrideValueError`. Returning ``None`` means "no override"
+        (used by the whitespace-only cases). Unused for ``"switch"``.
+    :param resolve: ``(override, persisted) -> effective``. The override is
+        whatever is stored (``empty_factory()`` when unset).
+    :param fold: For ``"append"``, ``(store, parsed) -> store``; how one parsed
+        token accumulates into the stored value.
+    :param dump: ``effective -> JSON-safe``, for the ``/api/settings`` overlay.
+    :param empty_factory: Builds the "no override set" value (``None`` for
+        scalars, a fresh empty dict for the accumulating ones).
+    """
+
+    name: str
+    flag: str
+    env: str
+    kind: str
+    persisted_getter: str
+    effective_key: str
+    resolve: Callable[[Any, Any], Any]
+    help: str
+    metavar: str | None = None
+    parse: Callable[[str], Any] | None = None
+    fold: Callable[[Any, Any], Any] | None = None
+    dump: Callable[[Any], Any] = lambda value: value
+    empty_factory: Callable[[], Any] = lambda: None
+
+    @property
+    def dest(self) -> str:
+        """argparse ``dest`` for this flag (the registry name)."""
+        return self.name
+
+    def parse_env(self, raw: str) -> Any:
+        """Parse the *whole* env-var value into a stored override.
+
+        Returns ``None`` when the variable asks for nothing (blank, or a
+        switch set to something other than a truthy token). Raises
+        :class:`OverrideValueError` with the variable named -- not the flag --
+        so the operator is pointed at what they actually set.
+        """
+        if self.kind == "switch":
+            return True if raw.strip().lower() in _TRUTHY else None
+        if self.kind == "append":
+            store = self.empty_factory()
+            found = False
+            for token in raw.split(","):
+                token = token.strip()
+                if not token:
+                    continue
+                parsed = self.parse_token(token, source=self.env)
+                if parsed is None:
+                    continue
+                assert self.fold is not None  # every "append" override sets it
+                store = self.fold(store, parsed)
+                found = True
+            return store if found else None
+        return self.parse_token(raw, source=self.env)
+
+    def parse_token(self, raw: str, *, source: str) -> Any:
+        """Run :attr:`parse`, re-labelling the error with *source*.
+
+        The validators are written against the flag spelling (that is what a
+        CLI user sees). When the same value arrived from the environment, swap
+        the label so the message names the variable instead.
+        """
+        assert self.parse is not None  # only "switch" overrides omit it
+        try:
+            return self.parse(raw)
+        except OverrideValueError as exc:
+            if source == self.flag:
+                raise
+            raise OverrideValueError(str(exc).replace(self.flag, source)) from None
+
+
+# ---------------------------------------------------------------------------
+# Validators / parsers (registry lookups are imported lazily)
+# ---------------------------------------------------------------------------
+
+
+def _parse_solo_media_type(raw: str) -> str:
+    from vtscore.media import all_type_ids
+
+    valid = set(all_type_ids())
+    if raw not in valid:
+        raise OverrideValueError(f"Unknown --solo-media-type: {raw!r}. Valid values: {sorted(valid)}")
+    return raw
+
+
+def _parse_solo_embedder(raw: str) -> tuple[str, str]:
+    from vtscore.media import all_embedders, all_type_ids, embedders_for_type
+
+    if "=" not in raw:
+        raise OverrideValueError(f"Invalid --solo-embedder value: {raw!r}. Expected TYPE=EMBEDDER (e.g. image=siglip).")
+    mt, _, emb = raw.partition("=")
+    mt = mt.strip()
+    emb = emb.strip()
+    if not mt or not emb:
+        raise OverrideValueError(f"Invalid --solo-embedder value: {raw!r}. Both TYPE and EMBEDDER must be non-empty.")
+    valid_types = set(all_type_ids())
+    if mt not in valid_types:
+        raise OverrideValueError(
+            f"Unknown mediaType in --solo-embedder {raw!r}: {mt!r}. Valid values: {sorted(valid_types)}"
+        )
+    if emb not in {e.name for e in all_embedders()}:
+        raise OverrideValueError(
+            f"Unknown embedder in --solo-embedder {raw!r}: {emb!r}. "
+            f"Valid embedder names: {sorted(e.name for e in all_embedders())}"
+        )
+    valid_for_type = {e.name for e in embedders_for_type(mt)}
+    if emb not in valid_for_type:
+        raise OverrideValueError(
+            f"Embedder {emb!r} is not registered for media type {mt!r}. "
+            f"Valid embedders for {mt}: {sorted(valid_for_type)}"
+        )
+    return mt, emb
+
+
+def _parse_hidden_plugin(raw: str) -> tuple[str, str]:
+    from vtscore.plugins.inventory import FAMILIES
+
+    valid_families = set(FAMILIES)
+    if ":" not in raw:
+        raise OverrideValueError(
+            f"--hide-plugin expects FAMILY:NAME, got {raw!r}. Valid families: {sorted(valid_families)}"
+        )
+    family, _, plugin_name = raw.partition(":")
+    family = family.strip()
+    plugin_name = plugin_name.strip()
+    if not family or not plugin_name:
+        raise OverrideValueError(f"--hide-plugin {raw!r} has an empty family or name")
+    if family not in valid_families:
+        raise OverrideValueError(f"Unknown --hide-plugin family {family!r}. Valid: {sorted(valid_families)}")
+    return family, plugin_name
+
+
+def _parse_dataset_max_age_days(raw: str) -> int:
+    try:
+        days = int(raw)
+    except (TypeError, ValueError):
+        raise OverrideValueError(
+            f"--dataset-max-age-days must be a positive integer (number of days), got {raw!r}"
+        ) from None
+    if days < 1:
+        raise OverrideValueError("--dataset-max-age-days must be a positive integer (number of days)")
+    return days
+
+
+def _parse_support_email(raw: str) -> str:
+    email = raw.strip()
+    if not email:
+        raise OverrideValueError("--support-email must be a non-empty address")
+    return email
+
+
+# ---------------------------------------------------------------------------
+# Normalisers / resolvers
+# ---------------------------------------------------------------------------
+
+
+def normalize_hidden_plugins(value: Any) -> dict[str, set[str]]:
+    """Coerce arbitrary input to ``{family: {name, ...}}`` form.
+
+    Accepts ``dict[str, Iterable[str]]`` shapes and drops empty entries.
+    Non-string keys / names and ``None`` values are silently skipped so a
+    corrupt settings file doesn't crash plugin listings.
+    """
+    out: dict[str, set[str]] = {}
+    if not isinstance(value, dict):
+        return out
+    for family, names in value.items():
+        if not isinstance(family, str) or not family:
+            continue
+        if isinstance(names, (str, bytes)):
+            continue
+        try:
+            members = {n for n in names if isinstance(n, str) and n}
+        except TypeError:
+            continue
+        if members:
+            out[family] = members
+    return out
+
+
+def _resolve_scalar(override: Any, persisted: Any) -> Any:
+    """The plain two-step precedence: an override set at startup, else the file."""
+    return persisted if override is None else override
+
+
+def _resolve_solo_media_type(override: str | None, persisted: Any) -> str | None:
+    if override is not None:
+        return override
+    # Empty string from JSON drift normalises to None.
+    if isinstance(persisted, str) and not persisted.strip():
+        return None
+    return persisted
+
+
+def _resolve_semantic_only(override: bool | None, persisted: Any) -> bool:
+    return bool(persisted) if override is None else override
+
+
+def _resolve_solo_embedders(override: dict[str, str], persisted: Any) -> dict[str, str]:
+    """Layer the per-user map over the process-level fallbacks, per key.
+
+    User entries win per-key; missing user keys fall through to the startup
+    value. An **empty-string value** in the user map is a per-type opt-out
+    sentinel -- it removes that type from the merged map even if the startup
+    fallback has a value for it. (``solo_media_type`` has no such per-user
+    opt-out: it is an admin-set server restriction.)
+
+    Validity (does the embedder still exist for this type?) is *not* checked
+    here -- the frontend resolves it against the live embedder registry on its
+    end and falls back to the normal picker for any entry that no longer
+    matches. Keeping validation client-side means a rename or removal never
+    blocks the settings UI from rendering.
+    """
+    merged: dict[str, str] = {}
+    for mt, emb in override.items():
+        if mt and isinstance(emb, str) and emb.strip():
+            merged[mt] = emb.strip()
+    if isinstance(persisted, dict):
+        for mt, emb in persisted.items():
+            if not isinstance(mt, str) or not mt:
+                continue
+            if isinstance(emb, str) and emb.strip():
+                merged[mt] = emb.strip()
+            else:
+                # Empty-string sentinel - user explicitly opted out for this
+                # type, so drop the startup fallback too.
+                merged.pop(mt, None)
+    return merged
+
+
+def _resolve_hidden_plugins(override: dict[str, set[str]], persisted: Any) -> dict[str, set[str]]:
+    """Union the persisted hide list with the startup one.
+
+    The union semantics matter: a plugin is hidden if either source asks for
+    it, so ``--hide-plugin`` can only add hides (never un-hide something the
+    settings file marks hidden).
+    """
+    merged = {family: set(names) for family, names in normalize_hidden_plugins(persisted).items()}
+    for family, names in override.items():
+        merged.setdefault(family, set()).update(names)
+    return merged
+
+
+def _fold_pair(store: dict[str, str], parsed: tuple[str, str]) -> dict[str, str]:
+    key, value = parsed
+    store[key] = value
+    return store
+
+
+def _fold_family(store: dict[str, set[str]], parsed: tuple[str, str]) -> dict[str, set[str]]:
+    family, name = parsed
+    store.setdefault(family, set()).add(name)
+    return store
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+_REGISTRY: tuple[AdminOverride, ...] = (
+    AdminOverride(
+        name="solo_media_type",
+        flag="--solo-media-type",
+        env="VTSEARCH_SOLO_MEDIA_TYPE",
+        kind="value",
+        persisted_getter="get_solo_media_type",
+        effective_key="solo_media_type",
+        parse=_parse_solo_media_type,
+        resolve=_resolve_solo_media_type,
+        help=(
+            "Streamline the UI for a single mediaType. Hides mediaType pickers "
+            "in the dataset-importer and new-detector flows, locks them to the "
+            "given type, filters converter offerings to converters whose output "
+            "is this type, and preloads that type's default embedder at startup. "
+            "This is an admin-set restriction: it applies to every user, and "
+            "users cannot change or opt out of it from the settings UI. "
+            "Overrides the persisted ``solo_media_type`` key in the server "
+            "settings file for the lifetime of the process. Valid values are "
+            "the registered media-type ids (e.g. audio, image, video, text, "
+            "document)."
+        ),
+    ),
+    AdminOverride(
+        name="solo_embedders",
+        flag="--solo-embedder",
+        env="VTSEARCH_SOLO_EMBEDDERS",
+        kind="append",
+        metavar="TYPE=EMBEDDER",
+        persisted_getter="get_solo_embedder_per_media_type",
+        effective_key="effective_solo_embedder_per_media_type",
+        parse=_parse_solo_embedder,
+        fold=_fold_pair,
+        resolve=_resolve_solo_embedders,
+        empty_factory=dict,
+        help=(
+            "Lock a single embedder for a mediaType so the dataset-importer "
+            "modal hides its embedder picker for that type and silently uses "
+            "the named embedder. Repeatable, one --solo-embedder per mediaType "
+            "(e.g. --solo-embedder image=siglip --solo-embedder audio=clap). "
+            "Format is TYPE=EMBEDDER, where TYPE is a registered media-type id "
+            "and EMBEDDER is a registered embedder name for that type. Acts as "
+            "a per-process fallback. Any user who sets their own value via "
+            "the settings UI overrides this flag per-mediaType for themselves. "
+            "Other mediaTypes still show the normal embedder picker. Also "
+            "settable as a comma-separated VTSEARCH_SOLO_EMBEDDERS."
+        ),
+    ),
+    AdminOverride(
+        name="hidden_plugins",
+        flag="--hide-plugin",
+        env="VTSEARCH_HIDE_PLUGINS",
+        kind="append",
+        metavar="FAMILY:NAME",
+        persisted_getter="get_hidden_plugins",
+        effective_key="hidden_plugins",
+        parse=_parse_hidden_plugin,
+        fold=_fold_family,
+        resolve=_resolve_hidden_plugins,
+        dump=lambda merged: {family: sorted(names) for family, names in merged.items()},
+        empty_factory=dict,
+        help=(
+            "Hide a plugin from picker / listing API responses for this "
+            "process (declutter the UI without editing the codebase). "
+            "Repeatable. FAMILY is a plugin-family id (importers, exporters, "
+            "label_importers, labelset_sources, converters, media_sources, "
+            "media_types, embedders, clippers, settings_importers, "
+            "settings_exporters, settings_sources); NAME is the plugin's "
+            "registered name. Hidden plugins remain importable and callable "
+            "by name via execution endpoints (e.g. autodetect, label "
+            "import). This is a UI flag, not a security boundary. Merges "
+            "with the persisted ``hidden_plugins`` key in the server "
+            "settings file. Use ``--list-plugins --format names`` to see "
+            "the available family:name pairs. Also settable as a "
+            "comma-separated VTSEARCH_HIDE_PLUGINS."
+        ),
+    ),
+    AdminOverride(
+        name="dataset_max_age_days",
+        flag="--dataset-max-age-days",
+        env="VTSEARCH_DATASET_MAX_AGE_DAYS",
+        kind="value",
+        metavar="DAYS",
+        persisted_getter="get_dataset_max_age_days",
+        effective_key="dataset_max_age_days",
+        parse=_parse_dataset_max_age_days,
+        resolve=_resolve_scalar,
+        help=(
+            "Stamp every dataset created by this server process with an "
+            "expiry DAYS days after creation; expired datasets are aged off "
+            "from the registry. Applies to all users and overrides any "
+            "persisted dataset_max_age_days in the settings file for the "
+            "lifetime of the process; the value is not editable via the "
+            "settings API. Must be a positive integer. Omit to use the "
+            "persisted value (no expiry if none is set)."
+        ),
+    ),
+    AdminOverride(
+        name="support_email",
+        flag="--support-email",
+        env="VTSEARCH_SUPPORT_EMAIL",
+        kind="value",
+        metavar="ADDRESS",
+        persisted_getter="get_support_email",
+        effective_key="support_email",
+        parse=_parse_support_email,
+        resolve=_resolve_scalar,
+        help=(
+            "Recipient address for the Help modal's 'Email us' contact link. "
+            "Applies to all users and overrides any persisted support_email in "
+            "the settings file for the lifetime of the process; the value is "
+            "not editable via the settings API. Omit to use the persisted value "
+            "(defaults to the built-in project address)."
+        ),
+    ),
+    AdminOverride(
+        name="semantic_only",
+        flag="--semantic-only",
+        env="VTSEARCH_SEMANTIC_ONLY",
+        kind="switch",
+        persisted_getter="get_semantic_only",
+        effective_key="semantic_only",
+        resolve=_resolve_semantic_only,
+        help=(
+            "Lock this instance to Semantic embedders: the prototype Patch "
+            "Semantic and Structural embedder types are hidden from every "
+            "picker and rejected by the dataset-load and detector-create "
+            "routes. Applies to all users for the lifetime of the process and "
+            "is not editable via the settings API. There is no "
+            "--no-semantic-only: the flag can only enable the lock, never "
+            "loosen one the persisted semantic_only setting asked for."
+        ),
+    ),
+)
+
+#: ``name -> AdminOverride``, in registration order. The order is the one the
+#: ``/api/settings`` overlay and the startup log walk, so it is worth keeping
+#: readable rather than alphabetical.
+OVERRIDES: dict[str, AdminOverride] = {ov.name: ov for ov in _REGISTRY}
+
+
+# ---------------------------------------------------------------------------
+# Process-level store
+# ---------------------------------------------------------------------------
+
+#: The values in force for this process. Every entry starts at its override's
+#: ``empty_factory()`` ("nothing set"); ``settings.get_effective_override``
+#: falls through to the persisted setting for those.
+_values: dict[str, Any] = {name: ov.empty_factory() for name, ov in OVERRIDES.items()}
+
+#: Where each set value came from (``"--support-email"``,
+#: ``"VTSEARCH_SUPPORT_EMAIL"``), for the startup banner. ``None`` while unset.
+_sources: dict[str, str | None] = dict.fromkeys(OVERRIDES)
+
+
+def get_override(name: str) -> Any:
+    """Return the stored override for *name* (its empty value when unset).
+
+    Dict-valued overrides are copied defensively, so a caller cannot mutate
+    the process-level store by accident.
+    """
+    value = _values[name]
+    if isinstance(value, dict):
+        return {k: (set(v) if isinstance(v, set) else v) for k, v in value.items()}
+    return value
+
+
+def set_override(name: str, value: Any, *, source: str | None = None) -> None:
+    """Store *value* as the override for *name* (``None`` / empty clears it).
+
+    This is the un-validated entry point the ``settings.set_cli_X`` wrappers
+    delegate to: it stores whatever it is given. Values arriving from an
+    operator go through :func:`apply_flag_values` or
+    :func:`apply_env_overrides`, which validate first.
+    """
+    ov = OVERRIDES[name]
+    _values[name] = ov.empty_factory() if value is None else value
+    _sources[name] = source if value is not None else None
+
+
+def override_source(name: str) -> str | None:
+    """Return what set this override (a flag or env-var name), or ``None``."""
+    return _sources[name]
+
+
+def snapshot() -> dict[str, Any]:
+    """Return a deep-enough copy of the whole store, for tests to restore."""
+    return {
+        "values": {name: get_override(name) for name in OVERRIDES},
+        "sources": dict(_sources),
+    }
+
+
+def restore(state: dict[str, Any]) -> None:
+    """Put back a :func:`snapshot`."""
+    for name in OVERRIDES:
+        _values[name] = state["values"][name]
+    _sources.update(state["sources"])
+
+
+def reset_overrides() -> None:
+    """Clear every override (used by tests between cases)."""
+    for name, ov in OVERRIDES.items():
+        _values[name] = ov.empty_factory()
+        _sources[name] = None
+
+
+# ---------------------------------------------------------------------------
+# Entry points: argparse and the environment
+# ---------------------------------------------------------------------------
+
+
+def register_override_flags(parser: Any) -> None:
+    """Add every override's CLI flag to *parser*.
+
+    Value-taking flags are registered as ``type=str`` even where the value is
+    numeric, so the descriptor's own validator produces the error message
+    rather than argparse's generic "invalid int value" -- and so the flag and
+    the env var fail identically.
+    """
+    for ov in OVERRIDES.values():
+        if ov.kind == "switch":
+            parser.add_argument(ov.flag, action="store_true", default=False, dest=ov.dest, help=ov.help)
+        elif ov.kind == "append":
+            parser.add_argument(ov.flag, action="append", default=[], dest=ov.dest, metavar=ov.metavar, help=ov.help)
+        else:
+            parser.add_argument(ov.flag, type=str, default=None, dest=ov.dest, metavar=ov.metavar, help=ov.help)
+
+
+def apply_flag_values(args: Any) -> None:
+    """Validate and stash whatever argparse parsed for the override flags.
+
+    Raises :class:`OverrideValueError` on the first bad value;
+    :mod:`vtsearch.cli_main` turns that into ``parser.error``. Runs before any
+    dataset is created or any listing endpoint is served, so a typo fails fast
+    instead of silently no-opping the restriction.
+    """
+    for ov in OVERRIDES.values():
+        raw = getattr(args, ov.dest, None)
+        if ov.kind == "switch":
+            if raw:
+                set_override(ov.name, True, source=ov.flag)
+            continue
+        if ov.kind == "append":
+            tokens: Iterable[str] = raw or []
+            store = ov.empty_factory()
+            found = False
+            for token in tokens:
+                parsed = ov.parse_token(token, source=ov.flag)
+                if parsed is None:
+                    continue
+                assert ov.fold is not None
+                store = ov.fold(store, parsed)
+                found = True
+            if found:
+                set_override(ov.name, store, source=ov.flag)
+            continue
+        if raw is not None:
+            set_override(ov.name, ov.parse_token(raw, source=ov.flag), source=ov.flag)
+
+
+def apply_env_overrides(*, warn: Callable[[str], None] | None = None) -> list[tuple[AdminOverride, Any]]:
+    """Apply the env-var form of every override that no flag already set.
+
+    This is what makes the knobs reachable under Docker: the gunicorn-launched
+    images import ``app.py`` without ever parsing ``argv``, so the flags above
+    are unreachable there. An explicit flag always wins.
+
+    A malformed value is reported through *warn* (default: ``print``) and the
+    override is left unset -- a typo in a container's environment should not
+    stop the server booting, which is the opposite of the CLI's fail-fast
+    stance where a human is watching.
+
+    Returns the ``(override, value)`` pairs actually applied, so the caller can
+    log them.
+    """
+    emit = warn if warn is not None else (lambda msg: print(msg, flush=True))
+    applied: list[tuple[AdminOverride, Any]] = []
+    for ov in OVERRIDES.values():
+        if override_source(ov.name) is not None:
+            continue
+        raw = os.environ.get(ov.env)
+        if not raw or not raw.strip():
+            continue
+        try:
+            value = ov.parse_env(raw)
+        except OverrideValueError as exc:
+            emit(f"⚠️  Ignoring {ov.env}={raw!r}: {exc}")
+            continue
+        if value is None:
+            continue
+        set_override(ov.name, value, source=ov.env)
+        applied.append((ov, value))
+    return applied

--- a/vtsearch/cli_main.py
+++ b/vtsearch/cli_main.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from vtscore.media import set_progress_callback
 
+from vtsearch import admin_overrides
 from vtsearch.logging_config import setup_logging
 from vtsearch.port_preflight import _acquire_single_instance_lock, _preflight_port
 
@@ -238,110 +239,6 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--hide-plugin",
-        action="append",
-        default=[],
-        dest="hide_plugin",
-        metavar="FAMILY:NAME",
-        help=(
-            "Hide a plugin from picker / listing API responses for this "
-            "process (declutter the UI without editing the codebase). "
-            "Repeatable. FAMILY is a plugin-family id (importers, exporters, "
-            "label_importers, labelset_sources, converters, media_sources, "
-            "media_types, embedders, clippers, settings_importers, "
-            "settings_exporters, settings_sources); NAME is the plugin's "
-            "registered name. Hidden plugins remain importable and callable "
-            "by name via execution endpoints (e.g. autodetect, label "
-            "import). This is a UI flag, not a security boundary. Merges "
-            "with the persisted ``hidden_plugins`` key in the server "
-            "settings file. Use ``--list-plugins --format names`` to see "
-            "the available family:name pairs."
-        ),
-    )
-    parser.add_argument(
-        "--solo-media-type",
-        type=str,
-        default=None,
-        dest="solo_media_type",
-        help=(
-            "Streamline the UI for a single mediaType. Hides mediaType pickers "
-            "in the dataset-importer and new-detector flows, locks them to the "
-            "given type, filters converter offerings to converters whose output "
-            "is this type, and preloads that type's default embedder at startup. "
-            "This is an admin-set restriction: it applies to every user, and "
-            "users cannot change or opt out of it from the settings UI. "
-            "Overrides the persisted ``solo_media_type`` key in the server "
-            "settings file for the lifetime of the process. Valid values are "
-            "the registered media-type ids (e.g. audio, image, video, text, "
-            "document)."
-        ),
-    )
-    parser.add_argument(
-        "--solo-embedder",
-        action="append",
-        default=None,
-        dest="solo_embedders",
-        metavar="TYPE=EMBEDDER",
-        help=(
-            "Lock a single embedder for a mediaType so the dataset-importer "
-            "modal hides its embedder picker for that type and silently uses "
-            "the named embedder. Repeatable, one --solo-embedder per mediaType "
-            "(e.g. --solo-embedder image=siglip --solo-embedder audio=clap). "
-            "Format is TYPE=EMBEDDER, where TYPE is a registered media-type id "
-            "and EMBEDDER is a registered embedder name for that type. Acts as "
-            "a per-process fallback. Any user who sets their own value via "
-            "the settings UI overrides this flag per-mediaType for themselves. "
-            "Other mediaTypes still show the normal embedder picker."
-        ),
-    )
-    parser.add_argument(
-        "--dataset-max-age-days",
-        type=int,
-        default=None,
-        dest="dataset_max_age_days",
-        metavar="DAYS",
-        help=(
-            "Stamp every dataset created by this server process with an "
-            "expiry DAYS days after creation; expired datasets are aged off "
-            "from the registry. Applies to all users and overrides any "
-            "persisted dataset_max_age_days in the settings file for the "
-            "lifetime of the process; the value is not editable via the "
-            "settings API. Must be a positive integer. Omit to use the "
-            "persisted value (no expiry if none is set)."
-        ),
-    )
-    parser.add_argument(
-        "--support-email",
-        type=str,
-        default=None,
-        dest="support_email",
-        metavar="ADDRESS",
-        help=(
-            "Recipient address for the Help modal's 'Email us' contact link. "
-            "Applies to all users and overrides any persisted support_email in "
-            "the settings file for the lifetime of the process; the value is "
-            "not editable via the settings API. Omit to use the persisted value "
-            "(defaults to the built-in project address)."
-        ),
-    )
-    parser.add_argument(
-        "--semantic-only",
-        action="store_true",
-        default=False,
-        dest="semantic_only",
-        help=(
-            "Lock this instance to Semantic embedders. The prototype Patch "
-            "Semantic and Structural embedder types are dropped from "
-            "/api/embedders (so no Region / Instance embedder picker appears "
-            "under Add Dataset > Advanced), the New-detector modal offers no "
-            "embedder-type choice, and any request that asks for a "
-            "patch/structural embedder is rejected with 400. Applies to all "
-            "users and overrides any persisted semantic_only in the settings "
-            "file for the lifetime of the process; the value is not editable "
-            "via the settings API."
-        ),
-    )
-    parser.add_argument(
         "--progress-format",
         type=str,
         default="text",
@@ -354,6 +251,11 @@ def _build_parser() -> argparse.ArgumentParser:
             "for the event schema. Applies to --autodetect."
         ),
     )
+    # The process-level admin overrides (--solo-media-type, --solo-embedder,
+    # --hide-plugin, --dataset-max-age-days, --support-email, --semantic-only)
+    # are declared once in vtsearch.admin_overrides, which owns their flag
+    # spellings, help text, env-var equivalents and validators together.
+    admin_overrides.register_override_flags(parser)
     return parser
 
 
@@ -503,127 +405,25 @@ def _apply_verbosity(args) -> None:
         setup_logging(level=logging.getLevelName(effective))
 
 
-def _apply_solo_media_type(args, parser) -> None:
-    """Validate and stash ``--solo-media-type`` as a process-level override."""
-    # --solo-media-type applies to both the autodetect CLI path and the
-    # server path: validate and stash before any code reads the resolver.
-    if getattr(args, "solo_media_type", None) is not None:
-        from vtscore.media import all_type_ids
-        from vtsearch.settings import set_cli_solo_media_type
+def _apply_admin_overrides(args, parser) -> None:
+    """Validate and stash every process-level admin override the flags carried.
 
-        valid = set(all_type_ids())
-        if args.solo_media_type not in valid:
-            parser.error(f"Unknown --solo-media-type: {args.solo_media_type!r}. Valid values: {sorted(valid)}")
-        set_cli_solo_media_type(args.solo_media_type)
+    One loop over :data:`vtsearch.admin_overrides.OVERRIDES` replaces what used
+    to be six near-identical ``_apply_X`` helpers. Each descriptor owns its own
+    validator, so ``--solo-media-type`` still checks the media-type registry
+    and ``--solo-embedder`` still checks that the embedder is registered *for
+    that type* -- but the same validator now runs for the env-var form, so the
+    two entry paths can no longer disagree.
 
-
-def _apply_hidden_plugins(args, parser) -> None:
-    """Validate and stash repeatable ``--hide-plugin FAMILY:NAME`` specs."""
-    # --hide-plugin family:name (repeatable): stash before any listing
-    # endpoint is served so hidden plugins are filtered from API responses.
-    # ``register_app_plugin_families`` ran at module load (top of app.py),
-    # so the settings_io families are already in ``FAMILIES``.
-    hide_specs = getattr(args, "hide_plugin", None) or []
-    if hide_specs:
-        from vtscore.plugins.inventory import FAMILIES
-        from vtsearch.settings import add_cli_hidden_plugin
-
-        valid_families = set(FAMILIES)
-        for spec in hide_specs:
-            if ":" not in spec:
-                parser.error(
-                    f"--hide-plugin expects FAMILY:NAME, got {spec!r}. Valid families: {sorted(valid_families)}"
-                )
-            family, _, plugin_name = spec.partition(":")
-            family = family.strip()
-            plugin_name = plugin_name.strip()
-            if not family or not plugin_name:
-                parser.error(f"--hide-plugin {spec!r} has an empty family or name")
-            if family not in valid_families:
-                parser.error(f"Unknown --hide-plugin family {family!r}. Valid: {sorted(valid_families)}")
-            add_cli_hidden_plugin(family, plugin_name)
-
-
-def _apply_solo_embedders(args, parser) -> None:
-    """Validate and stash repeatable ``--solo-embedder TYPE=EMBEDDER`` locks."""
-    # --solo-embedder is repeatable; each value is TYPE=EMBEDDER. Validate
-    # both halves against the live registry before stashing; a typo here
-    # would silently no-op the lock and the user would only notice when
-    # the picker reappeared.
-    raw_solo_embedders = getattr(args, "solo_embedders", None) or []
-    if raw_solo_embedders:
-        from vtscore.media import all_embedders, all_type_ids, embedders_for_type
-        from vtsearch.settings import set_cli_solo_embedder
-
-        valid_types = set(all_type_ids())
-        valid_embedder_names = {e.name for e in all_embedders()}
-        for raw in raw_solo_embedders:
-            if "=" not in raw:
-                parser.error(f"Invalid --solo-embedder value: {raw!r}. Expected TYPE=EMBEDDER (e.g. image=siglip).")
-            mt, _, emb = raw.partition("=")
-            mt = mt.strip()
-            emb = emb.strip()
-            if not mt or not emb:
-                parser.error(f"Invalid --solo-embedder value: {raw!r}. Both TYPE and EMBEDDER must be non-empty.")
-            if mt not in valid_types:
-                parser.error(
-                    f"Unknown mediaType in --solo-embedder {raw!r}: {mt!r}. Valid values: {sorted(valid_types)}"
-                )
-            if emb not in valid_embedder_names:
-                parser.error(
-                    f"Unknown embedder in --solo-embedder {raw!r}: {emb!r}. "
-                    f"Valid embedder names: {sorted(valid_embedder_names)}"
-                )
-            valid_for_type = {e.name for e in embedders_for_type(mt)}
-            if emb not in valid_for_type:
-                parser.error(
-                    f"Embedder {emb!r} is not registered for media type {mt!r}. "
-                    f"Valid embedders for {mt}: {sorted(valid_for_type)}"
-                )
-            set_cli_solo_embedder(mt, emb)
-
-
-def _apply_dataset_max_age(args, parser) -> None:
-    """Validate and stash the process-level ``--dataset-max-age-days`` override."""
-    # --dataset-max-age-days: process-level server retention override applied
-    # to every user for the lifetime of the process (not user-editable via
-    # the API). Validate before any dataset is created so a bad value fails
-    # fast rather than silently never expiring.
-    if getattr(args, "dataset_max_age_days", None) is not None:
-        if args.dataset_max_age_days < 1:
-            parser.error("--dataset-max-age-days must be a positive integer (number of days)")
-        from vtsearch.settings import set_cli_dataset_max_age_days
-
-        set_cli_dataset_max_age_days(args.dataset_max_age_days)
-
-
-def _apply_support_email(args, parser) -> None:
-    """Validate and stash the process-level ``--support-email`` override."""
-    # --support-email: process-level override for the Help modal's contact
-    # address, applied to every user for the lifetime of the process (not
-    # user-editable via the API). Require a non-empty value so an accidental
-    # blank flag doesn't ship an empty mailto: recipient.
-    if getattr(args, "support_email", None) is not None:
-        email = args.support_email.strip()
-        if not email:
-            parser.error("--support-email must be a non-empty address")
-        from vtsearch.settings import set_cli_support_email
-
-        set_cli_support_email(email)
-
-
-def _apply_semantic_only(args, parser) -> None:
-    """Stash the process-level ``--semantic-only`` lock."""
-    # --semantic-only is a one-way switch: passing it locks the process to
-    # Semantic embedders, omitting it leaves the persisted server setting in
-    # charge (so a deployment can enable the lock from settings.json without
-    # the flag). There is no --no-semantic-only counterpart for the same
-    # reason --hide-plugin can only add hides: a flag should not silently
-    # loosen a restriction the settings file asked for.
-    if getattr(args, "semantic_only", False):
-        from vtsearch.settings import set_cli_semantic_only
-
-        set_cli_semantic_only(True)
+    Runs for both the autodetect CLI path and the server path, before any
+    media is loaded or any listing endpoint is served: a typo here would
+    otherwise silently no-op the restriction and the user would only notice
+    when the picker reappeared.
+    """
+    try:
+        admin_overrides.apply_flag_values(args)
+    except admin_overrides.OverrideValueError as exc:
+        parser.error(str(exc))
 
 
 def _authenticate_cli_user(args, parser) -> None:
@@ -886,12 +686,7 @@ def main(app, initialize_server) -> None:
     args, importer, exporter = _resolve_plugins(args, parser, remaining)
 
     _apply_verbosity(args)
-    _apply_solo_media_type(args, parser)
-    _apply_hidden_plugins(args, parser)
-    _apply_solo_embedders(args, parser)
-    _apply_dataset_max_age(args, parser)
-    _apply_support_email(args, parser)
-    _apply_semantic_only(args, parser)
+    _apply_admin_overrides(args, parser)
 
     if args.autodetect:
         _run_autodetect(args, parser, importer, exporter)

--- a/vtsearch/routes/settings/api.py
+++ b/vtsearch/routes/settings/api.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, NamedTuple
 from flask_smorest import Blueprint, abort
 from marshmallow import fields
 
-from vtsearch import settings
+from vtsearch import admin_overrides, settings
 from vtsearch.schemas.settings import AppSettingsSchema, SettingsUpdateSchema
 from vtsearch.state import (
     set_calibrate_count as _state_set_calibrate_count,
@@ -187,38 +187,23 @@ def _coerce_dict_fields(data: dict) -> dict:
 def _with_effective(data: dict) -> dict:
     """Overlay the resolver-computed (read-only) views onto *data*.
 
-    Centralises the augmentation shared by the GET and PUT responses:
+    Every process-level **admin override** -- the solo mediaType lock, the
+    per-mediaType solo-embedder locks, the plugin hide list, the dataset
+    retention window, the support email, the Semantic-only lock -- publishes
+    the value *actually in force* here, so the frontend never has to know
+    whether a restriction came from a CLI flag, an env var, or the settings
+    file. The set is not spelled out: each knob declares its own
+    ``effective_key`` (and any JSON coercion) in
+    :mod:`vtsearch.admin_overrides`, and this loops the registry, so a new
+    override is surfaced without touching this route.
 
-    * ``effective_solo_embedder_per_media_type`` - the per-user embedder
-      locks layered over their CLI fallbacks; the frontend reads this to
-      decide whether to hide the embedder picker for a given mediaType.
-    * ``hidden_plugins`` - the persisted server setting unioned with any
-      ``--hide-plugin`` CLI flags, normalised to sorted lists so the
-      "Server" settings tab can render what's actually in force.
-
-    Stale dict fields are coerced to ``{}`` first so a corrupt persisted
-    value can't 500 the endpoint (see :func:`_coerce_dict_fields`).
+    Shared by the GET and PUT responses. Stale dict fields are coerced to
+    ``{}`` first so a corrupt persisted value can't 500 the endpoint (see
+    :func:`_coerce_dict_fields`).
     """
     _coerce_dict_fields(data)
-    data["effective_solo_embedder_per_media_type"] = settings.get_effective_solo_embedders()
-    data["hidden_plugins"] = {
-        family: sorted(names) for family, names in settings.get_effective_hidden_plugins().items()
-    }
-    # Surface the CLI-overridable retention policy as the value actually in
-    # force (``--dataset-max-age-days`` wins over the persisted file), so the
-    # dashboard's Age-Off column reflects what new datasets are stamped with.
-    data["dataset_max_age_days"] = settings.get_effective_dataset_max_age_days()
-    # Surface the CLI/env-overridable "Email us" recipient as the value
-    # actually in force, so the Help modal's mailto link is pre-addressed.
-    data["support_email"] = settings.get_effective_support_email()
-    # Surface the CLI/env-overridable Semantic-only lock as the value actually
-    # in force, so the New-detector modal can drop its embedder-type picker and
-    # the Server settings tab can report the restriction.
-    data["semantic_only"] = settings.get_effective_semantic_only()
-    # Surface the CLI-overridable solo-mediaType restriction as the value
-    # actually in force, so the importer / new-detector / import-defaults
-    # surfaces lock their mediaType pickers to what the admin allowed.
-    data["solo_media_type"] = settings.get_effective_solo_media_type()
+    for override in admin_overrides.OVERRIDES.values():
+        data[override.effective_key] = override.dump(settings.get_effective_override(override.name))
     return data
 
 

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Annotated, Any
 from pydantic import TypeAdapter, ValidationError
 
 from vtscore.config import DATA_DIR
+from vtsearch import admin_overrides as _admin
 from vtsearch.settings_models import (
     VALID_FOCUS_MODES,
     VALID_GRID_ICON_SIZES,
@@ -188,58 +189,15 @@ if TYPE_CHECKING:
 #: ``set_settings_path()`` helper also points it at a different file.
 SETTINGS_PATH: Path = DATA_DIR / "settings.json"
 
-#: Process-level override for the server-tier ``solo_media_type`` setting,
-#: set by :func:`set_cli_solo_media_type` from the ``--solo-media-type``
-#: flag in :mod:`app`. ``None`` means "no CLI override" - reads fall
-#: through to the persisted server setting. When a value is set it applies
-#: to every user and wins over the persisted file for the lifetime of the
-#: process; the setting is not user-editable via the API (see
-#: :func:`get_effective_solo_media_type`).
-_cli_solo_media_type: str | None = None
-
-#: Process-level fallback for the ``hidden_plugins`` server setting, set
-#: by :func:`set_cli_hidden_plugins` / :func:`add_cli_hidden_plugin` from
-#: the repeatable ``--hide-plugin family:name`` flag in :mod:`app`. Maps
-#: a plugin-family id to the set of plugin ``name``s to hide. Merged with
-#: the persisted ``hidden_plugins`` server setting at read time - see
-#: :func:`get_effective_hidden_plugins`. Empty dict means "no CLI hides".
-_cli_hidden_plugins: dict[str, set[str]] = {}
-
-#: Process-level fallback for the per-user
-#: ``solo_embedder_per_media_type`` setting, set by
-#: :func:`set_cli_solo_embedder` from the (repeatable) ``--solo-embedder``
-#: flag in :mod:`app`. Maps ``media_type_id`` → embedder name. Empty means
-#: "no CLI default". The resolver :func:`get_effective_solo_embedders`
-#: layers per-user entries over this dict (per-key), so a user can override
-#: individual mediaTypes without losing the others.
-_cli_solo_embedders: dict[str, str] = {}
-
-#: Process-level override for the server-tier ``dataset_max_age_days``
-#: setting, set by :func:`set_cli_dataset_max_age_days` from the
-#: ``--dataset-max-age-days`` flag in :mod:`app`. ``None`` means "no CLI
-#: override" - reads fall through to the persisted server setting. When a
-#: value is set it applies to every user and wins over the persisted file
-#: for the lifetime of the process; the setting is not user-editable via
-#: the API (see :func:`get_effective_dataset_max_age_days`).
-_cli_dataset_max_age_days: int | None = None
-
-#: Process-level override for the server-tier ``support_email`` setting, set
-#: by :func:`set_cli_support_email` from the ``--support-email`` flag in
-#: :mod:`app`. ``None`` means "no CLI override" - reads fall through to the
-#: persisted server setting (and then the model default). When a value is set
-#: it applies to every user and wins over the persisted file for the lifetime
-#: of the process; the setting is not user-editable via the API (see
-#: :func:`get_effective_support_email`).
-_cli_support_email: str | None = None
-
-#: Process-level override for the server-tier ``semantic_only`` setting, set by
-#: :func:`set_cli_semantic_only` from the ``--semantic-only`` flag (or the
-#: ``VTSEARCH_SEMANTIC_ONLY`` env var) in :mod:`app`. ``None`` means "no CLI
-#: override" - reads fall through to the persisted server setting. ``True``
-#: locks the instance to Semantic embedders for the lifetime of the process;
-#: the setting is not user-editable via the API (see
-#: :func:`get_effective_semantic_only`).
-_cli_semantic_only: bool | None = None
+#: The process-level **admin overrides** (the solo mediaType lock, the
+#: solo-embedder locks, the plugin hide list, the dataset retention window,
+#: the support email, the Semantic-only lock) live in
+#: :mod:`vtsearch.admin_overrides`, which owns one declarative descriptor per
+#: knob covering its CLI flag, its env var, the validator both share, how it
+#: combines with the persisted setting, and the key it is published under at
+#: ``/api/settings``. The ``set_cli_X`` / ``get_cli_X`` / ``get_effective_X``
+#: accessors further down are thin wrappers over that registry, kept as named
+#: functions because they are what the rest of the app (and the tests) call.
 
 #: Filename used for the per-user settings file inside
 #: ``get_user_data_dir(user)``.
@@ -1026,26 +984,42 @@ def set_last_embedder_for_media_type(media_type: str, embedder: str) -> None:
     set_last_embedder_per_media_type(updated)
 
 
+def get_effective_override(name: str) -> Any:
+    """Resolve one :mod:`~vtsearch.admin_overrides` knob against its setting.
+
+    Reads the persisted value through the getter the descriptor names, then
+    hands both to the descriptor's ``resolve`` rule. The named
+    ``get_effective_X`` functions below are one-liners over this, and
+    ``/api/settings`` loops the registry through it to build its read-only
+    overlay -- so a new knob is published without touching the route.
+    """
+    override = _admin.OVERRIDES[name]
+    return override.resolve(_admin.get_override(name), globals()[override.persisted_getter]())
+
+
 def set_cli_solo_media_type(value: str | None) -> None:
     """Set the process-level override for the ``solo_media_type`` setting.
 
     Called once from ``app.py`` startup when ``--solo-media-type`` is
-    passed on the command line. The value applies server-wide (every user)
-    and is fixed for the process lifetime;
-    :func:`get_effective_solo_media_type` returns it in preference to the
-    persisted server setting. Pass ``None`` (or an empty / whitespace-only
-    string) to clear the override so reads fall back to the persisted file
-    value.
+    passed on the command line (or ``VTSEARCH_SOLO_MEDIA_TYPE`` is set).
+    The value applies server-wide (every user) and is fixed for the process
+    lifetime; :func:`get_effective_solo_media_type` returns it in preference
+    to the persisted server setting. Pass ``None`` (or an empty /
+    whitespace-only string) to clear the override so reads fall back to the
+    persisted file value.
+
+    This stores whatever it is given: validation against the live media-type
+    registry happens on the way in, in
+    :func:`vtsearch.admin_overrides.apply_flag_values`.
     """
-    global _cli_solo_media_type
     if value is not None:
         value = value.strip() or None
-    _cli_solo_media_type = value
+    _admin.set_override("solo_media_type", value)
 
 
 def get_cli_solo_media_type() -> str | None:
-    """Return the process-level CLI override (``None`` if unset)."""
-    return _cli_solo_media_type
+    """Return the process-level CLI / env override (``None`` if unset)."""
+    return _admin.get_override("solo_media_type")
 
 
 def get_effective_solo_media_type() -> str | None:
@@ -1053,9 +1027,9 @@ def get_effective_solo_media_type() -> str | None:
 
     Resolution order:
 
-    1. The process-level CLI override set by
-       :func:`set_cli_solo_media_type` (``--solo-media-type``), which
-       applies to every user for the lifetime of the process.
+    1. The process-level override set by :func:`set_cli_solo_media_type`
+       (``--solo-media-type`` / ``VTSEARCH_SOLO_MEDIA_TYPE``), which applies
+       to every user for the lifetime of the process.
     2. The persisted server-tier setting (``data/settings.json``), which
        defaults to ``None``.
 
@@ -1064,32 +1038,25 @@ def get_effective_solo_media_type() -> str | None:
     pickers to. This is an admin-set restriction: there is no per-user
     override, and ``PUT /api/settings`` cannot change it.
     """
-    if _cli_solo_media_type is not None:
-        return _cli_solo_media_type
-    persisted = get_solo_media_type()
-    # Empty string from JSON drift normalises to None.
-    if isinstance(persisted, str) and not persisted.strip():
-        return None
-    return persisted
+    return get_effective_override("solo_media_type")
 
 
 def set_cli_dataset_max_age_days(value: int | None) -> None:
     """Set the process-level override for the ``dataset_max_age_days`` setting.
 
     Called once from ``app.py`` startup when ``--dataset-max-age-days`` is
-    passed on the command line. The value applies server-wide (every user)
-    and is fixed for the process lifetime;
+    passed (or ``VTSEARCH_DATASET_MAX_AGE_DAYS`` is set). The value applies
+    server-wide (every user) and is fixed for the process lifetime;
     :func:`get_effective_dataset_max_age_days` returns it in preference to
     the persisted server setting. Pass ``None`` to clear the override
     (reads fall back to the persisted file value).
     """
-    global _cli_dataset_max_age_days
-    _cli_dataset_max_age_days = value
+    _admin.set_override("dataset_max_age_days", value)
 
 
 def get_cli_dataset_max_age_days() -> int | None:
-    """Return the process-level CLI override (``None`` if unset)."""
-    return _cli_dataset_max_age_days
+    """Return the process-level CLI / env override (``None`` if unset)."""
+    return _admin.get_override("dataset_max_age_days")
 
 
 def get_effective_dataset_max_age_days() -> int | None:
@@ -1097,9 +1064,10 @@ def get_effective_dataset_max_age_days() -> int | None:
 
     Resolution order:
 
-    1. The process-level CLI override set by
-       :func:`set_cli_dataset_max_age_days` (``--dataset-max-age-days``),
-       which applies to every user for the lifetime of the process.
+    1. The process-level override set by
+       :func:`set_cli_dataset_max_age_days` (``--dataset-max-age-days`` /
+       ``VTSEARCH_DATASET_MAX_AGE_DAYS``), which applies to every user for
+       the lifetime of the process.
     2. The persisted server-tier setting (``data/settings.json``).
 
     ``None`` means datasets never expire. This is the value the dataset
@@ -1107,30 +1075,28 @@ def get_effective_dataset_max_age_days() -> int | None:
     at ``/api/settings`` so the dashboard's Age-Off column reflects what is
     actually in force.
     """
-    if _cli_dataset_max_age_days is not None:
-        return _cli_dataset_max_age_days
-    return get_dataset_max_age_days()
+    return get_effective_override("dataset_max_age_days")
 
 
 def set_cli_support_email(value: str | None) -> None:
     """Set the process-level override for the ``support_email`` setting.
 
-    Called once from ``app.py`` startup when ``--support-email`` is passed on
-    the command line. The value applies server-wide (every user) and is fixed
-    for the process lifetime; :func:`get_effective_support_email` returns it in
-    preference to the persisted server setting. Pass ``None`` (or an empty /
-    whitespace-only string) to clear the override so reads fall back to the
-    persisted file value.
+    Called once from ``app.py`` startup when ``--support-email`` is passed (or
+    ``VTSEARCH_SUPPORT_EMAIL`` is set). The value applies server-wide (every
+    user) and is fixed for the process lifetime;
+    :func:`get_effective_support_email` returns it in preference to the
+    persisted server setting. Pass ``None`` (or an empty / whitespace-only
+    string) to clear the override so reads fall back to the persisted file
+    value.
     """
-    global _cli_support_email
     if value is not None:
         value = value.strip() or None
-    _cli_support_email = value
+    _admin.set_override("support_email", value)
 
 
 def get_cli_support_email() -> str | None:
-    """Return the process-level CLI override (``None`` if unset)."""
-    return _cli_support_email
+    """Return the process-level CLI / env override (``None`` if unset)."""
+    return _admin.get_override("support_email")
 
 
 def get_effective_support_email() -> str:
@@ -1138,18 +1104,16 @@ def get_effective_support_email() -> str:
 
     Resolution order:
 
-    1. The process-level CLI override set by :func:`set_cli_support_email`
-       (``--support-email``), which applies to every user for the lifetime of
-       the process.
+    1. The process-level override set by :func:`set_cli_support_email`
+       (``--support-email`` / ``VTSEARCH_SUPPORT_EMAIL``), which applies to
+       every user for the lifetime of the process.
     2. The persisted server-tier setting (``data/settings.json``), which
        defaults to :data:`~vtsearch.settings_models.DEFAULT_SUPPORT_EMAIL`.
 
     This is the value surfaced at ``/api/settings`` so the Help modal's
     "Email us" link opens a pre-addressed compose window.
     """
-    if _cli_support_email is not None:
-        return _cli_support_email
-    return get_support_email()
+    return get_effective_override("support_email")
 
 
 def set_cli_semantic_only(value: bool | None) -> None:
@@ -1162,13 +1126,12 @@ def set_cli_semantic_only(value: bool | None) -> None:
     persisted server setting. Pass ``None`` to clear the override so reads fall
     back to the persisted file value.
     """
-    global _cli_semantic_only
-    _cli_semantic_only = None if value is None else bool(value)
+    _admin.set_override("semantic_only", None if value is None else bool(value))
 
 
 def get_cli_semantic_only() -> bool | None:
-    """Return the process-level CLI override (``None`` if unset)."""
-    return _cli_semantic_only
+    """Return the process-level CLI / env override (``None`` if unset)."""
+    return _admin.get_override("semantic_only")
 
 
 def get_effective_semantic_only() -> bool:
@@ -1176,7 +1139,7 @@ def get_effective_semantic_only() -> bool:
 
     Resolution order:
 
-    1. The process-level CLI override set by :func:`set_cli_semantic_only`
+    1. The process-level override set by :func:`set_cli_semantic_only`
        (``--semantic-only`` / ``VTSEARCH_SEMANTIC_ONLY``), which applies to
        every user for the lifetime of the process.
     2. The persisted server-tier setting (``data/settings.json``), which
@@ -1186,68 +1149,46 @@ def get_effective_semantic_only() -> bool:
     hidden from every picker (``GET /api/embedders`` filters them out) and
     rejected by the dataset-load and detector-create routes.
     """
-    if _cli_semantic_only is not None:
-        return _cli_semantic_only
-    return bool(get_semantic_only())
+    return get_effective_override("semantic_only")
 
 
 def set_cli_solo_embedder(media_type: str, embedder: str | None) -> None:
     """Set or clear a process-level solo-embedder fallback for *media_type*.
 
     Called from ``app.py`` startup for each ``--solo-embedder TYPE=EMB``
-    pair on the command line. Pass ``embedder=None`` (or an empty
+    pair on the command line (or each comma-separated entry in
+    ``VTSEARCH_SOLO_EMBEDDERS``). Pass ``embedder=None`` (or an empty
     string) to clear an entry. Both arguments are stripped; an empty
-    *media_type* is silently ignored (the CLI parser already validates).
+    *media_type* is silently ignored (the parser already validates).
     """
     mt = (media_type or "").strip()
     if not mt:
         return
     emb = (embedder or "").strip() if embedder else ""
+    current = _admin.get_override("solo_embedders")
     if not emb:
-        _cli_solo_embedders.pop(mt, None)
-        return
-    _cli_solo_embedders[mt] = emb
+        current.pop(mt, None)
+    else:
+        current[mt] = emb
+    _admin.set_override("solo_embedders", current or None)
 
 
 def get_cli_solo_embedders() -> dict[str, str]:
-    """Return a copy of the process-level solo-embedder CLI fallbacks."""
-    return dict(_cli_solo_embedders)
+    """Return a copy of the process-level solo-embedder fallbacks."""
+    return _admin.get_override("solo_embedders")
 
 
 def get_effective_solo_embedders() -> dict[str, str]:
     """Return the merged ``{media_type: embedder}`` dict for the current user.
 
-    Combines the per-user :func:`get_solo_embedder_per_media_type` map
-    (user explicit) with the process-level
-    :data:`_cli_solo_embedders` (CLI fallback). User entries win per-key;
-    missing user keys fall through to the CLI value. An **empty-string
-    value** in the user map is a per-type opt-out sentinel - it removes
-    that type from the merged map even if the CLI fallback has a
-    value for it. (``solo_media_type`` has no such per-user opt-out: it is
-    an admin-set server restriction.)
-
-    Validity (does the embedder still exist for this type?) is *not*
-    checked here - the frontend resolves it against the live embedder
-    registry on its end and falls back to the normal picker for any
-    entry that no longer matches. Keeping validation client-side means a
-    rename or removal never blocks the settings UI from rendering.
+    Combines the per-user :func:`get_solo_embedder_per_media_type` map (user
+    explicit) with the process-level ``--solo-embedder`` /
+    ``VTSEARCH_SOLO_EMBEDDERS`` fallbacks. The merge rule -- user entries win
+    per-key, an empty-string user value is a per-type opt-out sentinel -- lives
+    with the descriptor, in
+    :func:`vtsearch.admin_overrides._resolve_solo_embedders`.
     """
-    merged: dict[str, str] = {}
-    for mt, emb in _cli_solo_embedders.items():
-        if mt and isinstance(emb, str) and emb.strip():
-            merged[mt] = emb.strip()
-    user_map = get_solo_embedder_per_media_type()
-    if isinstance(user_map, dict):
-        for mt, emb in user_map.items():
-            if not isinstance(mt, str) or not mt:
-                continue
-            if isinstance(emb, str) and emb.strip():
-                merged[mt] = emb.strip()
-            else:
-                # Empty-string sentinel - user explicitly opted out for
-                # this type, so drop the CLI fallback too.
-                merged.pop(mt, None)
-    return merged
+    return get_effective_override("solo_embedders")
 
 
 def get_effective_solo_embedder(media_type: str) -> str | None:
@@ -1350,71 +1291,49 @@ def is_autofind_detector(name: str) -> bool:
 # -------------------------------------------------------------------
 
 
-def _normalize_hidden_plugins(value: Any) -> dict[str, set[str]]:
-    """Coerce arbitrary input to ``{family: {name, ...}}`` form.
-
-    Accepts ``dict[str, Iterable[str]]`` shapes and drops empty entries.
-    Non-string keys / names and ``None`` values are silently skipped so a
-    corrupt settings file doesn't crash plugin listings.
-    """
-    out: dict[str, set[str]] = {}
-    if not isinstance(value, dict):
-        return out
-    for family, names in value.items():
-        if not isinstance(family, str) or not family:
-            continue
-        if isinstance(names, (str, bytes)):
-            continue
-        try:
-            members = {n for n in names if isinstance(n, str) and n}
-        except TypeError:
-            continue
-        if members:
-            out[family] = members
-    return out
+#: Re-exported for the settings-file readers that normalise a persisted
+#: ``hidden_plugins`` value; the canonical definition sits beside the
+#: descriptor that uses it.
+_normalize_hidden_plugins = _admin.normalize_hidden_plugins
 
 
 def set_cli_hidden_plugins(value: dict[str, Any] | None) -> None:
     """Replace the process-level ``--hide-plugin`` fallback in one shot.
 
-    Called by ``app.py`` after parsing ``--hide-plugin family:name`` flags
-    (or by tests that want to seed a known CLI hide list). ``None`` or an
-    empty dict clears the fallback.
+    Called by tests that want to seed a known hide list. ``None`` or an empty
+    dict clears the fallback. The ``--hide-plugin`` /
+    ``VTSEARCH_HIDE_PLUGINS`` entry points accumulate through
+    :func:`vtsearch.admin_overrides.apply_flag_values` instead, which
+    validates each family against the live registry first.
     """
-    global _cli_hidden_plugins
-    _cli_hidden_plugins = _normalize_hidden_plugins(value or {})
+    normalized = _admin.normalize_hidden_plugins(value or {})
+    _admin.set_override("hidden_plugins", normalized or None)
 
 
 def add_cli_hidden_plugin(family: str, name: str) -> None:
-    """Append ``(family, name)`` to the CLI hide list (idempotent).
-
-    Used by the ``--hide-plugin`` argparse hook to accumulate one entry
-    per flag occurrence.
-    """
+    """Append ``(family, name)`` to the process-level hide list (idempotent)."""
     if not family or not name:
         return
-    _cli_hidden_plugins.setdefault(family, set()).add(name)
+    current = _admin.get_override("hidden_plugins")
+    current.setdefault(family, set()).add(name)
+    _admin.set_override("hidden_plugins", current)
 
 
 def get_cli_hidden_plugins() -> dict[str, set[str]]:
-    """Return a defensive copy of the CLI-only hide map."""
-    return {family: set(names) for family, names in _cli_hidden_plugins.items()}
+    """Return a defensive copy of the CLI/env-only hide map."""
+    return _admin.get_override("hidden_plugins")
 
 
 def get_effective_hidden_plugins() -> dict[str, set[str]]:
     """Return the merged ``{family: {name, ...}}`` hide map.
 
     Combines the persisted ``hidden_plugins`` server setting with the
-    process-level ``--hide-plugin`` fallback. The union semantics matter:
-    a plugin is hidden if either source asks for it, so the CLI flag can
-    only add hides (never un-hide something the settings file marks
-    hidden).
+    process-level ``--hide-plugin`` / ``VTSEARCH_HIDE_PLUGINS`` fallback. The
+    union semantics matter: a plugin is hidden if either source asks for it,
+    so the flag can only add hides (never un-hide something the settings file
+    marks hidden).
     """
-    persisted = _normalize_hidden_plugins(get_hidden_plugins())
-    merged: dict[str, set[str]] = {family: set(names) for family, names in persisted.items()}
-    for family, names in _cli_hidden_plugins.items():
-        merged.setdefault(family, set()).update(names)
-    return merged
+    return get_effective_override("hidden_plugins")
 
 
 def is_plugin_hidden(family: str, name: str) -> bool:
@@ -1425,7 +1344,7 @@ def is_plugin_hidden(family: str, name: str) -> bool:
     ``to_dict()`` and filtered client-side. This function only answers
     "is the admin hiding this in this deployment?"
     """
-    hidden = _cli_hidden_plugins.get(family)
+    hidden = _admin.get_override("hidden_plugins").get(family)
     if hidden and name in hidden:
         return True
     persisted = get_hidden_plugins()


### PR DESCRIPTION
Six process-level admin knobs — the solo mediaType lock, the per-mediaType solo-embedder locks, the plugin hide list, the dataset retention window, the support email and the Semantic-only lock — were each hand-plumbed through four places with nothing tying them together: a `set_cli_X` / `get_cli_X` / `get_effective_X` triad in `vtsearch/settings.py`, an `_apply_X` argparse hook in `vtsearch/cli_main.py`, an `_apply_env_X` startup hook in `app.py`, and a line in the `/api/settings` overlay.

## A note on the issue's premise

Two of #3415's claims turned out to be stale or overstated, and are worth recording since they shaped the scope:

- The `_with_effective` overlay in `vtsearch/routes/settings/api.py` already covered **all six** knobs, not four.
- The six were never "four identical implementations". `solo_embedders` (per-key user-wins with an empty-string opt-out sentinel) and `hidden_plugins` (union) *merge* rather than replace, and every CLI validator is genuinely different — registry lookups, `FAMILY:NAME` parsing, `TYPE=EMBEDDER` parsing. The ~390 lines in `settings.py` were mostly docstrings; the bodies were 2–6 lines each.

What *was* real is the drift the issue's last line names ("which knobs work under Docker is arbitrary"), and it was a user-visible defect rather than a tidiness one — see below. So the registry is built to make that class of drift impossible rather than to delete line count.

## The defect

Only three of the six were reachable from the environment. The gunicorn-launched Docker images never parse `argv`, so a containerised deployment could set `--support-email`, `--semantic-only` and `--dataset-max-age-days` from the environment but had **no way at all** to set `--solo-media-type`, `--solo-embedder` or `--hide-plugin`.

The env path also re-implemented validation instead of sharing it, so the two entry points disagreed: `--dataset-max-age-days 0` was an argparse error, while `VTSEARCH_DATASET_MAX_AGE_DAYS=0` warned and carried on.

## The change

`vtsearch/admin_overrides.py` is now the single source of truth. One `AdminOverride` descriptor per knob carries its flag spelling and help text, its env-var name, the validator both entry paths share, how the override combines with the persisted setting, and the key it publishes under at `/api/settings`. The argparse arguments, the env fallbacks, the effective-value resolvers and the response overlay all derive from the registry.

Behaviour changes:

- **All six knobs gain an env var.** `VTSEARCH_SOLO_MEDIA_TYPE`, `VTSEARCH_SOLO_EMBEDDERS` and `VTSEARCH_HIDE_PLUGINS` are new; the two repeatable ones take a comma-separated list (`image=siglip,audio=clap`).
- **Flag and env share one validator**, so they can no longer disagree. The CLI still fails fast (`parser.error`, exit 2); the env path warns and leaves the override unset, because a typo in a container's environment should not stop the server booting.
- `--dataset-max-age-days` is parsed as a string so the descriptor's own message ("must be a positive integer") replaces argparse's generic "invalid int value".
- **The startup banner now reports every restriction in force**, naming whether it came from the flag, the env var or the settings key, and skipping any knob still at its shipped default. Previously only three knobs were reported and only some named their source; `hidden_plugins` was never reported at all.

`settings.py` keeps every public `set_cli_X` / `get_cli_X` / `get_effective_X` name as a thin wrapper over the registry, so callers are unaffected; the six module-level `_cli_*` globals are gone.

## What stops it drifting again

`tests/core/test_admin_overrides.py` asserts *structurally* that every registered override carries a flag, an env var, a real `settings` getter, a parser registration and an `/api/settings` key. A seventh knob that forgets one fails there rather than being discovered by an operator.

## Also in this PR

`npm audit` was failing on `dev` (unrelated to this change) on four high-severity `fast-uri` advisories — host confusion and SSRF via URI normalization. Bumped the transitive dev-only dependency 3.1.5 → 3.1.7; lockfile-only, nothing in the app imports it.

## Testing

- Full `./run-tests.sh`: **RUN PASSED**, 9839 passed / 6 skipped, every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).
- Verified the new env path end to end against a real interpreter: `VTSEARCH_SOLO_MEDIA_TYPE`, `VTSEARCH_HIDE_PLUGINS` and `VTSEARCH_SEMANTIC_ONLY` apply and print their source in the banner; `VTSEARCH_DATASET_MAX_AGE_DAYS=0` warns naming the *variable* (not the flag) and leaves the override unset.
- Confirmed `python app.py --help` still renders all six flags with their help text.

Docs updated: three new rows in the `docs/DEPLOYMENT.md` env table, the env equivalents noted in `docs/CLI.md`, and the registry described in `docs/ARCHITECTURE.md` (directory map + settings section).

Closes #3415

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K68hqGuPk1udRj2Dzi12UZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01K68hqGuPk1udRj2Dzi12UZ)_