### PR TITLE
Move routes/sorting.py's external-query sort pipeline into vtscore/training/query_sort.py

### DIFF
--- a/docs/plans/codebase-audit-2026-09.md
+++ b/docs/plans/codebase-audit-2026-09.md
@@ -103,7 +103,6 @@ care.
 
 ## App tier — routes, schemas, facades
 
-- [ ] #3419 — Move `routes/sorting.py`'s ML pipeline logic into `vtscore/training/` (Sonnet 5)
 - [ ] #3420 — Split `routes/_shared.py`: nine unrelated modules in one 866-line file (Haiku 4.5)
 - [ ] #3427 — Register one dynamic plugin route and generate its bodies at spec-build time (Opus 4.8)
 - [ ] #3438 — Small app-tier batch: exempt prefixes as a route attribute, plus the orphan-endpoint decision (Sonnet 5)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/tests_lib/sorting/test_query_sort.py
+++ b/tests_lib/sorting/test_query_sort.py
@@ -41,7 +41,8 @@ def _fill_active_medias(dim: int = 8, n: int = 6) -> np.ndarray:
         vec = base + (i * 0.4) * off
         medias[i + 1] = {
             "id": i + 1,
-            "embedding": (vec / np.linalg.norm(vec)).astype(np.float32),
+            "embeddings": {"test_emb": (vec / np.linalg.norm(vec)).astype(np.float32)},
+            "embedder": "test_emb",
             "media_type": "image",
         }
     return base
@@ -100,9 +101,7 @@ class TestEmbedExternalLabels:
             def embed_media(self, media):
                 return None
 
-        X, y, loaded, skipped = embed_external_labels(
-            [{"path": str(real), "label": "good"}], _NullEmb()
-        )
+        X, y, loaded, skipped = embed_external_labels([{"path": str(real), "label": "good"}], _NullEmb())
         assert (X, y, loaded, skipped) == ([], [], 0, 1)
 
 

--- a/tests_lib/sorting/test_query_sort.py
+++ b/tests_lib/sorting/test_query_sort.py
@@ -1,0 +1,136 @@
+"""Library-tier tests for the external-query sorts (issue #3419).
+
+These four entry points used to be private helpers inside
+``vtsearch/routes/sorting.py``, reachable only through a Flask test client
+(and, for three of them, only via a cross-blueprint import of another route
+module's underscore names).  They now live in
+:mod:`vtscore.training.query_sort`, so this file exercises them with nothing
+but an active dataset context — no app, no request, no client.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import numpy as np
+import pytest
+
+from vtscore.state.core import get_active_context
+from vtscore.training.query_sort import (
+    apply_crop_or_keep,
+    cosine_sort_active,
+    embed_external_labels,
+    parse_label_file,
+)
+
+
+def _fill_active_medias(dim: int = 8, n: int = 6) -> np.ndarray:
+    """Populate the active context with medias whose vectors fan out from a target.
+
+    Media 1 is the target; each later media is rotated further away, so the
+    expected cosine ranking is exactly the id order.  Returns the query vector.
+    """
+    medias = get_active_context().medias
+    medias.clear()
+    base = np.zeros(dim, dtype=np.float32)
+    base[0] = 1.0
+    off = np.zeros(dim, dtype=np.float32)
+    off[1] = 1.0
+    for i in range(n):
+        vec = base + (i * 0.4) * off
+        medias[i + 1] = {
+            "id": i + 1,
+            "embedding": (vec / np.linalg.norm(vec)).astype(np.float32),
+            "media_type": "image",
+        }
+    return base
+
+
+class TestParseLabelFile:
+    """The label-file reader raises ValueError; the route owns the HTTP mapping."""
+
+    def test_returns_the_labels_list(self):
+        payload = {"labels": [{"path": "a.png", "label": "good"}]}
+        assert parse_label_file(io.BytesIO(json.dumps(payload).encode())) == payload["labels"]
+
+    def test_non_json_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid label file format"):
+            parse_label_file(io.BytesIO(b"not json at all"))
+
+    def test_non_object_document_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid label file format"):
+            parse_label_file(io.BytesIO(b'["a", "b"]'))
+
+    def test_empty_labels_raises_value_error(self):
+        with pytest.raises(ValueError, match="No labels found in file"):
+            parse_label_file(io.BytesIO(b'{"labels": []}'))
+
+
+class TestEmbedExternalLabels:
+    """Malformed / unreachable entries are skipped and counted, never raised on."""
+
+    class _Emb:
+        def embed_media(self, media):
+            return np.ones(4, dtype=np.float32)
+
+    def test_skips_malformed_missing_and_unembeddable_entries(self, tmp_path):
+        real = tmp_path / "real.png"
+        real.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        labels = [
+            {"path": str(real), "label": "good"},
+            {"path": str(real), "label": "bad"},
+            {"path": str(real), "label": "maybe"},  # not good/bad
+            {"label": "good"},  # no path at all
+            {"path": str(tmp_path / "missing.png"), "label": "bad"},
+        ]
+        X, y, loaded, skipped = embed_external_labels(labels, self._Emb())
+
+        assert loaded == 2
+        assert skipped == 3
+        assert len(X) == len(y) == 2
+        assert y == [1.0, 0.0]
+
+    def test_none_embedding_counts_as_skipped(self, tmp_path):
+        real = tmp_path / "real.png"
+        real.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        class _NullEmb:
+            def embed_media(self, media):
+                return None
+
+        X, y, loaded, skipped = embed_external_labels(
+            [{"path": str(real), "label": "good"}], _NullEmb()
+        )
+        assert (X, y, loaded, skipped) == ([], [], 0, 1)
+
+
+class TestCosineSortActive:
+    """The whole-dataset cosine sort runs against the active context alone."""
+
+    def test_ranks_every_media_by_similarity_to_the_query(self):
+        query = _fill_active_medias()
+        results, threshold = cosine_sort_active(query)
+
+        assert [r["id"] for r in results] == [1, 2, 3, 4, 5, 6]
+        sims = [r["similarity"] for r in results]
+        assert sims == sorted(sims, reverse=True)
+        assert threshold == round(threshold, 4)
+
+    def test_returns_a_row_per_loaded_media(self):
+        query = _fill_active_medias(n=4)
+        results, _ = cosine_sort_active(query)
+        assert len(results) == 4
+
+
+class TestApplyCropOrKeep:
+    """A falsy crop spec is a no-op that leaves the file byte-for-byte intact."""
+
+    @pytest.mark.parametrize("crop", [None, {}])
+    def test_no_crop_params_keeps_the_file_untouched(self, tmp_path, crop):
+        path = tmp_path / "example.bin"
+        path.write_bytes(b"original bytes")
+
+        assert apply_crop_or_keep(path, crop) is path
+        assert path.read_bytes() == b"original bytes"

--- a/vtscore/training/__init__.py
+++ b/vtscore/training/__init__.py
@@ -2,9 +2,16 @@
 
 Detector-specific glue (vote-aware training, origin-based detector
 training, the train→threshold→serialise pipeline) lives in
-:mod:`vtscore.detectors`. The neural-net primitives here are media-
-agnostic: they take feature matrices and labels in, and return models
-and decision thresholds out.
+:mod:`vtscore.detectors`. The neural-net primitives in :mod:`~vtscore.training.mlp`
+and :mod:`~vtscore.training.svm` are media-agnostic: they take feature
+matrices and labels in, and return models and decision thresholds out.
+
+Two modules here sit one level up from that, scoring a *media snapshot*
+rather than a bare feature matrix: :mod:`~vtscore.training.region_similarity`
+(and :mod:`~vtscore.training.structural_similarity`) rank a snapshot against a
+query vector, and :mod:`~vtscore.training.query_sort` composes them into the
+whole-dataset sorts driven by an external query — an example media file or a
+label file. Neither is re-exported here; import them by module.
 """
 
 from vtscore.training.mlp import (

--- a/vtscore/training/query_sort.py
+++ b/vtscore/training/query_sort.py
@@ -1,0 +1,283 @@
+"""External-query sorts of the active dataset: example media, and label files.
+
+These helpers backed the ``/api/example-sort`` and ``/api/label-file-sort``
+route handlers in ``vtsearch/routes/sorting.py`` (and, by cross-blueprint
+reach-in, the three server-media example-sort routes in
+``vtsearch/routes/media/server.py``).  None of it touches Flask or the
+request context: every function takes plain paths, file objects and vectors,
+reads the active dataset through :mod:`vtscore.state`, and returns results or
+raises :class:`ValueError`.  So it belongs in the library tier, where the CLI
+can reach it and tests can exercise it without a Flask client.  Same move,
+same reason, as :mod:`vtscore.detectors.learned_sort`.
+
+The routes are now request↔library glue: they materialise the upload into a
+temp file, call in here, and translate a :class:`ValueError` into the HTTP
+error envelope.
+
+The primitives these compose over live next door:
+:func:`vtscore.training.region_similarity.cosine_sort_with_boxes` scores a
+media snapshot against a query vector, and
+:mod:`vtscore.detectors.training` owns the train→threshold→score pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from vtscore.media.embedder import MediaEmbedder
+
+
+def cosine_sort_active(query_vec, *, role: str = "score", snap=None) -> tuple[list[dict], float]:
+    """Sort every media in the active dataset by cosine similarity to *query_vec*.
+
+    Returns ``(results, threshold)`` where *results* is a list of
+    ``{"id": …, "similarity": …}`` dicts sorted descending, and
+    *threshold* is the GMM-based boundary (rounded to 4 decimals).
+
+    *role* selects which bound embedder the haystack is scored against (the
+    v3 routing table, see :meth:`DatasetContext.routed_embedder`): ``"text"``
+    for a text query, ``"score"`` (patch-else-text) for an example/cosine
+    query.  *query_vec* must have been embedded by that same embedder.
+
+    For datasets embedded with a patch-aware embedder (DINOv2, DINOv3,
+    EUPE), each result also carries a ``best_region`` field containing the
+    bounding box of the region that scored highest, in normalised
+    image coordinates ``[x0, y0, x1, y1]``.  Single-vector embedders
+    take a fast vectorised numpy path with no per-result box.
+
+    Both paths live in :mod:`vtscore.training.region_similarity`.
+
+    *snap* lets the caller thread in a medias snapshot it already took, so a
+    single handler doesn't copy the full medias dict under ``_state_lock`` more
+    than once per request; when ``None`` a fresh snapshot is taken.
+    """
+    from vtscore.state import snapshot_medias
+    from vtscore.state.core import get_active_context
+    from vtscore.training.region_similarity import cosine_sort_with_boxes
+    from vtscore.training.thresholds import calculate_gmm_threshold
+
+    ctx = get_active_context()
+    embedder_name = ctx.routed_embedder(role)
+    # Region vectors belong to the patch embedder; the per-region max-pool is
+    # valid only when the query was scored against that same embedder.
+    region_aware = embedder_name is not None and embedder_name == ctx.patch_embedder
+
+    if snap is None:
+        snap = snapshot_medias()
+    results, sims_list = cosine_sort_with_boxes(snap, query_vec, embedder_name, region_aware=region_aware)
+    threshold = calculate_gmm_threshold(sims_list)
+    return results, round(threshold, 4)
+
+
+def score_embedder_for_active(snap=None) -> tuple[MediaEmbedder | None, str | None]:
+    """Return ``(embedder, embedder_name)`` for the active dataset's score embedder.
+
+    The score embedder is the patch slot if bound, else the text slot (the v3
+    routing table; see :meth:`DatasetContext.routed_embedder`).  Used to embed
+    an example/label query so it shares the space the haystack is scored
+    against.  A slot-less single-vector dataset falls back to the embedder
+    resolved from the medias themselves and a ``None`` name (the matrix layer
+    then reads the primary vector); for single-embedder datasets the two
+    coincide.
+
+    *snap* threads in an already-taken medias snapshot to avoid re-copying the
+    medias dict under ``_state_lock``; when ``None`` a fresh snapshot is taken.
+    """
+    from vtscore.media import embedder_for_medias, get_embedder
+    from vtscore.state import snapshot_medias
+    from vtscore.state.core import get_active_context
+
+    score_name = get_active_context().routed_embedder("score")
+    if score_name is not None:
+        try:
+            return get_embedder(score_name), score_name
+        except KeyError:
+            pass
+    if snap is None:
+        snap = snapshot_medias()
+    return embedder_for_medias(snap), score_name
+
+
+def example_sort_from_paths(file_paths: list[Path]) -> tuple[list[dict], float]:
+    """Embed one or more media files and sort all loaded medias by similarity.
+
+    Returns ``(results_list, threshold)`` on success, or raises
+    :class:`ValueError` when there are no example files, no medias loaded, no
+    embedder for the dataset, or a file that the embedder cannot embed.
+
+    Each file is embedded using the score embedder of the currently loaded
+    dataset.  A single example sorts by cosine similarity to its vector;
+    multiple examples sort against their centroid (the mean of the
+    L2-normalised example vectors), so each example contributes equally
+    regardless of its embedding norm.
+    """
+    import numpy as np
+
+    from vtscore.media.embedder import media_from_path
+    from vtscore.state import snapshot_medias
+
+    if not file_paths:
+        raise ValueError("No example files provided")
+
+    snap = snapshot_medias()
+    if not snap:
+        raise ValueError("No medias loaded")
+
+    # Embed the examples with the dataset's score embedder so the query shares
+    # the space the haystack is scored against.
+    emb, _score_name = score_embedder_for_active(snap)
+    if emb is None:
+        raise ValueError("No embedder available for loaded dataset")
+
+    medias = [media_from_path(p) for p in file_paths]
+    embeddings = []
+    for path, media in zip(file_paths, medias, strict=True):
+        vec = emb.embed_media(media)
+        if vec is None:
+            raise ValueError(f"Failed to embed media file: {path.name}")
+        embeddings.append(np.asarray(vec, dtype=np.float32))
+
+    if len(embeddings) == 1:
+        query_vec = embeddings[0]
+    else:
+        normed = [v / n if (n := float(np.linalg.norm(v))) > 0 else v for v in embeddings]
+        query_vec = np.mean(np.stack(normed), axis=0)
+
+    results, threshold = cosine_sort_active(query_vec, snap=snap)
+
+    # Stage-2 structural re-rank (a no-op for non-structural datasets): for a
+    # SIFT/VLAD dataset, geometrically verify the VLAD shortlist against the
+    # uploaded example's own local features.  The example is the template; any
+    # crop was already applied to the file above, so it restricts the template.
+    # Geometric verification needs a single template, so the multi-example
+    # centroid path skips it and keeps the pure cosine ranking.
+    if len(medias) == 1 and getattr(emb, "supports_geometric_verification", False):
+        from vtscore.training.structural_similarity import maybe_structural_rerank_example
+
+        example_features = emb.local_features_forward(medias[0])
+        results, threshold = maybe_structural_rerank_example(
+            results, threshold, snap, example_features, score_key="similarity"
+        )
+
+    return results, threshold
+
+
+def apply_crop_or_keep(temp_path: Path, crop_params: dict | None) -> Path:
+    """Apply *crop_params* to *temp_path* in-place when set; otherwise keep file.
+
+    Resolves the target media type from the loaded dataset's first media
+    item (the embedder is the same one we're about to use).  Writes the
+    cropped bytes back to *temp_path* and returns it.
+    """
+    if not crop_params:
+        return temp_path
+
+    from vtscore.media.cropping import crop_file_bytes
+    from vtscore.state import snapshot_medias
+
+    snap = snapshot_medias()
+    if not snap:
+        return temp_path
+    first_media = next(iter(snap.values()))
+    media_type = first_media.get("media_type", "")
+
+    cropped = crop_file_bytes(temp_path, media_type, crop_params)
+    temp_path.write_bytes(cropped)
+    return temp_path
+
+
+def parse_label_file(fp) -> list[dict]:
+    """Read *fp* as a JSON label file and return its ``labels`` list.
+
+    *fp* is any binary file-like object (an upload stream, an open file).
+    Raises :class:`ValueError` when the bytes are not valid UTF-8 JSON, or
+    when the document carries no non-empty ``labels`` list; the caller maps
+    that onto whatever error surface it owns.
+    """
+    try:
+        label_data = json.loads(fp.read().decode("utf-8"))
+    except Exception as exc:
+        raise ValueError("Invalid label file format") from exc
+    if not isinstance(label_data, dict):
+        raise ValueError("Invalid label file format")
+    labels = label_data.get("labels", [])
+    if not labels:
+        raise ValueError("No labels found in file")
+    return labels
+
+
+def embed_external_labels(labels: list[dict], emb) -> tuple[list, list[float], int, int]:
+    """Embed every well-formed entry in *labels* using *emb*.
+
+    Returns ``(X_list, y_list, loaded_count, skipped_count)``. Entries are
+    skipped (not raised on) when the label is malformed, the path is missing
+    or escapes the allowed directory, the file doesn't exist, or the
+    embedder returns None.
+    """
+    import vtscore.security.path_validation as _paths
+    from vtscore.media.embedder import media_from_path
+
+    X_list: list = []
+    y_list: list[float] = []
+    loaded = 0
+    skipped = 0
+    file_base = _paths.get_file_access_base_dir()
+
+    for entry in labels:
+        label = entry.get("label")
+        if label not in ("good", "bad"):
+            skipped += 1
+            continue
+
+        raw_path = entry.get("path") or entry.get("file") or entry.get("filename")
+        if not raw_path:
+            skipped += 1
+            continue
+
+        try:
+            # Embed the approved path, not the raw one: under confinement the
+            # check anchors a relative path at the user's data dir while
+            # ``Path(...)`` would anchor it at the process CWD.
+            media_path = Path(_paths.confine_server_filepath(str(raw_path), file_base))
+        except ValueError:
+            skipped += 1
+            continue
+        if not media_path.exists():
+            skipped += 1
+            continue
+
+        embedding = emb.embed_media(media_from_path(media_path))
+        if embedding is None:
+            skipped += 1
+            continue
+
+        X_list.append(embedding)
+        y_list.append(1.0 if label == "good" else 0.0)
+        loaded += 1
+
+    return X_list, y_list, loaded, skipped
+
+
+def train_and_score_active(
+    X_list: list, y_list: list[float], embedder_name: str | None = None
+) -> tuple[list[dict[str, Any]], float]:
+    """Train an MLP on (X, y), then score every media in the active dataset.
+
+    *embedder_name* is the embedder the external labels in *X_list* were
+    embedded with; scoring sources the haystack vectors from the same embedder
+    so the trained MLP and the scored vectors share one space.  ``None`` reads
+    each media's primary vector.  The same name is handed to
+    :func:`vtscore.detectors.training.train_and_threshold` so the safe-threshold
+    GMM is fitted on exactly the score distribution returned here - including
+    the region max-pool on a patch dataset, where results also gain a
+    ``best_region`` box.
+    """
+    from vtscore.detectors.training import score_media_with_model, train_and_threshold
+    from vtscore.state import snapshot_medias
+
+    snap = snapshot_medias()
+    model, threshold = train_and_threshold(X_list, y_list, snap=snap, embedder_name=embedder_name)
+    return score_media_with_model(model, snap, embedder_name), threshold

--- a/vtsearch/routes/_shared.py
+++ b/vtsearch/routes/_shared.py
@@ -630,20 +630,6 @@ def windowed_sort_response(
     }
 
 
-def get_embedder_for_medias(media_dict: dict):
-    """Return the appropriate embedder for the given medias, or ``None``.
-
-    Thin alias for :func:`vtscore.media.embedder_for_medias`, kept so route
-    code can keep importing it from here.  The implementation moved to the
-    library tier because the dataset-load pipeline needs it too, and
-    reaching back into ``vtsearch.routes`` for it made a library code path
-    hard-require Flask (issue #2931).
-    """
-    from vtscore.media import embedder_for_medias  # noqa: PLC0415
-
-    return embedder_for_medias(media_dict)
-
-
 #: Message used by both Semantic-lock guards below, so the API surfaces one
 #: consistent explanation whichever route the request hit.
 SEMANTIC_ONLY_MESSAGE = (

--- a/vtsearch/routes/media/server.py
+++ b/vtsearch/routes/media/server.py
@@ -279,7 +279,7 @@ def example_sort_server(body: dict):
         abort(400, message="crop_params applies to a single example; omit it when passing multiple filenames")
 
     try:
-        from vtsearch.routes.sorting import _apply_crop_or_keep, _example_sort_from_paths
+        from vtscore.training.query_sort import apply_crop_or_keep, example_sort_from_paths
 
         if crop_params:
             # Crop into a temp file so the saved server-side example is unchanged.
@@ -292,12 +292,12 @@ def example_sort_server(body: dict):
             tmp = DATA_DIR / f"temp_example_{uuid.uuid4().hex}{file_path.suffix or '.bin'}"
             tmp.write_bytes(file_path.read_bytes())
             try:
-                _apply_crop_or_keep(tmp, crop_params)
-                results, thresh = _example_sort_from_paths([tmp])
+                apply_crop_or_keep(tmp, crop_params)
+                results, thresh = example_sort_from_paths([tmp])
             finally:
                 tmp.unlink(missing_ok=True)
         else:
-            results, thresh = _example_sort_from_paths(file_paths)
+            results, thresh = example_sort_from_paths(file_paths)
         return {"results": results, "threshold": thresh}
     except HTTPException:
         raise
@@ -382,16 +382,16 @@ def example_sort_origin(body: dict):
         if fetched.path is None and fetched.embedding is not None:
             if crop_params:
                 abort(400, message="Cannot crop an archive-member example (no extracted bytes)")
-            from vtsearch.routes.sorting import _cosine_sort
+            from vtscore.training.query_sort import cosine_sort_active
 
-            results, thresh = _cosine_sort(fetched.embedding)
+            results, thresh = cosine_sort_active(fetched.embedding)
             return {"results": results, "threshold": thresh}
 
         file_path = fetched.path
         if file_path is None:
             abort(404, message=f"File not found: {key}")
 
-        from vtsearch.routes.sorting import _apply_crop_or_keep, _example_sort_from_paths
+        from vtscore.training.query_sort import apply_crop_or_keep, example_sort_from_paths
 
         if crop_params:
             import uuid
@@ -402,12 +402,12 @@ def example_sort_origin(body: dict):
             tmp = DATA_DIR / f"temp_example_{uuid.uuid4().hex}{file_path.suffix or '.bin'}"
             tmp.write_bytes(file_path.read_bytes())
             try:
-                _apply_crop_or_keep(tmp, crop_params)
-                results, thresh = _example_sort_from_paths([tmp])
+                apply_crop_or_keep(tmp, crop_params)
+                results, thresh = example_sort_from_paths([tmp])
             finally:
                 tmp.unlink(missing_ok=True)
         else:
-            results, thresh = _example_sort_from_paths([file_path])
+            results, thresh = example_sort_from_paths([file_path])
         return {"results": results, "threshold": thresh}
     except HTTPException:
         raise
@@ -505,10 +505,10 @@ def example_sort_by_id(body: dict):
     crop_params = body.get("crop_params") if isinstance(body.get("crop_params"), dict) else None
 
     try:
-        from vtsearch.routes.sorting import (
-            _apply_crop_or_keep,
-            _cosine_sort,
-            _example_sort_from_paths,
+        from vtscore.training.query_sort import (
+            apply_crop_or_keep,
+            cosine_sort_active,
+            example_sort_from_paths,
         )
 
         if crop_params:
@@ -522,14 +522,14 @@ def example_sort_by_id(body: dict):
             tmp = DATA_DIR / f"temp_example_{uuid.uuid4().hex}{_media_extension(media)}"
             tmp.write_bytes(media_bytes)
             try:
-                _apply_crop_or_keep(tmp, crop_params)
-                results, thresh = _example_sort_from_paths([tmp])
+                apply_crop_or_keep(tmp, crop_params)
+                results, thresh = example_sort_from_paths([tmp])
             finally:
                 tmp.unlink(missing_ok=True)
         else:
             # Sort by this media's own vector in the score embedder's space
             # (patch-else-text; the v3 routing table), so the query matches the
-            # haystack _cosine_sort scores against.
+            # haystack cosine_sort_active scores against.
             from vtscore.embedding.media_vectors import media_embedding
             from vtscore.state.core import get_active_context
 
@@ -537,7 +537,7 @@ def example_sort_by_id(body: dict):
             embedding = media_embedding(media, score_name)
             if embedding is None:
                 abort(400, message="Media has no embedding (cannot sort)")
-            results, thresh = _cosine_sort(embedding)
+            results, thresh = cosine_sort_active(embedding)
         return {"results": results, "threshold": thresh}
     except HTTPException:
         raise

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -19,20 +19,17 @@ import json
 import logging
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from flask import request
 from flask_smorest import Blueprint, abort
 
 from vtsearch.routes._shared import (
     format_exception_detail,
-    get_embedder_for_medias,
     require_detector_header,
     windowed_sort_response,
 )
 
 from vtscore.config import DATA_DIR
-import vtscore.security.path_validation as _paths
 from vtscore.embedding import embed_text_query
 from vtsearch.schemas.sorting import (
     CoverageAtlasNextResponseSchema,
@@ -52,7 +49,15 @@ from vtsearch.schemas.sorting import (
     TextsortSuggestionsResponseSchema,
     VotesResponseSchema,
 )
-from vtscore.training.thresholds import calculate_gmm_threshold
+from vtscore.training.query_sort import (
+    apply_crop_or_keep,
+    cosine_sort_active,
+    embed_external_labels,
+    example_sort_from_paths,
+    parse_label_file,
+    score_embedder_for_active,
+    train_and_score_active,
+)
 from vtsearch.state import (
     add_textsort_suggestion,
     bad_votes,
@@ -70,9 +75,6 @@ from vtsearch.state import (
     vote_region_boxes,
 )
 from vtscore.concurrency.progress import sort_progress, update_sort_progress
-
-if TYPE_CHECKING:
-    from vtscore.media.embedder import MediaEmbedder
 
 sorting_bp = Blueprint(
     "sorting",
@@ -98,46 +100,6 @@ def _sort_idle() -> None:
     update_sort_progress("idle", "", step=None, total_steps=None)
 
 
-def _cosine_sort(query_vec, *, role: str = "score", snap=None):
-    """Sort all loaded medias by cosine similarity to *query_vec*.
-
-    Returns ``(results, threshold)`` where *results* is a list of
-    ``{"id": …, "similarity": …}`` dicts sorted descending, and
-    *threshold* is the GMM-based boundary (rounded to 4 decimals).
-
-    *role* selects which bound embedder the haystack is scored against (the
-    v3 routing table, see :meth:`DatasetContext.routed_embedder`): ``"text"``
-    for a text query, ``"score"`` (patch-else-text) for an example/cosine
-    query.  *query_vec* must have been embedded by that same embedder.
-
-    For datasets embedded with a patch-aware embedder (DINOv2, DINOv3,
-    EUPE), each result also carries a ``best_region`` field containing the
-    bounding box of the region that scored highest, in normalised
-    image coordinates ``[x0, y0, x1, y1]``.  Single-vector embedders
-    take a fast vectorised numpy path with no per-result box.
-
-    Both paths live in :mod:`vtscore.training.region_similarity`.
-
-    *snap* lets the caller thread in a medias snapshot it already took, so a
-    single handler doesn't copy the full medias dict under ``_state_lock`` more
-    than once per request; when ``None`` a fresh snapshot is taken.
-    """
-    from vtscore.state.core import get_active_context  # noqa: PLC0415
-    from vtscore.training.region_similarity import cosine_sort_with_boxes  # noqa: PLC0415
-
-    ctx = get_active_context()
-    embedder_name = ctx.routed_embedder(role)
-    # Region vectors belong to the patch embedder; the per-region max-pool is
-    # valid only when the query was scored against that same embedder.
-    region_aware = embedder_name is not None and embedder_name == ctx.patch_embedder
-
-    if snap is None:
-        snap = snapshot_medias()
-    results, sims_list = cosine_sort_with_boxes(snap, query_vec, embedder_name, region_aware=region_aware)
-    threshold = calculate_gmm_threshold(sims_list)
-    return results, round(threshold, 4)
-
-
 _embedder_load_lock = threading.Lock()
 
 
@@ -147,32 +109,11 @@ def _get_embedder_for_loaded_data(snap=None):
     *snap* threads in an already-taken medias snapshot to avoid re-copying the
     medias dict under ``_state_lock``; when ``None`` a fresh snapshot is taken.
     """
+    from vtscore.media import embedder_for_medias
+
     if snap is None:
         snap = snapshot_medias()
-    return get_embedder_for_medias(snap)
-
-
-def _score_embedder_for_loaded_data(snap=None) -> tuple["MediaEmbedder | None", str | None]:
-    """Return ``(embedder, embedder_name)`` for the dataset's score embedder.
-
-    The score embedder is the patch slot if bound, else the text slot (the v3
-    routing table; see :meth:`DatasetContext.routed_embedder`).  Used to embed
-    an example/label query so it shares the space the haystack is scored
-    against.  A slot-less single-vector dataset falls back to the primary
-    embedder and a ``None`` name (the matrix layer then reads the primary
-    vector); for single-embedder datasets the two coincide.
-    """
-    from vtscore.state.core import get_active_context  # noqa: PLC0415
-
-    score_name = get_active_context().routed_embedder("score")
-    if score_name is not None:
-        from vtscore.media import get_embedder  # noqa: PLC0415
-
-        try:
-            return get_embedder(score_name), score_name
-        except KeyError:
-            pass
-    return _get_embedder_for_loaded_data(snap), score_name
+    return embedder_for_medias(snap)
 
 
 def _load_embedder_with_progress(snap=None):
@@ -272,7 +213,7 @@ def sort_clips(body: dict):
             abort(500, message=f"Could not embed text for media type {media_type}")
 
         update_sort_progress("sorting", "Computing similarities…", 0, 0, step=3, total_steps=_SORT_STEPS)
-        results, threshold = _cosine_sort(text_vec, role="text", snap=snap)
+        results, threshold = cosine_sort_active(text_vec, role="text", snap=snap)
         _sort_idle()
         return windowed_sort_response(results, threshold)
     except Exception as exc:
@@ -629,65 +570,6 @@ def _active_detector_threshold() -> float | None:
     return getattr(det_ctx, "threshold", None)
 
 
-def _example_sort_from_paths(file_paths: list[Path]) -> tuple:
-    """Embed one or more media files and sort all loaded medias by similarity.
-
-    Returns ``(results_list, threshold)`` on success or raises on error.
-    Each file is embedded using the embedder of the currently loaded
-    dataset.  A single example sorts by cosine similarity to its vector;
-    multiple examples sort against their centroid (the mean of the
-    L2-normalised example vectors), so each example contributes equally
-    regardless of its embedding norm.
-    """
-    import numpy as np  # noqa: PLC0415
-
-    if not file_paths:
-        raise ValueError("No example files provided")
-
-    snap = snapshot_medias()
-    if not snap:
-        raise ValueError("No medias loaded")
-
-    # Embed the examples with the dataset's score embedder so the query shares
-    # the space the haystack is scored against.
-    emb, _score_name = _score_embedder_for_loaded_data(snap)
-    if emb is None:
-        raise ValueError("No embedder available for loaded dataset")
-    from vtscore.media.embedder import media_from_path  # noqa: PLC0415
-
-    medias = [media_from_path(p) for p in file_paths]
-    embeddings = []
-    for path, media in zip(file_paths, medias, strict=True):
-        vec = emb.embed_media(media)
-        if vec is None:
-            raise ValueError(f"Failed to embed media file: {path.name}")
-        embeddings.append(np.asarray(vec, dtype=np.float32))
-
-    if len(embeddings) == 1:
-        query_vec = embeddings[0]
-    else:
-        normed = [v / n if (n := float(np.linalg.norm(v))) > 0 else v for v in embeddings]
-        query_vec = np.mean(np.stack(normed), axis=0)
-
-    results, threshold = _cosine_sort(query_vec, snap=snap)
-
-    # Stage-2 structural re-rank (a no-op for non-structural datasets): for a
-    # SIFT/VLAD dataset, geometrically verify the VLAD shortlist against the
-    # uploaded example's own local features.  The example is the template; any
-    # crop was already applied to the file above, so it restricts the template.
-    # Geometric verification needs a single template, so the multi-example
-    # centroid path skips it and keeps the pure cosine ranking.
-    if len(medias) == 1 and getattr(emb, "supports_geometric_verification", False):
-        from vtscore.training.structural_similarity import maybe_structural_rerank_example  # noqa: PLC0415
-
-        example_features = emb.local_features_forward(medias[0])
-        results, threshold = maybe_structural_rerank_example(
-            results, threshold, snap, example_features, score_key="similarity"
-        )
-
-    return results, threshold
-
-
 def _parse_crop_params(raw: str | None) -> dict | None:
     """Parse a JSON string of crop bounds, or return None if absent.
 
@@ -703,29 +585,6 @@ def _parse_crop_params(raw: str | None) -> dict | None:
     if not isinstance(params, dict):
         return None
     return params
-
-
-def _apply_crop_or_keep(temp_path: Path, crop_params: dict | None) -> Path:
-    """Apply *crop_params* to *temp_path* in-place when set; otherwise keep file.
-
-    Resolves the target media type from the loaded dataset's first media
-    item (the embedder is the same one we're about to use).  Writes the
-    cropped bytes back to *temp_path*.
-    """
-    if not crop_params:
-        return temp_path
-
-    snap = snapshot_medias()
-    if not snap:
-        return temp_path
-    first_media = next(iter(snap.values()))
-    media_type = first_media.get("media_type", "")
-
-    from vtscore.media.cropping import crop_file_bytes
-
-    cropped = crop_file_bytes(temp_path, media_type, crop_params)
-    temp_path.write_bytes(cropped)
-    return temp_path
 
 
 @sorting_bp.route("/api/example-sort", methods=["POST"])
@@ -764,8 +623,8 @@ def example_sort():
 
         try:
             crop_params = _parse_crop_params(request.form.get("crop_params"))
-            _apply_crop_or_keep(temp_path, crop_params)
-            results, thresh = _example_sort_from_paths([temp_path])
+            apply_crop_or_keep(temp_path, crop_params)
+            results, thresh = example_sort_from_paths([temp_path])
         finally:
             # Clean up temp file even if sorting raises
             temp_path.unlink(missing_ok=True)
@@ -779,74 +638,6 @@ def example_sort():
             raise
         logging.getLogger(__name__).exception("example-sort failed")
         abort(500, message=f"Example sort failed: {format_exception_detail(exc)}")
-
-
-def _parse_label_file(file) -> list[dict]:
-    """Parse the uploaded label file and return its ``labels`` list, or abort 400."""
-    text = file.read().decode("utf-8")
-    try:
-        label_data = json.loads(text)
-    except Exception:
-        abort(400, message="Invalid label file format")
-    labels = label_data.get("labels", [])
-    if not labels:
-        abort(400, message="No labels found in file")
-    return labels
-
-
-def _embed_external_labels(labels: list[dict], emb) -> tuple[list, list[float], int, int]:
-    """Embed every well-formed entry in *labels* using *emb*.
-
-    Returns ``(X_list, y_list, loaded_count, skipped_count)``. Entries are
-    skipped (not aborted) when the label is malformed, the path is missing
-    or escapes the allowed directory, the file doesn't exist, or the
-    embedder returns None.
-    """
-    from vtscore.media.embedder import media_from_path  # noqa: PLC0415
-
-    X_list: list = []
-    y_list: list[float] = []
-    loaded = 0
-    skipped = 0
-    file_base = _paths.get_file_access_base_dir()
-
-    for entry in labels:
-        label = entry.get("label")
-        if label not in ("good", "bad"):
-            skipped += 1
-            continue
-
-        raw_path = entry.get("path") or entry.get("file") or entry.get("filename")
-        if not raw_path:
-            skipped += 1
-            continue
-
-        try:
-            # Embed the approved path, not the raw one: under confinement the
-            # check anchors a relative path at the user's data dir while
-            # ``Path(...)`` would anchor it at the process CWD.
-            media_path = Path(_paths.confine_server_filepath(str(raw_path), file_base))
-        except ValueError:
-            skipped += 1
-            continue
-        if not media_path.exists():
-            skipped += 1
-            continue
-
-        embedding = emb.embed_media(media_from_path(media_path))
-        if embedding is None:
-            skipped += 1
-            continue
-
-        X_list.append(embedding)
-        y_list.append(1.0 if label == "good" else 0.0)
-        loaded += 1
-
-    return X_list, y_list, loaded, skipped
-
-
-def _train_and_score_dataset(
-    X_list: list, y_list: list[float], embedder_name: str | None = None
 ) -> tuple[list[dict], float]:
     """Train an MLP on (X, y), then score every media in the active dataset.
 
@@ -893,13 +684,16 @@ def label_file_sort():
 
     # Embed external labels with (and later score against) the dataset's
     # score embedder so training and scoring share one space.
-    emb, score_name = _score_embedder_for_loaded_data()
+    emb, score_name = score_embedder_for_active()
     if emb is None:
         abort(400, message="No embedder available for loaded dataset")
 
     try:
-        labels = _parse_label_file(file)
-        X_list, y_list, loaded, skipped = _embed_external_labels(labels, emb)
+        try:
+            labels = parse_label_file(file)
+        except ValueError as exc:
+            abort(400, message=str(exc))
+        X_list, y_list, loaded, skipped = embed_external_labels(labels, emb)
 
         if loaded < 2:
             abort(
@@ -914,7 +708,7 @@ def label_file_sort():
         except ValueError:
             abort(400, message="Need at least one good and one bad labeled example")
 
-        results, threshold = _train_and_score_dataset(X_list, y_list, score_name)
+        results, threshold = train_and_score_active(X_list, y_list, score_name)
         threshold = round(threshold, 4)
         return {**windowed_sort_response(results, threshold), "loaded": loaded, "skipped": skipped}
 

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -638,22 +638,6 @@ def example_sort():
             raise
         logging.getLogger(__name__).exception("example-sort failed")
         abort(500, message=f"Example sort failed: {format_exception_detail(exc)}")
-) -> tuple[list[dict], float]:
-    """Train an MLP on (X, y), then score every media in the active dataset.
-
-    *embedder_name* is the embedder the external labels in *X_list* were
-    embedded with; scoring sources the haystack vectors from the same embedder
-    so the trained MLP and the scored vectors share one space.  ``None`` reads
-    each media's primary vector.  The same name is handed to
-    :func:`train_and_threshold` so the safe-threshold GMM is fitted on exactly
-    the score distribution returned here - including the region max-pool on a
-    patch dataset, where results also gain a ``best_region`` box.
-    """
-    from vtscore.detectors.training import score_media_with_model, train_and_threshold  # noqa: PLC0415
-
-    snap = snapshot_medias()
-    model, threshold = train_and_threshold(X_list, y_list, snap=snap, embedder_name=embedder_name)
-    return score_media_with_model(model, snap, embedder_name), threshold
 
 
 @sorting_bp.route("/api/label-file-sort", methods=["POST"])


### PR DESCRIPTION
Closes #3419

## What moved

Seven helpers in `vtsearch/routes/sorting.py` were library code wearing an app-tier coat: they touch no `request`, render no HTTP, and drive the whole example-sort / label-file-sort pipeline off the active dataset context. They now live in a new `vtscore.training.query_sort`, named as library entry points, next to the `region_similarity` primitives they compose over — the same move, for the same reason, as `vtscore.detectors.learned_sort`.

| was (private, app tier) | is (library entry point) |
|---|---|
| `_cosine_sort` | `cosine_sort_active` |
| `_score_embedder_for_loaded_data` | `score_embedder_for_active` |
| `_example_sort_from_paths` | `example_sort_from_paths` |
| `_apply_crop_or_keep` | `apply_crop_or_keep` |
| `_parse_label_file` | `parse_label_file` |
| `_embed_external_labels` | `embed_external_labels` |
| `_train_and_score_dataset` | `train_and_score_active` |

`sorting.py` drops from 980 to 715 lines and is now request↔library glue.

## Two places the issue's premise needed adjusting

**`_parse_label_file` was not HTTP-free.** It called `flask_smorest.abort(400)` twice, so it could not cross the tier as a pure move. It now raises `ValueError` carrying the same two messages (`Invalid label file format`, `No labels found in file`) and the route maps them onto the same 400s — the HTTP surface is byte-identical. It also now rejects a non-object JSON document, which previously reached `.get()` on a list and 500'd.

**`_score_embedder_for_loaded_data` had to come along.** It isn't in the issue's list of six, but `example_sort_from_paths` and the label-file route both call it, and it is library-clean (`routed_embedder` + `embedder_for_medias`). Leaving it behind would have meant a library function calling back into a route module.

## The stronger motivation the issue didn't mention

`vtsearch/routes/media/server.py` was reaching **cross-blueprint** into `sorting.py`'s underscore names — four lazy `from vtsearch.routes.sorting import _apply_crop_or_keep, _example_sort_from_paths, _cosine_sort` imports, to serve its own three server-media example-sort routes. That is a route module depending on another route module's privates. Both blueprints now import the library function directly and no such import remains.

## `get_embedder_for_medias`

Deleted from `routes/_shared.py`. It was a two-line re-export of `vtscore.media.embedder_for_medias` left behind by #2931 with a single real importer — exactly the legacy alias the repo's backwards-compatibility policy forbids on internal surfaces. Its caller imports the library function directly.

## Tests

Adds `tests_lib/sorting/test_query_sort.py` — ten library-tier tests exercising the pipeline with nothing but an active dataset context: no app, no request, no Flask client. That was the point of the move, and it was not possible before it. Covers `parse_label_file`'s four outcomes, `embed_external_labels`' skip-and-count behaviour across malformed / pathless / missing / unembeddable entries, `cosine_sort_active`'s ranking over the active context, and `apply_crop_or_keep`'s no-op path.

Behaviour is otherwise unchanged, and the 644 pre-existing tests in the `sorting` group passed against the refactor before any new test was added.

## Drive-by fix

`frontend/package.json` carried `fast-uri: ^3.1.7` twice in `overrides` (from `dfad4201`), which esbuild reports as `duplicate-object-key`. `run-tests.sh` treats every `▲ [WARNING]` from `build:prod` as a hard failure, so the frontend gate was already red on `dev`. Both entries pinned the same version, so removing the second changes no resolution.

## Verification

Full `./run-tests.sh`: **9927 passed, 6 skipped**, and every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4z1KsTpKNAFtan5HwuoYe

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4z1KsTpKNAFtan5HwuoYe)_