### PR TITLE
Give every converted demo output its own disambiguated origin

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1130,8 +1130,14 @@ recoverable long after the import job ended:
   of the real source file**), `converter_param_<key>`, the replay
   disambiguators `converter_out_index` / `converter_n_out` /
   `converter_content_hash`, and `parent_importer` plus the parent importer's
-  locator (`parent_path` / `parent_url` / `parent_paths_file` /
-  `parent_manifest`).  `source_file` and `source_path` diverge whenever the
+  own locator param under a `parent_` prefix (`parent_path` / `parent_url` /
+  `parent_paths_file` / `parent_manifest`, or `parent_name` for a demo
+  dataset).  The resolver rebuilds the parent origin by stripping that prefix,
+  so a new importer's locator resolves with no resolver change.  The same
+  keys are stamped whether the source corpus was a scanned folder or a demo
+  dataset, and every one of a source's N outputs gets its own origin dict —
+  sharing one would leave page 3 and page 7 indistinguishable on replay.
+  `source_file` and `source_path` diverge whenever the
   scanned folder is a staging area of symlinks — the `server_files`
   (Manifest) importer links listed paths into a temp dir under their
   basenames, disambiguating collisions as `name__1.ext` — so `source_path` is

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/tests/converters/test_document_and_converters.py
+++ b/tests/converters/test_document_and_converters.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -853,7 +853,45 @@ class TestLoadDemoWithConverter:
             assert m["origin"]["importer"] == "converter"
             assert m["origin"]["params"]["converter"] == "document2image"
             assert m["origin"]["params"]["parent_importer"] == "demo"
-            assert m["origin"]["params"]["parent_demo"] == "test_demo"
+            assert m["origin"]["params"]["parent_name"] == "test_demo"
             assert "test.pdf" in m["origin"]["params"]["source_file"]
             # Category should be preserved from source
             assert m["category"] == "test_cat"
+            # Every output carries the sub-output disambiguators, so a label on
+            # one page can be replayed back to *that* page.
+            assert m["origin"]["params"]["converter_out_index"] == str(m["id"] - 1)
+            assert m["origin"]["params"]["converter_n_out"] == str(len(medias))
+            assert m["origin"]["params"]["converter_content_hash"]
+
+    def test_apply_converter_to_demo_gives_each_output_its_own_origin(self):
+        """N outputs of one source must not share a single origin dict."""
+        from vtscore.converters.runner import apply_converter_to_demo
+
+        outputs = [
+            {"filename": f"page_{i}.png", "media_bytes": f"page-{i}-bytes".encode(), "duration": 0} for i in range(3)
+        ]
+        converter = MagicMock()
+        converter.name = "document2image"
+        converter.display_name = "Document \u2192 Images"
+        converter.target_type = "image"
+        converter.convert_normalized.return_value = outputs
+
+        medias = {1: {"id": 1, "media_type": "document", "filename": "doc.pdf", "media_path": "/data/doc.pdf"}}
+        with patch("vtscore.converters.get_converter", return_value=converter):
+            apply_converter_to_demo(
+                converter_name="document2image",
+                dataset_name="test_demo",
+                medias=medias,
+            )
+
+        assert len(medias) == 3
+        origins = [medias[mid]["origin"] for mid in sorted(medias)]
+        # Distinct objects, not one aliased dict.
+        assert origins[0] is not origins[1]
+        indexes = [o["params"]["converter_out_index"] for o in origins]
+        assert indexes == ["0", "1", "2"]
+        hashes = {o["params"]["converter_content_hash"] for o in origins}
+        assert len(hashes) == 3
+        assert all(o["params"]["converter_n_out"] == "3" for o in origins)
+        # The demo path is not reference mode, so nothing is lazified.
+        assert all("_lazy_source" not in m for m in medias.values())

--- a/tests/detectors/test_resolver.py
+++ b/tests/detectors/test_resolver.py
@@ -155,6 +155,50 @@ class TestResolveConverterOrigin:
         result = resolve_file_from_origin(origin)
         assert result == folder / "clip.mp4"
 
+    def test_resolves_demo_parent(self, tmp_path):
+        """A converted *demo* media resolves back to its source file.
+
+        The parent origin is rebuilt by stripping the ``parent_`` prefix, so
+        the demo importer's own locator key (``name``) arrives intact and its
+        resolve_file can find the file.
+        """
+        import vtscore.datasets.importers.demo as demo_mod
+
+        root = tmp_path / "ucsf_documents"
+        root.mkdir()
+        (root / "doc.pdf").write_bytes(b"%PDF-")
+
+        origin = {
+            "importer": "converter",
+            "params": {
+                "converter": "document2image",
+                "source_file": "doc.pdf",
+                "parent_importer": "demo",
+                "parent_name": "ucsf_documents",
+                "converter_out_index": "2",
+                "converter_n_out": "5",
+            },
+        }
+        old_dirs = demo_mod._SOURCE_DIRS
+        demo_mod._SOURCE_DIRS = {"ucsf_documents": root}
+        try:
+            with patch.dict(
+                "vtscore.datasets.config.DEMO_DATASETS",
+                {"ucsf_documents": {"source": "ucsf_documents", "categories": [], "media_type": "document"}},
+                clear=False,
+            ):
+                result = resolve_file_from_origin(origin)
+        finally:
+            demo_mod._SOURCE_DIRS = old_dirs
+        assert result == root / "doc.pdf"
+
+    def test_returns_none_without_a_parent_importer(self):
+        origin = {
+            "importer": "converter",
+            "params": {"converter": "video2image", "source_file": "clip.mp4"},
+        }
+        assert resolve_file_from_origin(origin) is None
+
 
 class TestResolveDemoOrigin:
     """Verify that resolve_file_from_origin handles demo dataset origins."""

--- a/tests_lib/datasets/test_demo_origin_stamp.py
+++ b/tests_lib/datasets/test_demo_origin_stamp.py
@@ -1,0 +1,69 @@
+"""`_stamp_demo_origin` must not clobber a converted media's converter origin.
+
+The demo pickle is written *after* the converter has replaced each source
+media with its N converted outputs, so a cached converted demo already carries
+the full converter recipe.  Re-stamping the flat demo origin over it discarded
+which source file and which sub-output each media came from.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vtscore.datasets.loader_demo import _stamp_demo_origin
+
+
+def _converter_origin(out_index: int) -> dict[str, Any]:
+    return {
+        "importer": "converter",
+        "params": {
+            "converter": "document2image",
+            "source_file": "doc.pdf",
+            "parent_importer": "demo",
+            "parent_name": "ucsf_documents",
+            "converter_out_index": str(out_index),
+            "converter_n_out": "3",
+        },
+    }
+
+
+class TestStampDemoOrigin:
+    def test_stamps_plain_medias(self):
+        medias: dict[int, dict[str, Any]] = {
+            1: {"id": 1},
+            2: {"id": 2, "origin": {"importer": "demo", "params": {}}},
+        }
+        _stamp_demo_origin(medias, "esc50")
+        for media in medias.values():
+            assert media["origin"] == {"importer": "demo", "params": {"name": "esc50"}}
+
+    def test_records_the_converter_name(self):
+        medias: dict[int, dict[str, Any]] = {1: {"id": 1}}
+        _stamp_demo_origin(medias, "ucsf_documents", converter_name="document2image")
+        assert medias[1]["origin"]["params"] == {
+            "name": "ucsf_documents",
+            "converter": "document2image",
+        }
+
+    def test_each_media_gets_its_own_params_dict(self):
+        medias: dict[int, dict[str, Any]] = {1: {"id": 1}, 2: {"id": 2}}
+        _stamp_demo_origin(medias, "esc50")
+        assert medias[1]["origin"]["params"] is not medias[2]["origin"]["params"]
+
+    def test_preserves_converter_origins(self):
+        medias: dict[int, dict[str, Any]] = {i + 1: {"id": i + 1, "origin": _converter_origin(i)} for i in range(3)}
+        _stamp_demo_origin(medias, "ucsf_documents", converter_name="document2image")
+        for i, mid in enumerate(sorted(medias)):
+            params = medias[mid]["origin"]["params"]
+            assert medias[mid]["origin"]["importer"] == "converter"
+            assert params["source_file"] == "doc.pdf"
+            assert params["converter_out_index"] == str(i)
+
+    def test_still_stamps_unconverted_medias_alongside_converted_ones(self):
+        medias: dict[int, dict[str, Any]] = {
+            1: {"id": 1, "origin": _converter_origin(0)},
+            2: {"id": 2},
+        }
+        _stamp_demo_origin(medias, "ucsf_documents", converter_name="document2image")
+        assert medias[1]["origin"]["importer"] == "converter"
+        assert medias[2]["origin"]["importer"] == "demo"

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -218,33 +218,41 @@ def _origin_with_disambiguators(
 def _emit_converted_outputs(
     *,
     outputs: list[dict[str, Any]],
-    source_rel: str,
-    source_path: Path,
+    source_name: str,
+    media_path: str,
     target_type: str,
     origin: dict[str, Any],
     medias: dict[int, dict[str, Any]],
     start_id: int,
     category: str,
-    thin: bool = False,
+    lazy_source: str | None = None,
 ) -> int:
     """Append each converter output to *medias*; return next media_id.
+
+    Shared by both emitters - the folder scan
+    (:func:`run_converters_on_folder`) and the demo conversion
+    (:func:`apply_converter_to_demo`).  They differ only in where the source
+    name, path and category come from, so they pass those in rather than
+    keeping two copies of this loop: a copy is exactly how the demo path came
+    to hand one shared origin dict to all N outputs of a source, leaving lazy
+    replay and label re-resolution unable to tell page 3 from page 7.
 
     Outputs leave with ``embedding=None``; the framework embed stage
     embeds them from ``media_bytes`` / ``media_string``.
 
-    In reference (*thin*) mode each output keeps its ``media_bytes`` for the
-    embed stage but is tagged with a ``_lazy_source`` marker carrying the
-    source file path.  ``_relazify_reference_clips_stage`` strips those bytes
-    after embedding so the saved dataset stores only the source path plus the
-    converter recipe (in ``origin.params``); the bytes are reproduced on demand
-    by :mod:`vtscore.media.lazy_clip`.
+    When *lazy_source* is given (reference / *thin* mode) each output keeps
+    its ``media_bytes`` for the embed stage but is tagged with a
+    ``_lazy_source`` marker carrying that path.
+    ``_relazify_reference_clips_stage`` strips those bytes after embedding so
+    the saved dataset stores only the source path plus the converter recipe
+    (in ``origin.params``); the bytes are reproduced on demand by
+    :mod:`vtscore.media.lazy_clip`.
     """
     media_id = start_id
     n_out = len(outputs)
-    resolved_source = str(source_path.resolve())
     for out_index, output in enumerate(outputs):
         output_filename = output.get("filename", f"converted_{media_id}")
-        origin_name = f"{source_rel}\u2192{output_filename}"
+        origin_name = f"{source_name}\u2192{output_filename}"
 
         per_output_origin = _origin_with_disambiguators(origin, out_index, n_out, output)
         media_data = _build_converted_media_dict(
@@ -253,11 +261,11 @@ def _emit_converted_outputs(
             target_type,
             per_output_origin,
             origin_name,
-            resolved_source,
+            media_path,
             category,
         )
-        if thin:
-            media_data["_lazy_source"] = resolved_source
+        if lazy_source is not None:
+            media_data["_lazy_source"] = lazy_source
         medias[media_id] = media_data
         media_id += 1
     return media_id
@@ -359,16 +367,17 @@ def run_converters_on_folder(
                 continue
 
             origin = _build_converter_origin(converter.name, source_rel, source_path, conv_params, base_origin)
+            resolved_source = str(source_path.resolve())
             media_id = _emit_converted_outputs(
                 outputs=outputs,
-                source_rel=source_rel,
-                source_path=source_path,
+                source_name=source_rel,
+                media_path=resolved_source,
                 target_type=target_mt.type_id,
                 origin=origin,
                 medias=medias,
                 start_id=media_id,
                 category="custom",
-                thin=thin,
+                lazy_source=resolved_source if thin else None,
             )
 
 
@@ -436,11 +445,18 @@ def apply_converter_to_demo(
         if not outputs:
             continue
 
+        # ``parent_name`` rather than ``parent_demo``: the parent locator keys
+        # are named for the *parent importer's* own origin param (see
+        # _PARENT_LOCATOR_KEYS), and the demo importer locates its corpus with
+        # ``name``.  Spelling it that way lets the resolver rebuild the parent
+        # origin by stripping the ``parent_`` prefix, with no per-importer
+        # special case, and makes the "Imported Via" line read the same for a
+        # converted demo media as for an unconverted one.
         origin_params: dict[str, Any] = {
             "converter": converter_name,
             "source_file": src_media.get("filename", ""),
             "parent_importer": "demo",
-            "parent_demo": dataset_name,
+            "parent_name": dataset_name,
         }
         # A demo media held purely in memory has no path; record one only when
         # the source actually came off disk, so ``Source`` never points at "".
@@ -449,48 +465,16 @@ def apply_converter_to_demo(
             origin_params["source_path"] = str(source_path)
         origin = {"importer": "converter", "params": origin_params}
         source_name = src_media.get("filename", str(src_media.get("id", "")))
-        new_id = _emit_converted_demo_outputs(
+        new_id = _emit_converted_outputs(
             outputs=outputs,
             source_name=source_name,
-            source_media=src_media,
+            media_path=src_media.get("media_path", ""),
             target_type=converter.target_type,
             origin=origin,
-            converted=converted,
+            medias=converted,
             start_id=new_id,
+            category=src_media.get("category", "custom"),
         )
 
     medias.clear()
     medias.update(converted)
-
-
-def _emit_converted_demo_outputs(
-    *,
-    outputs: list[dict[str, Any]],
-    source_name: str,
-    source_media: dict[str, Any],
-    target_type: str,
-    origin: dict[str, Any],
-    converted: dict[int, dict[str, Any]],
-    start_id: int,
-) -> int:
-    """Append each converter output to *converted*, return next id.
-
-    Outputs leave with ``embedding=None`` for the framework embed stage.
-    """
-    new_id = start_id
-    for output in outputs:
-        output_filename = output.get("filename", f"converted_{new_id}")
-        origin_name = f"{source_name}\u2192{output_filename}"
-
-        media_data = _build_converted_media_dict(
-            new_id,
-            output,
-            target_type,
-            origin,
-            origin_name,
-            source_media.get("media_path", ""),
-            source_media.get("category", "custom"),
-        )
-        converted[new_id] = media_data
-        new_id += 1
-    return new_id

--- a/vtscore/datasets/loader_demo.py
+++ b/vtscore/datasets/loader_demo.py
@@ -56,11 +56,26 @@ def _stamp_demo_origin(
     """Stamp the demo origin on all medias (fresh dict per media).
 
     Ensures every media has ``origin = {"importer": "demo", "params": {"name": ...}}``.
+
+    A media that already carries a ``converter`` origin is left alone.  That
+    only happens on the cached path: the pickle is written *after*
+    :func:`~vtscore.converters.runner.apply_converter_to_demo` has replaced
+    each source media with its N converted outputs, so the cached medias
+    already record the full converter recipe - which source file, which
+    sub-output, which params.  Overwriting it with the flat demo origin threw
+    all of that away, so a label on page 3 of a converted demo document could
+    not be resolved back to a file at all (its ``origin_name`` is
+    ``"doc.pdf\u2192page_3.png"``, which names nothing on disk), and the
+    labelling UI showed no "Derived Via" row for a cached converted demo while
+    showing one for the same dataset freshly built.
     """
     demo_origin_params: dict[str, str] = {"name": dataset_name}
     if converter_name:
         demo_origin_params["converter"] = converter_name
     for media in medias.values():
+        origin = media.get("origin")
+        if isinstance(origin, dict) and origin.get("importer") == "converter":
+            continue
         media["origin"] = {"importer": "demo", "params": dict(demo_origin_params)}
 
 

--- a/vtscore/detectors/resolver.py
+++ b/vtscore/detectors/resolver.py
@@ -357,18 +357,28 @@ def _resolve_example_media(params: dict[str, Any]) -> Path | None:
 
 
 def _resolve_converter(stack: ExitStack, params: dict[str, str]) -> Path | None:
-    """Resolve a converter origin by rebuilding its parent origin."""
+    """Resolve a converter origin by rebuilding its parent origin.
+
+    Every ``parent_<key>`` the converter runner copied over is a locator param
+    of the *parent* importer's own origin, stored under its own key with a
+    ``parent_`` prefix (see ``_PARENT_LOCATOR_KEYS`` in
+    :mod:`vtscore.converters.runner`).  Rebuilding the parent origin is
+    therefore just stripping that prefix - deliberately generic rather than an
+    allow-list of ``path`` / ``url``, because an allow-list silently drops the
+    locators of every other importer (``paths_file`` for Manifest, ``manifest``
+    for an archive, ``name`` for a demo dataset), leaving their converted
+    outputs unresolvable with no signal that anything was missing.
+    """
     source_file = params.get("source_file", "")
     parent_importer = params.get("parent_importer", "")
     if not source_file or not parent_importer:
         return None
 
-    # Reconstruct a parent origin dict from the converter's stored params
-    parent_params: dict[str, str] = {}
-    if params.get("parent_path"):
-        parent_params["path"] = params["parent_path"]
-    if params.get("parent_url"):
-        parent_params["url"] = params["parent_url"]
+    parent_params: dict[str, str] = {
+        key[len("parent_") :]: value
+        for key, value in params.items()
+        if key.startswith("parent_") and key != "parent_importer" and value
+    }
 
     parent_origin = {"importer": parent_importer, "params": parent_params}
     return _resolve_with_stack(stack, parent_origin, origin_name=source_file)

--- a/vtscore/docs/packages/converters.md
+++ b/vtscore/docs/packages/converters.md
@@ -353,7 +353,7 @@ Vectors"). The recorded `params` are:
 | `converter_out_index` / `converter_n_out` | This output's position in the converter's returned list, and the list's length at import time |
 | `converter_content_hash` | Short md5 of the output bytes - the authoritative replay disambiguator |
 | `parent_importer` | The importer that supplied the source corpus |
-| `parent_path` / `parent_url` / `parent_paths_file` / `parent_manifest` | That importer's locator, so the corpus itself is recoverable, not just the file inside it |
+| `parent_<key>` (`parent_path`, `parent_url`, `parent_paths_file`, `parent_manifest`, `parent_name` for a demo dataset) | That importer's own locator param, prefixed - so the corpus itself is recoverable, not just the file inside it.  The resolver rebuilds the parent origin by stripping the prefix, so a new importer's locator needs no resolver change |
 
 `source_file` and `source_path` differ whenever the scanned folder is a
 staging area of symlinks: the `server_files` (Manifest) importer links every


### PR DESCRIPTION
Closes #3402

## The premise holds, and the demo path is worse than the issue describes

`apply_converter_to_demo` didn't just give N outputs *equal* origins — it stored the **same dict object** in all of them. So a converted demo dataset recorded nothing about which page of the PDF or which frame of the video each media was.

But applying `_origin_with_disambiguators` on its own, as the issue proposes, would have changed **nothing observable**. Two further links in the demo replay chain were broken, and either one alone makes the disambiguators dead weight:

1. **`_resolve_converter` couldn't rebuild a demo parent origin.** It reconstructed parent params from a hardcoded allow-list of `parent_path` / `parent_url`, silently dropping every other importer's locator. The demo importer locates its corpus with `name`, and the runner stamped it as `parent_demo` — read by nothing. So a demo-parented converter origin resolved to `None` before sub-output selection was ever reached. (`parent_paths_file` and `parent_manifest` were dropped the same way.)

2. **`_stamp_demo_origin` clobbered the converter origin on every cache hit.** The demo pickle is written *after* the converter has replaced each source media with its outputs, so the cached medias already carry the full recipe — and the reload path overwrote all of it with the flat demo origin. Its `origin_name` is `doc.pdf→page_3.png`, which names nothing on disk, so the media became unresolvable and lost its `Derived Via` / `Source` provenance rows too.

Fixing only what the issue asks for would have left a passing test asserting keys nothing reads. So this fixes all three.

## Changes

**Collapse the two emitters** (`vtscore/converters/runner.py`) — the issue's second suggested direction. Their bodies differed only in where the source name, path and category came from and whether reference mode tags `_lazy_source`; the callers now pass those in. A copy is how the demo path came to lack the disambiguators in the first place, so one emitter is the fix that can't re-diverge.

**Generic parent-locator reconstruction** (`vtscore/detectors/resolver.py`) — `_resolve_converter` now rebuilds the parent origin by stripping the `parent_` prefix, which is what the prefix meant all along. The demo path stamps `parent_name` instead of the ad-hoc `parent_demo`, matching the demo importer's own locator key. A new importer's locator now resolves with no resolver change, and `Imported Via` reads the same for a converted demo media as for an unconverted one.

**Preserve converter origins across the demo cache** (`vtscore/datasets/loader_demo.py`) — `_stamp_demo_origin` skips medias that already carry a `converter` origin. Unconverted medias, and old pickles with empty params, are stamped exactly as before.

End to end: a label on page 3 of a converted demo document now resolves back to the source file, replays the converter, and re-embeds *that page*. Before, it either failed to resolve outright or fell through to `embed_file` on the whole source PDF with the target type's image embedder.

**Also**: `frontend/package.json` had a literal duplicate `"fast-uri"` key in `overrides` (same value twice), which `npm run build:prod` flagged as a warning — a hard failure under `run-tests.sh`. Pre-existing on `dev`; removed per the repo's fix-all-errors rule.

## Backwards compatibility

`parent_demo` → `parent_name` is a persisted-origin change in demo dataset pickles. Per the repo's policy this is a saved-data surface, broken without a shim. There is no regression for existing pickles: those origins were being discarded wholesale by `_stamp_demo_origin` on load anyway, so they were equally unresolvable before. No `vtscore` public API changes.

## Tests

- `tests/converters/test_document_and_converters.py` — demo outputs carry `converter_out_index` / `converter_n_out` / `converter_content_hash`; N outputs get distinct origin dicts with distinct content hashes; the demo path stamps no `_lazy_source`.
- `tests/detectors/test_resolver.py` — a `parent_importer: demo` + `parent_name` converter origin resolves to its source file; a converter origin with no parent importer still returns `None`.
- `tests_lib/datasets/test_demo_origin_stamp.py` (new) — `_stamp_demo_origin` preserves converter origins, still stamps plain and unconverted medias, and gives each its own params dict.

Full `./run-tests.sh`: **9925 passed, 6 skipped**, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfdQnFNzDS5cALfAf52AbH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfdQnFNzDS5cALfAf52AbH)_