### PR TITLE
Single-source the weighted FP/FN cost the Inclusion knob prices

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/scripts/check-eval-app-sync.py
+++ b/scripts/check-eval-app-sync.py
@@ -196,7 +196,11 @@ MIRRORS: list[Mirror] = [
             "scored: the caller (`step_trainers._labelset_error_costs`) re-scores the "
             "whole window against the *current* labelset every step, as `_eval_cached_models` "
             "does. Handing in a history of frozen per-step costs instead would silently change "
-            "the statistic the slope measures (issue #2923), which is not a declared divergence."
+            "the statistic the slope measures (issue #2923), which is not a declared divergence. "
+            "The weighted-cost arithmetic underneath both is no longer a copy at all: since "
+            "#3414 both score through `vtscore.training.thresholds.weighted_error_cost` and "
+            "price inclusion through `inclusion_cost_weights`, so that half cannot drift and "
+            "needs no pin - only the flatness rule above it does."
         ),
     ),
     Mirror(

--- a/tests_lib/detectors/test_eval_voting_iterations.py
+++ b/tests_lib/detectors/test_eval_voting_iterations.py
@@ -10,7 +10,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from vtscore.eval.step_model import StepModel, good_training_vec, inclusion_weights
+from vtscore.eval.calibration_metrics import inclusion_weights
+from vtscore.eval.step_model import StepModel, good_training_vec
 from vtscore.eval.step_trainers import _labelset_error_costs
 from vtscore.eval.voting_columns import TIMING_COLUMNS
 from vtscore.eval.voting_iterations import (

--- a/tests_lib/detectors/test_weighted_error_cost.py
+++ b/tests_lib/detectors/test_weighted_error_cost.py
@@ -1,0 +1,118 @@
+"""The one weighted-FPR/FNR definition, and the two tiers that score through it.
+
+Issue #3414: the shipped Smart indicator
+(:func:`vtscore.detectors.labeling_progress._score_step`) and the eval
+harness's window scorer
+(:func:`vtscore.eval.step_trainers._labelset_error_costs`) used to carry
+independent hand copies of the same FP/FN counting loop, with nothing in
+``scripts/check-eval-app-sync.py`` pinning them together.  Both now delegate to
+:func:`vtscore.training.thresholds.weighted_error_cost`, so the parity test
+below is a check on the *plumbing* rather than on two arithmetics staying in
+step - which is the point: a delegation cannot drift.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.training.thresholds import inclusion_cost_weights, weighted_error_cost
+
+
+class TestWeightedErrorCost:
+    def test_rates_and_weighting(self):
+        # 2 positives (1.0, 0.9), 2 negatives (0.6, 0.1); cut at 0.5 flags three
+        # of them, so one negative is a false positive and nothing is missed.
+        scores = np.array([1.0, 0.9, 0.6, 0.1])
+        labels = np.array([1.0, 1.0, 0.0, 0.0])
+        cost, fpr, fnr = weighted_error_cost(scores, labels, 0.5, 1.0, 1.0)
+        assert (fpr, fnr) == (0.5, 0.0)
+        assert cost == pytest.approx(0.5)
+
+        # Inclusion +2 quadruples the price of a miss and leaves a false alarm
+        # at 1.0, so the same errors cost the same here but a miss would not.
+        wf, wn = inclusion_cost_weights(2)
+        assert weighted_error_cost(scores, labels, 0.5, wf, wn)[0] == pytest.approx(0.5)
+        assert weighted_error_cost(scores, labels, 0.95, wf, wn) == (
+            pytest.approx(4 * 0.5),
+            0.0,
+            0.5,
+        )
+
+    def test_threshold_is_inclusive(self):
+        """``>=``, the codebase-wide convention: a score *at* the cut is Good."""
+        scores = np.array([0.5, 0.5])
+        labels = np.array([1.0, 0.0])
+        assert weighted_error_cost(scores, labels, 0.5, 1.0, 1.0) == (1.0, 1.0, 0.0)
+
+    def test_empty_denominators_are_zero_rates(self):
+        """No negatives -> FPR 0; no positives -> FNR 0.  Never a NaN or a raise."""
+        assert weighted_error_cost([0.9, 0.9], [1.0, 1.0], 0.5, 3.0, 3.0) == (0.0, 0.0, 0.0)
+        assert weighted_error_cost([0.1, 0.1], [0.0, 0.0], 0.5, 3.0, 3.0) == (0.0, 0.0, 0.0)
+        assert weighted_error_cost([], [], 0.5, 1.0, 1.0) == (0.0, 0.0, 0.0)
+
+    def test_non_positive_labels_count_as_negatives(self):
+        """Only ``1.0`` is a positive; both callers pass exactly ``1.0``/``0.0``."""
+        assert weighted_error_cost([0.9], [0.0], 0.5, 1.0, 1.0)[1] == 1.0
+
+    def test_operating_cost_is_this_function(self):
+        """The harness's public name delegates rather than re-deriving."""
+        from vtscore.eval.calibration_metrics import operating_cost
+
+        rng = np.random.default_rng(3414)
+        scores = rng.random(64)
+        labels = (rng.random(64) < 0.4).astype(np.float64)
+        for k in (-3, 0, 1, 5):
+            wf, wn = inclusion_cost_weights(k)
+            for thr in (0.0, 0.25, 0.5, 0.9, 1.5):
+                assert operating_cost(scores, labels, thr, wf, wn) == weighted_error_cost(
+                    scores, labels, thr, wf, wn
+                )
+
+
+class TestAppAndHarnessScoreAlike:
+    """One model, one labelset, one cost - through both tiers' plumbing."""
+
+    @staticmethod
+    def _clips(values):
+        return {cid: {"id": cid, "embeddings": {"emb": np.array([v], np.float32)}} for cid, v in values.items()}
+
+    @pytest.mark.parametrize("inclusion", [-2, 0, 3])
+    def test_score_step_matches_labelset_error_costs(self, inclusion):
+        torch = pytest.importorskip("torch")
+
+        from vtscore.detectors.labeling_progress import _build_eval_set, _score_step
+        from vtscore.eval.step_model import StepModel
+        from vtscore.eval.step_trainers import _labelset_error_costs
+
+        # A 1-D sigmoid ranker both tiers can run: the app side calls the torch
+        # module directly, the harness side goes through StepModel.predict.
+        torch.manual_seed(0)
+        net = torch.nn.Linear(1, 1)
+        with torch.no_grad():
+            net.weight.fill_(4.0)
+            net.bias.fill_(-2.0)
+
+        def predict(embs):
+            with torch.no_grad():
+                x = torch.tensor(np.asarray(embs), dtype=torch.float32)
+                return torch.sigmoid(net(x)).squeeze(1).numpy()
+
+        # Two of each class, one of them on the wrong side of the cut, so the
+        # cost is neither 0 nor saturated and both error kinds are exercised.
+        values = {1: 0.9, 2: 0.2, 3: 0.1, 4: 0.8}
+        good, bad = {1: None, 2: None}, {3: None, 4: None}
+        clips = self._clips(values)
+        threshold = 0.5
+
+        harness = _labelset_error_costs([(StepModel(predict, net, "test", "cpu"), threshold)], good, bad, clips, inclusion)
+
+        eval_set = _build_eval_set(clips, good, bad)
+        assert eval_set is not None
+        X_eval, eval_labels = eval_set
+        wf, wn = inclusion_cost_weights(inclusion)
+        step = {"model": net, "threshold": threshold, "good_ids": list(good), "bad_ids": list(bad)}
+        app = _score_step(step, X_eval, eval_labels, wf, wn, 0)
+
+        assert app["error_cost"] == pytest.approx(harness[0], abs=1e-4)
+        assert (app["fpr"], app["fnr"]) == (0.5, 0.5)

--- a/tests_lib/detectors/test_weighted_error_cost.py
+++ b/tests_lib/detectors/test_weighted_error_cost.py
@@ -7,7 +7,7 @@ harness's window scorer
 independent hand copies of the same FP/FN counting loop, with nothing in
 ``scripts/check-eval-app-sync.py`` pinning them together.  Both now delegate to
 :func:`vtscore.training.thresholds.weighted_error_cost`, so the parity test
-below is a check on the *plumbing* rather than on two arithmetics staying in
+below is a check on the *plumbing* rather than on two copies of the arithmetic staying in
 step - which is the point: a delegation cannot drift.
 """
 
@@ -65,9 +65,7 @@ class TestWeightedErrorCost:
         for k in (-3, 0, 1, 5):
             wf, wn = inclusion_cost_weights(k)
             for thr in (0.0, 0.25, 0.5, 0.9, 1.5):
-                assert operating_cost(scores, labels, thr, wf, wn) == weighted_error_cost(
-                    scores, labels, thr, wf, wn
-                )
+                assert operating_cost(scores, labels, thr, wf, wn) == weighted_error_cost(scores, labels, thr, wf, wn)
 
 
 class TestAppAndHarnessScoreAlike:
@@ -105,7 +103,9 @@ class TestAppAndHarnessScoreAlike:
         clips = self._clips(values)
         threshold = 0.5
 
-        harness = _labelset_error_costs([(StepModel(predict, net, "test", "cpu"), threshold)], good, bad, clips, inclusion)
+        harness = _labelset_error_costs(
+            [(StepModel(predict, net, "test", "cpu"), threshold)], good, bad, clips, inclusion
+        )
 
         eval_set = _build_eval_set(clips, good, bad)
         assert eval_set is not None

--- a/vtscore/detectors/labeling_progress.py
+++ b/vtscore/detectors/labeling_progress.py
@@ -48,7 +48,7 @@ import numpy as np
 from vtscore.concurrency.async_jobs import check_job_cancelled
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.training.mlp import LINEAR_SVM_HEAD, train_model
-from vtscore.training.thresholds import conformal_threshold
+from vtscore.training.thresholds import conformal_threshold, inclusion_cost_weights, weighted_error_cost
 
 if TYPE_CHECKING:
     import torch.nn as nn
@@ -742,8 +742,6 @@ def _score_step(
     step: dict[str, Any],
     X_eval: Any,
     eval_labels: list[float],
-    total_positives: int,
-    total_negatives: int,
     fpr_weight: float,
     fnr_weight: float,
     t: int,
@@ -752,6 +750,11 @@ def _score_step(
 
     Returns an error-cost dict for the step.  The caller guarantees
     ``step["model"]`` is not ``None``.
+
+    The weighted FPR/FNR arithmetic is
+    :func:`~vtscore.training.thresholds.weighted_error_cost`, shared with the
+    eval harness (``vtscore.eval.step_trainers._labelset_error_costs``) so the
+    Smart indicator a study measures is the one the app shows.
     """
     import torch  # noqa: PLC0415
 
@@ -759,17 +762,7 @@ def _score_step(
         X_in = X_eval.to(next(step["model"].parameters()).device)
         scores = torch.sigmoid(step["model"](X_in)).squeeze(1).cpu().tolist()
 
-    fp = fn = 0
-    for score, true_label in zip(scores, eval_labels, strict=True):
-        predicted = 1 if score >= step["threshold"] else 0
-        if predicted == 1 and true_label == 0:
-            fp += 1
-        elif predicted == 0 and true_label == 1:
-            fn += 1
-
-    fpr = fp / total_negatives if total_negatives > 0 else 0.0
-    fnr = fn / total_positives if total_positives > 0 else 0.0
-    error_cost = fpr_weight * fpr + fnr_weight * fnr
+    error_cost, fpr, fnr = weighted_error_cost(scores, eval_labels, step["threshold"], fpr_weight, fnr_weight)
 
     return {
         "time_index": t,
@@ -784,11 +777,13 @@ def _build_eval_set(
     clips_dict: dict[int, dict[str, Any]],
     current_good_votes: dict[int, None],
     current_bad_votes: dict[int, None],
-) -> Optional[tuple[Any, list[float], int, int]]:
+) -> Optional[tuple[Any, list[float]]]:
     """Build the evaluation tensor and label set from the current votes.
 
-    Returns ``(X_eval, eval_labels, total_positives, total_negatives)`` or
-    ``None`` when there are no usable labeled medias to evaluate against.
+    Returns ``(X_eval, eval_labels)`` or ``None`` when there are no usable
+    labeled medias to evaluate against.  Built once and reused by every model
+    in the window, so all points of the Smart indicator's slope regression
+    share one eval set.
     """
     # Build evaluation set from current votes
     current_labels: dict[int, float] = {}
@@ -812,10 +807,7 @@ def _build_eval_set(
 
     import torch  # noqa: PLC0415
 
-    X_eval = torch.tensor(np.array(eval_embs), dtype=torch.float32)
-    total_positives = sum(1 for lbl in eval_labels if lbl == 1)
-    total_negatives = len(eval_labels) - total_positives
-    return X_eval, eval_labels, total_positives, total_negatives
+    return torch.tensor(np.array(eval_embs), dtype=torch.float32), eval_labels
 
 
 def _eval_cached_models(
@@ -830,19 +822,17 @@ def _eval_cached_models(
     """Score *cache*'s models against the current labelset (forward passes only).
 
     Returns a list of error-cost dicts for every cached step in
-    ``[start, end)`` that has a trained model.
+    ``[start, end)`` that has a trained model.  The Inclusion weights come from
+    the shipped :func:`~vtscore.training.thresholds.inclusion_cost_weights`, so
+    the indicator prices a miss exactly as the threshold rule that produced the
+    cut does.
     """
-    if inclusion_value >= 0:
-        fpr_weight = 1.0
-        fnr_weight = 2.0**inclusion_value
-    else:
-        fpr_weight = 2.0 ** (-inclusion_value)
-        fnr_weight = 1.0
+    fpr_weight, fnr_weight = inclusion_cost_weights(inclusion_value)
 
     eval_set = _build_eval_set(clips_dict, current_good_votes, current_bad_votes)
     if eval_set is None:
         return []
-    X_eval, eval_labels, total_positives, total_negatives = eval_set
+    X_eval, eval_labels = eval_set
 
     if end is None:
         end = len(cache.steps)
@@ -853,9 +843,7 @@ def _eval_cached_models(
         if step["model"] is None:
             continue
 
-        results.append(
-            _score_step(step, X_eval, eval_labels, total_positives, total_negatives, fpr_weight, fnr_weight, t)
-        )
+        results.append(_score_step(step, X_eval, eval_labels, fpr_weight, fnr_weight, t))
 
     return results
 

--- a/vtscore/eval/calibration_metrics.py
+++ b/vtscore/eval/calibration_metrics.py
@@ -4,7 +4,8 @@ This module has **no torch / vtscore-heavy imports** so it can be unit-tested on
 a CPU-only box without the model stack.  It provides:
 
 * :func:`operating_cost` — inclusion-weighted ``FPR + FNR`` cost at a fixed cut
-  (the number the trained threshold actually pays on a held-out set).
+  (the number the trained threshold actually pays on a held-out set), delegated
+  to :func:`vtscore.training.thresholds.weighted_error_cost`.
 * :func:`oracle_cut` — the cut that *minimises* that same weighted cost over a
   score/label set (the best a threshold rule could possibly do on this ranking),
   via an O(n log n) sweep over the observed scores.  The gap between the trained
@@ -23,7 +24,10 @@ a CPU-only box without the model stack.  It provides:
   remedial arms (re-pool the same model's node scores; see the plan).
 
 Every threshold uses the ``predicted positive iff score >= threshold``
-convention, matching :func:`vtscore.eval.voting_iterations._evaluate_on_test`.
+convention - the codebase-wide one, since
+:func:`vtscore.eval.voting_iterations._evaluate_on_test` and the app's Smart
+indicator now score through the same
+:func:`vtscore.training.thresholds.weighted_error_cost`.
 """
 
 from __future__ import annotations
@@ -54,22 +58,16 @@ def operating_cost(
 ) -> tuple[float, float, float]:
     """Return ``(cost, fpr, fnr)`` at *threshold* (predict positive iff ``>=``).
 
-    ``cost = fpr_weight * FPR + fnr_weight * FNR``.  Empty denominators yield a
-    zero rate (no negatives -> FPR 0; no positives -> FNR 0), matching the
-    harness's historical behaviour.
+    Delegates to :func:`vtscore.training.thresholds.weighted_error_cost` - the
+    same arithmetic the shipped Smart indicator scores through - so a measured
+    arm and the app can never disagree about what a cut costs.  ``cost =
+    fpr_weight * FPR + fnr_weight * FNR``; empty denominators yield a zero rate
+    (no negatives -> FPR 0; no positives -> FNR 0), matching the harness's
+    historical behaviour.
     """
-    scores = np.asarray(scores, dtype=np.float64)
-    labels = np.asarray(labels, dtype=np.float64)
-    predicted = scores >= threshold
-    pos = labels == 1.0
-    neg = ~pos
-    total_pos = float(pos.sum())
-    total_neg = float(neg.sum())
-    fp = float(np.count_nonzero(predicted & neg))
-    fn = float(np.count_nonzero(~predicted & pos))
-    fpr = fp / total_neg if total_neg > 0 else 0.0
-    fnr = fn / total_pos if total_pos > 0 else 0.0
-    return fpr_weight * fpr + fnr_weight * fnr, fpr, fnr
+    from vtscore.training.thresholds import weighted_error_cost
+
+    return weighted_error_cost(scores, labels, threshold, fpr_weight, fnr_weight)
 
 
 #: Every metric :func:`detection_metrics` returns, and how a reader should read

--- a/vtscore/eval/step_model.py
+++ b/vtscore/eval/step_model.py
@@ -4,9 +4,11 @@
 :mod:`vtscore.eval.step_trainers` returns and every scorer in
 :mod:`vtscore.eval.voting_iterations` consumes: a ``predict`` callable plus the
 provenance the result rows record.  The rest of this module is the handful of
-primitives that sit on both sides of that contract - the head sentinels, the
-cost weights, and the two functions that turn a media into a training vector or
-a simulation set into scores.
+primitives that sit on both sides of that contract - the head sentinels and the
+two functions that turn a media into a training vector or a simulation set into
+scores.  The Inclusion cost weights are *not* here: there is one eval-tier
+spelling of them, :func:`vtscore.eval.calibration_metrics.inclusion_weights`,
+over the shipped :func:`vtscore.training.thresholds.inclusion_cost_weights`.
 
 They live here rather than in the harness module because the trainers and the
 loop both need them, and a module that is *only* the contract keeps that
@@ -88,17 +90,6 @@ def resolve_hidden_dim(head: str, n_votes: int) -> int:
     if head == "mlp":
         return _auto_hidden_dim(n_votes)
     raise ValueError(f"unknown head {head!r}; expected one of {HEADS}")
-
-
-def inclusion_weights(inclusion: int) -> tuple[float, float]:
-    """``(fpr_weight, fnr_weight)`` for an inclusion value.
-
-    Delegates to the production definition so a measured cost and the shipped
-    threshold rule can never disagree about what an inclusion value prices.
-    """
-    from vtscore.training.thresholds import inclusion_cost_weights  # noqa: PLC0415
-
-    return inclusion_cost_weights(inclusion)
 
 
 def good_training_vec(

--- a/vtscore/eval/step_trainers.py
+++ b/vtscore/eval/step_trainers.py
@@ -25,11 +25,11 @@ if TYPE_CHECKING:
 
 from vtscore.embedding.media_vectors import media_embedding
 from vtscore.eval.labels import region_box_for_category
+from vtscore.eval.calibration_metrics import inclusion_weights
 from vtscore.eval.step_model import (
     PRODUCTION_HEAD,
     StepModel,
     good_training_vec,
-    inclusion_weights,
     resolve_hidden_dim,
     score_sim_set_with_model,
 )
@@ -113,8 +113,10 @@ def _labelset_error_costs(
 ) -> list[float]:
     """Weighted FPR/FNR of **every** recent model on the current labelled set.
 
-    Feeds the Smart indicator.  Mirrors ``labeling_progress._eval_cached_models``
-    /``_score_step``: every model in the window is re-scored against the
+    Feeds the Smart indicator.  Reproduces ``labeling_progress._eval_cached_models``
+    /``_score_step`` - and shares their arithmetic, via
+    :func:`~vtscore.training.thresholds.weighted_error_cost`, so only the input
+    plumbing differs: every model in the window is re-scored against the
     *current* labelset — the only ground truth the app has — with its own cached
     threshold, so all points of the slope regression share one eval set and the
     trend isolates model improvement.  Scoring each model against the labelset
@@ -129,11 +131,11 @@ def _labelset_error_costs(
     """
     import numpy as np  # noqa: PLC0415
 
+    from vtscore.training.thresholds import weighted_error_cost  # noqa: PLC0415
+
     ids = list(good_votes) + list(bad_votes)
     labels = [1.0] * len(good_votes) + [0.0] * len(bad_votes)
-    total_pos = len(good_votes)
-    total_neg = len(bad_votes)
-    if not model_steps or not ids or total_pos == 0 or total_neg == 0:
+    if not model_steps or not ids or not good_votes or not bad_votes:
         return []
 
     fpr_weight, fnr_weight = inclusion_weights(inclusion)
@@ -144,16 +146,7 @@ def _labelset_error_costs(
     costs: list[float] = []
     for step, threshold in model_steps:
         scores = np.asarray(step.predict(embs)).ravel()
-        fp = fn = 0
-        for score, true_label in zip(scores.tolist(), labels, strict=True):
-            predicted = 1 if score >= threshold else 0
-            if predicted == 1 and true_label == 0.0:
-                fp += 1
-            elif predicted == 0 and true_label == 1.0:
-                fn += 1
-        fpr = fp / total_neg
-        fnr = fn / total_pos
-        costs.append(fpr_weight * fpr + fnr_weight * fnr)
+        costs.append(weighted_error_cost(scores, labels, threshold, fpr_weight, fnr_weight)[0])
     return costs
 
 

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -64,7 +64,6 @@ from vtscore.eval.step_model import (
     HEADS,
     PRODUCTION_HEAD,
     StepModel,
-    inclusion_weights,
     score_sim_set_with_model,
 )
 from vtscore.eval.step_trainers import (
@@ -487,28 +486,17 @@ def _evaluate_on_test(
 
     true_labels = [1.0 if media_is_positive(clips_dict[cid], target_category) else 0.0 for cid in test_ids]
 
-    total_pos = sum(1 for lbl in true_labels if lbl == 1.0)
-    total_neg = len(true_labels) - total_pos
-
-    fp = fn = 0
-    for score, label in zip(scores, true_labels, strict=True):
-        predicted = 1 if score >= threshold else 0
-        if predicted == 1 and label == 0.0:
-            fp += 1
-        elif predicted == 0 and label == 1.0:
-            fn += 1
-
-    fpr = fp / total_neg if total_neg > 0 else 0.0
-    fnr = fn / total_pos if total_pos > 0 else 0.0
-
     maybe_dump_predictions(clips_dict, test_ids, scores, true_labels, threshold, target_category, suffix="__eval")
-
-    fpr_weight, fnr_weight = inclusion_weights(inclusion)
-    cost = fpr_weight * fpr + fnr_weight * fnr
 
     scores_arr = np.asarray(scores, dtype=np.float64)
     labels_arr = np.asarray(true_labels, dtype=np.float64)
-    from vtscore.eval.calibration_metrics import detection_metrics  # noqa: PLC0415
+    from vtscore.eval.calibration_metrics import (  # noqa: PLC0415
+        detection_metrics,
+        inclusion_weights,
+        operating_cost,
+    )
+
+    cost, fpr, fnr = operating_cost(scores_arr, labels_arr, threshold, *inclusion_weights(inclusion))
 
     det = detection_metrics(scores_arr, labels_arr, threshold)
     return {

--- a/vtscore/training/thresholds/__init__.py
+++ b/vtscore/training/thresholds/__init__.py
@@ -6,11 +6,14 @@ float threshold. Detector-specific glue (sourcing ``X_list`` / ``y_list``
 from votes, caching on ``DetectorContext``) lives in
 :mod:`vtscore.detectors`.
 
-The implementation is split across five submodules, layered so that each one
+The implementation is split across six submodules, layered so that each one
 only reads from those above it:
 
 * :mod:`~vtscore.training.thresholds.knobs` - what an Inclusion value, a
   Train/Calibrate split and the sentinels *mean*.  Depends on nothing.
+* :mod:`~vtscore.training.thresholds.costs` - what a cut *costs* on a labelled
+  sample, under the weights the knob names.  Numpy only; the one definition the
+  shipped Smart indicator and the eval harness both score through.
 * :mod:`~vtscore.training.thresholds.gmm` - the 1-D two-component mixture, its
   anchored variant, and the rules that read a cut off a fit.  Self-contained.
 * :mod:`~vtscore.training.thresholds.anchored` - the shipped path: per-fold
@@ -111,6 +114,7 @@ from vtscore.training.thresholds.gmm import (
     scored_ordering,
     snap_cut_to_sample,
 )
+from vtscore.training.thresholds.costs import weighted_error_cost
 from vtscore.training.thresholds.knobs import (
     ACQUISITION_INCLUSION_OFFSET,
     INCLUSION_MAX,
@@ -135,6 +139,7 @@ __all__ = [
     "classify_threshold_provenance",
     "inclusion_cost_weights",
     "production_split_for",
+    "weighted_error_cost",
     "ANCHOR_WEIGHT_DEFAULT",
     "CUT_KIND_CONTINUED",
     "CUT_KIND_DEGENERATE_MIDPOINT",

--- a/vtscore/training/thresholds/costs.py
+++ b/vtscore/training/thresholds/costs.py
@@ -1,0 +1,66 @@
+"""What a threshold *costs* on a labelled sample.
+
+:mod:`~vtscore.training.thresholds.knobs` says what an Inclusion value prices
+(:func:`~vtscore.training.thresholds.knobs.inclusion_cost_weights` returns the
+two rate weights); this module is the other half of that sentence - the one
+place that turns those weights, a set of scores and their labels into the
+number the knob is defined to minimise::
+
+    cost = fpr_weight * FPR + fnr_weight * FNR
+
+It lives at the bottom of the threshold stack rather than in the eval harness
+because *both* tiers need it and neither may import the other: the shipped
+Smart indicator (``vtscore.detectors.labeling_progress``) scores its cached
+models against the live labelset, and the eval harness
+(``vtscore.eval.calibration_metrics``, ``vtscore.eval.step_trainers``) scores
+arms against held-out splits.  Those used to be three hand copies of the same
+FP/FN counting loop with nothing holding them together (issue #3414); a
+delegation cannot drift, which is the only fix that does not need a
+``Mirror(...)`` entry in ``scripts/check-eval-app-sync.py`` to stay honest.
+
+Numpy only - no torch - so the eval tier stays unit-testable without the model
+stack.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def weighted_error_cost(
+    scores: ArrayLike,
+    labels: ArrayLike,
+    threshold: float,
+    fpr_weight: float,
+    fnr_weight: float,
+) -> tuple[float, float, float]:
+    """Return ``(cost, fpr, fnr)`` at *threshold* (predict positive iff ``>=``).
+
+    *labels* are ``1.0`` for positives and anything else (conventionally
+    ``0.0``) for negatives.  ``cost = fpr_weight * FPR + fnr_weight * FNR``.
+
+    Empty denominators yield a zero rate - no negatives in the sample means an
+    FPR of 0, no positives means an FNR of 0 - so a degenerate sample scores as
+    costless rather than raising or returning NaN.  Callers that need to
+    distinguish "cheap" from "unmeasurable" must check the class counts
+    themselves; the harness's per-step scorers return an empty series in that
+    case rather than a zero.
+
+    The ``>=`` convention is the one every threshold in the codebase uses,
+    including :data:`~vtscore.training.thresholds.knobs.NO_GOOD_THRESHOLD`,
+    which is deliberately above every possible sigmoid score so that no item
+    clears it.
+    """
+    scores = np.asarray(scores, dtype=np.float64)
+    labels = np.asarray(labels, dtype=np.float64)
+    predicted = scores >= threshold
+    pos = labels == 1.0
+    neg = ~pos
+    total_pos = float(pos.sum())
+    total_neg = float(neg.sum())
+    fp = float(np.count_nonzero(predicted & neg))
+    fn = float(np.count_nonzero(~predicted & pos))
+    fpr = fp / total_neg if total_neg > 0 else 0.0
+    fnr = fn / total_pos if total_pos > 0 else 0.0
+    return fpr_weight * fpr + fnr_weight * fnr, fpr, fnr


### PR DESCRIPTION
Closes #3414.

## The premise, checked

The issue's core claim holds and is worse than it says: the weighted-error arithmetic `fpr_weight * FPR + fnr_weight * FNR` existed in **four** hand copies, not two —

| copy | tier |
|---|---|
| `labeling_progress._score_step` | shipped Smart indicator |
| `eval.step_trainers._labelset_error_costs` | eval harness (the Smart indicator's simulated twin) |
| `eval.voting_iterations._evaluate_on_test` | eval harness (held-out test metrics) |
| `eval.calibration_metrics.operating_cost` | eval harness (the #2781 study's shared definition) |

— plus a fifth: `labeling_progress._eval_cached_models` inlined the body of `inclusion_cost_weights` rather than calling it, which quietly falsified that function's own docstring claim to be "the single definition … so a measured arm and the shipped path can never disagree."

Three details in the issue are stale or wrong, and they change what the fix should be:

- **The `Mirror(...)` to "re-pin or retire" does not exist.** No entry in `scripts/check-eval-app-sync.py` covers `_score_step` or `_labelset_error_costs`; the only mention of them is prose inside `progress.smart_status`'s `divergence=`, which pins `_compute_smart_status` instead. So this arithmetic was duplicated *and* unguarded — an argument for the change, not a constraint on it. The gate passes here with no `--update`, since no digested function moved.
- **`voting_iterations._inclusion_weights` is already gone.** The surviving instance of that complaint is `step_model.inclusion_weights` vs `calibration_metrics.inclusion_weights` — two wrappers in one package over the same production function.
- **The proposed `weighted_error_cost` already exists**, as `calibration_metrics.operating_cost`, with exactly the proposed signature and eleven callers. Adding a new one to `vtscore/training/thresholds/` would have made five copies, not four. So this is a *move*, not an add.

Direction otherwise stands: the shared home has to be `vtscore/training/thresholds/`, because `vtscore/detectors/` importing `vtscore/eval/` would be a new reverse edge (nothing in `detectors/` or `training/` imports `eval/` today).

## What changed

New `vtscore/training/thresholds/costs.py::weighted_error_cost(scores, labels, threshold, fpr_weight, fnr_weight) -> (cost, fpr, fnr)` — the bottom of the threshold stack, reachable from both tiers, numpy-only so the eval tier stays torch-free at import. It sits beside `knobs.inclusion_cost_weights` in the layering (that module says what the weights *are*; this one says what they *cost*), but not inside it: `knobs` documents itself as touching no score distribution.

Every caller now routes through it, keeping its own plumbing:

- `labeling_progress._score_step` — the shipped Smart indicator.
- `labeling_progress._eval_cached_models` — now calls `inclusion_cost_weights` instead of inlining it.
- `eval.step_trainers._labelset_error_costs`.
- `eval.voting_iterations._evaluate_on_test`.
- `eval.calibration_metrics.operating_cost` keeps its name (eleven callers, one docs reference) and delegates.

`_build_eval_set` no longer computes per-class totals, since its only consumer now derives them itself; it returns a 2-tuple.

`step_model.inclusion_weights` is deleted in favour of `calibration_metrics.inclusion_weights`, which has the wider call set and the doc reference. Both were three-line delegations to the same function, so nothing can change behaviour; four import sites move.

`progress.smart_status`'s `divergence=` text said the scoring underneath was a copy. It now says it is a delegation, and that only the flatness rule above it still needs a pin.

## Also fixed, unrelated

`frontend/package.json` carried two identical `fast-uri` overrides, added independently by 0342b296 and dfad4201. `build:prod` reports that as `duplicate-object-key`, and `run-tests.sh` treats every build warning as a hard failure — so the full gate could not pass without it. Identical values, so no resolution changes and the lockfile is untouched.

## Tests

New `tests_lib/detectors/test_weighted_error_cost.py`: the shared function's rates, weighting, `>=` convention and empty-denominator behaviour; that `operating_cost` is now literally it; and a cross-tier parity case running one torch ranker through *both* the app's `_build_eval_set`/`_score_step` plumbing and the harness's `_labelset_error_costs`, at three inclusion values.

Full `./run-tests.sh`: **RUN PASSED**, 9925 passed / 6 skipped, all gates green including `check-eval-app-sync` (no re-pin needed), pyright, pip-audit and Vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEhinxszC462z9nnXcgD6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEhinxszC462z9nnXcgD6h)_