### PR TITLE
#3258: record the combine-rule verdict; keep the pooled conformal cut

### DIFF
--- a/docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md
+++ b/docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md
@@ -246,6 +246,31 @@ inclusion 0, `PRODUCTION_HEAD`. Analyzed at dev `e87c90956` + this branch.
 > effect is neither cleanly, and would need a second patch embedder to take
 > further.
 
+> ### ⚠ Resolved, 2026-09-02 (#3310): the missing corner was filled, and the answer is the embedder
+>
+> The disambiguating run above was never launched *for this study* — but
+> [#3310](../2026-08-28-calibration-fold-count-3310/REPORT.md) ran exactly the
+> three-cell design three days later, on the same `vg_scale_any` grid:
+> `siglip/whole_image`, **`dinov3_patch/whole_image`**, `dinov3_patch/max_patch`.
+> On its own question (the fold count) the decomposition is unambiguous:
+>
+> | contrast | holds fixed | early-band Δ at K=6 |
+> |---|---|---|
+> | `dinov3/whole` vs `dinov3/max_patch` | the embedder | −0.0056 vs −0.0057 — **no difference** |
+> | `siglip/whole` vs `dinov3/whole` | the voting mode | −0.0015 vs −0.0056 — **the whole effect** |
+>
+> Switching the voting mode changes nothing; switching the embedder changes
+> everything. #3287's calibration-fraction optimum followed the embedder too.
+>
+> **This is a neighbouring knob, not this study's `space` leg**, so it does not
+> *measure* the sign flip's attribution — the combine arms have never been run on
+> the middle cell. What it does is remove the prior that made "voting mode" the
+> natural reading: two independent calibration knobs on this exact grid both
+> follow the embedder once the corner is filled. Anyone picking this up should
+> key on the embedder, and should read the mode framing here as an artifact of
+> the two-cell design. That is why #3258 — which proposed a mode-dependent
+> combine rule — was closed unbuilt rather than rescoped.
+
 ### BLUF
 
 **Both docstrings are wrong, and they are wrong in different places.**
@@ -254,7 +279,10 @@ inclusion 0, `PRODUCTION_HEAD`. Analyzed at dev `e87c90956` + this branch.
   reason — *"the pool is exchangeable enough for the quantile rule"* — does not
   survive contact: averaging the folds' own conformal cuts beats pooling their
   scores by **−0.0078 ± 0.0015** (binary) and **−0.016 ± 0.003** (region).
-- **The comparability premise is mode-dependent, and that is the finding.** The
+- **The comparability premise is cell-dependent, and that is the finding.**
+  (Written as *mode*-dependent; see the two correction boxes above — the cells
+  confound mode with the embedder, and #3310 later found the embedder is what
+  neighbouring knobs follow.) The
   anchored path keeps each fold's haystack *"to read a cut's quantile in the
   scale it was measured on"*. On **region** voting that is right and worth
   **−0.032 ± 0.005**; on **binary** voting it is wrong and costs
@@ -320,6 +348,50 @@ So `qmean` is *better* than pooling for the first ~20 votes on binary and
 regime to ship on — it is where a real search spends its votes — but a
 recommendation quoted without the band is wrong about the first twenty clicks in
 both modes.
+
+### So does the `combine` leg — and that is what un-recommends `tmean`
+
+> **Added 2026-09-02 (#3258's evaluation).** The table above is the `total` leg.
+> The prose below it, and the follow-up calling `tmean` "the cheap, safe half",
+> both left the reader to assume the `combine` leg does not cross. **It does**,
+> and reading it off the two `regret_over_votes_*_k4` figures above is what
+> closed #3258 unbuilt.
+
+`tmean` (the dark blue line in both figures) sits **above** zero — worse than
+pooling — over the whole cold start, and the two cells cross at very different
+places:
+
+| cell | `tmean` crosses zero at | worst cold-start cost | deep-regime gain |
+|---|---:|---:|---:|
+| binary (`siglip`/`whole_image`) | ~45 votes | **≈ +0.03** near 20 votes | −0.0078 ± 0.0015 |
+| region (`dinov3_patch`/`max_patch`) | ~15–18 votes | ≈ +0.01 near 0–10 votes | −0.016 ± 0.003 |
+
+**The mechanism is the pooled rule's *other* argument.** Its docstring makes two
+claims, and this study refutes only one of them:
+
+- *Exchangeability* — "all folds' scores live on the same sigmoid scale" —
+  refuted, in the deep regime, by the `combine` leg's headline numbers.
+- *Resolution* — "per-fold quantiles on a handful of votes each would waste the
+  other folds' scores" — **vindicated**, in the cold regime, by the crossing
+  above. Each fold's cut is a quantile over its own few held-out points;
+  averaging K coarse cuts loses to one quantile over the pool until the folds
+  are individually well-populated. That is also why the cell holding out more
+  per fold crosses earlier.
+
+Two consequences the deep-regime number on its own does not carry:
+
+- **The crossing is a property of held-out points per fold, not of the calendar.**
+  This run predates #3287, so both cells shared one `calibration_fraction`.
+  Production now splits per space (0.3 single-vector, 0.5 patch), so a
+  single-vector detector today holds out **fewer** votes per fold than this run's
+  binary cell did — pushing that ~45-vote crossing later, not earlier.
+- **"Ship on the deep regime" no longer describes where the rule fires.** It was
+  written when the pooled cut was believed to threshold every reloaded detector.
+  After the three corrections below, its one remaining app site is the Inclusion
+  slider's re-cut for a *degenerate anchored fit*, joined by two library-tier
+  re-derivation entry points — all haystack-less fallbacks, none of which has any
+  reason to sit past 45 votes. Promoting `tmean` would buy −0.008/−0.016 in a
+  regime these paths do not reliably occupy, at up to +0.03 in the one they do.
 
 ### Does the gap grow with K?
 
@@ -542,13 +614,21 @@ Still: `vg_scale_any` inherits whatever `vg_scale` holds, and `build_pile.py
   path fuses against the haystack like any other training pass and starts on the
   fold-anchored cut (see the correction above). The conformal cut still never
   reaches acquisition; what it does reach is cold Find's verdicts.
-- **#3258 — a mode-dependent combine for the conformal path.** The evidence points at
-  quantile space for region and score space for binary. `threshold_from_fold_orderings`
-  takes no voting-mode argument today, so this is a signature change, not a
-  constant.
-- **`tmean` is the cheap, safe half.** Averaging beats pooling in *both* modes
-  and needs no haystack, no rank transfer, and no mode switch. It is the part of
-  this result that could ship on its own.
+- **~~#3258 — a mode-dependent combine for the conformal path.~~ CLOSED UNBUILT
+  2026-09-02**, on both halves. The mode framing is an artifact of the two-cell
+  design, and #3310 filled the missing corner: on this grid, calibration knobs
+  follow the **embedder**, not the voting mode (see the resolution note above).
+  Anyone reviving this should key on the embedder and must run the combine arms
+  on the middle cell first.
+- **~~`tmean` is the cheap, safe half.~~ Withdrawn 2026-09-02 — it is cheap but
+  it is not safe here.** Averaging does beat pooling in both cells past ~100
+  votes, with no haystack, rank transfer or mode switch. But the `combine` leg
+  crosses zero on the vote axis just as the `total` leg does (≈45 votes binary,
+  ≈15 region, costing up to +0.03 before that), and after the three corrections
+  above the pooled rule's only remaining sites are haystack-less fallbacks that
+  have no reason to sit past the crossing. The bullet was written when the
+  pooled cut was believed to threshold every reloaded detector, which the
+  2026-09-02 correction refuted.
 - **#3115's contamination hypothesis needs a different instrument** — the
   splitter prevents it, so testing it at all would mean deliberately disabling
   stratification, which is not obviously worth doing.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/vtscore/training/thresholds/conformal.py
+++ b/vtscore/training/thresholds/conformal.py
@@ -846,12 +846,35 @@ def threshold_from_fold_orderings(
     """Apply the conformal inclusion rule to the pooled fold orderings.
 
     Cheap: pools every fold's cached held-out ``(scores, labels)`` and runs
-    :func:`conformal_threshold` once - no fold refits.  Pooling (rather than
-    averaging per-fold thresholds) is deliberate: the knob's resolution is
-    bounded by the number of calibration scores the quantiles are taken over,
-    and per-fold quantiles on a handful of votes each would waste the other
-    folds' scores.  All folds' scores live on the same sigmoid scale, so the
-    pool is exchangeable enough for the quantile rule.
+    :func:`conformal_threshold` once - no fold refits.
+
+    **Pooling is deliberate, and only one of its two historical justifications
+    survived measurement** (issue #3115, run 2026-08-25,
+    ``docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md``):
+
+    * *Resolution* - "the knob's resolution is bounded by the number of
+      calibration scores the quantiles are taken over, and per-fold quantiles
+      on a handful of votes each would waste the other folds' scores" - **holds,
+      and it is what keeps this rule shipped.**  Below roughly 45 votes on the
+      run's single-vector cell (roughly 15 on its patch cell), averaging the
+      folds' own cuts is *worse* than pooling, by as much as +0.03 paired regret
+      around 20 votes.  Each fold's cut is then a quantile over a handful of
+      held-out points, and averaging K coarse cuts loses to one quantile over
+      the pool.
+    * *Exchangeability* - "all folds' scores live on the same sigmoid scale, so
+      the pool is exchangeable enough for the quantile rule" - **is refuted in
+      the deep regime.**  Past ~100 votes, averaging the per-fold conformal cuts
+      in score space beats pooling by −0.0078 ± 0.0015 and −0.016 ± 0.003 on the
+      run's two cells.
+
+    The two regimes point opposite ways and the rule is not switched, because
+    every path that still reaches this function is a *haystack-less* one - the
+    Inclusion slider's re-cut for a detector whose anchored fit degenerated, and
+    the library-tier re-derivation entry points - none of which has any reason to
+    sit in the deep regime.  A detector with a haystack is cut by
+    :func:`~vtscore.training.thresholds.fold_anchored_gmm_threshold` and never
+    arrives here.  :func:`combined_fold_conformal_threshold` is the measured
+    challenger, kept eval-only for exactly this reason.
 
     Callers must pass a non-empty ``fold_orderings`` (the empty case is
     handled via the ``fallback`` from :func:`compute_fold_orderings`);
@@ -879,8 +902,19 @@ def threshold_from_fold_orderings(
 #: same sigmoid scale".  :meth:`FoldAnchoredCut._combined_fold_quantile` takes
 #: one cut per fold and averages them in **quantile** space specifically so that
 #: no cross-scale averaging of raw cuts ever happens - i.e. it is built on the
-#: premise that fold scores are *not* directly comparable.  Both cannot be right,
-#: and nobody has measured which.
+#: premise that fold scores are *not* directly comparable.
+#:
+#: **Both were measured, and each is right in a different regime** (#3115, run
+#: 2026-08-25; see :func:`threshold_from_fold_orderings` for the numbers and
+#: ``docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md`` for the
+#: run).  Averaging beats pooling past ~100 votes in both of the run's cells and
+#: loses to it in the cold start; the *quantile*-space step flips sign between
+#: the cells outright.  That sign flip is **not attributable to the voting
+#: mode**: the run's two cells confounded mode with the embedder, and #3310
+#: later filled the missing corner on the same grid and found the neighbouring
+#: fold-count effect follows the **embedder**, not the mode (as #3287's
+#: calibration-fraction optimum also did).  So there is no measured licence for a
+#: mode-dependent rule, and issue #3258, which proposed one, was closed unbuilt.
 #:
 #: The four rules here are the challengers, and they factor the disagreement
 #: rather than confounding it.  Against the pooled control they decompose as:
@@ -938,9 +972,16 @@ def combined_fold_conformal_threshold(
     """Combine the folds' *own* conformal cuts instead of pooling their scores.
 
     The challenger to :func:`threshold_from_fold_orderings` (issue #3115); see
-    :data:`FOLD_CONFORMAL_COMBINES` for what each rule isolates.  **Eval-only**
-    - nothing in the app calls this, and the run it exists for is what would
-    license changing that.
+    :data:`FOLD_CONFORMAL_COMBINES` for what each rule isolates.
+
+    **Still eval-only, now by verdict rather than by default.**  The run this
+    exists for happened (2026-08-25) and did resolve the combine leg above its
+    pre-registered margin - but in the *deep* regime only, and every path that
+    still reaches the pooled rule is a haystack-less fallback with no reason to
+    be deep.  :func:`threshold_from_fold_orderings` carries the regimes and the
+    numbers; the short version is that promoting ``tmean`` would trade a
+    −0.008/−0.016 deep-regime gain for a cold-start loss up to +0.03 on exactly
+    the paths that remain.
 
     ``"tmean"`` / ``"tmedian"`` average the per-fold cuts in **score** space.
     This is the rule that presumes the folds' sigmoid scales are comparable, and


### PR DESCRIPTION
Evaluation of #3258, which proposed keying the conformal fold-combine rule on the voting mode. **Both halves are declined**, and the reasoning is written into the code and the report rather than left in a closed issue. No algorithm change, so no eval/app-sync re-pin.

Refs #3258 (closed as `not_planned` — dismissal, not a fix). Refs #3115, refs #3310.

## The mode-dependent half is refuted by a run that already happened

The issue's own hold comment flagged that #3115's two-cell grid confounded voting mode with the embedder, and named the design that would separate them: `dinov3_patch` running `whole_image` beside `max_patch`.

**#3310 ran exactly that**, three days later, on the same `vg_scale_any` grid. On its own question (the fold count): switching the *mode* changes nothing (−0.0056 vs −0.0057), switching the *embedder* changes everything (−0.0015 vs −0.0056). #3287's calibration-fraction optimum followed the embedder too. That report names this confound by number.

It is a neighbouring knob rather than this issue's `space` leg, so it does not *measure* the sign flip's attribution — but it removes the prior that made "voting mode" the natural reading. Threading a mode argument through `threshold_from_fold_orderings` would build a signature change on the hypothesis the evidence disfavours.

## The `tmean` half is a regression on the sites that are left

The issue calls `tmean` "the safe floor," and its guard rail tabulates the vote-axis crossing for the **`total`** leg only. The `combine` leg crosses too — visible in the report's own committed figures, but never in its prose:

| cell | `tmean` crosses zero at | worst cold-start cost | deep-regime gain |
|---|---:|---:|---:|
| binary (`siglip`/`whole_image`) | ~45 votes | **≈ +0.03** near 20 votes | −0.0078 ± 0.0015 |
| region (`dinov3_patch`/`max_patch`) | ~15–18 votes | ≈ +0.01 near 0–10 votes | −0.016 ± 0.003 |

The mechanism is the pooled docstring's *other* argument. It makes two claims and the study refutes only one: *exchangeability* is refuted (deep regime), while *resolution* — "per-fold quantiles on a handful of votes each would waste the other folds' scores" — is **vindicated** (cold regime). Averaging K coarse cuts loses to one quantile over the pool until the folds are individually well-populated, which is why the cell holding out more per fold crosses earlier.

Two consequences the deep-regime number alone does not carry:

- **The app has drifted since the run.** #3115 predates #3287, so both cells shared one `calibration_fraction`. Production now splits per space (0.3 single-vector / 0.5 patch), so a single-vector detector today holds out *fewer* votes per fold than the run's binary cell did — pushing that ~45-vote crossing **later**.
- **"Ship on the deep regime" no longer describes where the rule fires.** After #3516 and #3525 fused cold Find, the pooled rule's only remaining app site is the Inclusion slider's re-cut for a degenerate anchored fit, joined by two library-tier re-derivation entry points. All haystack-less fallbacks; none has reason to sit past the crossing. Promoting `tmean` would buy −0.008/−0.016 in a regime these paths do not reliably occupy, at up to +0.03 in the one they do.

## Changes

**`vtscore/training/thresholds/conformal.py`** — docstrings only, so the eval/app-sync digests are untouched:

- `threshold_from_fold_orderings` no longer asserts the refuted exchangeability claim as fact. It now records which of its two justifications held, in which regime, and why the rule is not switched.
- `FOLD_CONFORMAL_COMBINES` no longer says "nobody has measured which."
- `combined_fold_conformal_threshold` stays eval-only **by verdict** rather than by default.

**`docs/experiments/2026-08-25-calibration-fold-combine/REPORT.md`** — adds the `combine` leg's crossing beside the `total` leg's, records #3310's resolution of the confound, and withdraws the two follow-up bullets that recommended `tmean` and the mode-dependent rule.

**`frontend/package.json`** — drops a duplicate `"fast-uri"` key in `overrides`. Unrelated to the above and pre-existing, but esbuild emits `▲ [WARNING] Duplicate key` on every `build:prod` and `run-tests.sh` treats that as a hard failure, so the full gate could not go green without it. Both entries carried the identical specifier and JSON keeps the last, so no resolution changes and `package-lock.json` is untouched.

## Testing

Full `./run-tests.sh`: **RUN PASSED**, all gates green — 9917 passed, 6 skipped, 1 xfailed, 1 xpassed; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all OK. The frontend build is now warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5fvRJKvvxLMmcHAsygJst

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5fvRJKvvxLMmcHAsygJst)_