### PR TITLE
Declare image_response on the MediaType ABC and document both undeclared hooks

### DIFF
--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -241,6 +241,7 @@ changes to `vtscore/media/__init__.py` are needed.
 | Method                        | Signature                          | Description                        |
 |-------------------------------|------------------------------------|------------------------------------|
 | `display_metadata(media)`     | `(dict) -> dict[str, Any]`         | Metadata for the labeling UI       |
+| `image_response(media)`       | `(dict) -> MediaResponse \| None`  | A *paintable image* for the media (waveform, frame, first page, crop) for every surface that shows a picture rather than plays the media. Defaults to `None` — "this type has no visual form" |
 | `ensure_thumbnail_bytes(media)` | `(dict) -> bytes \| None`        | Generate + memoise `media["thumbnail_bytes"]` from the media's *resolvable* bytes, for media that had no file at ingest. Defaults to a plain read of what's cached (no generation) |
 | `load_models()`               | `() -> None`                       | Load inline embedding models (legacy) |
 | `embed_text(text)`            | `(str) -> Optional[np.ndarray]`    | Inline text embedding (legacy)     |
@@ -255,6 +256,20 @@ changes to `vtscore/media/__init__.py` are needed.
 > per-media signpost text a Browse-prepped dataset already carries (see
 > `vtscore/projection/signpost_texts.py`). A type that returns its own dict
 > without merging silently drops all of them.
+
+> **Override `image_response` if your type has a picture but is not one.**
+> `media_response` serves your media's *own* bytes, and for most types those
+> are not an image: audio is a WAV, video an MP4, a document an
+> `application/pdf`. Every surface that shows a **picture** of a media — the
+> grid tile, the VTSBrowse bin popup, the labeling thumbnail,
+> `GET /api/medias/<id>/image` and `/api/medias/<id>/thumbnail` — calls
+> `image_response` instead, and paints a placeholder when it returns `None`.
+> Audio returns its waveform PNG, video its mid-frame, `document` its first
+> page rasterised, `face` the crop; `text` has no visual form and keeps the
+> `None` default, and so does `image`, whose source bytes the routes stream
+> directly without consulting the hook. Generate through
+> `ensure_thumbnail_bytes` (below) rather than inline, so the bytes you serve
+> match the ones the warm-up pass produces.
 
 > **Override `ensure_thumbnail_bytes` if your type has a browsable thumbnail.**
 > The path-based hooks above only fire for media the loader can read at ingest.

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -149,7 +149,11 @@ GET /api/medias/{media_id}/image
 
 → Image binary stream (`image/jpeg`, `image/png`, `image/gif`, `image/webp`, or
 `image/bmp` based on filename extension).
-400 if not an image. 404 if not found.
+For a non-image media type the route delegates to that type's
+`image_response` hook, so audio serves its waveform PNG, video its
+mid-frame, and a PDF document its first page.
+400 if the media is not an image and its `image_response` hook yielded
+nothing. 404 if not found.
 
 ### Get text content
 
@@ -260,7 +264,8 @@ Streams a downscaled thumbnail bounded to a fixed longest-side length, the
 same regardless of zoom level (an `ETag` lets the browser reuse it across
 scrolls/zoom). Grid and list tiles use this instead of `/image` so a gallery
 of high-resolution items doesn't decode every full-size bitmap at once.
-400 if the media is not an image and has no `image_response` delegate. 404 if
+400 if the media is not an image and its `image_response` hook yielded
+nothing. 404 if
 not found or bytes unavailable.
 
 ---

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12714,7 +12714,7 @@
     },
     "/api/medias/{media_id}/image": {
       "get": {
-        "description": "Determines the MIME type from the media's filename extension, defaulting\nto ``image/jpeg`` for unrecognised extensions. For non-image media types\nthat declare an ``image_response`` hook (audio waveforms, video frames),\nthe route delegates to that hook.",
+        "description": "Determines the MIME type from the media's filename extension, defaulting\nto ``image/jpeg`` for unrecognised extensions. For non-image media types\nthe route delegates to the type's ``image_response`` hook (audio\nwaveforms, video frames), which returns ``None`` for a type with no\npaintable form.",
         "operationId": "media_image",
         "parameters": [
           {
@@ -12734,7 +12734,7 @@
         ],
         "responses": {
           "400": {
-            "description": "Media is not an image and has no image_response delegate."
+            "description": "Media is not an image and its image_response hook yielded nothing."
           },
           "404": {
             "description": "Media not found, or media bytes unavailable."
@@ -12958,7 +12958,7 @@
         ],
         "responses": {
           "400": {
-            "description": "Media is not an image and has no image_response delegate."
+            "description": "Media is not an image and its image_response hook yielded nothing."
           },
           "404": {
             "description": "Media not found, or media bytes unavailable."

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/tests/core/test_media_list_edge_paths.py
+++ b/tests/core/test_media_list_edge_paths.py
@@ -381,9 +381,19 @@ class TestImageRoute:
         assert resp.content_type == "image/jpeg"
 
     def test_unregistered_non_image_type_returns_400(self, client):
-        # A non-image type with no registered MediaType (so no image_response
-        # delegate) has no image to serve.
+        # A non-image type with no registered MediaType at all: there is no
+        # instance to ask for an image_response, so nothing to serve.
         mid = _inject(media_type="mystery_type", media_bytes=b"whatever")
+        resp = client.get(f"/api/medias/{mid}/image")
+        assert resp.status_code == 400
+
+    def test_registered_type_inheriting_the_default_returns_400(self, client):
+        # Text is registered and reaches the delegate, but has no visual form,
+        # so it keeps ``MediaType.image_response``'s ``None`` default. The 400
+        # must come from the hook answering "no picture", not from the route
+        # failing to find a hook -- the distinction the getattr duck-typing
+        # this replaced could not make.
+        mid = _inject(media_type="text", filename="note.txt", media_string="hello")
         resp = client.get(f"/api/medias/{mid}/image")
         assert resp.status_code == 400
 

--- a/tests_lib/core/test_media_type_hooks.py
+++ b/tests_lib/core/test_media_type_hooks.py
@@ -1,0 +1,137 @@
+"""Contract tests for the two ``MediaType`` hooks the app calls but the ABC
+used to leave undeclared.
+
+``image_response`` was, until #3401, implemented by four shipped types and
+reached only through ``getattr(mt, "image_response", None)`` in two route
+helpers.  Duck-typing an ABC's own hook makes it invisible three ways: a
+third-party author reading ``MediaType`` cannot find it, the extension guides
+cannot document it (``scripts/check-extension-docs.py`` rejects a table naming
+a member the class does not define), and a typo in an override degrades to
+"this type has no picture" instead of failing.  These tests pin the declared
+shape: a ``None`` default that keeps a minimal type working, an override that
+the callers see, and the ``load_demo_source`` parameters that used to hide
+inside ``**kwargs``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from vtscore.media.base import MediaResponse, MediaType
+
+
+class _MinimalMediaType(MediaType):
+    """The smallest legal media type: every abstract member, nothing else.
+
+    Stands in for a third-party type written against the ABC alone, which is
+    exactly the plugin the ``return None`` default has to keep working.
+    """
+
+    @property
+    def type_id(self) -> str:
+        return "minimal"
+
+    @property
+    def name(self) -> str:
+        return "Minimal"
+
+    @property
+    def icon(self) -> str:
+        return "file"
+
+    @property
+    def file_extensions(self) -> list[str]:
+        return ["*.min"]
+
+    @property
+    def loops(self) -> bool:
+        return False
+
+    @property
+    def demo_datasets(self) -> list:
+        return []
+
+    def load_media_data(self, file_path, media_bytes=None) -> dict:
+        return {"duration": 0}
+
+    def media_response(self, media: dict) -> MediaResponse:
+        return MediaResponse(data=b"", mimetype="application/octet-stream", download_name="m")
+
+
+class TestImageResponseDefault:
+    def test_declared_on_the_abc(self):
+        """The hook is a real member, not something four subclasses invented.
+
+        The extension guides tabulate ``image_response`` under the
+        ``MediaType`` contract, and ``check-extension-docs.py`` resolves every
+        tabulated name against the class — so an undeclared hook would fail
+        that gate rather than ship undocumented again.
+        """
+        assert "image_response" in vars(MediaType)
+
+    def test_default_returns_none(self):
+        assert _MinimalMediaType().image_response({"id": 1}) is None
+
+    def test_default_is_not_abstract(self):
+        """A type with no visual form must instantiate without overriding it."""
+        assert _MinimalMediaType() is not None
+        assert "image_response" not in MediaType.__abstractmethods__
+
+    def test_text_type_keeps_the_default(self):
+        """Text has no picture; it inherits ``None`` rather than overriding."""
+        from vtscore.media.text.media_type import TextMediaType
+
+        assert TextMediaType().image_response({"id": 1, "media_string": "hello"}) is None
+
+    def test_override_is_seen_through_the_base_class(self):
+        class _Painted(_MinimalMediaType):
+            def image_response(self, media: dict) -> MediaResponse | None:
+                return MediaResponse(data=b"PNG", mimetype="image/png", download_name="x.png")
+
+        resp = _Painted().image_response({"id": 2})
+        assert resp is not None
+        assert resp.mimetype == "image/png"
+
+
+class TestEnsureThumbnailBytesDefault:
+    def test_default_is_a_pure_read(self):
+        """No generation, no mutation: a type with no cheap thumbnail says so."""
+        mt = _MinimalMediaType()
+        assert mt.ensure_thumbnail_bytes({"id": 1}) is None
+        assert mt.ensure_thumbnail_bytes({"id": 1, "thumbnail_bytes": b"PNG"}) == b"PNG"
+
+    def test_default_does_not_invent_a_key(self):
+        media = {"id": 1}
+        _MinimalMediaType().ensure_thumbnail_bytes(media)
+        assert "thumbnail_bytes" not in media
+
+
+class TestLoadDemoSourceSignature:
+    """``vtscore.datasets.loader_demo`` passes four keyword arguments that the
+    ABC used to swallow into ``**kwargs``, so the declared signature told a
+    plugin author nothing about what their override would receive."""
+
+    def test_declares_every_argument_the_loader_passes(self):
+        params = inspect.signature(MediaType.load_demo_source).parameters
+        for expected in ("embedder", "slice_frac_start", "slice_frac_end", "skip_embedding"):
+            assert expected in params, f"{expected} is passed by the demo loader but undeclared"
+
+    def test_keeps_a_kwargs_tail(self):
+        """Additive by construction: an override predating the change, or one
+        accepting only what it uses, still satisfies the contract."""
+        params = inspect.signature(MediaType.load_demo_source).parameters
+        assert any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+    def test_new_arguments_are_optional(self):
+        params = inspect.signature(MediaType.load_demo_source).parameters
+        for expected in ("embedder", "slice_frac_start", "slice_frac_end", "skip_embedding"):
+            assert params[expected].default is not inspect.Parameter.empty
+
+    def test_base_still_rejects_an_unknown_source(self):
+        mt = _MinimalMediaType()
+        try:
+            mt.load_demo_source("nope", [], 0, None, {})
+        except ValueError as exc:
+            assert "minimal" in str(exc)
+        else:  # pragma: no cover - the base must not silently succeed
+            raise AssertionError("expected ValueError for an unrecognised source")

--- a/tests_lib/core/test_video.py
+++ b/tests_lib/core/test_video.py
@@ -18,6 +18,7 @@ depending on a particular codec being present in the container.
 from __future__ import annotations
 
 import io
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pytest
@@ -33,6 +34,9 @@ from vtscore.media.video.media_type import (
     generate_video_thumbnail_from_file,
     generate_video_thumbnail_from_file_at,
 )
+
+if TYPE_CHECKING:
+    from vtscore.media.embedder import MediaEmbedder
 
 _PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
 
@@ -484,5 +488,7 @@ class TestVideoLoadDemoSourceErrors:
                 slice_end=None,
                 clips={},
                 on_progress=lambda *a, **k: None,
-                embedder=object(),  # non-None so no embedder registry lookup happens
+                # Non-None so no embedder registry lookup happens; the source
+                # check rejects it before anything touches the embedder.
+                embedder=cast("MediaEmbedder", object()),
             )

--- a/vtscore/docs/extending/media-types.md
+++ b/vtscore/docs/extending/media-types.md
@@ -89,6 +89,58 @@ Optional overrides:
 | `dir_key` | `type_id + "_dir"` | Key in pickle files for external directories |
 | `pickle_extra_fields` | `[]` | Custom clip-dict keys to preserve through pickle round-trip |
 | `display_metadata(media)` | base fields | Extra fields surfaced in the labeling UI |
+| `image_response(media)` | `None` | A *paintable image* for the media, as a `MediaResponse` - the waveform, frame, or page a grid tile shows. `None` = this type has no visual form |
+| `ensure_thumbnail_bytes(media)` | cached value | Build + memoise `media["thumbnail_bytes"]` from the media's *resolvable* bytes, for media that arrived with no readable file |
+| `load_demo_source(...)` | raises `ValueError` | Download and embed one of this type's `demo_datasets` entries |
+
+### `image_response` vs. `media_response`
+
+`media_response` serves the media's **own** bytes, which for most types are
+not an image: audio is a WAV, video an MP4, a document an
+`application/pdf`. Everything that shows a *picture* of a media - the grid
+tile, the VTSBrowse bin popup, the labeling thumbnail,
+`GET /api/medias/<id>/image` and `/api/medias/<id>/thumbnail` - calls
+`image_response` instead, and falls back to a placeholder when it returns
+`None`.
+
+The shipped answers: audio returns its waveform PNG, video its mid-frame,
+`document` its first page rasterised, `face` the crop itself. `text` has no
+visual form and keeps the `None` default; the `image` type also keeps it,
+because the routes stream an image media's source bytes directly without
+consulting the hook.
+
+```python
+def image_response(self, media: dict) -> MediaResponse | None:
+    thumb = self.ensure_thumbnail_bytes(media)
+    if not thumb:
+        return None
+    return MediaResponse(
+        data=thumb,
+        mimetype="image/png",
+        download_name=f"media_{media['id']}_thumb.png",
+    )
+```
+
+### `ensure_thumbnail_bytes`
+
+`load_media_data` covers media the loader can read from a file at ingest.
+Some media have no file: an **archive-member** media
+([`vtscore/datasets/importers/local_archive_member/`](../../datasets/importers/local_archive_member/))
+carries only `{archive path, member}` and re-derives its bytes by streaming
+one tar/zip member, so it leaves import with no thumbnail at all. Override
+`ensure_thumbnail_bytes` to generate one on demand; the background warm-up
+pass in [`vtscore/datasets/thumbnail_warm.py`](../../datasets/thumbnail_warm.py)
+calls it per media after a load, and the serving path calls it too - so
+route the `image_response` above through it and a warmed thumbnail is
+byte-identical to a lazily generated one.
+
+Two rules bind implementations: memoise onto `media["thumbnail_bytes"]`, and
+**never** retain the resolved payload on the media - keeping member bytes out
+of memory is the whole point of the archive-member importer. Like every
+`thumbnail_bytes` these are in-memory only; they ride along on an explicit
+save and are otherwise regenerated. The default is a plain read of what is
+already cached, which is the right answer for a type with no cheap way to
+build one.
 
 `MediaResponse` is a small dataclass (`data`, `mimetype`,
 `download_name`) that decouples the library from Flask

--- a/vtscore/media/base.py
+++ b/vtscore/media/base.py
@@ -24,7 +24,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 
@@ -37,6 +37,10 @@ from vtscore.concurrency.progress import (  # noqa: E402
     ProgressCallback,
     noop_progress as _noop_progress,
 )
+
+if TYPE_CHECKING:  # ``vtscore.media.embedder`` imports this module, so the
+    # annotation on ``load_demo_source`` can only be a type-time reference.
+    from vtscore.media.embedder import MediaEmbedder
 
 __all__ = [
     "DemoDataset",
@@ -504,6 +508,10 @@ class MediaType(ABC):
         slice_end: int | None,
         clips: dict[int, dict],
         on_progress: "ProgressCallback | None" = None,
+        embedder: "MediaEmbedder | None" = None,
+        slice_frac_start: float | None = None,
+        slice_frac_end: float | None = None,
+        skip_embedding: bool = False,
         **kwargs,
     ) -> str | None:
         """Download and embed a demo dataset source, populating *clips* in-place.
@@ -511,6 +519,14 @@ class MediaType(ABC):
         Each media type overrides this to handle its own demo sources (e.g.
         the audio type handles ESC-50, the image type handles CIFAR-10 /
         Caltech-101/256, etc.).
+
+        Every parameter below the callback used to hide inside ``**kwargs``,
+        even though :mod:`vtscore.datasets.loader_demo` passes all four on
+        every call and all five shipped types spell them out — so an author
+        reading this signature could not see what their override would be
+        handed.  They are declared now; the trailing ``**kwargs`` stays so an
+        override that predates the change (or one that accepts only the
+        parameters it uses) keeps working.
 
         Args:
             source: The ``source`` identifier from the :class:`DemoDataset`.
@@ -521,12 +537,21 @@ class MediaType(ABC):
             clips: Dict to populate in-place.  The caller has already cleared
                 it.  Keys should be sequential integer clip IDs starting at 1.
             on_progress: Optional progress callback.
-            skip_embedding: When ``True`` (passed via ``**kwargs``), populate
-                each media with a deferred-embed placeholder (``embeddings={}``)
-                instead of embedding it here.  The demo loader sets this when a
-                clipper will split + re-embed every clip, so embedding the full
-                parent would be wasted (and, for audio, can fail on parents
-                longer than the embedder window before the clipper trims them).
+            embedder: The resolved :class:`~vtscore.media.embedder.MediaEmbedder`
+                to embed each loaded media with.  ``None`` means "use this
+                type's default embedder"; a non-embeddable type (``document``)
+                ignores it, since the converter's target type embeds instead.
+            slice_frac_start: Optional fractional start of the per-category
+                slice (``0.0``-``1.0``), for sources whose per-category counts
+                are only known after the download.  Takes precedence over
+                *slice_start* where a type supports it.
+            slice_frac_end: Fractional end of that slice, same convention.
+            skip_embedding: When ``True``, populate each media with a
+                deferred-embed placeholder (``embeddings={}``) instead of
+                embedding it here.  The demo loader sets this when a clipper
+                will split + re-embed every clip, so embedding the full parent
+                would be wasted (and, for audio, can fail on parents longer
+                than the embedder window before the clipper trims them).
 
         Returns:
             An optional external media directory path (absolute string) to
@@ -721,3 +746,31 @@ class MediaType(ABC):
         :meth:`_resolve_media_string` to transparently support both preloaded
         medias and thin (lazy-loaded) medias.
         """
+
+    def image_response(self, media: dict) -> MediaResponse | None:
+        """Return a *paintable image* for *media*, or ``None`` if it has none.
+
+        :meth:`media_response` serves a media's own bytes, which for most
+        types are not an image: an audio clip is a WAV, a video is an MP4, a
+        PDF is ``application/pdf``.  Every surface that shows a *picture* of a
+        media — the grid tile, the VTSBrowse bin popup, the labeling
+        thumbnail, ``GET /api/medias/<id>/image`` and
+        ``/api/medias/<id>/thumbnail`` — needs something it can decode as an
+        image instead, and this hook is where a type supplies it: the audio
+        waveform PNG, the video mid-frame, a PDF's first page rasterised, a
+        face crop.
+
+        The default returns ``None``, which is the right answer for a type
+        with no visual form (text) and for the ``image`` type itself, whose
+        source bytes the routes stream directly without consulting this hook.
+        A type that returns ``None`` gets the caller's placeholder rather than
+        an error.
+
+        Implementations that have a cacheable thumbnail should generate it
+        through :meth:`ensure_thumbnail_bytes` and wrap the result, so the
+        bytes served here are byte-identical to the ones the background
+        warm-up pass in :mod:`vtscore.datasets.thumbnail_warm` produces.  The
+        result is *not* persisted — like every ``thumbnail_bytes``, it lives
+        in memory only.
+        """
+        return None

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -521,10 +521,11 @@ def _in_memory_thumbnail_response(media: dict, media_type: str, crop=None):
         return image_thumbnail_response(bytes(resp.data), resp.mimetype, resp.download_name, crop=crop)
 
     resp = mt.image_response(media)
-    if resp is None:
+    # ``bytes | dict``, as in the image branch above: only bytes are paintable.
+    if resp is None or not isinstance(resp.data, (bytes, bytearray)):
         return None
     return send_file(
-        io.BytesIO(resp.data),
+        io.BytesIO(bytes(resp.data)),
         mimetype=resp.mimetype,
         download_name=resp.download_name,
     )

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -499,8 +499,9 @@ def _in_memory_thumbnail_response(media: dict, media_type: str, crop=None):
     when ``media_bytes`` is not held in memory (thin-loaded datasets, e.g. a
     local folder import). This mirrors the center viewer's
     ``/api/medias/<id>/image`` byte resolution so a thumbnail never 404s for an
-    item the center can display. Audio/video/document: defer to the media
-    type's ``image_response`` (cached waveform / midframe PNG). Returns
+    item the center can display. Every other type: defer to the media type's
+    ``image_response`` (cached waveform / midframe PNG / first PDF page),
+    which returns ``None`` for a type with no paintable form. Returns
     ``None`` if no thumbnail can be produced.
 
     ``crop`` (a normalised region box) restricts an image thumbnail to the
@@ -519,10 +520,7 @@ def _in_memory_thumbnail_response(media: dict, media_type: str, crop=None):
             return None
         return image_thumbnail_response(bytes(resp.data), resp.mimetype, resp.download_name, crop=crop)
 
-    image_response_fn = getattr(mt, "image_response", None)
-    if image_response_fn is None:
-        return None
-    resp = image_response_fn(media)
+    resp = mt.image_response(media)
     if resp is None:
         return None
     return send_file(

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -791,8 +791,12 @@ def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
         except KeyError:
             mt = None
         resp = mt.image_response(c) if mt else None
-        if resp is not None:
-            return resp.data, resp.mimetype, resp.download_name
+        # ``MediaResponse.data`` is ``bytes | dict`` (text types serve JSON),
+        # but an image is always bytes.  A hook handing back a dict is a
+        # broken plugin, not an image: treat it as "no picture" rather than
+        # letting it reach ``send_file``.
+        if resp is not None and isinstance(resp.data, (bytes, bytearray)):
+            return bytes(resp.data), resp.mimetype, resp.download_name
         abort(400, message="no image available")
 
     media_bytes = _resolve_bytes(c)

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -781,7 +781,8 @@ def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
 
     media_type = c.get("media_type")
 
-    # For non-image types, delegate to the media type's image_response if available
+    # For non-image types, delegate to the media type's ``image_response``
+    # hook; a type with no paintable form returns None and we 400.
     if media_type and media_type != "image":
         from vtscore.media import get as get_media_type  # noqa: PLC0415
 
@@ -789,11 +790,9 @@ def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
             mt = get_media_type(media_type)
         except KeyError:
             mt = None
-        image_response_fn = getattr(mt, "image_response", None) if mt else None
-        if image_response_fn is not None:
-            resp = image_response_fn(c)
-            if resp is not None:
-                return resp.data, resp.mimetype, resp.download_name
+        resp = mt.image_response(c) if mt else None
+        if resp is not None:
+            return resp.data, resp.mimetype, resp.download_name
         abort(400, message="no image available")
 
     media_bytes = _resolve_bytes(c)
@@ -811,15 +810,16 @@ def _resolve_display_image(media_id: int) -> tuple[bytes, str, str]:
 
 @medias_bp.route("/api/medias/<int:media_id>/image")
 @medias_bp.arguments(MediaVariantQuerySchema, location="query")
-@medias_bp.alt_response(400, description="Media is not an image and has no image_response delegate.")
+@medias_bp.alt_response(400, description="Media is not an image and its image_response hook yielded nothing.")
 @medias_bp.alt_response(404, description="Media not found, or media bytes unavailable.")
 def media_image(query: dict, media_id: int):
     """Stream the image bytes for a single image media item.
 
     Determines the MIME type from the media's filename extension, defaulting
     to ``image/jpeg`` for unrecognised extensions. For non-image media types
-    that declare an ``image_response`` hook (audio waveforms, video frames),
-    the route delegates to that hook.
+    the route delegates to the type's ``image_response`` hook (audio
+    waveforms, video frames), which returns ``None`` for a type with no
+    paintable form.
     """
     data, mimetype, download_name = _resolve_display_image(media_id)
     return send_file(io.BytesIO(data), mimetype=mimetype, download_name=download_name)
@@ -827,7 +827,7 @@ def media_image(query: dict, media_id: int):
 
 @medias_bp.route("/api/medias/<int:media_id>/thumbnail")
 @medias_bp.arguments(MediaVariantQuerySchema, location="query")
-@medias_bp.alt_response(400, description="Media is not an image and has no image_response delegate.")
+@medias_bp.alt_response(400, description="Media is not an image and its image_response hook yielded nothing.")
 @medias_bp.alt_response(404, description="Media not found, or media bytes unavailable.")
 def media_thumbnail(query: dict, media_id: int):
     """Stream a downscaled thumbnail of a media item's image.


### PR DESCRIPTION
Closes #3401

## The premise, checked

It holds, and the doc gate is what makes it self-reinforcing.

`image_response` is implemented by four shipped media types (`audio`, `video`, `document`, `face`) and reached only through `getattr(mt, "image_response", None)` in two route helpers (`vtsearch/routes/media/list.py`, `vtsearch/routes/detectors/labels.py`). Duck-typing an ABC's *own* hook hides it three ways:

- a third-party author reading `MediaType` cannot find it;
- the extension guides **cannot** document it — `scripts/check-extension-docs.py` resolves every member named in a contract table against the class, so a table row for an undeclared hook fails the gate. That is precisely why both guides omitted it;
- a typo in an override degrades silently to "this type has no picture" instead of failing.

`load_demo_source` had the same shape of gap in its signature. `vtscore/datasets/loader_demo.py` passes `embedder`, `slice_frac_start`, `slice_frac_end` and `skip_embedding` on **every** call, and all five shipped types spell them out — but the ABC declared a bare `**kwargs` tail and mentioned only one of the four in its docstring.

## What changed

**`vtscore/media/base.py`**
- `image_response(media) -> MediaResponse | None` declared with a `return None` default. Additive, as the issue requires: an existing third-party type that does not implement it keeps working, and `None` is the correct answer for `text` (no visual form) and for `image` itself (the routes stream its source bytes without consulting the hook).
- `load_demo_source` declares all four hidden parameters with their defaults, **keeping the trailing `**kwargs`** so no out-of-tree override breaks. The docstring now describes each one.

**Route layer** — both `getattr` sites become direct calls. Behaviour is unchanged: a type with no override returns `None` where the route previously found no attribute, and both paths already handled `None`.

**A latent hole the type checker then found.** Declaring the hook gave pyright a real return type where `getattr` had handed it `Any`, exposing that `MediaResponse.data` is `bytes | dict` (text types serve JSON) and both callers passed it straight to `send_file`. A hook returning a dict is a broken plugin, not an image, so it is now treated as "no picture" — 400 in the media route, `None` in the labeling thumbnail — mirroring the `isinstance` guard the image branch in `labels.py` already had.

**Docs** — `vtscore/docs/extending/media-types.md` gains both hooks (it documented neither), with a section on `image_response` vs. `media_response` and the `ensure_thumbnail_bytes` memoisation rules. `docs/EXTENDING-media.md` gains `image_response` beside the `ensure_thumbnail_bytes` note it already had. The `/image` and `/thumbnail` 400 descriptions stop claiming a type can *lack* the delegate (`docs/api/medias.md` + the OpenAPI snapshot).

**Tests** — `tests_lib/core/test_media_type_hooks.py` pins the declared shape against a minimal ABC-only subclass: the `None` default, that it is not abstract, that an override is seen through the base class, the pure-read `ensure_thumbnail_bytes` default, and that `load_demo_source` declares all four loader-passed arguments while keeping a `**kwargs` tail. `tests/core/test_media_list_edge_paths.py` adds the case the `getattr` version could not distinguish: a *registered* type inheriting the `None` default (`text`) must 400 from the hook answering "no picture", not from the route failing to find a hook.

## Unrelated failure fixed en route

`frontend/package.json` carried `"fast-uri": "^3.1.7"` twice in `overrides` — two PRs (`0342b296`, `dfad4201`) pinned it independently and the merge kept both lines. esbuild emitted a duplicate-object-key warning on every build, and `run-tests.sh` treats any `▲ [WARNING]` from `build:prod` as a hard failure, so `dev`'s frontend gate was red before this branch touched anything. Same value in both entries; one removed.

## Verification

Full `./run-tests.sh`: **RUN PASSED** — 9929 passed, 6 skipped, 2 xpassed; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012D8cssmEBV55PqDzWsh6vx

---
_Generated by [Claude Code](https://claude.ai/code/session_012D8cssmEBV55PqDzWsh6vx)_