### PR TITLE
DocMarks: a merge slate, so the pairwise audit can actually be finished

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/scripts/experiments/docmarks/GRID-RUNBOOK.md
+++ b/scripts/experiments/docmarks/GRID-RUNBOOK.md
@@ -156,19 +156,54 @@ python build_corpus.py --sources spods,staver,tobacco800,ucsf --roster $VTS_DOCM
 Rebuilding is cheap — the sources are cached, so only clustering and manifest
 writing re-run.
 
-## Stage 3 — the human passes (interactive)
+## Stage 3 — the human passes (one bundle, then interactive)
+
+Render both sheet sets on the cluster and take the result away as one archive:
 
 ```bash
-python make_audit_slate.py --task membership --corpus $VTS_DOCMARKS_OUT
-python make_audit_slate.py --task confusable --corpus $VTS_DOCMARKS_OUT
-# fill in the verdict fields, then:
-python audit_to_corrections.py --task membership --corpus $VTS_DOCMARKS_OUT --apply
-python audit_to_corrections.py --task confusable --corpus $VTS_DOCMARKS_OUT --apply
+bash launch_docmarks.sh slate           # ~minutes, CPU, no refetch
+# when it finishes, the log names the bundle:
+scp $GRID:$VTS_DOCMARKS_OUT/audit/docmarks-audit-<date>.tar.gz .
 ```
+
+Rendering happens on the GRID because that is where the pages are: the sheets
+crop from full-resolution scans that live under `$VTS_DOCMARKS_OUT`, and pulling
+200k pages to a laptop to make four contact sheets is the wrong direction. The
+bundle is small — a few dozen PNGs — so the *reviewing* happens wherever you
+like.
+
+**Work `audit/merge` first, then `audit/membership`.** They are one sitting, and
+they answer different questions: the merge slate fixes the *partition* (which
+clustering proposals are one mark) and membership fixes the *instances* (whether
+each crop really is that mark). Doing them a week apart means re-deriving the
+same context twice.
+
+- `merge/slate_*.png` — every class as a numbered 3-up strip, similarity-ordered.
+- `merge/pairs_*.png` — the closest class pairs, explicitly side by side.
+- `merge/merges.txt` — the answer: one line per group of same-mark indices, plus
+  `REVIEWED-ALL` once you have worked every sheet. See README's **The slate**.
+- `membership/*.png` — every instance of every class, numbered.
+- `membership/verdicts.jsonl` — `ok`, or the indices that are not this mark.
+
+Then fold both back in, on the cluster, against the corpus they came from:
+
+```bash
+python audit_to_corrections.py --task merge      --corpus $VTS_DOCMARKS_OUT   # dry run
+python audit_to_corrections.py --task merge      --corpus $VTS_DOCMARKS_OUT --apply
+python audit_to_corrections.py --task membership --corpus $VTS_DOCMARKS_OUT --apply
+```
+
+Both default to a dry run; read it before passing `--apply`. Merge first: a
+membership rejection is scoped to one class, and which class that is can change
+under a merge.
 
 Do this **before** stage 4. A membership rejection changes which pages are
 positives, and the embedding cells carry the labels; embedding first means
 rebuilding every cell afterwards.
+
+`--task confusable` is the same adjudication one pair per sheet. It remains the
+right form for a roster small enough to work the full matrix; at v2's 60 classes
+that is 1,770 sheets, which is why the slate exists.
 
 ## Stage 4 — embedding cells (GPU)
 

--- a/scripts/experiments/docmarks/README.md
+++ b/scripts/experiments/docmarks/README.md
@@ -18,8 +18,10 @@ python shortlist.py --corpus <dir> --write-roster     # rank them, draft a roste
 $EDITOR <dir>/roster.json                             # pick your two dozen
 python build_corpus.py --sources spods --roster <dir>/roster.json
 
+python make_audit_slate.py --task merge               # which classes are one mark?
 python make_audit_slate.py --task membership          # verify every instance
-python make_audit_slate.py --task confusable          # adjudicate every pair
+$EDITOR <dir>/audit/merge/merges.txt                  # one line per same-mark group
+python audit_to_corrections.py --task merge --apply
 python audit_to_corrections.py --task membership --apply
 
 source ../pile/pile_env.sh
@@ -221,23 +223,29 @@ Both behaviours are pinned by tests, including the negative one.
 
 In the order you run them. Only the first two are needed for a first eval.
 
-1. **`membership`** — every instance of every roster class, numbered on contact
+1. **`merge`** — the whole class list on a handful of numbered contact sheets,
+   ordered so near-identical classes sit next to each other, plus explicit
+   side-by-side sheets for the closest pairs. The answer is a list of index sets
+   in `merges.txt` — `12 37 41` means those three are one mark — and nothing at
+   all for the classes that are already right. See **The slate** below.
+2. **`membership`** — every instance of every roster class, numbered on contact
    sheets. Verdict is `ok` or the indices that are *not* this mark (`3,17`), so
    a 30-crop class is one line. Afterwards no positive is unexamined, which is
    what lets a miss be blamed on the detector rather than the label. A rejected
    crop keeps its box and stays on its page — it becomes a known negative.
-2. **`confusable`** — every roster pair side by side, ranked by distance. 24
-   classes is 276 pairs, so the full matrix is adjudicated rather than sampled.
-   `same` sends you to `merge_into:` on the cluster task; `different` writes a
-   permanent separation.
-3. **`cluster`** — is a class one mark at all? Mostly useful while choosing a
+3. **`confusable`** — the same question as `merge`, asked one pair per sheet.
+   Correct, and the form to use on a roster small enough that the full matrix is
+   a sitting; past a couple of dozen classes prefer the slate, which compiles to
+   exactly these verdicts. `same` sends you to `merge_into:` on the cluster task;
+   `different` writes a permanent separation.
+4. **`cluster`** — is a class one mark at all? Mostly useful while choosing a
    roster. `split` is productive: it re-clusters that class alone at half the
    threshold and re-sheets the pieces, disturbing nothing else.
-4. **`distinctive`** — mark vs shape. A plain warning triangle or ruled box is a
+5. **`distinctive`** — mark vs shape. A plain warning triangle or ruled box is a
    *shape*: "find this rectangle" is not a well-posed retrieval query. The prior
    study's worst classes (`warning_diamond` at 17 keypoints, `hospital_cross`)
    are exactly this. Generic classes are kept and labelled, never deleted.
-5. **`letterhead`** — for the later UCSF expansion: sample bands per candidate
+6. **`letterhead`** — for the later UCSF expansion: sample bands per candidate
    author and count how many carry a printed mark at all. Decides whether that
    pool is worth clustering.
 
@@ -247,6 +255,99 @@ crop). Band-located classes get none — auto-cropping the strip would hand the
 query a banner of letterhead plus address plus rule line and call it a logo,
 which is worse than no crop because it looks like ground truth. They are listed
 in `build_report.json` under `needs_hand_crop`.
+
+
+## The slate: ask for the partition, not the pairs
+
+The pairwise pass is right about what the corpus needs and wrong about what a
+person can deliver. Adjudicating a matrix means one sheet per pair, and pairs
+are quadratic: the 24-class roster the design was written around is 276 pairs,
+which is a sitting; **v2's 60 admitted classes are 1,770**, which is not. Worse,
+the answer it asks for is 1,770 independent binary verdicts, ~1,750 of them
+`different` between marks nobody could confuse.
+
+That is the wrong shape for the information a reviewer actually holds. What they
+know after looking at the classes is a **partition** — these three are one mark,
+everything else is already right — and almost all of it is the trivial part. So
+the slate elicits the partition directly:
+
+```
+python make_audit_slate.py --task merge
+$EDITOR <corpus>/audit/merge/merges.txt
+python audit_to_corrections.py --task merge --apply
+```
+
+`slate_*.png` is every class as a numbered 3-up strip of its own instances,
+4x6 to a sheet. `merges.txt` is the answer, and the format is the whole of it:
+
+```
+12 37 41
+3 8        # same elephant stamp, blue and red ink
+REVIEWED-ALL
+```
+
+One line per group of classes that are the same mark. A 60-class slate that
+over-split three times is four sheets and three lines. Nothing is written for a
+class that is already right, groups that share a member are unioned rather than
+refused (sameness is transitive; the file is allowed to be redundant about it),
+and any token that is not a resolvable index is refused rather than guessed at
+— each of those is a typo whose silent interpretation would write a permanent
+merge between classes nobody looked at.
+
+**Three instances per cell, not one.** A single exemplar fits every class on one
+page and is tempting for exactly that reason, but then a merge decision rests
+entirely on one crop being representative of its class — which is the assumption
+the membership pass exists because we do not trust.
+
+**Similarity order, plus an appendix.** Classes are laid out by a greedy
+nearest-neighbour seriation of the same descriptor the clustering uses, so an
+over-split shows up as two adjacent cells that look alike — a thing people are
+good at. But a 1-D order cannot preserve a metric that is not 1-D, and the row
+wrap breaks adjacency every four cells regardless, so the ordering is an aid to
+scanning and not a guarantee. The guarantee is `pairs_*.png`: the
+`MERGE_SLATE_NEAR_PAIRS` closest pairs, explicitly side by side, so no pair
+where a wrong call costs anything depends on the layout having been kind.
+
+### `REVIEWED-ALL` is the closed world, and it is deliberately narrow
+
+A partition asserts both directions at once: within a group is `same`, across
+groups is `different`. Taken literally, one reviewed slate would adjudicate all
+1,770 pairs — the complete "different" half of the ground truth, from one
+sitting, which is the half this README elsewhere says usually goes missing.
+
+It is not taken literally, because it would be a lie. A reviewer scanning sixty
+thumbnails has genuinely compared the cells next to each other and every pair on
+the appendix sheets. They have not compared the far end of the distance ranking.
+Recording those as adjudicated would put a decision nobody made into
+`adjudications.json`, which every future re-cluster is then bound by — the exact
+failure the separations exist to prevent, committed by the mechanism meant to
+prevent it.
+
+So `REVIEWED-ALL` separates **the appendix pairs and only those**. Everything
+else stays unadjudicated: still separated by the threshold, still liable to move
+if the threshold moves, and honestly labelled as such. `MERGE_SLATE_NEAR_PAIRS`
+is that honesty budget — raise it to buy more of the matrix, and pay for it in
+sheets to work through. Leave the line off entirely and only the merges are
+recorded; nothing is assumed about what was looked at.
+
+The slate is an input *format*, not a second path through the ground truth:
+`merge_verdicts` compiles it into the same `same`/`different` rows the pairwise
+pass produces, and `apply_confusable` records them. A group becomes a star
+rather than a clique (sameness is transitive and the classes are merged
+outright, so n-1 rows state a group of n), every `same` is emitted before every
+`different` (the applier merges as it goes and follows the chain afterwards, so
+a separation pinned first would name a class about to stop existing), and a pair
+that a merge put inside one group is never also separated — `save_adjudications`
+refuses a pair ruled both ways, so that is a correctness gate rather than
+tidiness.
+
+### What it does not do
+
+It does not check instances. `merge` fixes the *partition* — which proposals are
+one mark; `membership` fixes the *instances* — whether each crop really is that
+mark. Both are needed before the classes stop being proposals, they are one
+sitting rather than two, and `launch_docmarks.sh slate` renders both into one
+bundle for that reason.
 
 ## Output
 
@@ -258,6 +359,8 @@ separations.json    adjudicated "different mark" pairs, keyed on page ids
 queries/            one query crop per box-located roster class
 shortlist.png/json  ranked candidates for choosing a roster
 cluster_report.json what clustering did, and how many separations it honoured
+audit/merge/       the slate: slate_*.png, pairs_*.png, index.json, merges.txt
+audit/membership/  numbered instance sheets + verdicts.jsonl
 build_report.json   counts, survival curve, tier cutoffs, rejections, warnings
 ```
 

--- a/scripts/experiments/docmarks/audit_to_corrections.py
+++ b/scripts/experiments/docmarks/audit_to_corrections.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Fold filled-in audit verdicts back into the corpus.
 
+    python audit_to_corrections.py --task merge --apply        # the merge slate
     python audit_to_corrections.py --task membership --apply
     python audit_to_corrections.py --task cluster --apply
     python audit_to_corrections.py --task confusable --apply
@@ -274,6 +275,209 @@ def apply_confusable(
     return changes, problems, separations, merges
 
 
+# --------------------------------------------------------------------------
+# The merge slate
+# --------------------------------------------------------------------------
+#
+# `merges.txt` is a partition, not a stream of verdicts, and that is the whole
+# reason the slate is usable: a reviewer states the few groups that are one mark
+# and says nothing about the thousand pairs that obviously are not.  Everything
+# below turns that statement back into the same/different pairs `apply_confusable`
+# already knows how to record, so the merge slate adds an input format and not a
+# second code path through the ground truth.
+
+REVIEWED_ALL = "REVIEWED-ALL"
+
+
+def parse_merge_groups(text: str, n_classes: int) -> tuple[list[dict[str, Any]], bool, list[str]]:
+    """Parse a filled-in ``merges.txt`` into ``(groups, reviewed_all, problems)``.
+
+    A group is a set of slate indices the reviewer says are one mark.  Groups
+    that share an index are **unioned** rather than refused: "3 8" and "8 12" are
+    two observations of one equivalence class, and treating that as a
+    contradiction would punish a reviewer for writing down the same truth twice.
+    Sameness is transitive; the file is allowed to be redundant about it.
+
+    What is refused is anything that cannot be resolved into indices at all --
+    an out-of-range number, a one-element group, a token that is not a number --
+    because each of those is a typo whose silent interpretation would write a
+    wrong permanent merge.
+    """
+    groups: list[dict[str, Any]] = []
+    problems: list[str] = []
+    reviewed_all = False
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        body, _, note = raw.partition("#")
+        body = body.strip()
+        if not body:
+            continue
+        if body.upper() == REVIEWED_ALL:
+            reviewed_all = True
+            continue
+
+        indices: list[int] = []
+        bad = False
+        for token in body.replace(",", " ").split():
+            try:
+                idx = int(token)
+            except ValueError:
+                problems.append(f"line {lineno}: {token!r} is not a slate index")
+                bad = True
+                continue
+            if not 0 <= idx < n_classes:
+                problems.append(f"line {lineno}: index {idx} is outside the slate (0..{n_classes - 1})")
+                bad = True
+                continue
+            indices.append(idx)
+        if bad:
+            continue
+        if len(set(indices)) < 2:
+            problems.append(f"line {lineno}: {body!r} names fewer than two distinct classes — a group needs a pair")
+            continue
+        groups.append({"indices": sorted(set(indices)), "note": note.strip(), "line": lineno})
+
+    return _union_groups(groups), reviewed_all, problems
+
+
+def _union_groups(groups: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Fold groups that share an index into one, keeping every note."""
+    parent: dict[int, int] = {}
+
+    def find(i: int) -> int:
+        parent.setdefault(i, i)
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[min(ra, rb)] = parent[max(ra, rb)] = min(ra, rb)
+
+    for group in groups:
+        head = group["indices"][0]
+        for idx in group["indices"][1:]:
+            union(head, idx)
+
+    merged: dict[int, dict[str, Any]] = {}
+    for group in groups:
+        root = find(group["indices"][0])
+        slot = merged.setdefault(root, {"indices": set(), "notes": [], "lines": []})
+        slot["indices"].update(group["indices"])
+        slot["lines"].append(group["line"])
+        if group["note"]:
+            slot["notes"].append(group["note"])
+
+    return [
+        {"indices": sorted(v["indices"]), "note": "; ".join(v["notes"]), "lines": sorted(v["lines"])}
+        for _root, v in sorted(merged.items())
+    ]
+
+
+def merge_verdicts(
+    index: dict[str, Any],
+    groups: Sequence[dict[str, Any]],
+    reviewed_all: bool,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Compile the partition into ``confusable``-shaped verdict rows.
+
+    Order matters and is not cosmetic: every ``same`` row is emitted before every
+    ``different`` row, because :func:`apply_confusable` merges as it goes and
+    follows the resulting chain when a later row names a class that has since
+    been absorbed.  Emitting a separation first would pin it against a class id
+    that is about to stop existing.
+
+    ``reviewed_all`` is what licenses the separations, and it licenses exactly
+    the appendix pairs -- the ones that got their own side-by-side sheet.  Pairs
+    that appear nowhere but the far end of the distance ranking stay
+    unadjudicated, because nobody looked at them; recording them would put a
+    decision no human made into the file every future re-cluster is bound by,
+    which is precisely the failure the separations exist to prevent.
+    """
+    by_index = {int(row["index"]): row["class_id"] for row in index.get("classes", [])}
+    problems: list[str] = []
+    rows: list[dict[str, Any]] = []
+
+    #: Every index mapped to the class it will *be* once the merges are applied
+    #: -- its group's lowest member, or itself. Two uses, and the first is a
+    #: correctness gate rather than tidiness: a near pair inside a group must
+    #: not also be separated, because `save_adjudications` refuses a pair ruled
+    #: both ways and would abort the whole apply. The second is deduplication:
+    #: once 3 and 8 are one class, the appendix pairs (3, 12) and (8, 12) are
+    #: one statement about one pair of classes, and emitting both prints a
+    #: contradiction-shaped log for a decision that was made once.
+    root: dict[int, int] = {}
+    for group in groups:
+        for idx in group["indices"]:
+            root[idx] = group["indices"][0]
+
+    for group in groups:
+        indices = group["indices"]
+        missing = [i for i in indices if i not in by_index]
+        if missing:
+            problems.append(f"group {indices}: index {missing} is not on the slate")
+            continue
+        # A star from the first member, not the full clique: sameness is
+        # transitive and `apply_confusable` merges the classes outright, so n-1
+        # rows state the whole group and n(n-1)/2 would restate it.
+        head = indices[0]
+        for other in indices[1:]:
+            rows.append(
+                {
+                    "left_class_id": by_index[head],
+                    "right_class_id": by_index[other],
+                    "verdict": "same",
+                    "notes": group.get("note", ""),
+                }
+            )
+
+    if reviewed_all:
+        seen: set[frozenset[int]] = set()
+        for pair in index.get("near_pairs", []):
+            li, ri = int(pair["left_index"]), int(pair["right_index"])
+            if li not in by_index or ri not in by_index:
+                problems.append(f"near pair [{li}]/[{ri}]: not on the slate")
+                continue
+            key = frozenset((root.get(li, li), root.get(ri, ri)))
+            if len(key) == 1:
+                continue  # merged by the reviewer; not a separation
+            if key in seen:
+                continue  # a nearer appendix pair already separated these two classes
+            seen.add(key)
+            rows.append(
+                {
+                    "left_class_id": by_index[li],
+                    "right_class_id": by_index[ri],
+                    "verdict": "different",
+                    "notes": f"slate REVIEWED-ALL; appendix rank {pair.get('rank')} at d={pair.get('distance')}",
+                }
+            )
+
+    return rows, problems
+
+
+def load_merge_answer(audit_dir: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    """Read ``index.json`` + ``merges.txt`` and compile them into verdict rows."""
+    index_path, answer_path = audit_dir / "index.json", audit_dir / "merges.txt"
+    if not index_path.exists():
+        raise SystemExit(f"no slate at {index_path} — run make_audit_slate.py --task merge first")
+    if not answer_path.exists():
+        raise SystemExit(f"no answer file at {answer_path} — the slate should have written a template")
+
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    groups, reviewed_all, problems = parse_merge_groups(
+        answer_path.read_text(encoding="utf-8"), len(index.get("classes", []))
+    )
+    rows, more = merge_verdicts(index, groups, reviewed_all)
+    n_same = sum(1 for r in rows if r["verdict"] == "same")
+    print(f"  slate: {len(groups)} merge group(s) -> {n_same} same, {len(rows) - n_same} different")
+    if not reviewed_all:
+        print(f"  slate: no {REVIEWED_ALL} line — recording merges only, no separations")
+    return rows, problems + more
+
+
 def apply_letterhead(classes: dict[str, Any], verdicts: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
     changes: list[str] = []
     problems: list[str] = []
@@ -342,7 +546,9 @@ def _refs_for_class(pages: list[Page], class_id: str) -> list[Any]:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument(
-        "--task", required=True, choices=("membership", "cluster", "confusable", "distinctive", "letterhead")
+        "--task",
+        required=True,
+        choices=("merge", "membership", "cluster", "confusable", "distinctive", "letterhead"),
     )
     ap.add_argument("--corpus", type=Path, default=cfg.OUT)
     ap.add_argument("--apply", action="store_true", help="write the changes (default is a dry run)")
@@ -354,9 +560,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     manifest_path = args.corpus / "corpus.jsonl"
     adjudications_path = args.corpus / "adjudications.json"
     classes = json.loads(classes_path.read_text(encoding="utf-8"))
-    verdicts = load_verdicts(args.corpus / "audit" / args.task / "verdicts.jsonl")
+    audit_dir = args.corpus / "audit" / args.task
+    slate_problems: list[str] = []
+    if args.task == "merge":
+        # The slate is an input *format*, not a second way of recording ground
+        # truth: it compiles to the same same/different rows the pairwise pass
+        # produces and goes through the same applier.
+        verdicts, slate_problems = load_merge_answer(audit_dir)
+    else:
+        verdicts = load_verdicts(audit_dir / "verdicts.jsonl")
 
-    mutates_pages = args.task in ("cluster", "membership", "confusable")
+    mutates_pages = args.task in ("cluster", "membership", "confusable", "merge")
     pages = list(read_manifest(manifest_path)) if mutates_pages else []
     new_separations: list[dict[str, Any]] = []
     new_merges: list[dict[str, Any]] = []
@@ -366,8 +580,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         changes, problems = apply_membership(pages, classes, verdicts)
     elif args.task == "cluster":
         changes, problems, resplit = apply_cluster(pages, classes, verdicts)
-    elif args.task == "confusable":
+    elif args.task in ("confusable", "merge"):
         changes, problems, new_separations, new_merges = apply_confusable(pages, classes, verdicts)
+        problems += slate_problems
+        if args.task == "merge":
+            reviewed = any(str(r.get("notes", "")).startswith("slate REVIEWED-ALL") for r in verdicts)
+            if reviewed and not problems:
+                for meta in classes.values():
+                    meta.setdefault("audit", {})["partition_reviewed"] = True
+                changes.append(f"{len(classes)} class(es) marked partition_reviewed")
     elif args.task == "distinctive":
         changes, problems = apply_distinctive(classes, verdicts)
     else:

--- a/scripts/experiments/docmarks/docmarks_config.py
+++ b/scripts/experiments/docmarks/docmarks_config.py
@@ -332,3 +332,41 @@ def eligible_distractor(class_source: str, page_source: str, page_industry: str 
     if page_source == "ucsf" and page_industry and f"ucsf:{page_industry}" in banned:
         return False
     return True
+
+
+# --------------------------------------------------------------------------
+# The merge slate (human pass)
+# --------------------------------------------------------------------------
+#
+# The `confusable` pass adjudicates one pair per sheet, which is correct and
+# unusable at scale: 60 admitted classes is 1,770 pairs, so the reviewer is
+# handed 1,770 PNGs to open.  The `merge` slate asks the same question in the
+# shape a person can actually answer -- every class on a few contact sheets,
+# similarity-ordered and numbered, answered as a list of index sets -- and
+# compiles that answer back into exactly the same same/different verdicts.
+
+#: Instances shown per class cell on the slate.  One exemplar is denser and
+#: fits every class on a single page, but a merge call then rests entirely on
+#: one crop being representative of its class -- which is the assumption the
+#: membership pass exists because we do not trust.  Three is the smallest
+#: number that shows within-class variation.
+MERGE_SLATE_INSTANCES = int(os.environ.get("VTS_DOCMARKS_MERGE_INSTANCES", "3"))
+
+#: Cells per slate sheet.  4x6 at a 3-up cell is ~1,500x1,400 px: legible at
+#: 100% on a desktop, which is the only place these are ever looked at.
+MERGE_SLATE_COLS = 4
+MERGE_SLATE_ROWS = 6
+
+#: How many of the nearest class pairs get their own explicit side-by-side
+#: sheet, and thereby become eligible to be recorded as adjudicated.
+#:
+#: This number is the honesty budget for the closed-world rule.  A reviewer who
+#: works a whole slate has genuinely compared the pairs that sit next to each
+#: other and the pairs on the appendix; they have *not* compared all 1,770, and
+#: recording the far ones as adjudicated would assert a decision nobody made.
+#: So only these pairs are separated on a `REVIEWED-ALL` slate.  Raise it to
+#: buy more of the matrix at the cost of more sheets to work through.
+MERGE_SLATE_NEAR_PAIRS = int(os.environ.get("VTS_DOCMARKS_MERGE_NEAR_PAIRS", "120"))
+
+#: Pairs per appendix sheet.
+MERGE_PAIRS_PER_SHEET = 12

--- a/scripts/experiments/docmarks/launch_docmarks.sh
+++ b/scripts/experiments/docmarks/launch_docmarks.sh
@@ -3,6 +3,7 @@
 #
 #   bash launch_docmarks.sh probe          # can I reach every source?
 #   bash launch_docmarks.sh build          # stage 1: sources + clustering (CPU)
+#   bash launch_docmarks.sh slate          # stage 2: the human audit bundle (CPU)
 #   bash launch_docmarks.sh status         # queue + the real signal on disk
 #   bash launch_docmarks.sh embed s        # stage 5: cells for one tier (GPU)
 #
@@ -108,6 +109,43 @@ RUNNER_EOF
     --wrap="bash $RUNNER"
   ;;
 
+slate)
+  # The human pass, as one bundle to take away.  Both sheet sets in one job
+  # because they are one sitting: the merge slate fixes the *partition* (which
+  # proposals are one mark) and membership fixes the *instances* (which crops
+  # really are that mark), and doing them a week apart means re-deriving the
+  # same context twice.  Neither touches a GPU and neither refetches a source --
+  # this reads the built corpus and writes PNGs -- so it is minutes, not hours.
+  #
+  # MEM is 32G: rendering opens full-resolution scans (SPODS is A4 at 300 dpi,
+  # ~2,476x3,480) one at a time, but membership walks every instance of every
+  # class, so the page cache is the cost rather than any one image.
+  RUNNER="/exp/$USER/.docmarks-slate.$$.sh"
+  cat > "$RUNNER" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -uo pipefail
+source "$WT/gridenv.sh"
+source "$WT/scripts/experiments/pile/pile_env.sh"
+export VTS_REPO="$WT"
+export VTS_DOCMARKS_OUT="$VTS_DOCMARKS_OUT"
+export CUDA_VISIBLE_DEVICES=
+cd "$HERE"
+echo "node=\$(hostname) job=\$SLURM_JOB_ID start=\$(date -Is)"
+python -u make_audit_slate.py --task merge      --corpus "$VTS_DOCMARKS_OUT" || exit 1
+python -u make_audit_slate.py --task membership --corpus "$VTS_DOCMARKS_OUT" || exit 1
+cd "$VTS_DOCMARKS_OUT" && tar czf "audit/docmarks-audit-\$(date +%Y%m%d).tar.gz" audit/merge audit/membership
+echo "bundle: $VTS_DOCMARKS_OUT/audit/docmarks-audit-\$(date +%Y%m%d).tar.gz"
+echo "exit=\$? end=\$(date -Is)"
+RUNNER_EOF
+  chmod +x "$RUNNER"
+
+  sbatch --job-name="docmarks-slate" --partition="$PARTITION" \
+    --mem="${VTS_DOCMARKS_SLATE_MEM:-32G}" --cpus-per-task=2 \
+    --time="${VTS_DOCMARKS_SLATE_TIME:-02:00:00}" \
+    --output="$LOGS/slate-%j.out" --error="$LOGS/slate-%j.out" \
+    --wrap="bash $RUNNER"
+  ;;
+
 status)
   squeue -u "$USER" -n "$JOB_NAME" -o "%.10i %.16j %.8T %.12M %.12l %R"
   echo
@@ -116,6 +154,7 @@ status)
   echo "pdfs:   $(find "$VTS_DOCMARKS_RAW/ucsf/pdf" -name "*.pdf" 2>/dev/null | wc -l) fetched"
   echo "pages:  $(find "$VTS_DOCMARKS_OUT/images" -type f 2>/dev/null | wc -l) rendered"
   echo "free:   $(df -h "$VTS_DOCMARKS_OUT" | tail -1 | awk "{print \$4}")"
+  echo "slate:  $(ls "$VTS_DOCMARKS_OUT"/audit/merge/slate_*.png 2>/dev/null | wc -l) sheet(s), $(ls "$VTS_DOCMARKS_OUT"/audit/merge/pairs_*.png 2>/dev/null | wc -l) pair sheet(s)"
   tail -5 "$(ls -t "$LOGS"/build-*.out 2>/dev/null | head -1)" 2>/dev/null
   ;;
 
@@ -154,5 +193,5 @@ RUNNER_EOF
   ;;
 
 *)
-  echo "usage: $0 {probe|build|status|embed <tier>}" >&2; exit 2 ;;
+  echo "usage: $0 {probe|build|slate|status|embed <tier>}" >&2; exit 2 ;;
 esac

--- a/scripts/experiments/docmarks/make_audit_slate.py
+++ b/scripts/experiments/docmarks/make_audit_slate.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 """Render the contact sheets for the DocMarks human passes.
 
+    python make_audit_slate.py --task merge        # which of these classes are one mark?
+    python make_audit_slate.py --task membership   # is each crop really this mark?
     python make_audit_slate.py --task letterhead   # is a mark there at all?
     python make_audit_slate.py --task cluster      # is this class one mark?
     python make_audit_slate.py --task confusable   # are these two the same mark?
@@ -14,6 +16,15 @@ The corpus stores **both directions** of the ground truth, because an eval needs
 both: a shared class id says what the detector must find together, and a
 recorded separation says what it must tell apart.  Clustering can only ever
 propose the first.  These passes supply the second and confirm the first.
+
+``merge``
+    The pairwise pass in a shape that finishes.  Every class on a handful of
+    numbered contact sheets in similarity order, plus explicit side-by-side
+    sheets for the closest pairs; the answer is a list of index sets ("12 37 41
+    are the same mark") in ``merges.txt``, which compiles straight back into
+    ``confusable``'s same/different verdicts.  Use this instead of ``confusable``
+    on anything past a couple of dozen classes -- 60 classes is 1,770 pairs, and
+    a pass that hands a reviewer 1,770 PNGs does not get run.
 
 ``letterhead``
     Runs first, on UCSF candidate pages.  Not "are these crops one mark" but "is
@@ -217,6 +228,298 @@ def task_membership(pages: list[Page], classes: dict[str, Any], out: Path) -> li
     return verdicts
 
 
+def _font(size: int) -> Any:
+    """A truetype face at *size* if one is installed, else PIL's bitmap default.
+
+    The slate's whole answer format is the reviewer reading an index off a cell
+    and typing it, so the index has to be unmistakable at a glance.  PIL's
+    built-in font is 11 px and renders "37" and "87" nearly alike on a scan-grey
+    background; DejaVu is present on every machine this has run on so far, and
+    the fallback keeps the sheets rendering rather than crashing where it is not.
+    """
+    from PIL import ImageFont
+
+    for path in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+    ):
+        if Path(path).exists():
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def seriate(dist: np.ndarray) -> list[int]:
+    """Order classes so that near-identical ones land next to each other.
+
+    A slate in class-id order is a slate the reviewer has to scan quadratically:
+    the two crops of the same stamp are wherever the alphabet put them.  Ordered
+    by similarity, an over-split shows up as two adjacent cells that look the
+    same, which is the thing a person is genuinely good at spotting.
+
+    Greedy nearest-neighbour from the most isolated class, which is a cheap
+    approximation of the shortest Hamiltonian path.  It is *not* a claim about
+    global structure -- a 1-D order cannot preserve a metric that isn't 1-D, and
+    the row wrap breaks adjacency every ``MERGE_SLATE_COLS`` cells anyway.  That
+    is why the near-pair appendix exists: the ordering is an aid to scanning,
+    and the appendix is what guarantees every risky pair is actually seen.
+
+    Deterministic, including ties, so a re-rendered slate has the same numbering
+    and a half-finished answer file stays valid.
+    """
+    n = dist.shape[0]
+    if n == 0:
+        return []
+    work = dist.copy()
+    np.fill_diagonal(work, np.inf)
+    # Start at the most isolated class: it is an endpoint of the path, so the
+    # chain runs through the crowd rather than starting inside it.
+    start = int(np.argmax(np.where(np.isinf(work), -np.inf, work).min(axis=1)))
+    order = [start]
+    unvisited = set(range(n)) - {start}
+    while unvisited:
+        last = order[-1]
+        nxt = min(unvisited, key=lambda j: (float(work[last, j]), j))
+        order.append(nxt)
+        unvisited.discard(nxt)
+    return order
+
+
+def near_pairs(dist: np.ndarray, k: int) -> list[tuple[float, int, int]]:
+    """The *k* closest class pairs, nearest first, ties broken by index."""
+    n = dist.shape[0]
+    pairs = [(float(dist[i, j]), i, j) for i in range(n) for j in range(i + 1, n)]
+    pairs.sort(key=lambda t: (t[0], t[1], t[2]))
+    return pairs[:k]
+
+
+def _cell(strip: Sequence[Any], index: int, label: str, *, thumb: int = 120) -> Any:
+    """One class as a numbered horizontal strip of its own instances."""
+    from PIL import Image, ImageDraw
+
+    slots = max(1, len(strip))
+    head = 22
+    width = slots * (thumb + 4) + 4
+    cell = Image.new("RGB", (width, head + thumb + 6), "white")
+    draw = ImageDraw.Draw(cell)
+    draw.rectangle([0, 0, width - 1, cell.height - 1], outline="#999999")
+    draw.rectangle([0, 0, width - 1, head], fill="#eef1f5", outline="#999999")
+    draw.text((5, 3), f"[{index}]", fill="#0b3d91", font=_font(16))
+    draw.text((52, 5), label[:46], fill="#333333", font=_font(11))
+
+    for i, im in enumerate(strip[:slots]):
+        t = im.convert("RGB").copy()
+        t.thumbnail((thumb, thumb))
+        x = 4 + i * (thumb + 4) + (thumb - t.width) // 2
+        y = head + 3 + (thumb - t.height) // 2
+        cell.paste(t, (x, y))
+    return cell
+
+
+def _paste_grid(cells: Sequence[Any], title: str, out_path: Path, *, cols: int) -> None:
+    from PIL import Image, ImageDraw
+
+    if not cells:
+        return
+    cw = max(c.width for c in cells)
+    ch = max(c.height for c in cells)
+    rows = (len(cells) + cols - 1) // cols
+    font = _font(14)
+    # Widen for the heading if the grid is narrower than it: the heading is what
+    # says which sheet this is and what the reviewer is being asked, and a
+    # two-column pairs sheet is narrower than its own instructions.
+    title_w = int(ImageDraw.Draw(Image.new("RGB", (1, 1))).textlength(title, font=font)) + 2 * PAD
+    sheet = Image.new("RGB", (max(cols * (cw + PAD) + PAD, title_w), rows * (ch + PAD) + PAD + 26), "white")
+    ImageDraw.Draw(sheet).text((PAD, 6), title, fill="black", font=font)
+    for i, cell in enumerate(cells):
+        r, c = divmod(i, cols)
+        sheet.paste(cell, (PAD + c * (cw + PAD), 26 + PAD + r * (ch + PAD)))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    sheet.save(out_path)
+
+
+def _class_strip(page_ids: Sequence[str], by_id: dict[str, Page], class_id: str, limit: int) -> list[Any]:
+    """Up to *limit* instance crops of *class_id*, evenly spread over the class.
+
+    Spread rather than the first *limit*: page ids sort by source and number, so
+    the head of the list is whatever the scanner did first, and a class whose
+    later instances drifted (a re-inked stamp, a second printing) would look
+    homogeneous on the slate for no better reason than alphabetical order.
+    """
+    crops: list[Any] = []
+    resolved = [pid for pid in page_ids if pid in by_id]
+    if not resolved:
+        return crops
+    step = max(1, len(resolved) // max(1, limit))
+    for page_id in resolved[::step][:limit]:
+        page = by_id[page_id]
+        for mark in page.marks:
+            if mark.class_id == class_id:
+                crops.append(_crop(page, mark.box))
+                break
+    return crops
+
+
+def task_merge(
+    pages: list[Page],
+    classes: dict[str, Any],
+    out: Path,
+    *,
+    top_pairs: int = cfg.MERGE_SLATE_NEAR_PAIRS,
+) -> dict[str, Any]:
+    """Every class on a few numbered sheets; the answer is a list of index sets.
+
+    This is ``confusable`` asked in a shape a person can finish.  The pairwise
+    pass is correct and, past a couple of dozen classes, unusable: a 60-class
+    corpus is 1,770 pairs, so adjudicating the matrix means opening 1,770 PNGs
+    to type ``different`` 1,750 times.  The information a reviewer actually has
+    is not a stream of independent binary answers -- it is a *partition*, and
+    almost all of it is the trivial part.
+
+    So the slate elicits the partition directly.  Classes are laid out in
+    similarity order and numbered; the reviewer writes one line per group of
+    classes that are the same mark, and nothing at all for the overwhelming
+    majority that are already right.  A 60-class slate whose clustering
+    over-split three times is four sheets and three lines of answer.
+
+    Two things keep that cheap answer honest:
+
+    * **The near-pair appendix.**  A 1-D ordering cannot keep every close pair
+      adjacent, and the row wrap breaks adjacency every few cells regardless.
+      The ``top_pairs`` closest pairs therefore also get an explicit
+      side-by-side sheet, so no pair where a wrong call costs anything depends
+      on the layout having been kind.
+    * **A closed world that only covers what was looked at.**  ``REVIEWED-ALL``
+      in the answer file records every *appendix* pair the reviewer did not
+      merge as a permanent separation -- the half of the ground truth clustering
+      cannot produce, bought from one sitting.  It does not touch the pairs that
+      appear nowhere but the far end of the distance ranking: those were never
+      compared, and claiming them would put a decision nobody made into the file
+      that every future re-cluster is bound by.
+    """
+    from PIL import Image
+
+    by_id = {p.page_id: p for p in pages}
+    pool = {k: v for k, v in classes.items() if v.get("on_roster")} or classes
+
+    exemplars: list[tuple[str, Any]] = []
+    for class_id, meta in sorted(pool.items()):
+        crop = meta.get("query_crop")
+        if crop and Path(crop).exists():
+            exemplars.append((class_id, Image.open(crop)))
+    if len(exemplars) < 2:
+        return {"classes": [], "near_pairs": [], "sheets": []}
+
+    desc = np.array([_cluster.phash(im) for _cid, im in exemplars], dtype=bool)
+    bits = desc.astype(np.uint8)
+    inv = 1 - bits
+    dist = (bits @ inv.T + inv @ bits.T).astype(float) / desc.shape[1]
+    np.fill_diagonal(dist, 0.0)
+
+    order = seriate(dist)
+    slate_index = {orig: slot for slot, orig in enumerate(order)}
+
+    cells, index_rows = [], []
+    for slot, orig in enumerate(order):
+        class_id, exemplar = exemplars[orig]
+        meta = pool[class_id]
+        strip = _class_strip(meta.get("page_ids", []), by_id, class_id, cfg.MERGE_SLATE_INSTANCES) or [exemplar]
+        cells.append(_cell(strip, slot, f"{class_id}  ({int(meta.get('n_instances', len(strip)))}x)"))
+        index_rows.append(
+            {
+                "index": slot,
+                "class_id": class_id,
+                "n_instances": int(meta.get("n_instances", 0)),
+                "sheet": f"slate_{slot // (cfg.MERGE_SLATE_COLS * cfg.MERGE_SLATE_ROWS):02d}.png",
+            }
+        )
+
+    per_sheet = cfg.MERGE_SLATE_COLS * cfg.MERGE_SLATE_ROWS
+    sheets = []
+    for start in range(0, len(cells), per_sheet):
+        name = f"slate_{start // per_sheet:02d}.png"
+        _paste_grid(
+            cells[start : start + per_sheet],
+            f"DocMarks merge slate — classes [{start}]..[{start + len(cells[start : start + per_sheet]) - 1}] "
+            f"of {len(cells)} — which of these are the SAME mark?",
+            out / name,
+            cols=cfg.MERGE_SLATE_COLS,
+        )
+        sheets.append(name)
+
+    pair_rows = []
+    pairs = near_pairs(dist, top_pairs)
+    for rank, (d, i, j) in enumerate(pairs):
+        li, ri = slate_index[i], slate_index[j]
+        pair_rows.append(
+            {
+                "rank": rank,
+                "left_index": li,
+                "right_index": ri,
+                "left_class_id": exemplars[i][0],
+                "right_class_id": exemplars[j][0],
+                "distance": round(float(d), 4),
+                "sheet": f"pairs_{rank // cfg.MERGE_PAIRS_PER_SHEET:02d}.png",
+            }
+        )
+
+    for start in range(0, len(pairs), cfg.MERGE_PAIRS_PER_SHEET):
+        chunk = pairs[start : start + cfg.MERGE_PAIRS_PER_SHEET]
+        pair_cells = []
+        for d, i, j in chunk:
+            li, ri = slate_index[i], slate_index[j]
+            pair_cells.append(_cell([exemplars[i][1], exemplars[j][1]], li, f"vs [{ri}]   distance {d:.3f}", thumb=150))
+        _paste_grid(
+            pair_cells,
+            f"DocMarks — the {len(pairs)} closest pairs, {start}..{start + len(chunk) - 1} — "
+            "merge these on the slate, or they are recorded as DIFFERENT",
+            out / f"pairs_{start // cfg.MERGE_PAIRS_PER_SHEET:02d}.png",
+            cols=2,
+        )
+
+    payload = {"classes": index_rows, "near_pairs": pair_rows, "sheets": sheets}
+    (out / "index.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_merge_template(out / "merges.txt", index_rows, len(pair_rows))
+    return payload
+
+
+MERGE_TEMPLATE_HEADER = """\
+# DocMarks merge slate — {n} classes, {p} near pairs on the appendix sheets.
+#
+# One line per GROUP of classes that are THE SAME MARK, as slate indices:
+#
+#     12 37 41
+#     3 8        # same elephant stamp, blue and red ink
+#
+# That is the whole answer format. Classes named on no line are left alone,
+# which is the expected outcome for most of them — you are correcting an
+# over-split, not re-labelling the corpus. Text after '#' is kept as a note.
+# Groups that share a class are unioned, so you cannot contradict yourself by
+# writing the same merge twice.
+#
+# When you have worked every slate sheet AND every pairs_*.png sheet, add:
+#
+#     REVIEWED-ALL
+#
+# on a line of its own. That records the {p} appendix pairs you did NOT merge as
+# permanently DIFFERENT — a cannot-link every future re-cluster honours. It is
+# the half of the ground truth clustering cannot produce, and it is why the
+# appendix is worth working through. Leave the line off and only your merges are
+# recorded; nothing else is assumed about what you looked at.
+#
+# Then:  python audit_to_corrections.py --task merge --apply
+"""
+
+
+def _write_merge_template(path: Path, index_rows: Sequence[dict[str, Any]], n_pairs: int) -> None:
+    lines = [MERGE_TEMPLATE_HEADER.format(n=len(index_rows), p=n_pairs), "\n"]
+    path.write_text("".join(lines), encoding="utf-8")
+
+
 def task_confusable(
     pages: list[Page],
     classes: dict[str, Any],
@@ -382,10 +685,17 @@ def task_letterhead(pages: list[Page], out: Path, *, sample_per_author: int = 60
 def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument(
-        "--task", required=True, choices=("membership", "cluster", "confusable", "distinctive", "letterhead")
+        "--task", required=True, choices=("merge", "membership", "cluster", "confusable", "distinctive", "letterhead")
     )
     ap.add_argument("--corpus", type=Path, default=cfg.OUT)
     ap.add_argument("--sample-per-author", type=int, default=60)
+    ap.add_argument(
+        "--near-pairs",
+        type=int,
+        default=cfg.MERGE_SLATE_NEAR_PAIRS,
+        help="merge: how many of the closest class pairs get an explicit side-by-side sheet, "
+        "and so become eligible for a REVIEWED-ALL separation",
+    )
     ap.add_argument(
         "--top-pairs",
         type=int,
@@ -400,6 +710,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     out = args.corpus / "audit" / args.task
     out.mkdir(parents=True, exist_ok=True)
+
+    if args.task == "merge":
+        payload = task_merge(pages, classes, out, top_pairs=args.near_pairs)
+        print(f"merge: {len(payload['classes'])} class(es) on {len(payload['sheets'])} slate sheet(s)")
+        print(f"  slate    {out}/slate_*.png")
+        print(f"  pairs    {out}/pairs_*.png   ({len(payload['near_pairs'])} nearest pairs)")
+        print(f"  answer   {out}/merges.txt  (one line per group of same-mark indices)")
+        return 0
 
     if args.task == "membership":
         verdicts = task_membership(pages, classes, out)

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -62,6 +62,7 @@ def mods(_on_path):
         "roster": importlib.import_module("roster"),
         "shortlist": importlib.import_module("shortlist"),
         "audit": importlib.import_module("audit_to_corrections"),
+        "slate": importlib.import_module("make_audit_slate"),
         "report": importlib.import_module("make_report"),
     }
 
@@ -718,6 +719,224 @@ class TestMembershipAudit:
         row = {"class_id": "spods/a", "page_ids": classes["spods/a"]["page_ids"], "verdict": "maybe"}
         _changes, problems = mods["audit"].apply_membership(pages, classes, [row])
         assert "must be 'ok' or comma-separated indices" in problems[0]
+
+
+class TestMergeSlateOrdering:
+    """The slate's numbering is what the reviewer's answer refers to."""
+
+    def test_seriation_puts_near_identical_classes_next_to_each_other(self, mods):
+        # Three tight pairs, scrambled: 0~4, 1~3, 2~5.
+        far = 0.9
+        d = np.full((6, 6), far)
+        for a, b in ((0, 4), (1, 3), (2, 5)):
+            d[a, b] = d[b, a] = 0.01
+        np.fill_diagonal(d, 0.0)
+        order = mods["slate"].seriate(d)
+        assert sorted(order) == list(range(6))
+        adjacent = {frozenset(pair) for pair in zip(order, order[1:])}
+        for pair in ((0, 4), (1, 3), (2, 5)):
+            assert frozenset(pair) in adjacent, f"{pair} was split by the ordering"
+
+    def test_seriation_is_deterministic_including_ties(self, mods):
+        # An all-equal matrix is nothing but ties; a re-render must still
+        # produce the same numbering or a half-finished merges.txt goes stale.
+        d = np.full((8, 8), 0.5)
+        np.fill_diagonal(d, 0.0)
+        assert mods["slate"].seriate(d) == mods["slate"].seriate(d.copy())
+
+    def test_seriation_of_an_empty_or_single_slate(self, mods):
+        assert mods["slate"].seriate(np.zeros((0, 0))) == []
+        assert mods["slate"].seriate(np.zeros((1, 1))) == [0]
+
+    def test_near_pairs_are_the_closest_ones_nearest_first(self, mods):
+        d = np.array([[0.0, 0.3, 0.1], [0.3, 0.0, 0.2], [0.1, 0.2, 0.0]])
+        assert mods["slate"].near_pairs(d, 2) == [(0.1, 0, 2), (0.2, 1, 2)]
+
+
+class TestMergeAnswerParsing:
+    def test_a_group_is_a_line_of_indices(self, mods):
+        groups, reviewed, problems = mods["audit"].parse_merge_groups("3 8 12\n", 20)
+        assert not problems and reviewed is False
+        assert [g["indices"] for g in groups] == [[3, 8, 12]]
+
+    def test_commas_and_trailing_notes_are_accepted(self, mods):
+        groups, _reviewed, problems = mods["audit"].parse_merge_groups("3, 8   # same elephant, blue and red\n", 20)
+        assert not problems
+        assert groups[0]["indices"] == [3, 8]
+        assert groups[0]["note"] == "same elephant, blue and red"
+
+    def test_overlapping_groups_are_unioned_not_refused(self, mods):
+        # "3 8" and "8 12" are two observations of one equivalence class. A
+        # reviewer writing the same truth twice is redundant, not contradictory.
+        groups, _reviewed, problems = mods["audit"].parse_merge_groups("3 8\n8 12\n", 20)
+        assert not problems
+        assert [g["indices"] for g in groups] == [[3, 8, 12]]
+
+    def test_comments_and_blank_lines_are_ignored(self, mods):
+        groups, reviewed, problems = mods["audit"].parse_merge_groups("# a header\n\n   \n1 2\n", 5)
+        assert not problems and [g["indices"] for g in groups] == [[1, 2]]
+
+    def test_reviewed_all_is_a_line_of_its_own(self, mods):
+        _groups, reviewed, problems = mods["audit"].parse_merge_groups("REVIEWED-ALL\n", 5)
+        assert reviewed is True and not problems
+
+    @pytest.mark.parametrize(
+        "line, fragment",
+        [
+            ("99 1", "outside the slate"),
+            ("foo 2", "not a slate index"),
+            ("4", "fewer than two distinct classes"),
+            ("3 3", "fewer than two distinct classes"),
+        ],
+    )
+    def test_a_typo_is_refused_never_guessed_at(self, mods, line, fragment):
+        # Every one of these silently reinterpreted would write a permanent
+        # merge between classes nobody looked at.
+        groups, _reviewed, problems = mods["audit"].parse_merge_groups(line + "\n", 6)
+        assert groups == []
+        assert fragment in problems[0]
+
+
+class TestMergeVerdictCompilation:
+    def _index(self, n=6, near=((0, 1, 0.01), (2, 3, 0.02), (4, 5, 0.03))):
+        return {
+            "classes": [{"index": i, "class_id": f"spods/c{i}", "n_instances": 5} for i in range(n)],
+            "near_pairs": [
+                {"rank": r, "left_index": a, "right_index": b, "distance": d} for r, (a, b, d) in enumerate(near)
+            ],
+        }
+
+    def test_a_group_compiles_to_a_star_not_a_clique(self, mods):
+        # Sameness is transitive and apply_confusable merges outright, so n-1
+        # rows state the whole group; n(n-1)/2 would just restate it.
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1 2\n", 6)
+        rows, problems = mods["audit"].merge_verdicts(self._index(), groups, reviewed)
+        assert not problems
+        assert [(r["left_class_id"], r["right_class_id"]) for r in rows] == [
+            ("spods/c0", "spods/c1"),
+            ("spods/c0", "spods/c2"),
+        ]
+
+    def test_without_reviewed_all_only_merges_are_recorded(self, mods):
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\n", 6)
+        rows, _problems = mods["audit"].merge_verdicts(self._index(), groups, reviewed)
+        assert {r["verdict"] for r in rows} == {"same"}
+
+    def test_reviewed_all_separates_the_appendix_pairs_and_only_those(self, mods):
+        # The closed world covers what the reviewer was actually shown: the
+        # near-pair sheets. Pairs that live only at the far end of the ranking
+        # were never compared and stay unadjudicated.
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("REVIEWED-ALL\n", 6)
+        rows, _problems = mods["audit"].merge_verdicts(self._index(), groups, reviewed)
+        different = {(r["left_class_id"], r["right_class_id"]) for r in rows if r["verdict"] == "different"}
+        assert different == {("spods/c0", "spods/c1"), ("spods/c2", "spods/c3"), ("spods/c4", "spods/c5")}
+        assert ("spods/c0", "spods/c5") not in different
+
+    def test_a_merged_near_pair_is_never_also_separated(self, mods):
+        # save_adjudications refuses a pair ruled both ways outright, so this is
+        # a correctness gate rather than tidiness: without it, merging an
+        # appendix pair on a REVIEWED-ALL slate would abort the whole apply.
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\nREVIEWED-ALL\n", 6)
+        rows, _problems = mods["audit"].merge_verdicts(self._index(), groups, reviewed)
+        ruled = {(r["left_class_id"], r["right_class_id"]): r["verdict"] for r in rows}
+        assert ruled[("spods/c0", "spods/c1")] == "same"
+        assert list(ruled.values()).count("same") == 1
+        assert ("spods/c1", "spods/c0") not in ruled
+
+    def test_transitively_merged_classes_do_not_separate_each_other(self, mods):
+        # 0~1 and 1~2 makes {0,1,2} one class, so an appendix pair (0,2) is
+        # inside the group even though no line named that pair.
+        index = self._index(near=((0, 2, 0.01),))
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\n1 2\nREVIEWED-ALL\n", 6)
+        rows, _problems = mods["audit"].merge_verdicts(index, groups, reviewed)
+        assert [r["verdict"] for r in rows] == ["same", "same"]
+
+    def test_every_same_row_is_emitted_before_every_different_row(self, mods):
+        # apply_confusable merges as it goes and follows the chain afterwards;
+        # a separation pinned first would name a class about to stop existing.
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\nREVIEWED-ALL\n", 6)
+        rows, _problems = mods["audit"].merge_verdicts(self._index(), groups, reviewed)
+        verdicts = [r["verdict"] for r in rows]
+        assert verdicts == sorted(verdicts, key=lambda v: v != "same")
+
+    def test_pairs_that_name_the_same_two_post_merge_classes_are_stated_once(self, mods):
+        # Once 0 and 1 are one class, the appendix pairs (0, 2) and (1, 2) are
+        # one statement about one pair of classes. Emitting both prints a
+        # contradiction-shaped log for a decision that was made once.
+        index = self._index(near=((0, 1, 0.01), (0, 2, 0.02), (1, 2, 0.03)))
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\nREVIEWED-ALL\n", 6)
+        rows, _problems = mods["audit"].merge_verdicts(index, groups, reviewed)
+        different = [r for r in rows if r["verdict"] == "different"]
+        assert len(different) == 1
+        assert "rank 1" in different[0]["notes"], "the nearest of the redundant pairs is the one kept"
+
+    def test_an_index_missing_from_the_slate_is_reported(self, mods):
+        index = self._index()
+        index["classes"] = index["classes"][:3]
+        rows, problems = mods["audit"].merge_verdicts(index, [{"indices": [0, 5], "note": ""}], False)
+        assert rows == []
+        assert "not on the slate" in problems[0]
+
+
+class TestMergeSlateEndToEnd:
+    """The slate is an input format, not a second path through the ground truth."""
+
+    def _corpus(self, mods):
+        pages = [
+            _page(mods, f"spods/{c}{i}", "spods", [("logo", (0, 0, 200, 120), f"spods/{c}", "clustered")])
+            for c in "abcd"
+            for i in range(3)
+        ]
+        classes = {
+            f"spods/{c}": {
+                "class_id": f"spods/{c}",
+                "n_instances": 3,
+                "page_ids": [f"spods/{c}{i}" for i in range(3)],
+                "audit": {"membership_verified": False, "rejected_page_ids": []},
+            }
+            for c in "abcd"
+        }
+        return pages, classes
+
+    def _index(self, near):
+        return {
+            "classes": [{"index": i, "class_id": f"spods/{c}", "n_instances": 3} for i, c in enumerate("abcd")],
+            "near_pairs": [
+                {"rank": r, "left_index": a, "right_index": b, "distance": 0.01 * (r + 1)}
+                for r, (a, b) in enumerate(near)
+            ],
+        }
+
+    def test_a_slate_answer_merges_and_separates_through_the_pairwise_applier(self, mods):
+        pages, classes = self._corpus(mods)
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\nREVIEWED-ALL\n", 4)
+        rows, _ = mods["audit"].merge_verdicts(self._index([(0, 1), (2, 3)]), groups, reviewed)
+        _changes, problems, separations, merges = mods["audit"].apply_confusable(pages, classes, rows)
+        assert not problems
+        assert "spods/b" not in classes
+        assert classes["spods/a"]["n_instances"] == 6
+        assert len(merges) == 1 and len(separations) == 1
+        assert classes["spods/c"]["distinct_from"] == ["spods/d"]
+
+    def test_the_resulting_adjudications_never_rule_a_pair_both_ways(self, mods, tmp_path):
+        # save_adjudications raises on a conflicting pair by design. Compiling a
+        # slate that merges one of its own appendix pairs must not trip it.
+        pages, classes = self._corpus(mods)
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("0 1\n2 3\nREVIEWED-ALL\n", 4)
+        rows, _ = mods["audit"].merge_verdicts(self._index([(0, 1), (2, 3), (0, 2)]), groups, reviewed)
+        _c, _p, separations, merges = mods["audit"].apply_confusable(pages, classes, rows)
+        mods["cluster"].save_adjudications(merges, separations, tmp_path / "adjudications.json")
+        same, diff = mods["cluster"].load_adjudications(tmp_path / "adjudications.json")
+        assert not (set(map(frozenset, same)) & set(map(frozenset, diff)))
+        assert len(same) == 2 and len(diff) == 1
+
+    def test_separations_are_keyed_on_page_ids_so_they_survive_a_recluster(self, mods):
+        pages, classes = self._corpus(mods)
+        groups, reviewed, _ = mods["audit"].parse_merge_groups("REVIEWED-ALL\n", 4)
+        rows, _ = mods["audit"].merge_verdicts(self._index([(0, 1)]), groups, reviewed)
+        _c, _p, separations, _m = mods["audit"].apply_confusable(pages, classes, rows)
+        assert separations[0]["left_page_id"] == "spods/a0"
+        assert separations[0]["right_page_id"] == "spods/b0"
 
 
 # -------------------------------------------------------------------- tiers


### PR DESCRIPTION
Answers #3561 — "how should we do the DocMarks audit?" — by building the pass it asks for.

## The problem

The `confusable` pass asks for the right thing in a shape that does not scale. It renders **one PNG per class pair**, and pairs are quadratic: the 24-class roster it was designed around is 276 sheets, but v2 admitted **60 classes, which is 1,770**. The answer it wants is 1,770 independent binary verdicts, ~1,750 of them `different` between marks nobody could confuse.

A pass that hands a reviewer 1,770 files does not get run — and every class in the corpus stays a clustering proposal until one of them is.

The information a reviewer actually holds is not a stream of binary answers. It is a **partition** — these three are one mark, everything else is already right — and almost all of it is the trivial part. So elicit the partition directly.

## The slate

`make_audit_slate.py --task merge` renders every class as a numbered 3-up strip of its own instances, 4×6 to a sheet, ordered by a greedy nearest-neighbour seriation of the clustering descriptor so an over-split shows up as two adjacent cells that look alike. The answer is `merges.txt`:

```
12 37 41
3 8        # same elephant stamp, blue and red ink
REVIEWED-ALL
```

One line per group of classes that are the same mark, nothing at all for the classes that are right. A 60-class slate that over-split three times is four sheets and three lines.

**Three instances per cell, not one.** A single exemplar fits every class on one page and is tempting for that reason, but then a merge rests on that crop being representative of its class — which is the assumption the membership pass exists because we do not trust.

**Similarity order is an aid, the appendix is the guarantee.** A 1-D order cannot preserve a metric that is not 1-D, and the row wrap breaks adjacency every four cells anyway. `pairs_*.png` renders the closest `MERGE_SLATE_NEAR_PAIRS` pairs explicitly side by side, so no pair where a wrong call costs anything depends on the layout having been kind.

## `REVIEWED-ALL` is a deliberately narrow closed world

A partition asserts both directions at once, so taken literally one reviewed slate would adjudicate all 1,770 pairs — the complete "different" half of the ground truth from one sitting.

It is not taken literally, because it would be a lie. A reviewer who scanned sixty thumbnails compared the adjacent cells and every appendix pair; they did not compare the far end of the distance ranking. Recording those as adjudicated would write a decision nobody made into `adjudications.json`, which every future re-cluster is then bound by — the exact failure separations exist to prevent, committed by the mechanism meant to prevent it.

So `REVIEWED-ALL` separates **the appendix pairs and only those**. `MERGE_SLATE_NEAR_PAIRS` is that honesty budget: raise it to buy more of the matrix, pay for it in sheets. Leave the line off and only the merges are recorded.

## An input format, not a second path through the ground truth

`merge_verdicts` compiles the slate into the same `same`/`different` rows `apply_confusable` already records, so nothing here is a parallel route into the corpus. Four properties, each tested:

- A group compiles to a **star, not a clique** — sameness is transitive and the classes are merged outright, so n−1 rows state a group of n.
- Every `same` is emitted **before** every `different` — the applier merges as it goes and follows the chain afterwards, so a separation pinned first would name a class about to stop existing.
- A pair a merge put inside one group is **never also separated** — `save_adjudications` refuses a pair ruled both ways, so this is a correctness gate rather than tidiness.
- Appendix pairs naming the same two **post-merge** classes are stated once.

Typos are refused, never guessed at: an out-of-range index, a non-numeric token, or a one-element group each stops the apply, because silently reinterpreting any of them writes a permanent merge between classes nobody looked at. Groups sharing a member are *unioned* rather than refused — a reviewer writing the same truth twice is redundant, not contradictory.

## On the GRID

`launch_docmarks.sh slate` renders the merge **and** membership sheets in one CPU job and tars them into one bundle. They are one sitting: merge fixes the *partition* (which proposals are one mark), membership fixes the *instances* (whether each crop really is that mark), and doing them a week apart means re-deriving the same context twice. Rendering happens on the cluster because that is where the full-resolution pages are; the bundle is a few dozen PNGs, so reviewing happens anywhere.

## Also in here

`frontend/package.json` listed `"fast-uri": "^3.1.7"` twice in one `overrides` object. JSON keeps the last so nothing ever resolved differently, but esbuild warns on a duplicate key and `run-tests.sh` treats every `build:prod` warning as a hard failure — the gate was red for everyone regardless of what they had changed. Fixed here because it blocked this branch's own test run.

## Testing

`./run-tests.sh` full: **9,941 passed, 6 skipped**, every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest). 32 new tests cover seriation, answer parsing, verdict compilation, and the end-to-end apply through `apply_confusable` + `save_adjudications`.

Verified by rendering a synthetic 8-class corpus containing a deliberate over-split (two classes of the same thin circle). The slate placed them adjacent at `[0]`/`[1]`, the appendix surfaced them as the rank-0 pair at distance 0.000, and a two-line answer merged them and recorded three separations with no both-ways conflict.

Refs #3561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWfAeRVLnUqDhwHowiLCXh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWfAeRVLnUqDhwHowiLCXh)_