### PR TITLE
refactor(vtscore): share the streaming atomic-write ritual and label-JSON checks

### DIFF
--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -77,7 +77,7 @@ care.
 - [ ] #3379 — Collapse the five copies of the clip-dict builder in `image/_demo_sources.py` (Sonnet 5)
 - [ ] #3383 — Deduplicate the clipper family: tiling math, segment emission, six no-op clippers (Sonnet 5)
 - [ ] #3386 — Collapse the near-synonymous embedder-resolution wrappers (Sonnet 5)
-- [ ] #3389 — Deduplicate the media registries, the atomic-write ritual, and JSON label extraction (Haiku 4.5)
+- [x] #3389 — Deduplicate the streaming atomic-write ritual and JSON label extraction (Haiku 4.5)
 - [x] #3394 — Extract one background-import harness shared by both import pipelines (Sonnet 5)
 
 ## Library tier — dead code & unkept promises

--- a/tests_lib/io/test_io_helpers.py
+++ b/tests_lib/io/test_io_helpers.py
@@ -10,6 +10,7 @@ import pytest
 
 from vtscore.io import (
     atomic_write_json,
+    atomic_write_stream,
     atomic_write_text,
     desanitize_csv_cell,
     read_server_json,
@@ -56,6 +57,93 @@ class TestReadServerJson:
         p.write_bytes(b"\xff\xfe not valid utf-8")
         with pytest.raises(ValueError, match="Invalid JSON"):
             read_server_json(p)
+
+
+class TestAtomicWriteStream:
+    def test_basic_write(self, tmp_path):
+        p = tmp_path / "out.txt"
+        with atomic_write_stream(p) as f:
+            f.write("hello ")
+            f.write("world")
+        assert p.read_text() == "hello world"
+
+    def test_creates_parents(self, tmp_path):
+        p = tmp_path / "nested" / "dir" / "out.txt"
+        with atomic_write_stream(p) as f:
+            f.write("ok")
+        assert p.read_text() == "ok"
+
+    def test_no_tmp_left_behind_on_success(self, tmp_path):
+        p = tmp_path / "out.txt"
+        with atomic_write_stream(p) as f:
+            f.write("data")
+        assert [entry.name for entry in tmp_path.iterdir()] == ["out.txt"]
+
+    def test_destination_untouched_until_commit(self, tmp_path):
+        """A reader mid-stream sees the *previous* content, never a partial write."""
+        p = tmp_path / "out.txt"
+        p.write_text("old")
+        with atomic_write_stream(p) as f:
+            f.write("new")
+            f.flush()
+            assert p.read_text() == "old"
+        assert p.read_text() == "new"
+
+    def test_raising_block_leaves_destination_and_removes_tmp(self, tmp_path):
+        """The failure mode this helper exists for: a records iterator dying mid-export."""
+        p = tmp_path / "out.txt"
+        p.write_text("old")
+        with pytest.raises(RuntimeError, match="records blew up"):
+            with atomic_write_stream(p) as f:
+                f.write("partial")
+                raise RuntimeError("records blew up")
+        assert p.read_text() == "old"
+        assert [entry.name for entry in tmp_path.iterdir()] == ["out.txt"]
+
+    def test_tmp_removed_when_destination_did_not_exist(self, tmp_path):
+        p = tmp_path / "out.txt"
+        with pytest.raises(RuntimeError):
+            with atomic_write_stream(p) as f:
+                f.write("partial")
+                raise RuntimeError("boom")
+        assert not p.exists()
+        assert list(tmp_path.iterdir()) == []
+
+    def test_tmp_cleaned_up_when_rename_fails(self, tmp_path, monkeypatch):
+        from vtscore import io as vtio
+
+        p = tmp_path / "out.txt"
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(vtio.os, "replace", boom)
+        with pytest.raises(OSError, match="disk full"):
+            with atomic_write_stream(p) as f:
+                f.write("data")
+        assert list(tmp_path.iterdir()) == []
+
+    def test_preserves_csv_crlf(self, tmp_path):
+        """``newline=""`` keeps a ``csv`` writer's CRLF endings from being doubled."""
+        import csv
+
+        p = tmp_path / "out.csv"
+        with atomic_write_stream(p) as f:
+            writer = csv.writer(f)
+            writer.writerow(["a", "b"])
+            writer.writerow([1, 2])
+        assert p.read_bytes() == b"a,b\r\n1,2\r\n"
+
+    def test_tmp_name_is_per_writer_unique(self, tmp_path):
+        """Two writers racing on one destination must not share a tmp path."""
+        p = tmp_path / "out.txt"
+        seen = []
+        with atomic_write_stream(p):
+            seen.append(next(e.name for e in tmp_path.iterdir()))
+            with atomic_write_stream(p):
+                names = sorted(e.name for e in tmp_path.iterdir())
+        assert len(names) == 2, names
+        assert names[0] != names[1]
 
 
 class TestAtomicWriteText:

--- a/tests_lib/io/test_label_json_format.py
+++ b/tests_lib/io/test_label_json_format.py
@@ -1,0 +1,89 @@
+"""Tests for ``vtscore.labels.json_format``.
+
+The server-JSON label importer and the server-JSON labelset source both read
+this shape, and both used to validate it with their own copy of the check.
+These tests pin the shared behaviour so the two paths can't drift apart again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.labels.json_format import extract_labels, require_label_object
+
+
+class TestRequireLabelObject:
+    def test_returns_the_object_unchanged(self):
+        data = {"labels": [], "detector_meta": {"name": "d"}}
+        assert require_label_object(data) is data
+
+    @pytest.mark.parametrize("data", [[], "text", 3, None])
+    def test_rejects_non_object_top_level(self, data):
+        with pytest.raises(ValueError, match="object at the top level"):
+            require_label_object(data)
+
+    def test_rejects_missing_labels_key(self):
+        with pytest.raises(ValueError, match="top-level 'labels' list"):
+            require_label_object({"data": []})
+
+    def test_rejects_non_list_labels(self):
+        with pytest.raises(ValueError, match="top-level 'labels' list"):
+            require_label_object({"labels": {"md5": "abc"}})
+
+
+class TestExtractLabels:
+    def test_returns_entries(self):
+        entries = [{"md5": "abc", "label": "good"}, {"md5": "def", "label": "bad"}]
+        assert extract_labels({"labels": entries}) == entries
+
+    def test_empty_list_is_valid(self):
+        assert extract_labels({"labels": []}) == []
+
+    def test_drops_non_dict_entries(self):
+        """One stray row shouldn't cost the user the rest of a hand-edited file."""
+        data = {"labels": [{"md5": "abc"}, None, "junk", 7, {"md5": "def"}]}
+        assert extract_labels(data) == [{"md5": "abc"}, {"md5": "def"}]
+
+    def test_ignores_sibling_keys(self):
+        data = {"labels": [{"md5": "abc"}], "detector_meta": {"name": "d"}}
+        assert extract_labels(data) == [{"md5": "abc"}]
+
+    @pytest.mark.parametrize("data", [[], {"data": []}, {"labels": "nope"}])
+    def test_rejects_wrong_shapes(self, data):
+        with pytest.raises(ValueError):
+            extract_labels(data)
+
+
+class TestPluginsShareTheHelper:
+    """The importer and the source must agree, entry for entry and error for error."""
+
+    def _importer(self):
+        from vtscore.labels.importers import get_label_importer
+
+        return get_label_importer("server_json_file")
+
+    def _source(self):
+        from vtscore.labels.sources import get_labelset_source
+
+        return get_labelset_source("server_json_file")
+
+    def test_both_drop_the_same_junk_entries(self, tmp_path):
+        import json
+
+        p = tmp_path / "labels.json"
+        p.write_text(json.dumps({"labels": [{"md5": "abc"}, None, {"md5": "def"}]}))
+
+        via_importer = self._importer().run({"filepath": str(p)})
+        via_source = self._source().load({"filepath": str(p)})
+        assert via_importer == via_source == [{"md5": "abc"}, {"md5": "def"}]
+
+    def test_both_reject_a_non_object_top_level(self, tmp_path):
+        import json
+
+        p = tmp_path / "labels.json"
+        p.write_text(json.dumps([{"md5": "abc"}]))
+
+        with pytest.raises(ValueError, match="object at the top level"):
+            self._importer().run({"filepath": str(p)})
+        with pytest.raises(ValueError, match="object at the top level"):
+            self._source().load({"filepath": str(p)})

--- a/vtscore/docs/packages/exporters.md
+++ b/vtscore/docs/packages/exporters.md
@@ -295,7 +295,8 @@ rather than shipping one from your own distribution:
   declare - the entry-point route in the guide is for out-of-tree
   distributions.
 - Write files through `vtscore.io.atomic_write_bytes` /
-  `atomic_write_text` rather than hand-rolling the tmp-file +
+  `atomic_write_text` - or `atomic_write_stream` when the exporter
+  streams its rows - rather than hand-rolling the tmp-file +
   `os.replace` ritual, and default any path field under
   `vtscore.config.DATA_DIR` as the built-ins do (see [Template variables
   in path fields](#template-variables-in-path-fields)). New

--- a/vtscore/docs/packages/runtime-modules.md
+++ b/vtscore/docs/packages/runtime-modules.md
@@ -36,6 +36,9 @@ def sanitize_csv_cell(value: str) -> str: ...
 def desanitize_csv_cell(value: str) -> str: ...
 
 @contextmanager
+def atomic_write_stream(path, *, encoding="utf-8", newline="") -> Iterator[IO[str]]: ...
+
+@contextmanager
 def file_lock(path) -> Iterator[None]: ...
 ```
 
@@ -43,6 +46,13 @@ The helpers are deliberately small. Their job is to standardise the
 `ValueError` text the framework surfaces to users, and to make "a future
 file-writing plugin that forgets `fsync`" impossible without explicitly
 working around the helper.
+
+**Streaming writes.** `atomic_write_stream` is the same ritual for a writer
+that has no finished string to hand `atomic_write_text` - a `csv` writer fed
+from a generator, an NDJSON export written row by row. It yields the open
+handle, `fsync`s and renames on a clean exit, and unlinks the tmp file if the
+block raises, so an export that dies halfway through its record iterator
+leaves the destination untouched rather than half-written.
 
 **CSV cells.** `sanitize_csv_cell` prefixes a value starting with `=`,
 `+`, `-`, `@`, tab or carriage return with a single quote, so a label

--- a/vtscore/eval/score_dumps.py
+++ b/vtscore/eval/score_dumps.py
@@ -28,6 +28,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from vtscore.io import atomic_write_stream
+
 COLUMNS = (
     "media_id",
     "filename",
@@ -50,12 +52,12 @@ def write_prediction_dump(
 ) -> None:
     """Write one row per media in *ids* to *path* (created via a temp rename).
 
-    *scores* and *labels* must be positionally aligned with *ids*; the write is
-    atomic so a reader never sees a half-written dump from a re-run in flight.
+    *scores* and *labels* must be positionally aligned with *ids*; the write goes
+    through :func:`~vtscore.io.atomic_write_stream`, so a reader never sees a
+    half-written dump from a re-run in flight and two arms dumping the same path
+    can't collide on the temp file.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".csv.tmp")
-    with tmp.open("w", newline="") as fh:
+    with atomic_write_stream(path) as fh:
         writer = csv.writer(fh)
         writer.writerow(COLUMNS)
         for media_id, score, label in zip(ids, scores, labels, strict=True):
@@ -72,7 +74,6 @@ def write_prediction_dump(
                     "|".join(str(c) for c in categories),
                 ]
             )
-    tmp.replace(path)
 
 
 def maybe_dump_predictions(

--- a/vtscore/exporters/server_csv_file/__init__.py
+++ b/vtscore/exporters/server_csv_file/__init__.py
@@ -13,14 +13,12 @@ from __future__ import annotations
 import csv
 import io
 import json
-import os
-import uuid
 from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
 from vtscore.exporters.base import PluginField, ResultsExporter
-from vtscore.io import atomic_write_text, sanitize_csv_cell as _sanitize_csv_cell
+from vtscore.io import atomic_write_stream, atomic_write_text, sanitize_csv_cell as _sanitize_csv_cell
 
 _DEFAULT_CSV_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.csv"
 
@@ -116,52 +114,41 @@ class ServerCsvResultsExporter(ResultsExporter):
 
         Uses a fixed column superset (see :attr:`_STREAM_COLUMNS`) because a
         streaming writer cannot look ahead to decide which optional clip
-        columns are present.  The file is built at a per-writer-unique sibling
-        ``.tmp`` path and atomically renamed on success, so two concurrent
-        exports to the same path can't clobber each other's temp file.
+        columns are present.  :func:`~vtscore.io.atomic_write_stream` owns the
+        tmp-file/``fsync``/rename ritual, so a run that dies mid-stream leaves
+        no half-written export and two concurrent exports to the same path
+        can't clobber each other's temp file.
         """
         from vtscore.datasets.origin import Origin  # noqa: PLC0415
 
         filepath = Path(field_values["filepath"])
-        filepath.parent.mkdir(parents=True, exist_ok=True)
-        # Per-writer unique suffix (pid + uuid) so two threads/processes racing
-        # to export the same path can't truncate each other's in-flight tmp or
-        # chase one already renamed away.  Matches vtscore.io.atomic_write_text.
-        tmp_path = filepath.with_name(f"{filepath.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
 
         thresholds = {d.get("detector_name", ""): d.get("threshold", "") for d in header.get("detectors", [])}
 
         total_hits = 0
-        try:
-            with open(tmp_path, "w", encoding="utf-8", newline="") as f:
-                writer = csv.writer(f)
-                writer.writerow(self._STREAM_COLUMNS)
-                for detector_name, hit in records:
-                    origin = hit.get("origin")
-                    origin_str = Origin.from_dict(origin).display() if origin else ""
-                    clip_box = hit.get("clip_box")
-                    writer.writerow(
-                        [
-                            _sanitize_csv_cell(str(detector_name)),
-                            thresholds.get(detector_name, ""),
-                            _sanitize_csv_cell(hit.get("filename", "")),
-                            _sanitize_csv_cell(hit.get("category", "")),
-                            hit.get("score", ""),
-                            _sanitize_csv_cell(hit.get("label", "")),
-                            hit.get("clip_start", ""),
-                            hit.get("clip_end", ""),
-                            ",".join(str(v) for v in clip_box) if clip_box else "",
-                            _sanitize_csv_cell(origin_str),
-                            _sanitize_csv_cell(hit.get("origin_name", "")),
-                        ]
-                    )
-                    total_hits += 1
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, filepath)
-        finally:
-            if tmp_path.exists():
-                tmp_path.unlink()
+        with atomic_write_stream(filepath) as f:
+            writer = csv.writer(f)
+            writer.writerow(self._STREAM_COLUMNS)
+            for detector_name, hit in records:
+                origin = hit.get("origin")
+                origin_str = Origin.from_dict(origin).display() if origin else ""
+                clip_box = hit.get("clip_box")
+                writer.writerow(
+                    [
+                        _sanitize_csv_cell(str(detector_name)),
+                        thresholds.get(detector_name, ""),
+                        _sanitize_csv_cell(hit.get("filename", "")),
+                        _sanitize_csv_cell(hit.get("category", "")),
+                        hit.get("score", ""),
+                        _sanitize_csv_cell(hit.get("label", "")),
+                        hit.get("clip_start", ""),
+                        hit.get("clip_end", ""),
+                        ",".join(str(v) for v in clip_box) if clip_box else "",
+                        _sanitize_csv_cell(origin_str),
+                        _sanitize_csv_cell(hit.get("origin_name", "")),
+                    ]
+                )
+                total_hits += 1
 
         return {
             "message": (

--- a/vtscore/exporters/server_json_file/__init__.py
+++ b/vtscore/exporters/server_json_file/__init__.py
@@ -11,14 +11,12 @@ No additional pip packages are required; uses only Python's ``json`` and
 from __future__ import annotations
 
 import json
-import os
-import uuid
 from pathlib import Path
 from typing import Any, Iterator
 
 from vtscore.config import DATA_DIR
 from vtscore.exporters.base import PluginField, ResultsExporter
-from vtscore.io import atomic_write_json
+from vtscore.io import atomic_write_json, atomic_write_stream
 
 _DEFAULT_JSON_PATH = f"{DATA_DIR}/autodetect_results_{{YYYYMMDD-HHMMSS}}.json"
 
@@ -89,17 +87,12 @@ class ServerJsonResultsExporter(ResultsExporter):
         The first line is a metadata object describing the run; every
         subsequent line is a single hit with its ``detector`` name merged in.
         Lines are flushed as they stream, so the full result set is never
-        held in memory.  The file is built at a per-writer-unique sibling
-        ``.tmp`` path and atomically renamed on success, so a crash mid-run
-        cannot leave a half-written file at the destination and two concurrent
-        exports to the same path can't clobber each other's temp file.
+        held in memory.  :func:`~vtscore.io.atomic_write_stream` owns the
+        tmp-file/``fsync``/rename ritual, so a crash mid-run cannot leave a
+        half-written file at the destination and two concurrent exports to the
+        same path can't clobber each other's temp file.
         """
         filepath = Path(field_values["filepath"])
-        filepath.parent.mkdir(parents=True, exist_ok=True)
-        # Per-writer unique suffix (pid + uuid) so two threads/processes racing
-        # to export the same path can't truncate each other's in-flight tmp or
-        # chase one already renamed away.  Matches vtscore.io.atomic_write_text.
-        tmp_path = filepath.with_name(f"{filepath.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
 
         meta = {
             "format": "vtsearch-hits-ndjson/v1",
@@ -109,20 +102,11 @@ class ServerJsonResultsExporter(ResultsExporter):
         }
 
         total_hits = 0
-        try:
-            with open(tmp_path, "w", encoding="utf-8") as f:
-                f.write(json.dumps({"_meta": meta}) + "\n")
-                for detector_name, hit in records:
-                    f.write(json.dumps({"detector": detector_name, **hit}) + "\n")
-                    total_hits += 1
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, filepath)
-        finally:
-            # Clean up the temp file if the rename never happened (e.g. an
-            # exception propagated out of the records iterator).
-            if tmp_path.exists():
-                tmp_path.unlink()
+        with atomic_write_stream(filepath) as f:
+            f.write(json.dumps({"_meta": meta}) + "\n")
+            for detector_name, hit in records:
+                f.write(json.dumps({"detector": detector_name, **hit}) + "\n")
+                total_hits += 1
 
         return {
             "message": (

--- a/vtscore/io.py
+++ b/vtscore/io.py
@@ -27,7 +27,7 @@ import threading
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 try:
     import fcntl as _fcntl  # POSIX-only; falls back to in-process locking on Windows.
@@ -39,6 +39,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "atomic_write_bytes",
     "atomic_write_json",
+    "atomic_write_stream",
     "atomic_write_text",
     "desanitize_csv_cell",
     "file_lock",
@@ -179,6 +180,62 @@ def atomic_write_json(path: Path | str, obj: Any, *, indent: int = 2) -> None:
     newline don't complain).
     """
     atomic_write_text(path, json.dumps(obj, indent=indent) + "\n")
+
+
+@contextlib.contextmanager
+def atomic_write_stream(
+    path: Path | str,
+    *,
+    encoding: str = "utf-8",
+    newline: str = "",
+) -> Iterator[IO[str]]:
+    """Open *path* for incremental text writes, committing atomically on exit.
+
+    The streaming twin of :func:`atomic_write_text`, for writers that build
+    their content a piece at a time - a :mod:`csv` writer fed from a
+    generator, an NDJSON export written row by row - and so have no finished
+    string to hand the whole-file helper.  Yields the open handle::
+
+        with atomic_write_stream(path) as f:
+            writer = csv.writer(f)
+            for row in rows:
+                writer.writerow(row)
+
+    Writes land in a per-writer-unique sibling ``.tmp`` file that is
+    ``fsync``\\ ed and then renamed into place with :func:`os.replace` once
+    the block exits normally, so a reader of *path* sees either the previous
+    content or the complete new content - never a partial write - and two
+    concurrent writers targeting the same destination cannot truncate each
+    other's in-flight tmp file.  Parent directories are created if needed.
+
+    If the block raises - including from the generator feeding it, which is
+    the common case for a streaming export - the tmp file is removed and
+    *path* is left untouched, so a run that dies halfway through leaves no
+    half-written export behind.
+
+    Like :func:`atomic_write_text`, the handle is opened with ``newline=""``
+    so ``\\r\\n`` sequences a :mod:`csv` writer emits are preserved exactly
+    rather than being translated a second time.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name(f"{p.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    committed = False
+    try:
+        with open(tmp, "w", encoding=encoding, newline=newline) as f:
+            yield f
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, p)
+        committed = True
+    finally:
+        # Best-effort cleanup of the tmp file on any non-completing exit.
+        # Tracking the commit explicitly (rather than probing with
+        # ``tmp.exists()``) keeps a concurrent writer's freshly-renamed file
+        # out of reach and avoids the exists/unlink race.
+        if not committed:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
 
 
 # ---------------------------------------------------------------------------

--- a/vtscore/labels/importers/server_json_file/__init__.py
+++ b/vtscore/labels/importers/server_json_file/__init__.py
@@ -18,6 +18,7 @@ from typing import Any
 from vtscore.config import DATA_DIR
 from vtscore.io import read_server_json
 from vtscore.labels.importers.base import LabelImporter, PluginField
+from vtscore.labels.json_format import extract_labels
 
 
 class ServerJsonLabelImporter(LabelImporter):
@@ -53,7 +54,7 @@ class ServerJsonLabelImporter(LabelImporter):
     def run(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
         """Read and parse the JSON labels file from the server filesystem."""
         data = read_server_json(field_values["filepath"])
-        return _extract_labels(data)
+        return extract_labels(data)
 
     def run_cli(self, field_values: dict[str, Any]) -> list[dict[str, str]]:
         """Load labels from a file-path string (CLI usage)."""
@@ -66,14 +67,6 @@ class ServerJsonLabelImporter(LabelImporter):
             help="Path to a VTSearch labels JSON file on the server.",
             required=False,
         )
-
-
-def _extract_labels(data: Any) -> list[dict[str, str]]:
-    """Pull the labels list out of an already-parsed JSON object."""
-    labels = data.get("labels") if isinstance(data, dict) else None
-    if not isinstance(labels, list):
-        raise ValueError("JSON must contain a top-level 'labels' list.")
-    return [entry for entry in labels if isinstance(entry, dict)]
 
 
 LABEL_IMPORTER = ServerJsonLabelImporter()

--- a/vtscore/labels/json_format.py
+++ b/vtscore/labels/json_format.py
@@ -1,0 +1,50 @@
+"""Shared shape checks for the VTSearch label-JSON format.
+
+Both the server-JSON label *importer* and the server-JSON labelset *source*
+read the same on-disk shape::
+
+    {"labels": [{"md5": "...", "label": "good"}, ...], "detector_meta": {...}}
+
+The two plugins live in different packages (``vtscore.labels.importers`` and
+``vtscore.labels.sources``) but validate that shape identically, and the error
+text they raise is user-facing - it surfaces verbatim when someone points a
+plugin at the wrong file.  Keeping the check here means the message can't
+drift between the two paths, and a third reader of the format gets it for
+free.
+
+Parsing the file itself belongs to :func:`vtscore.io.read_server_json`; these
+helpers only interpret an already-parsed object.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["extract_labels", "require_label_object"]
+
+
+def require_label_object(data: Any) -> dict[str, Any]:
+    """Return *data* as a label-file mapping, or raise :class:`ValueError`.
+
+    Checks the two invariants every reader of the format depends on: the
+    top level is an object, and it carries a ``"labels"`` list.  Callers that
+    want the entries themselves should use :func:`extract_labels`; this one is
+    for callers that go on to read sibling keys (``detector_meta``) out of the
+    same object.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("JSON must contain an object at the top level.")
+    if not isinstance(data.get("labels"), list):
+        raise ValueError("JSON must contain a top-level 'labels' list.")
+    return data
+
+
+def extract_labels(data: Any) -> list[dict[str, str]]:
+    """Pull the label entries out of an already-parsed label-file object.
+
+    Non-dict entries are dropped rather than rejected: a hand-edited file with
+    a stray ``null`` in the list should import the labels around it instead of
+    failing outright.  A missing or non-list ``"labels"`` key *is* an error -
+    that is the file being the wrong format, not one bad row.
+    """
+    return [entry for entry in require_label_object(data)["labels"] if isinstance(entry, dict)]

--- a/vtscore/labels/sources/server_json_file/__init__.py
+++ b/vtscore/labels/sources/server_json_file/__init__.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from vtscore.config import DATA_DIR
 from vtscore.io import atomic_write_json, read_server_json
+from vtscore.labels.json_format import extract_labels, require_label_object
 from vtscore.labels.sources.base import LabelsetSource, PluginField
 
 if TYPE_CHECKING:
@@ -41,10 +42,7 @@ class ServerFileLabelsetSource(LabelsetSource):
         data = read_server_json(field_values["filepath"], missing_ok=True)
         if data is None:
             return []
-        labels = data.get("labels") if isinstance(data, dict) else None
-        if not isinstance(labels, list):
-            raise ValueError("JSON must contain a top-level 'labels' list.")
-        return [entry for entry in labels if isinstance(entry, dict)]
+        return extract_labels(data)
 
     def _do_load_full(self, field_values: dict[str, Any]) -> LabelSet:
         """Read labels *and* any ``detector_meta`` block into a :class:`LabelSet`."""
@@ -53,11 +51,7 @@ class ServerFileLabelsetSource(LabelsetSource):
         data = read_server_json(field_values["filepath"], missing_ok=True)
         if data is None:
             return _LabelSet()
-        if not isinstance(data, dict):
-            raise ValueError("JSON must contain an object at the top level.")
-        if not isinstance(data.get("labels"), list):
-            raise ValueError("JSON must contain a top-level 'labels' list.")
-        return _LabelSet.from_dict(data)
+        return _LabelSet.from_dict(require_label_object(data))
 
     def _do_save(self, labelset: LabelSet, field_values: dict[str, Any]) -> None:
         """Write labels to a JSON file on the server."""


### PR DESCRIPTION
Closes #3389

Two small plumbing dedups in the library tier. **The issue's third item was dropped after evaluation** — see the last section.

## `atomic_write_stream`

`vtscore/io.py` exists to own the tmp-file/`fsync`/`os.replace` ritual, but only for writers that can hand it a finished string. Writers that stream — a `csv` writer fed from a generator, an NDJSON export written row by row — had to hand-roll it, and three did: both server-file exporters and the eval prediction dump. New context manager yields the open handle; all three adopt it.

Two correctness improvements fall out:

- **The eval dump gains real atomicity.** `write_prediction_dump` used a fixed `.csv.tmp` sibling with no `fsync`, so two arms dumping the same path collided on the temp file.
- **The exporters lose an exists/unlink race.** Both cleaned up with `finally: if tmp_path.exists(): tmp_path.unlink()`. After a successful `os.replace` the tmp is gone, so the `exists()` check normally holds — but a *concurrent* writer's tmp can appear at that name between the two calls. The helper tracks the commit with a flag instead of probing the filesystem.

One deliberate behaviour change: the NDJSON exporter previously opened with the default `newline=None`, so on Windows its explicit `"\n"` line terminators were translated to `\r\n`. The helper uses `newline=""` (matching `atomic_write_text`), so NDJSON now gets LF everywhere — which is what the format wants.

## Shared label-JSON checks

The label-file shape check was written three times across `vtscore/labels/importers/server_json_file/` and `vtscore/labels/sources/server_json_file/`. The two `_do_load*` methods **on the same class** disagreed: `_do_load` reported a non-object top level as `"JSON must contain a top-level 'labels' list."`, while `_do_load_full` correctly said `"JSON must contain an object at the top level."`.

New `vtscore/labels/json_format.py` holds `extract_labels` and `require_label_object`, and both plugins use them. The more precise pair of messages wins, so the importer and the source can no longer drift — a new test asserts they agree entry-for-entry and error-for-error. No existing test asserted the old text.

## The media-registry section was dropped, not implemented

The issue's first item asked for a generic `_PluginRegistry` to collapse "four copy-paste registries in `vtscore/media/__init__.py`", claiming "~130 lines where ~40 would do". The premise doesn't hold:

- **The saving isn't there.** The issue's own Constraints require keeping all 20 public function names, and those are module-level functions with docstrings — the plugin-registration API third-party plugins call directly. 15 already have single-line bodies, which a generic registry cannot shorten: `_clippers.register(clipper)` is exactly as long as `_clipper_registry[clipper.name] = clipper`. Only the five `get_*` functions shrink, by 2 lines each. Net ~6 lines saved against a ~35-line generic class, plus indirection on a public surface.
- **It isn't four copies.** The media-type registry isn't a five-function block at all — 10 functions, 7 bespoke (`get_by_extension`, `all_demo_datasets`, `normalize_type_id`, …). The embedder block differs in 2 of 5 (`embedders_for_type` sorts the default first and filters `eval_only`; `all_embedders_dict` filters too). The real duplication is one pair, clipper and cleaner, at ~40 lines.

Collapsing a real-but-irreducible twin behind a generic that makes the file *longer* is a net loss. The issue body has been rescoped to record this.

## Testing

Full `./run-tests.sh` on the current head: **9956 passed, 6 skipped**, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest). 17 new tests cover the helper's commit/rollback behaviour, CRLF preservation, per-writer-unique tmp naming, and the two plugins' agreement.

> **Rebase note.** This branch originally also dropped a duplicate `fast-uri` key from `frontend/package.json`, which was failing the frontend build gate on `dev`. Two other sessions fixed it independently (`9eba37bc`, `77096710`) while this PR was open, so on rebase that hunk dropped out as already-applied and is no longer part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXF7BsLJPzhhbcCXBFSGzy