### PR TITLE
One JobManager registry, uniform plugin-registry construction (#3404)

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -298,15 +298,6 @@ cost_k  # noqa: F821 - vtscore.eval.voting_iterations operating-cost triple
 _allow_test_tmp_paths  # noqa: F821
 
 # ---------------------------------------------------------------------------
-# ``reset_all_async_jobs_for_tests`` is called from
-# ``tests_shared/state_reset.py``, which is not in vulture's SCAN_PATHS (the
-# shared helpers package sits outside both test trees). It is also part of
-# ``vtscore.concurrency``'s public surface, tabulated in
-# ``vtscore/docs/packages/concurrency.md``.
-# ---------------------------------------------------------------------------
-reset_all_async_jobs_for_tests  # noqa: F821
-
-# ---------------------------------------------------------------------------
 # ``StreamProgress.readable`` overrides ``io.IOBase.readable`` on a stream
 # wrapper the container reader hands to ``pickle.load``. Python's io / pickle
 # machinery queries ``.readable()`` reflectively before pulling bytes; there

--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -85,7 +85,7 @@ care.
 - [x] #3397 — Keep the resolver extension point but delete its auto-wire dance and import-error mask (Sonnet 5)
 - [ ] #3401 — Declare `image_response` on the `MediaType` ABC and document both undeclared hooks (Sonnet 5)
 - [ ] #3402 — Apply the sub-output disambiguators in the converted-demo emitter (Sonnet 5)
-- [ ] #3404 — Small vtscore batch: `JOB_MANAGERS` coverage, registry construction, `SAVED_DATASETS_DIR` (Haiku 4.5)
+- [x] #3404 — Small vtscore batch: `JOB_MANAGERS` coverage, registry construction, `SAVED_DATASETS_DIR` (Haiku 4.5)
 
 ## Concurrency & progress
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/tests_lib/integration/test_async_jobs.py
+++ b/tests_lib/integration/test_async_jobs.py
@@ -751,9 +751,7 @@ class TestSingletonRegistry:
 
         registered = set(map(id, async_jobs.JOB_MANAGERS.values()))
         missing = sorted(
-            name
-            for name, obj in vars(async_jobs).items()
-            if isinstance(obj, JobManager) and id(obj) not in registered
+            name for name, obj in vars(async_jobs).items() if isinstance(obj, JobManager) and id(obj) not in registered
         )
         assert not missing, (
             f"module-level JobManager singletons absent from JOB_MANAGERS: {missing}. "
@@ -801,9 +799,7 @@ class TestSingletonRegistry:
                 check_job_cancelled()
                 time.sleep(0.01)
 
-        job = labeling_status_jobs.start(
-            "sig", _target, dataset_id="ds1", detector_id="det1"
-        )
+        job = labeling_status_jobs.start("sig", _target, dataset_id="ds1", detector_id="det1")
         try:
             assert started.wait(timeout=5)
             assert list_active_pairs() == []

--- a/tests_lib/integration/test_async_jobs.py
+++ b/tests_lib/integration/test_async_jobs.py
@@ -733,3 +733,80 @@ class TestTrackerBackedProgress:
         job.progress.cancel()
         assert job.done_event.wait(timeout=5)
         assert job.status == "cancelled"
+
+
+class TestSingletonRegistry:
+    """``JOB_MANAGERS`` is the single registry of module-level managers.
+
+    It used to hold only the user-visible ones, which forced
+    ``reset_all_async_jobs_for_tests`` to re-list the hidden managers by
+    hand — and that second list went stale, leaving
+    ``archive_thumbnail_jobs`` unreset between tests (issue #3404).  These
+    tests fail if a future manager is added to the module but not to the
+    registry, which is the drift that caused the miss.
+    """
+
+    def test_every_module_level_manager_is_registered(self):
+        from vtscore.concurrency import async_jobs
+
+        registered = set(map(id, async_jobs.JOB_MANAGERS.values()))
+        missing = sorted(
+            name
+            for name, obj in vars(async_jobs).items()
+            if isinstance(obj, JobManager) and id(obj) not in registered
+        )
+        assert not missing, (
+            f"module-level JobManager singletons absent from JOB_MANAGERS: {missing}. "
+            "Add them to the registry (with user_visible=False if they earn no "
+            "/api/jobs/active spinner) rather than re-listing them by hand."
+        )
+
+    def test_reset_walks_hidden_managers_too(self):
+        """A hidden manager's in-flight job is cleared by the autouse reset."""
+        from vtscore.concurrency.async_jobs import (
+            archive_thumbnail_jobs,
+            reset_all_async_jobs_for_tests,
+        )
+
+        started = threading.Event()
+
+        def _target(job):
+            started.set()
+            while True:
+                check_job_cancelled()
+                time.sleep(0.01)
+
+        job = archive_thumbnail_jobs.start("sig", _target)
+        assert started.wait(timeout=5)
+        try:
+            reset_all_async_jobs_for_tests()
+            assert job.done_event.wait(timeout=5)
+            assert archive_thumbnail_jobs.active_jobs() == []
+        finally:
+            job.cancel()
+            job.done_event.wait(timeout=5)
+
+    def test_hidden_managers_earn_no_active_pairs_row(self):
+        """``/api/jobs/active`` still shows only user-visible work."""
+        from vtscore.concurrency.async_jobs import (
+            labeling_status_jobs,
+            list_active_pairs,
+        )
+
+        started = threading.Event()
+
+        def _target(job):
+            started.set()
+            while True:
+                check_job_cancelled()
+                time.sleep(0.01)
+
+        job = labeling_status_jobs.start(
+            "sig", _target, dataset_id="ds1", detector_id="det1"
+        )
+        try:
+            assert started.wait(timeout=5)
+            assert list_active_pairs() == []
+        finally:
+            job.cancel()
+            job.done_event.wait(timeout=5)

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -94,6 +94,23 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Changed
 
+- **`JOB_MANAGERS` is now the single registry of every module-level
+  `JobManager`, with visibility carried by the manager** (issue #3404). It
+  previously held only the managers surfaced by `/api/jobs/active`, which
+  forced `reset_all_async_jobs_for_tests()` to re-list the hidden ones by
+  hand — and that second list went stale, leaving `archive_thumbnail_jobs`
+  unreset between tests. `JobManager.__init__` gained a keyword-only
+  `user_visible: bool = True`, `list_active_pairs()` filters on it, and the
+  reset helper walks the whole registry. Registering a new manager is now one
+  edit in one place, and its visibility is declared at its own definition.
+
+  **For library consumers:** the `JobManager(...)` change is purely additive —
+  the default keeps existing constructions user-visible. `JOB_MANAGERS` itself
+  now enumerates the internal managers too (`labeling-status`,
+  `signpost-relabel`, `archive-thumbnail-warm`), so code that iterated it
+  expecting only user-facing work should read `list_active_pairs()` or filter
+  on `mgr.user_visible`. The keys of the visible entries are unchanged.
+
 - **`vtscore.training.evt_mixture` moved to `vtscore.eval.evt_mixture`** (issue
   #3396). The Gumbel/Normal score mixture is a research arm from the #2836 /
   #2846 cut studies, not a shipped threshold rule: nothing in the app or the

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -274,9 +274,7 @@ class JobManager:
     result instead of re-running.
     """
 
-    def __init__(
-        self, name: str, max_history: int = 8, *, user_visible: bool = True
-    ) -> None:
+    def __init__(self, name: str, max_history: int = 8, *, user_visible: bool = True) -> None:
         self._name = name
         #: Whether this manager's jobs are surfaced in ``/api/jobs/active``.
         #: Internal refreshes and warm-ups set this ``False``: they are not

--- a/vtscore/concurrency/async_jobs.py
+++ b/vtscore/concurrency/async_jobs.py
@@ -274,8 +274,16 @@ class JobManager:
     result instead of re-running.
     """
 
-    def __init__(self, name: str, max_history: int = 8) -> None:
+    def __init__(
+        self, name: str, max_history: int = 8, *, user_visible: bool = True
+    ) -> None:
         self._name = name
+        #: Whether this manager's jobs are surfaced in ``/api/jobs/active``.
+        #: Internal refreshes and warm-ups set this ``False``: they are not
+        #: user-initiated training work, so they get no spinner.  Every
+        #: manager - visible or not - still belongs in ``JOB_MANAGERS``, which
+        #: is what ``reset_all_async_jobs_for_tests`` walks.
+        self.user_visible = user_visible
         self._lock = threading.RLock()
         self._jobs: dict[str, AsyncJob] = {}
         self._current_id: str | None = None
@@ -587,9 +595,8 @@ eval_jobs = JobManager("eval-train-score")
 #: Background runner that advances the labeling-status per-step cache off the
 #: ``/api/labeling-status`` poll thread (issue #2397).  Not surfaced in
 #: ``/api/jobs/active`` - it is an internal refresh of a cheap 2 s poll, not a
-#: user-visible training job - so it is intentionally absent from
-#: ``JOB_MANAGERS`` below.
-labeling_status_jobs = JobManager("labeling-status")
+#: user-visible training job - hence ``user_visible=False``.
+labeling_status_jobs = JobManager("labeling-status", user_visible=False)
 
 #: Background runner for ``/api/projection/build`` (VTSBrowse UMAP + pyramid).
 projection_jobs = JobManager("projection")
@@ -600,9 +607,9 @@ projection_jobs = JobManager("projection")
 #: signs self-heal without a forced Re-project.  Kept on its own single slot so
 #: a self-heal never queues behind (or delays) a user-visible UMAP build in
 #: ``projection_jobs``.  Like ``labeling_status_jobs`` it is an internal
-#: refresh, not a user-visible training job, so it is intentionally absent from
-#: ``JOB_MANAGERS`` below (no ``/api/jobs/active`` spinner).
-signpost_relabel_jobs = JobManager("signpost-relabel")
+#: refresh, not a user-visible training job, so it is ``user_visible=False``
+#: (no ``/api/jobs/active`` spinner).
+signpost_relabel_jobs = JobManager("signpost-relabel", user_visible=False)
 
 #: Background runner for the archive-member thumbnail warm-up (issue #2738).
 #: An archive-member import reads no member bytes by design, so its media leave
@@ -611,20 +618,31 @@ signpost_relabel_jobs = JobManager("signpost-relabel")
 #: :mod:`vtscore.datasets.thumbnail_warm`, whose job target sweeps **every**
 #: loaded dataset precisely because this manager's single slot supersedes a
 #: parked pending job.  Like the two managers above it is an internal warm-up,
-#: not a user-visible training job, so it is intentionally absent from
-#: ``JOB_MANAGERS`` below (no ``/api/jobs/active`` spinner): browse is fully
-#: functional while it runs, just colder.
-archive_thumbnail_jobs = JobManager("archive-thumbnail-warm")
+#: not a user-visible training job, so it is ``user_visible=False`` (no
+#: ``/api/jobs/active`` spinner): browse is fully functional while it runs,
+#: just colder.
+archive_thumbnail_jobs = JobManager("archive-thumbnail-warm", user_visible=False)
 
-#: Logical name → :class:`JobManager` lookup used by ``/api/jobs/active`` to
-#: enumerate which (dataset_id, detector_id) pairs currently have background
-#: work in flight. The string keys are the public job-type names exposed in
-#: the response (consumed by the frontend pulldown for spinner tooltips), so
-#: keep them stable across releases.
+#: Logical name → :class:`JobManager` lookup: **every** singleton manager in
+#: the process, whether or not it is user-visible.  The string keys of the
+#: ``user_visible`` entries are the public job-type names exposed by
+#: ``/api/jobs/active`` (consumed by the frontend pulldown for spinner
+#: tooltips), so keep those stable across releases.
+#:
+#: This is deliberately one registry rather than "the visible ones here, the
+#: hidden ones re-listed by hand over there": the second list is what silently
+#: went stale, leaving ``archive_thumbnail_jobs`` unreset between tests.
+#: :func:`list_active_pairs` filters on :attr:`JobManager.user_visible`;
+#: :func:`reset_all_async_jobs_for_tests` walks the lot.  A new manager is
+#: registered in exactly one place, and declares its visibility at its own
+#: definition.
 JOB_MANAGERS: dict[str, JobManager] = {
     "learned-sort": learned_sort_jobs,
     "eval": eval_jobs,
     "projection": projection_jobs,
+    "labeling-status": labeling_status_jobs,
+    "signpost-relabel": signpost_relabel_jobs,
+    "archive-thumbnail-warm": archive_thumbnail_jobs,
 }
 
 
@@ -633,12 +651,16 @@ def list_active_pairs() -> list[dict[str, Any]]:
     with at least one running or pending job across every registered
     :class:`JobManager`.
 
-    Jobs with no ``(dataset_id, detector_id)`` recorded (legacy callers that
-    skipped the kwargs, e.g. test fixtures) are dropped - there is no row
-    in the pulldown to attach a spinner to without both ids.
+    Managers with ``user_visible=False`` are skipped: their work is an
+    internal refresh or warm-up, not user-initiated training, so it earns no
+    spinner.  Jobs with no ``(dataset_id, detector_id)`` recorded (legacy
+    callers that skipped the kwargs, e.g. test fixtures) are dropped - there
+    is no row in the pulldown to attach a spinner to without both ids.
     """
     pair_jobs: dict[tuple[str, str], list[str]] = {}
     for job_type, mgr in JOB_MANAGERS.items():
+        if not mgr.user_visible:
+            continue
         for job in mgr.active_jobs():
             ds, det = job.dataset_id, job.detector_id
             if not ds or not det:
@@ -651,11 +673,11 @@ def list_active_pairs() -> list[dict[str, Any]]:
 
 
 def reset_all_async_jobs_for_tests() -> None:
-    """Reset every singleton job manager.  Called from the autouse fixture."""
+    """Reset every singleton job manager.  Called from the autouse fixture.
+
+    Walks all of :data:`JOB_MANAGERS`, hidden managers included - test
+    isolation cares about every daemon thread in the process, not just the
+    ones that get a spinner.
+    """
     for mgr in JOB_MANAGERS.values():
         mgr.reset_for_tests()
-    # Not in ``JOB_MANAGERS`` (they are deliberately hidden from
-    # ``/api/jobs/active``), so reset them explicitly for test isolation.
-    labeling_status_jobs.reset_for_tests()
-    signpost_relabel_jobs.reset_for_tests()
-    archive_thumbnail_jobs.reset_for_tests()

--- a/vtscore/converters/__init__.py
+++ b/vtscore/converters/__init__.py
@@ -16,14 +16,14 @@ from vtscore.converters.document2text import Document2TextMediaConverter
 from vtscore.converters.image2text import Image2TextMediaConverter
 from vtscore.converters.video2audio import Video2AudioMediaConverter
 from vtscore.converters.video2image import Video2ImageMediaConverter
-from vtscore.plugins import PluginRegistry
+from vtscore.plugins import make_plugin_registry
 
 # ---------------------------------------------------------------------------
 # Converter registry (auto-discovered via CONVERTER sentinel)
 # ---------------------------------------------------------------------------
 
-_registry: PluginRegistry[MediaConverter] = PluginRegistry(
-    package="vtscore.converters",
+get_converter, list_converters = make_plugin_registry(
+    package=__name__,
     sentinel="CONVERTER",
     label="media converter",
     discover_modules=True,
@@ -31,24 +31,14 @@ _registry: PluginRegistry[MediaConverter] = PluginRegistry(
 )
 
 
-def list_converters() -> list[MediaConverter]:
-    """Return all registered converters."""
-    return _registry.list()
-
-
-def get_converter(name: str) -> MediaConverter | None:
-    """Return the converter with *name*, or ``None``."""
-    return _registry.get(name)
-
-
 def list_converters_for_target(target_type: str) -> list[MediaConverter]:
     """Return converters that produce *target_type* (a ``type_id``)."""
-    return [c for c in _registry.list() if c.target_type == target_type]
+    return [c for c in list_converters() if c.target_type == target_type]
 
 
 def list_converters_for_source(source_type: str) -> list[MediaConverter]:
     """Return converters that consume *source_type* (a ``type_id``)."""
-    return [c for c in _registry.list() if c.source_type == source_type]
+    return [c for c in list_converters() if c.source_type == source_type]
 
 
 __all__ = [

--- a/vtscore/datasets/registry.py
+++ b/vtscore/datasets/registry.py
@@ -39,7 +39,15 @@ def get_saved_datasets_dir() -> Path:
     return CoreConfig.from_settings().saved_datasets_dir
 
 
-# Backward-compat alias - prefer :func:`get_saved_datasets_dir` for live value.
+#: The built-in *default* saved-datasets location: the same path
+#: ``ServerSettings.saved_datasets_dir`` falls back to when nothing is
+#: configured.  Being a module-level constant it is fixed at import and cannot
+#: follow a directory the user has since pointed elsewhere in settings, so it
+#: is the right value only for tests and tooling that bypass settings
+#: entirely.  Everything that wants the directory actually in use must call
+#: :func:`get_saved_datasets_dir`.  (Mirrors ``vtscore.detectors.store``'s
+#: ``DETECTORS_DIR``, which stands in the same relation to
+#: ``get_detectors_dir``.)
 SAVED_DATASETS_DIR = DATA_DIR / "saved_datasets"
 
 _T = TypeVar("_T")

--- a/vtscore/datasets/sources/__init__.py
+++ b/vtscore/datasets/sources/__init__.py
@@ -20,22 +20,17 @@ from __future__ import annotations
 from typing import Any
 
 from vtscore.datasets.sources.base import MediaItem, MediaSource
-from vtscore.plugins import PluginRegistry
+from vtscore.plugins import make_plugin_registry
 
 __all__ = ["MediaItem", "MediaSource", "get_source_for_origin", "list_media_sources"]
 
-_registry: PluginRegistry = PluginRegistry(
-    package="vtscore.datasets.sources",
+_get_source_factory, list_media_sources = make_plugin_registry(
+    package=__name__,
     sentinel="SOURCE",
     label="media source",
     discover_modules=True,
     entry_point_group="vtscore.media_sources",
 )
-
-
-def list_media_sources() -> list:
-    """Return all registered media source factories."""
-    return _registry.list()
 
 
 def get_source_for_origin(origin: dict[str, Any] | None) -> MediaSource | None:
@@ -48,7 +43,7 @@ def get_source_for_origin(origin: dict[str, Any] | None) -> MediaSource | None:
         return None
 
     importer = origin.get("importer", "")
-    factory = _registry.get(importer)
+    factory = _get_source_factory(importer)
     if factory is not None:
         return factory.create_from_origin(origin)
     return None

--- a/vtscore/docs/packages/concurrency.md
+++ b/vtscore/docs/packages/concurrency.md
@@ -154,24 +154,40 @@ consumers leave `user=None`.
 # vtscore/concurrency/async_jobs.py
 learned_sort_jobs = JobManager("learned-sort")
 eval_jobs = JobManager("eval-train-score")
+labeling_status_jobs = JobManager("labeling-status", user_visible=False)
 
 JOB_MANAGERS: dict[str, JobManager] = {
     "learned-sort": learned_sort_jobs,
     "eval": eval_jobs,
+    "labeling-status": labeling_status_jobs,
 }
 ```
 
-`JOB_MANAGERS` is what `/api/jobs/active` reads. The string keys are
-public job-type names exposed in the response, so they're stable across
-releases. Library consumers can add their own manager and register it
-here for the active-jobs surface to pick up.
+`JOB_MANAGERS` holds **every** module-level manager, and is the single
+place a manager is registered. Whether one is surfaced to the user is a
+property of the manager itself, not of which list it appears in:
+`JobManager(..., user_visible=False)` marks the internal refreshes and
+warm-ups (labeling-status, signpost-relabel, archive-thumbnail-warm)
+that run no user-initiated training and so earn no spinner.
+
+`/api/jobs/active` reads the registry through `list_active_pairs()`,
+which skips the non-visible managers. The string keys of the visible
+entries are public job-type names exposed in the response, so they're
+stable across releases. Library consumers can add their own manager and
+register it here for the active-jobs surface to pick up.
 
 `list_active_pairs()` returns
 `[{dataset_id, detector_id, job_types}, ...]` for every (dataset,
 detector) pair with at least one running or pending job across every
-registered manager. Jobs missing `dataset_id` / `detector_id` are
-dropped. `reset_all_async_jobs_for_tests()` walks `JOB_MANAGERS` and
-clears state.
+user-visible manager. Jobs missing `dataset_id` / `detector_id` are
+dropped. `reset_all_async_jobs_for_tests()` walks the whole of
+`JOB_MANAGERS` — hidden managers included, since test isolation cares
+about every daemon thread — and clears state.
+
+Splitting these two concerns across two lists is what the single
+registry replaced: the visible managers lived in `JOB_MANAGERS` while
+the hidden ones were re-listed by hand inside the reset helper, and that
+second list went stale (issue #3404).
 
 ---
 

--- a/vtscore/docs/packages/converters.md
+++ b/vtscore/docs/packages/converters.md
@@ -187,12 +187,16 @@ are skipped.
 
 ### Public accessors
 
-| Function (`vtscore/converters/__init__.py`)                | Purpose                                       |
-|------------------------------------------------------------|-----------------------------------------------|
-| `list_converters()` (`:34`)                                | Every registered converter.                   |
-| `get_converter(name)` (`:39`)                              | Look up by `name`; returns `None` on miss.    |
-| `list_converters_for_target(target_type)` (`:44`)          | All converters producing `target_type`.       |
-| `list_converters_for_source(source_type)` (`:49`)          | All converters consuming `source_type`.       |
+| Function (`vtscore/converters/__init__.py`)     | Purpose                                    |
+|--------------------------------------------------|--------------------------------------------|
+| `list_converters()`                              | Every registered converter.                |
+| `get_converter(name)`                            | Look up by `name`; returns `None` on miss. |
+| `list_converters_for_target(target_type)`        | All converters producing `target_type`.    |
+| `list_converters_for_source(source_type)`        | All converters consuming `source_type`.    |
+
+`get_converter` / `list_converters` are the registry's own accessors,
+returned by `make_plugin_registry` — the same construction every other
+plugin family uses.
 
 `list_converters_for_target("image")` is the typical query for "give
 me every way to produce an image, regardless of source". This is


### PR DESCRIPTION
Closes #3404.

Evaluated the issue's three parts before implementing. Two hold up; the third is factually wrong, and I did not do what it asked.

## (a) `JOB_MANAGERS` coverage — premise sound, concrete bug already fixed

The issue says `reset_all_async_jobs_for_tests` "misses `archive_thumbnail_jobs`". That is **no longer true** — the current code resets it explicitly. But the *structural* hazard the audit identified is real, and it is what caused the miss in the first place: two hand-maintained lists, one for the user-visible managers and one re-listed by hand inside the reset helper.

`JOB_MANAGERS` is now the single registry of every module-level manager. Visibility moved onto the manager itself as a keyword-only `JobManager(..., user_visible=False)`, declared at each manager's own definition:

- `list_active_pairs()` filters on `user_visible`, so `/api/jobs/active` is unchanged.
- `reset_all_async_jobs_for_tests()` walks the whole registry — hidden managers included.
- Registering a new manager is one edit in one place.

A new `TestSingletonRegistry` closes the hole for good: it reflects over the module's globals and fails if any `JobManager` singleton is absent from the registry. Verified as a real gate — reverting the registry to visible-only makes 2 of its 3 cases fail.

## (b) Registry construction — premise sound

`vtscore.datasets.sources` and `vtscore.converters` built `PluginRegistry` directly while ten other families used `make_plugin_registry`. Both converted to the majority path; the four `list_converters_for_*` helpers now go through the returned accessor. Net −15 lines, no behaviour change.

## (c) `SAVED_DATASETS_DIR` — premise is wrong; nothing deleted, nothing deprecated

The issue claims the constant "misstates the live value". It does not:

```python
# vtscore/datasets/registry.py
SAVED_DATASETS_DIR = DATA_DIR / "saved_datasets"
# vtsearch/settings_models.py
saved_datasets_dir: str = Field(default_factory=lambda: str(DATA_DIR / "saved_datasets"))
```

Same value. It is an accurate statement of the shipped default, and the existing comment already pointed at `get_saved_datasets_dir()` for the live one. So the "make it correct" branch has nothing to correct, and I also declined the "explicitly deprecate it" branch: deprecation creates an obligation to remove a public `vtscore` name that costs nothing and is not wrong, which the backwards-compatibility rules argue against.

What *was* genuinely weak is that the name doesn't say it's the default rather than the configured directory. The comment now does, matching how `DETECTORS_DIR` already documents the identical relationship. The `.vulture-whitelist.py` entry already said "default dir" and was correct as-is.

## Incidental fixes

- **`frontend/package.json` had a duplicate `fast-uri` override key.** Pre-existing on `dev` (added independently by `0342b296` and `dfad4201`, identical values). esbuild flags the duplicate literal and `run-tests.sh` treats every `build:prod` `▲ [WARNING]` as a hard failure, so **the full suite was blocked on `dev` for everyone**. Removed the second key; resolution is unaffected.
- **Dropped the `reset_all_async_jobs_for_tests` vulture-whitelist entry.** It existed only because the function's sole caller lived in `tests_shared/`, outside vulture's scan paths. The new test calls it from `tests_lib/`, which *is* scanned, so the entry suppressed nothing and the whitelist-hygiene gate failed on it.
- Removed two rotted line anchors from `converters.md`. Note that `check-vtscore-docs.py`'s `LINE_ANCHOR` regex requires a filename (`\.py:\d+`), so bare `` (`:34`) `` anchors slip past it — `media.md` still carries nine of them. Left alone as out of scope.

## Docs

`vtscore/docs/packages/concurrency.md` rewritten for the single registry; `vtscore/CHANGELOG.md` gains an `[Unreleased]` **Changed** entry, since `JOB_MANAGERS` now enumerates the internal managers and an out-of-tree consumer iterating it should read `list_active_pairs()` or filter on `user_visible`. The `JobManager` signature change is purely additive.

## Testing

Full `./run-tests.sh`: **RUN PASSED**, all gates green — 9920 passed, 6 skipped, 2 xpassed; pyright, pip-audit, vulture whitelist, npm audit and Vitest all OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2Nux6XGvzupFbzeN68n9J

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2Nux6XGvzupFbzeN68n9J)_