### PR TITLE
Collapse the near-synonymous embedder resolvers onto two canonical entry points

### DIFF
--- a/tests/detectors/test_portable_export_route.py
+++ b/tests/detectors/test_portable_export_route.py
@@ -130,7 +130,7 @@ class TestPortableExport:
         import vtsearch.routes.detectors.scoring as scoring_mod
 
         monkeypatch.setattr(scoring_mod, "_dataset_supplies_detector_type", lambda *_a, **_kw: True)
-        monkeypatch.setattr(binding_mod, "keying_embedder_for_snap", lambda *_a, **_kw: DEFAULT_AUDIO_EMBEDDER)
+        monkeypatch.setattr(binding_mod, "keying_embedder_for_type", lambda *_a, **_kw: DEFAULT_AUDIO_EMBEDDER)
         detector_id = setup_trainable_model_in_registry(
             "portable-patch",
             good_ids=[1, 2, 3],

--- a/tests_lib/core/test_dataset_binding.py
+++ b/tests_lib/core/test_dataset_binding.py
@@ -18,6 +18,7 @@ from vtscore.embedding.binding import (
     derive_binding_from_names,
     score_marker_embedder,
     score_marker_embedder_for_snap,
+    slot_embedders_for_snap,
     validate_binding,
 )
 from vtscore.state.core import DatasetContext
@@ -332,6 +333,45 @@ class TestScoreMarkerEmbedder:
     def test_for_snap_uses_first_media(self, fake_caps):
         snap = {7: self._media("faketext", ["faketext", "fakepatch"])}
         assert score_marker_embedder_for_snap(snap) == "fakepatch"
+
+
+class TestSlotEmbeddersForSnap:
+    """The raw ``(text, patch, structural)`` slot read for a snapshot.
+
+    The single first-media derivation the training path's score- and
+    patch-slot resolvers both read off (issue #3386), so the two cannot
+    disagree about which media a snapshot's binding comes from.  Unlike
+    :func:`score_marker_embedder_for_snap` it does *not* collapse the triple
+    or fall back to the primary name: a slot-less dataset must read as
+    ``None`` so the matrix layer falls back to each media's own vector.
+    """
+
+    def _media(self, primary: str, names: list[str]) -> dict:
+        return {
+            "embedder": primary,
+            "embedding": np.ones(4, dtype=np.float32),
+            "embeddings": {n: np.ones(4, dtype=np.float32) for n in names},
+        }
+
+    def test_empty_snap_is_all_none(self):
+        assert slot_embedders_for_snap(None) == (None, None, None)
+        assert slot_embedders_for_snap({}) == (None, None, None)
+
+    def test_trio_fills_every_slot(self, fake_caps):
+        snap = {3: self._media("faketext", ["faketext", "fakepatch", "fakestructural"])}
+        assert slot_embedders_for_snap(snap) == ("faketext", "fakepatch", "fakestructural")
+
+    def test_slot_less_dataset_reads_none_not_the_primary(self, fake_caps):
+        # The difference that earns this function its keep: the score *marker*
+        # falls back to the primary name here, but the slot read must not, or
+        # the matrix layer stops collapsing to the cached primary path.
+        snap = {3: self._media("fakesingle", ["fakesingle"])}
+        assert slot_embedders_for_snap(snap) == (None, None, None)
+        assert score_marker_embedder_for_snap(snap) == "fakesingle"
+
+    def test_uses_the_first_media(self, fake_caps):
+        snap = {7: self._media("faketext", ["faketext"]), 8: self._media("fakepatch", ["fakepatch"])}
+        assert slot_embedders_for_snap(snap) == ("faketext", None, None)
 
 
 class TestRealRegisteredEmbedder:

--- a/tests_lib/detectors/test_per_detector_embedder_type.py
+++ b/tests_lib/detectors/test_per_detector_embedder_type.py
@@ -7,9 +7,11 @@ These cover the pure resolvers that route training/scoring through that choice:
 
 * ``embedder_type`` / ``embedder_of_type`` / ``dataset_supplied_types`` /
   ``detector_dataset_compatible`` - the type taxonomy.
-* ``keying_embedder_for_snap`` - the dataset's concrete embedder of the
-  detector's type when the snap supplies it, else the dataset score precedence
-  (the legacy / cross-dataset-portability fallback).
+* ``keying_embedder_for_snap`` / ``keying_embedder_for_type`` - the dataset's
+  concrete embedder of the detector's type when the snap supplies it, else the
+  dataset score precedence (the legacy / cross-dataset-portability fallback).
+  The two forms differ only in whether the type arrives on a context object or
+  as a bare string, and must never disagree.
 * ``detector_score_embedder`` - the scoring-space name handed to the matrix
   layer (delegates to keying).
 * ``_score_all_media`` region gating - region max-pool only when the detector
@@ -44,6 +46,7 @@ from vtscore.embedding.binding import (
     embedder_of_type,
     embedder_type,
     keying_embedder_for_snap,
+    keying_embedder_for_type,
 )
 
 DIM = 4
@@ -167,6 +170,39 @@ class TestKeyingEmbedder:
         # labelset re-embeds in clip - the same-type portability.
         clip_snap = {1: {"id": 1, "embedder": "clip", "embeddings": {"clip": _basis(0)}}}
         assert keying_embedder_for_snap(_det("semantic"), clip_snap) == "clip"
+
+
+class TestKeyingEmbedderForType:
+    """The bare-type entry point onto the same resolver (issue #3386).
+
+    Five call sites used to conjure a ``SimpleNamespace(embedder_type=...)``
+    carrier so a serialised detector's type string could reach
+    ``keying_embedder_for_snap``.  The two forms must resolve identically: the
+    name feeds model invalidation and ``resolve_calibration_fraction``, so drift
+    between them would change detector behaviour silently.
+    """
+
+    def test_matches_the_det_ctx_form_for_every_type(self):
+        snap = _dual_snap()
+        for det_type in ("semantic", "patch_semantic", "structural", ""):
+            assert keying_embedder_for_type(det_type, snap) == keying_embedder_for_snap(_det(det_type), snap)
+
+    def test_concrete_of_type_used_when_snap_supplies_it(self):
+        snap = _dual_snap()
+        assert keying_embedder_for_type("semantic", snap) == "siglip"
+        assert keying_embedder_for_type("patch_semantic", snap) == "dinov3_patch"
+
+    def test_falls_back_to_precedence_when_type_absent(self):
+        assert keying_embedder_for_type("structural", _dual_snap()) == "dinov3_patch"
+
+    def test_no_type_is_precedence_and_matches_a_null_context(self):
+        snap = _dual_snap()
+        assert keying_embedder_for_type("", snap) == "dinov3_patch"
+        assert keying_embedder_for_type("", snap) == keying_embedder_for_snap(None, snap)
+
+    def test_empty_snap_is_empty_string(self):
+        assert keying_embedder_for_type("semantic", {}) == ""
+        assert keying_embedder_for_type("semantic", None) == ""
 
 
 class TestDetectorScoreEmbedder:

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -10,6 +10,25 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`slot_embedders_for_snap(snap)` and `keying_embedder_for_type(type, snap)`
+  on `vtscore.embedding.binding`** (issue #3386). Purely additive companions to
+  the two existing snapshot resolvers, added so the near-synonymous private
+  wrappers scattered across `vtscore/detectors/` could collapse onto them.
+  `slot_embedders_for_snap` is `derive_binding_from_names` applied to a
+  snapshot's first media, returning the raw `(text, patch, structural)` triple
+  without `score_marker_embedder_for_snap`'s collapse-and-fall-back-to-primary
+  step. `keying_embedder_for_type` is `keying_embedder_for_snap`'s body taking
+  the detector's embedder *type* as a plain string, for callers holding a
+  serialised detector rather than a live context - four of them were conjuring
+  a throwaway `SimpleNamespace(embedder_type=...)` carrier to satisfy the
+  `det_ctx` parameter. `keying_embedder_for_snap` now delegates to it, so the
+  two cannot disagree. No resolved embedder name changes.
+
+  `vtscore.detectors.training.detector_score_embedder` keeps its name, its
+  signature and its `None`-for-empty-snap normalisation; only its docstring
+  moved. The four underscore-prefixed wrappers around it are private and were
+  inlined or collapsed.
+
 - **`vtscore.host_seams` snapshots the host seams** (issue #3385). The eight
   callbacks a host application installs into the library
   (`register_core_config_builder`, the context resolvers, the setting
@@ -24,18 +43,6 @@ instead, since every commit on `dev` is effectively a new app release.)
   `register_plugin_family` is deliberately **not** covered: the library
   registers its own families at import time, so it is a plugin extension point
   rather than a host seam, and restoring it would drop the built-ins.
-
-### Changed
-
-- **`register_setting_persister` rejects an unrecognised key** (issue #3385).
-  It previously stored a persister under any key, but only `inclusion`,
-  `calibrate_count` and `calibration_fraction` are ever fired, so any other key
-  was a typo in the host's wiring that sat there silently never firing — the
-  failure mode `achievements_hooks.KNOWN_EVENTS` already existed to catch. The
-  key set is now public as `vtscore.state.KNOWN_SETTING_KEYS`, and an unknown
-  key raises `ValueError`. This is an extension-facing behaviour change, but no
-  working integration can be relying on it: a rejected key could never have
-  persisted anything.
 
 - **The Toponymy signpost fit counts the library warnings it suppresses**
   (issue #3512). `signpost_build` keeps Toponymy's per-topic naming warnings
@@ -137,6 +144,16 @@ instead, since every commit on `dev` is effectively a new app release.)
   `signpost-relabel`, `archive-thumbnail-warm`), so code that iterated it
   expecting only user-facing work should read `list_active_pairs()` or filter
   on `mgr.user_visible`. The keys of the visible entries are unchanged.
+
+- **`register_setting_persister` rejects an unrecognised key** (issue #3385).
+  It previously stored a persister under any key, but only `inclusion`,
+  `calibrate_count` and `calibration_fraction` are ever fired, so any other key
+  was a typo in the host's wiring that sat there silently never firing — the
+  failure mode `achievements_hooks.KNOWN_EVENTS` already existed to catch. The
+  key set is now public as `vtscore.state.KNOWN_SETTING_KEYS`, and an unknown
+  key raises `ValueError`. This is an extension-facing behaviour change, but no
+  working integration can be relying on it: a rejected key could never have
+  persisted anything.
 
 - **`vtscore.training.evt_mixture` moved to `vtscore.eval.evt_mixture`** (issue
   #3396). The Gumbel/Normal score mixture is a research arm from the #2836 /

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 import numpy as np
 
 from vtscore.datasets.labelset import LabeledElement, LabelSet
+from vtscore.embedding.binding import keying_embedder_for_snap
 from vtscore.embedding.media_vectors import media_embedding
 
 
@@ -46,24 +47,6 @@ def _lookups_for_snap(
     from vtscore.state import build_media_lookup
 
     return build_media_lookup(snap)
-
-
-def _detector_embedder(det_ctx, snap: dict[int, dict[str, Any]] | None) -> str:
-    """The embedder a *detector* resolves and embeds its labels in.
-
-    The concrete embedder of the detector's locked type (``det_ctx.embedder_type``)
-    that the active dataset supplies wins; otherwise the dataset's score
-    precedence (the legacy-migration default and the cross-dataset portability
-    fallback - re-embed against whatever space the new dataset uses).  This is
-    :func:`keying_embedder_for_snap`, so it agrees with the model-invalidation
-    and re-embed checks.  Keeping a detector's label cache keyed to its type
-    means switching the active dataset under the detector no longer invalidates
-    the cache as long as the new dataset binds the same concrete embedder of
-    that type.  See ``docs/plans/patch-embedder.md`` → "Per-detector embedder type".
-    """
-    from vtscore.embedding.binding import keying_embedder_for_snap
-
-    return keying_embedder_for_snap(det_ctx, snap)
 
 
 def _patch_output_from_file(
@@ -432,7 +415,12 @@ def populate_label_embeddings(
     """
     from vtscore.detectors.labelset_elements import stable_element_id
 
-    embedder_name = _detector_embedder(det_ctx, snap)
+    # Labels are resolved and embedded in the same space the model-invalidation
+    # and re-embed checks key on, so the label cache stays valid across an
+    # active-dataset switch that keeps binding the same concrete embedder of the
+    # detector's type.  See ``docs/plans/patch-embedder.md`` → "Per-detector
+    # embedder type".
+    embedder_name = keying_embedder_for_snap(det_ctx, snap)
     _maybe_clear_cache_on_embedder_switch(det_ctx, embedder_name)
     cache: dict[str, np.ndarray] = det_ctx.label_embeddings
     region_cache: dict[str, tuple[float, float, float, float] | None] = det_ctx.label_embedding_regions
@@ -756,7 +744,12 @@ def populate_label_local_features(
     """
     from vtscore.detectors.labelset_elements import stable_element_id
 
-    embedder_name = _detector_embedder(det_ctx, snap)
+    # Labels are resolved and embedded in the same space the model-invalidation
+    # and re-embed checks key on, so the label cache stays valid across an
+    # active-dataset switch that keeps binding the same concrete embedder of the
+    # detector's type.  See ``docs/plans/patch-embedder.md`` → "Per-detector
+    # embedder type".
+    embedder_name = keying_embedder_for_snap(det_ctx, snap)
     embedder = None
     if embedder_name:
         from vtscore.media import get_embedder

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -42,14 +42,15 @@ def _score_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | No
     so the matrix layer falls back to each media's primary vector.  For a
     single-embedder dataset the resolved name equals the primary, which the
     matrix layer collapses to the cached primary path.
-    """
-    if not snap:
-        return None
-    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
-    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
 
-    first = next(iter(snap.values()))
-    text, patch, structural = derive_binding_from_names(media_embedder_names(first))
+    This is deliberately **not** :func:`~vtscore.embedding.binding.score_marker_embedder_for_snap`:
+    that one falls back to the media's primary *name* and returns ``""``, where
+    the matrix layer here wants ``None`` to mean "no bound slot, read each
+    media's primary vector".
+    """
+    from vtscore.embedding.binding import slot_embedders_for_snap  # noqa: PLC0415
+
+    text, patch, structural = slot_embedders_for_snap(snap)
     return structural or patch or text
 
 
@@ -60,10 +61,14 @@ def detector_score_embedder(det_ctx: Any, snap: dict[int, dict[str, Any]] | None
     (``det_ctx.embedder_type``) that the snap supplies wins; otherwise the
     dataset score precedence - the legacy-migration default and the
     cross-dataset portability fallback (a detector pointed at a dataset that
-    lacks its type re-embeds against that dataset's space).  This is exactly
-    :func:`keying_embedder_for_snap`.  Returns a concrete name (collapsed to the
-    cached primary path by the matrix layer when it equals the dataset's
-    primary), or ``None`` when there is nothing to resolve (empty snap).  See
+    lacks its type re-embeds against that dataset's space).
+
+    This is :func:`~vtscore.embedding.binding.keying_embedder_for_snap` with the
+    empty marker normalised to ``None``, which is the *only* reason the name
+    exists: the training and scoring paths read ``None`` as "no explicit
+    primary, fall back to each media's own vector", so the resolver's ``""``
+    for an empty snap has to become ``None`` before it reaches them.  Kept as a
+    public name because out-of-tree code may import it.  See
     ``docs/plans/patch-embedder.md`` → "Per-detector embedder type".
     """
     from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
@@ -73,14 +78,9 @@ def detector_score_embedder(det_ctx: Any, snap: dict[int, dict[str, Any]] | None
 
 def _patch_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> str | None:
     """Resolve the patch-slot embedder name for *snap*'s medias, or ``None``."""
-    if not snap:
-        return None
-    from vtscore.embedding.binding import derive_binding_from_names  # noqa: PLC0415
-    from vtscore.embedding.media_vectors import media_embedder_names  # noqa: PLC0415
+    from vtscore.embedding.binding import slot_embedders_for_snap  # noqa: PLC0415
 
-    first = next(iter(snap.values()), {})
-    _text, patch, _structural = derive_binding_from_names(media_embedder_names(first))
-    return patch
+    return slot_embedders_for_snap(snap)[1]
 
 
 def _scores_in_patch_space(snap: dict[int, dict[str, Any]] | None, embedder_name: str | None) -> bool:

--- a/vtscore/docs/packages/embedding.md
+++ b/vtscore/docs/packages/embedding.md
@@ -514,7 +514,9 @@ typing is a total function matching score-routing precedence:
 | `validate_binding(...)` | Reject a slot pointing at an embedder lacking that role's capability |
 | `embedder_of_type(names, target_type)` | The first name of a given type, or `None` |
 | `dataset_supplied_types(names)` / `detector_dataset_compatible(det_type, names)` | Which types a dataset supplies; whether a detector can run on it |
-| `score_marker_embedder(media)` / `..._for_snap(snap)` / `keying_embedder_for_snap(det_ctx, snap)` | Which embedder the score / cache key routes through |
+| `score_marker_embedder(media)` / `..._for_snap(snap)` | Which embedder the score / cache key routes through |
+| `slot_embedders_for_snap(snap)` | The raw `(text, patch, structural)` triple a snapshot's medias bind |
+| `keying_embedder_for_snap(det_ctx, snap)` / `keying_embedder_for_type(type, snap)` | The concrete embedder of a detector's locked type that a snapshot supplies, else the score precedence |
 
 `derive_binding` is how a **pre-v3 dataset** - one `embedder` name and
 nothing else - resolves into the three-slot model on load, by

--- a/vtscore/embedding/binding.py
+++ b/vtscore/embedding/binding.py
@@ -410,6 +410,50 @@ def score_marker_embedder_for_snap(snap: dict[int, dict[str, Any]] | None) -> st
     return score_marker_embedder(next(iter(snap.values()), {}))
 
 
+def slot_embedders_for_snap(
+    snap: dict[int, dict[str, Any]] | None,
+) -> tuple[str | None, str | None, str | None]:
+    """:func:`derive_binding_from_names` for the first media in a *snap* dict.
+
+    Returns the ``(text, patch, structural)`` slot triple a snapshot's medias
+    bind, or ``(None, None, None)`` when *snap* is empty.  A snapshot's medias
+    all come from one dataset and therefore share a binding, so the first media
+    determines it - the same first-media convention
+    :func:`score_marker_embedder_for_snap` and :func:`keying_embedder_for_snap`
+    use.
+
+    This is the raw-slot counterpart of :func:`score_marker_embedder_for_snap`:
+    that one collapses the triple to the score marker and falls back to the
+    media's primary name, while this one hands back the slots unresolved so a
+    caller can read the patch slot on its own, or distinguish "no slot bound"
+    (a slot-less single-vector dataset like ``dinov2_single``, ``None``) from
+    "the score slot is X".
+    """
+    if not snap:
+        return (None, None, None)
+    return derive_binding_from_names(media_embedder_names(next(iter(snap.values()), {})))
+
+
+def keying_embedder_for_type(embedder_type_name: str, snap: dict[int, dict[str, Any]] | None) -> str:
+    """:func:`keying_embedder_for_snap` for a bare embedder **type** string.
+
+    The type-locked resolution does not otherwise need a detector context - it
+    reads exactly one attribute off it - so a caller holding a detector's type
+    as a plain string (a serialised detector dict, a cold-load record) calls
+    this instead of conjuring a throwaway carrier object to satisfy the
+    ``det_ctx`` parameter.  ``""`` means "no type locked" and yields the snap's
+    score precedence, matching ``keying_embedder_for_snap(None, snap)``.
+
+    See :func:`keying_embedder_for_snap` for the full invalidation semantics;
+    this is that function's body, and it delegates here.
+    """
+    if embedder_type_name and snap:
+        concrete = embedder_of_type(media_embedder_names(next(iter(snap.values()), {})), embedder_type_name)
+        if concrete:
+            return concrete
+    return score_marker_embedder_for_snap(snap)
+
+
 def keying_embedder_for_snap(det_ctx: Any, snap: dict[int, dict[str, Any]] | None) -> str:
     """The marker to compare against ``det_ctx.embedder`` for cache invalidation.
 
@@ -438,12 +482,7 @@ def keying_embedder_for_snap(det_ctx: Any, snap: dict[int, dict[str, Any]] | Non
     so a single-embedder dataset and every existing detector are unaffected.
     """
     det_type = (getattr(det_ctx, "embedder_type", "") or "") if det_ctx is not None else ""
-    if det_type and snap:
-        first = next(iter(snap.values()), {})
-        concrete = embedder_of_type(media_embedder_names(first), det_type)
-        if concrete:
-            return concrete
-    return score_marker_embedder_for_snap(snap)
+    return keying_embedder_for_type(det_type, snap)
 
 
 def validate_binding(

--- a/vtsearch/routes/detectors/export.py
+++ b/vtsearch/routes/detectors/export.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import io
 import logging
 from datetime import datetime, timezone
-from types import SimpleNamespace
 
 from flask import send_file
 from flask_smorest import Blueprint, abort
@@ -69,7 +68,7 @@ def export_portable_bundle(detector_id: str):
     from vtscore.detectors.registry import get_detector as reg_get_detector  # noqa: PLC0415
     from vtscore.detectors.store import _detector_path, _read_detector, _slug  # noqa: PLC0415
     from vtscore.detectors.training import serialize_weights  # noqa: PLC0415
-    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
+    from vtscore.embedding.binding import keying_embedder_for_type  # noqa: PLC0415
     from vtscore.media import get_embedder  # noqa: PLC0415
     from vtsearch.routes.detectors.scoring import (  # noqa: PLC0415
         _dataset_supplies_detector_type,
@@ -120,7 +119,7 @@ def export_portable_bundle(detector_id: str):
 
     # Score-space embedder: the concrete embedder of the detector's locked type
     # this dataset supplies (matches Find / resolve_or_train_detector's space).
-    score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=det_type), snap)
+    score_emb = keying_embedder_for_type(det_type, snap)
     embedder_display = score_emb or ""
     embedder_model_id: str | None = None
     if score_emb:

--- a/vtsearch/routes/detectors/find.py
+++ b/vtsearch/routes/detectors/find.py
@@ -265,11 +265,9 @@ def _find_score_embedder(dc: dict, temp_medias: dict[int, dict]) -> str:
     against the same role-bound vector the active-context paths use rather than
     each media's primary vector.  Empty only when *temp_medias* is empty.
     """
-    from types import SimpleNamespace  # noqa: PLC0415
+    from vtscore.embedding.binding import keying_embedder_for_type  # noqa: PLC0415
 
-    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
-
-    return keying_embedder_for_snap(SimpleNamespace(embedder_type=dc.get("embedder_type", "")), temp_medias)
+    return keying_embedder_for_type(dc.get("embedder_type", ""), temp_medias)
 
 
 def _select_scorer(dc: dict, temp_medias: dict[int, dict]) -> str:

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -267,17 +267,15 @@ def find_label(body: dict):
         # Highlight overlay can outline it - matching the learned-sort path.  Plain
         # single-vector datasets take the cached embedding-matrix path inside and
         # gain no ``best_region`` field.
-        from types import SimpleNamespace
-
         from vtscore.detectors.training import score_media_with_model
-        from vtscore.embedding.binding import keying_embedder_for_snap
+        from vtscore.embedding.binding import keying_embedder_for_type
 
         # Score in the same space the MLP was trained in: the concrete embedder of
         # the detector's locked type this dataset supplies, else the dataset score
         # precedence (keying_embedder_for_snap) - matching resolve_or_train_detector's
         # cold path and the learned-sort cache-space marker.
         _abort_if_find_cancelled()
-        score_emb = keying_embedder_for_snap(SimpleNamespace(embedder_type=_detector_type(det_data)), snap)
+        score_emb = keying_embedder_for_type(_detector_type(det_data), snap)
         results = score_media_with_model(mlp, snap, embedder_name=score_emb or None)
         update_find_progress(
             "running",
@@ -915,14 +913,12 @@ def auto_detect(body: dict):
     # dataset, where every type resolves to the same name).  A legacy/typeless
     # detector falls back to the dataset score precedence, matching
     # resolve_or_train_detector's cold-train space.
-    from types import SimpleNamespace  # noqa: PLC0415
-
-    from vtscore.embedding.binding import keying_embedder_for_snap  # noqa: PLC0415
+    from vtscore.embedding.binding import keying_embedder_for_type  # noqa: PLC0415
 
     default_score = get_active_context().routed_embedder("score")
     det_embedders: dict[str, str | None] = {}
     for dname, ddata, _entry in detectors_to_run:
-        keyed = keying_embedder_for_snap(SimpleNamespace(embedder_type=_detector_type(ddata)), snap)
+        keyed = keying_embedder_for_type(_detector_type(ddata), snap)
         det_embedders[dname] = keyed or default_score
 
     # These are ``scoring_rows_for_snap`` rows - the app's single definition of


### PR DESCRIPTION
Closes #3386

## The premise, checked

Mostly right, with two of its targets already gone and one sub-point I did differently.

**Verified.** Call sites really did conjure `SimpleNamespace(embedder_type=…)` to feed `keying_embedder_for_snap` a serialised detector's type. `_detector_embedder` really was a pure alias behind sixteen lines of docstring. `_score_embedder_for_snap` and `_patch_embedder_for_snap` really did each carry their own copy of the same four-line "first media → `derive_binding_from_names(media_embedder_names(…))`" derivation.

**Two targets already gone.** `_embedder_for_active_dataset` (the issue's first bullet) was deleted by `efd187be` when the vulture audit widened to `vtscore/`, hours after the audit that surfaced this issue was written. And the fifth `SimpleNamespace` carrier, in `model_loading.py`, went the same way while this branch was open: `48eed1e8` delegated that cold-train body to the app's labelset training and deleted the whole region. Four carriers remained; all four are converted here.

**Overstated, slightly.** "Six names for two behaviours" is really three distinct resolutions plus two thin aliases. In particular `_score_embedder_for_snap` is *not* a wrapper for `score_marker_embedder_for_snap` — the latter falls back to the media's primary name and returns `""`, where the training path needs `None` to mean "no bound slot, read each media's own vector". Collapsing those two would have been exactly the silent behaviour change the issue's own constraint warns against. They now share the derivation but keep their distinct collapse, with the difference stated in each docstring rather than left to be rediscovered.

## What changed

Two additions to `vtscore/embedding/binding.py`:

- **`slot_embedders_for_snap(snap)`** — `derive_binding_from_names` over a snapshot's first media, handing back the raw `(text, patch, structural)` triple. `_score_embedder_for_snap` and `_patch_embedder_for_snap` are now one-liners over it.
- **`keying_embedder_for_type(type, snap)`** — `keying_embedder_for_snap`'s body taking the detector's embedder type as a plain string. All four remaining `SimpleNamespace` carriers are gone; `keying_embedder_for_snap` reads the attribute off its context and delegates here, so the two forms cannot drift.

`_detector_embedder` is deleted; its two callers call `keying_embedder_for_snap` directly, with the load-bearing half of its docstring (why the label cache is keyed to the detector's *type*) kept as a comment at each site.

## Where I diverged from the issue's direction

The issue also proposed routing `detector_score_embedder`'s two internal callers at `keying_embedder_for_snap` directly, "normalising `""`/`None` at the two sites that care". I kept them on the wrapper. The `or None` it applies is load-bearing rather than cosmetic — `_build_vote_xy` reads `None` as "no explicit primary" and would take a different branch on `""` (`_scores_in_patch_space("")` compares against the patch slot and returns `False`, where `None` returns `True`) — so spelling it out at each call site adds noise without removing a concept. The name stays public per the issue's constraint; its docstring now explains that normalisation instead of restating the resolver's semantics.

## Behaviour

Resolved embedder names are bit-identical throughout — `_blend_schedule_for_snap` and `resolve_calibration_fraction` read them, so drift would change detector behaviour silently. New tests pin `keying_embedder_for_type` against `keying_embedder_for_snap` for every embedder type including the empty one, and pin `slot_embedders_for_snap`'s divergence from the score marker on a slot-less dataset. `scripts/check-eval-app-sync.py` reports all 16 mirrors up to date (the mirrored `_blend_schedule_for_snap` is untouched; only its callee's body moved).

The one test that had to change is `tests/detectors/test_portable_export_route.py`, which monkeypatched the resolver the export route imports.

## Drive-by fix

Rebasing onto `dev` surfaced a stray second `### Changed` heading in `vtscore/CHANGELOG.md`, inserted mid-`### Added` list and stranding two additive entries (`autodetect_*_main`, the Toponymy warning counts) under it. Its one entry is folded into the `### Changed` section that already existed below, and the stray heading is gone. Touched because the conflict resolution landed my own entry in exactly that region.

(An earlier commit here fixed a duplicate `fast-uri` override key in `frontend/package.json`; `dev` fixed it independently, so the rebase dropped it as already-applied.)

## Tests

Full `./run-tests.sh` on the current head, rebased onto `dev` @ `9ef139a8`: **10321 passed, 6 skipped, 1 xfailed, 1 xpassed**; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all green. `RUN PASSED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148NyYGJ7hsc6zUGNDqov2i