### PR TITLE
Delete the settings migration shims for old persisted formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,26 @@ not list every commit. Use `git log` for the full history.
   `POST /api/dataset/import/server_folder`, and detector load respectively.
   (Issue #3438.)
 
+- **Old settings-file shapes are no longer migrated forward.** VTSearch used to
+  carry three shims for settings written by older versions: a one-shot rewrite
+  that split a pre-tier-split `data/settings.json` across the two files, and a
+  pair of coercions that read a pre-enum boolean `show_animations` as
+  `"show"` / `"hide"`. `CLAUDE.md`'s backwards-compatibility policy allows
+  breaking saved data freely and forbids exactly these shims, so they are gone.
+  A value the settings models reject -- one written before a field changed
+  shape, or a hand-edit out of range -- is now **ignored on load** and the
+  field's default applies. Your file is never rewritten, so nothing is lost:
+  fix the value and it takes effect on the next start. Concretely, a boolean
+  `show_animations` now reads as `"show"` (the default) rather than mapping
+  True-ish to `"show"` and False-ish to `"hide"`, and `PUT /api/settings` now
+  rejects the boolean with a 422 instead of silently rewriting it. Per-user
+  keys sitting in `data/settings.json` are inert rather than migrated into the
+  default user's file. The one deliberate tier exception is unchanged: the
+  built-in `default` user still reads `autofind_detectors`,
+  `autofind_exporter` and `autofind_exporter_field_values` through to
+  `data/settings.json`, which is what keeps the CLI's `--settings` flat-file
+  workflow working. (Issue #3413.)
+
 ### Changed
 
 - **Your Dashboard selection now survives leaving the Dashboard.** Going to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1075,9 +1075,11 @@ server-tier set is shared; everything else lives in
 Background threads spawned from a request handler propagate the user via the
 `vtsearch.auth.thread_user(...)` context manager (which snapshots and restores
 the prior thread-local automatically), so per-user writes — autopilot toggles,
-sync-source exports — land in the right file. Legacy single-file
-`data/settings.json` files that pre-date the split are migrated to the default
-user's file on first load.
+sync-source exports — land in the right file. A single-file
+`data/settings.json` that pre-dates the split is **not** migrated: its
+per-user keys simply have no effect where they sit, and the file is left as
+written (the one exception is the Auto-Find trio, which the built-in `default`
+user reads through to — see [Deployment](DEPLOYMENT.md#settings-file-schema)).
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -578,6 +578,12 @@ provider. Both files are auto-created on first use and auto-saved on every
 change. Both models accept extra keys, so an unrecognised key is preserved
 rather than dropped.
 
+A key the model *does* know but whose value it rejects — a hand-edit out of
+range, or a value written before the field changed shape — is **ignored on
+load**: the field reads as unset, so its default applies. Nothing is rewritten,
+so the file keeps whatever you put in it; fix the value and it takes effect on
+the next start. VTSearch does not migrate old settings shapes forward.
+
 **If you are changing a user preference, edit `user_settings.json`, not
 `settings.json`.** A `theme` or `autopilot_enabled` key placed in
 `data/settings.json` is simply ignored. The one deliberate exception is the

--- a/tests/core/test_per_user_settings.py
+++ b/tests/core/test_per_user_settings.py
@@ -90,15 +90,26 @@ class TestPerUserIsolation:
         assert "autofind_detectors" in out
 
 
-class TestLegacyMigration:
-    def test_legacy_mixed_file_migrates_user_keys(self, tmp_path, monkeypatch):
-        """A pre-refactor settings.json with both tiers must be split on load."""
+class TestUnmigratedFiles:
+    """Old on-disk shapes are *ignored*, not migrated.
+
+    VTSearch used to split a pre-refactor flat ``settings.json`` across the
+    two tiers on first load, rewriting both files. ``CLAUDE.md``'s
+    backwards-compatibility policy forbids migration shims for saved data, so
+    that one-shot rewrite is gone (issue #3413): a value the tier's model
+    can't accept is dropped from the in-memory cache on load and the pydantic
+    default applies, while the file on disk is left exactly as the user wrote
+    it.
+    """
+
+    def test_legacy_mixed_file_ignores_user_keys(self, tmp_path, monkeypatch):
+        """Per-user keys in the server file are inert - no migration, no rewrite."""
         from vtsearch import settings as settings_mod
 
         legacy = {
             "saved_datasets_dir": "/tmp/legacy",  # server tier
-            "volume": 0.33,  # user tier
-            "theme": "light",  # user tier
+            "volume": 0.33,  # user tier - ignored where it sits
+            "theme": "light",  # user tier - ignored where it sits
         }
         server_path = tmp_path / "settings.json"
         server_path.write_text(json.dumps(legacy))
@@ -106,148 +117,135 @@ class TestLegacyMigration:
         settings_mod.set_user_data_dir_override(tmp_path / "users")
         settings_mod.reset()
         try:
-            # Triggers _ensure_server_loaded + migration.
-            assert settings_mod.get_volume() == 0.33
-            assert settings_mod.get_theme() == "light"
+            # The server-tier key still applies.
             assert str(settings_mod.get_saved_datasets_dir()) == "/tmp/legacy"
+            # The stranded per-user keys do not: defaults win.
+            assert settings_mod.get_volume() == 1.0
+            assert settings_mod.get_theme() == "system"
 
-            # Server file now contains only server-tier keys.
-            remaining = json.loads(server_path.read_text())
-            assert "volume" not in remaining
-            assert "theme" not in remaining
-            assert remaining["saved_datasets_dir"] == "/tmp/legacy"
-
-            # Default user's file contains only per-user keys.
-            user_path = tmp_path / "users" / "default" / "user_settings.json"
-            assert user_path.exists()
-            user_data = json.loads(user_path.read_text())
-            assert user_data["volume"] == 0.33
-            assert user_data["theme"] == "light"
-            assert "saved_datasets_dir" not in user_data
+            # Nothing on disk was rewritten, and no user file was conjured.
+            assert json.loads(server_path.read_text()) == legacy
+            assert not (tmp_path / "users" / "default" / "user_settings.json").exists()
         finally:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()
 
-    def test_user_write_failure_keeps_cache_and_disk_consistent(self, tmp_path, monkeypatch):
-        """If the per-user write fails, the in-memory cache and on-disk
-        server file must stay aligned (no half-migrated state)."""
+    def test_autofind_keys_in_server_file_still_read_through(self, tmp_path, monkeypatch):
+        """The one deliberate tier exception survives: the Auto-Find trio.
+
+        The CLI's documented ``--settings`` flat-file workflow puts
+        ``autofind_detectors`` in the server file and expects the ``default``
+        user to see it (see ``_DEFAULT_USER_FALLBACK_KEYS``). That read-through
+        is a live feature, not a migration, so it is *not* sanitized away.
+        """
         from vtsearch import settings as settings_mod
 
-        legacy = {
-            "saved_datasets_dir": "/tmp/legacy",
-            "volume": 0.33,
-            "theme": "light",
-        }
         server_path = tmp_path / "settings.json"
-        server_path.write_text(json.dumps(legacy))
+        server_path.write_text(json.dumps({"autofind_detectors": ["Dog Barks"]}))
         monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
         settings_mod.set_user_data_dir_override(tmp_path / "users")
         settings_mod.reset()
-
-        real_atomic_write = settings_store_mod._atomic_write
-        user_settings_path = tmp_path / "users" / "default" / "user_settings.json"
-
-        def failing_atomic_write(path, data):
-            if path == user_settings_path:
-                raise OSError("simulated user-file write failure")
-            return real_atomic_write(path, data)
-
-        monkeypatch.setattr(settings_store_mod, "_atomic_write", failing_atomic_write)
         try:
-            # Triggers migration; user-file write raises and is swallowed.
-            settings_mod.get_saved_datasets_dir()
-
-            # Server file on disk is untouched (legacy keys still present).
-            on_disk = json.loads(server_path.read_text())
-            assert on_disk == legacy
-
-            # In-memory server cache matches disk (legacy keys still there).
-            assert settings_mod._store.server_cache is not None
-            assert settings_mod._store.server_cache.get("volume") == 0.33
-            assert settings_mod._store.server_cache.get("theme") == "light"
-
-            # No phantom user file was created.
-            assert not user_settings_path.exists()
+            assert settings_mod.get_autofind_detectors() == ["Dog Barks"]
+            assert settings_mod.get_all()["autofind_detectors"] == ["Dog Barks"]
         finally:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()
 
-    def test_server_rewrite_failure_keeps_cache_and_disk_consistent(self, tmp_path, monkeypatch):
-        """If the server-file rewrite fails after the user write succeeds,
-        the in-memory ``_server_cache`` must not have legacy keys popped;
-        otherwise it would silently disagree with the on-disk server file."""
+    def test_bad_autofind_value_in_server_file_is_dropped(self, tmp_path, monkeypatch):
+        """The read-through is an exception to the *tier* rule, not to the
+        value check: the trio is validated against ``UserSettings``, the model
+        that actually reads it, so a hand-edit of the wrong shape still falls
+        back to the default rather than reaching a caller."""
         from vtsearch import settings as settings_mod
 
-        legacy = {
-            "saved_datasets_dir": "/tmp/legacy",
-            "volume": 0.33,
-            "theme": "light",
-        }
         server_path = tmp_path / "settings.json"
-        server_path.write_text(json.dumps(legacy))
+        server_path.write_text(json.dumps({"autofind_detectors": "Dog Barks", "autofind_exporter": "json"}))
         monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
         settings_mod.set_user_data_dir_override(tmp_path / "users")
         settings_mod.reset()
-
-        real_atomic_write = settings_store_mod._atomic_write
-        user_settings_path = tmp_path / "users" / "default" / "user_settings.json"
-
-        def failing_atomic_write(path, data):
-            if path == server_path:
-                raise OSError("simulated server-file write failure")
-            return real_atomic_write(path, data)
-
-        monkeypatch.setattr(settings_store_mod, "_atomic_write", failing_atomic_write)
         try:
-            # Triggers migration; user write succeeds, server rewrite raises.
-            settings_mod.get_saved_datasets_dir()
+            assert settings_mod.get_autofind_detectors() == []  # bare string, not a list
+            assert settings_mod.get_autofind_exporter() == "json"  # the valid sibling survives
+        finally:
+            settings_mod.set_user_data_dir_override(None)
+            settings_mod.reset()
 
-            # User file was written successfully.
-            assert user_settings_path.exists()
-            user_data = json.loads(user_settings_path.read_text())
-            assert user_data["volume"] == 0.33
-            assert user_data["theme"] == "light"
+    def test_stranded_server_key_in_user_file_does_not_shadow(self, tmp_path, monkeypatch):
+        """A server-tier key left in a user file must not shadow the real value.
 
-            # Server file on disk still has legacy keys (rewrite failed).
-            on_disk = json.loads(server_path.read_text())
-            assert on_disk == legacy
+        ``browse_signpost_vocab`` was per-user before it became a server-tier
+        operator setting, so user files written before the move still carry a
+        copy. ``get_all`` layers the user cache over the server one, so the
+        stale copy used to be reported by GET while projection builds (which
+        read the accessor) used the operator's. It is dropped on load now.
+        """
+        from vtsearch import settings as settings_mod
 
-            # Crucially, in-memory cache matches disk; legacy keys NOT popped.
-            assert settings_mod._store.server_cache is not None
-            assert settings_mod._store.server_cache.get("volume") == 0.33
-            assert settings_mod._store.server_cache.get("theme") == "light"
-            assert settings_mod._store.server_cache.get("saved_datasets_dir") == "/tmp/legacy"
+        server_path = tmp_path / "settings.json"
+        server_path.write_text(json.dumps({"browse_signpost_vocab": {"image": ["operator"]}}))
+        user_path = tmp_path / "users" / "default" / "user_settings.json"
+        user_path.parent.mkdir(parents=True, exist_ok=True)
+        user_path.write_text(json.dumps({"browse_signpost_vocab": {"image": ["stale"]}}))
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
+        settings_mod.set_user_data_dir_override(tmp_path / "users")
+        settings_mod.reset()
+        try:
+            assert settings_mod.get_all()["browse_signpost_vocab"] == {"image": ["operator"]}
+            assert settings_mod.get_browse_signpost_vocab() == {"image": ["operator"]}
+            # The user's file itself is left alone - the drop is read-side only.
+            assert json.loads(user_path.read_text()) == {"browse_signpost_vocab": {"image": ["stale"]}}
+        finally:
+            settings_mod.set_user_data_dir_override(None)
+            settings_mod.reset()
+
+    def test_unrelated_write_does_not_delete_dropped_keys(self, tmp_path, monkeypatch):
+        """Sanitizing is a read-side view: a later setter must not eat the file.
+
+        Dropping a value the model rejects has to stay non-destructive, or the
+        migration we just deleted would come back in another form - silently,
+        on whatever unrelated setting the user happened to change next.
+        """
+        from vtsearch import settings as settings_mod
+
+        server_path = tmp_path / "settings.json"
+        server_path.write_text(json.dumps({}))
+        user_path = tmp_path / "users" / "default" / "user_settings.json"
+        user_path.parent.mkdir(parents=True, exist_ok=True)
+        user_path.write_text(json.dumps({"show_animations": "True", "hand_added": 7}))
+        monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
+        settings_mod.set_user_data_dir_override(tmp_path / "users")
+        settings_mod.reset()
+        try:
+            assert settings_mod.get_show_animations() == "show"  # default applies
+            settings_mod.set_volume(0.42)
+            on_disk = json.loads(user_path.read_text())
+            assert on_disk["show_animations"] == "True"  # untouched
+            assert on_disk["hand_added"] == 7  # extra keys still round-trip
+            assert on_disk["volume"] == 0.42
         finally:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()
 
 
-class TestMigrationCrossProcessLock:
-    """H28 residual follow-up: the one-shot legacy migration must run its two
-    ``_atomic_write`` calls under the cross-process ``file_lock`` (previously
-    it wrote bare), and must migrate exactly once even under concurrent first
-    loads."""
+class TestServerLoadCrossProcessLock:
+    """The first server-tier load runs under the cross-process ``file_lock``
+    (file-lock -> settings-lock order), and concurrent first loads must not
+    deadlock or disagree."""
 
-    def _seed_legacy(self, tmp_path, monkeypatch):
-        legacy = {
-            "saved_datasets_dir": "/tmp/legacy",  # server tier
-            "volume": 0.33,  # user tier
-            "theme": "light",  # user tier
-        }
+    def _seed(self, tmp_path, monkeypatch):
         server_path = tmp_path / "settings.json"
-        server_path.write_text(json.dumps(legacy))
+        server_path.write_text(json.dumps({"saved_datasets_dir": "/tmp/legacy"}))
         monkeypatch.setattr(settings_mod, "SETTINGS_PATH", server_path)
         settings_mod.set_user_data_dir_override(tmp_path / "users")
         settings_mod.reset()
         return server_path
 
-    def test_migration_writes_under_file_lock(self, tmp_path, monkeypatch):
-        """Both the default-user write and the server rewrite happen inside a
-        ``file_lock`` for their target file."""
+    def test_server_load_takes_file_lock(self, tmp_path, monkeypatch):
         import contextlib
         from pathlib import Path
 
-        server_path = self._seed_legacy(tmp_path, monkeypatch)
+        self._seed(tmp_path, monkeypatch)
 
         locked: list[str] = []
         real_file_lock = settings_store_mod.file_lock
@@ -260,44 +258,38 @@ class TestMigrationCrossProcessLock:
 
         monkeypatch.setattr(settings_store_mod, "file_lock", recording_file_lock)
         try:
-            # Triggers ensure_server_loaded -> load+migrate.
-            assert settings_mod.get_volume() == 0.33
-            # Server file locked for the load+migrate; default user's file
-            # locked for the migration write.
+            assert str(settings_mod.get_saved_datasets_dir()) == "/tmp/legacy"
             assert "settings.json" in locked
-            assert "user_settings.json" in locked
-            # Migration still produced the correct split.
-            remaining = json.loads(server_path.read_text())
-            assert "volume" not in remaining
-            assert remaining["saved_datasets_dir"] == "/tmp/legacy"
         finally:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()
 
-    def test_concurrent_first_load_migrates_once(self, tmp_path, monkeypatch):
-        """Four threads racing the first load must not double-migrate or
-        deadlock; the migration body runs exactly once."""
+    def test_concurrent_first_load_reads_file_once(self, tmp_path, monkeypatch):
+        """Four threads racing the first load must not deadlock, and only the
+        winner of the file lock actually reads the file."""
         import threading
 
-        server_path = self._seed_legacy(tmp_path, monkeypatch)
+        self._seed(tmp_path, monkeypatch)
 
         calls = {"n": 0}
-        real = settings_store_mod.UserSettingsStore._maybe_migrate_legacy_settings
+        real_load = settings_store_mod._load_path
+        server_name = "settings.json"
 
-        def counting(self, cache, path):
-            calls["n"] += 1
-            return real(self, cache, path)
+        def counting_load(path):
+            if path.name == server_name:
+                calls["n"] += 1
+            return real_load(path)
 
-        monkeypatch.setattr(settings_store_mod.UserSettingsStore, "_maybe_migrate_legacy_settings", counting)
+        monkeypatch.setattr(settings_store_mod, "_load_path", counting_load)
         try:
             barrier = threading.Barrier(4)
-            results: list[float] = []
+            results: list[str] = []
             errors: list[Exception] = []
 
             def worker():
                 try:
                     barrier.wait(timeout=5)
-                    results.append(settings_mod.get_volume())
+                    results.append(str(settings_mod.get_saved_datasets_dir()))
                 except Exception as exc:  # pragma: no cover - surfaced below
                     errors.append(exc)
 
@@ -310,12 +302,10 @@ class TestMigrationCrossProcessLock:
             assert not errors, f"workers raised: {errors}"
             for t in threads:
                 assert not t.is_alive(), "thread hung (likely deadlock)"
-            assert results == [0.33] * 4
-            # The first thread to win the server file lock migrates; the rest
-            # find the cache already published and skip the body entirely.
+            assert results == ["/tmp/legacy"] * 4
+            # The first thread to win the server file lock loads; the rest find
+            # the cache already published and skip the read entirely.
             assert calls["n"] == 1
-            remaining = json.loads(server_path.read_text())
-            assert "volume" not in remaining
         finally:
             settings_mod.set_user_data_dir_override(None)
             settings_mod.reset()

--- a/tests/core/test_settings_api_routes.py
+++ b/tests/core/test_settings_api_routes.py
@@ -44,15 +44,17 @@ class TestSettingsAPI:
         assert res.status_code == 200
         assert res.get_json()["browse_colormap"] == {}
 
-    def test_legacy_boolean_show_animations_migrates_on_read_and_save(self, client, isolated_settings):
-        """Pre-enum ``show_animations`` values must not wedge settings saves.
+    def test_pre_enum_boolean_show_animations_reads_as_default(self, client, isolated_settings):
+        """A pre-enum boolean ``show_animations`` is dropped, not migrated.
 
-        Until a3a37106 the setting was a boolean; a settings file carrying
+        Until a3a37106 the setting was a boolean. A settings file carrying
         ``"True"`` used to leak verbatim out of GET /api/settings (blank
         pulldown in the UI) and then fail the ``OneOf`` validator when the
         frontend echoed the whole blob back into PUT - every settings save
-        422ed until the file was hand-edited. Legacy True-ish values now read
-        as ``"show"`` and save cleanly.
+        422ed until the file was hand-edited. That was fixed with a pair of
+        coercion shims, which issue #3413 removed as a
+        backwards-compatibility violation: the value is now dropped on load
+        and the pydantic default applies, so GET is clean and the echo saves.
         """
         import json as _json
 
@@ -60,31 +62,27 @@ class TestSettingsAPI:
 
         isolated_settings._user.parent.mkdir(parents=True, exist_ok=True)
         isolated_settings._user.write_text(_json.dumps({"show_animations": "True"}) + "\n")
-        settings_mod.reset()  # re-read the legacy file
+        settings_mod.reset()  # re-read the unmigrated file
 
         res = client.get("/api/settings")
         assert res.status_code == 200
         assert res.get_json()["show_animations"] == "show"
 
-        # A stale client echoing the legacy value back must still save.
-        res = client.put("/api/settings", json={"show_animations": "True"})
+        # The value the client echoes back is the sanitized one, so the save
+        # round-trips rather than 422ing.
+        res = client.put("/api/settings", json={"show_animations": "show"})
         assert res.status_code == 200
         assert settings_mod.get_show_animations() == "show"
 
-    def test_legacy_false_show_animations_maps_to_hide(self, client, isolated_settings):
-        """False-ish legacy values keep their meaning (animations off)."""
-        import json as _json
+    def test_pre_enum_boolean_show_animations_is_rejected_on_put(self, client):
+        """The legacy shape is no longer accepted as *input* either.
 
-        from vtsearch import settings as settings_mod
-
-        isolated_settings._user.parent.mkdir(parents=True, exist_ok=True)
-        isolated_settings._user.write_text(_json.dumps({"show_animations": False}) + "\n")
-        settings_mod.reset()
-
-        res = client.get("/api/settings")
-        assert res.status_code == 200
-        assert res.get_json()["show_animations"] == "hide"
-        assert settings_mod.get_show_animations() == "hide"
+        The schema's ``@pre_load`` coercion went with the model's validator
+        (#3413), so a stale client sending the boolean gets a loud 422 rather
+        than a silent rewrite.
+        """
+        res = client.put("/api/settings", json={"show_animations": "True"})
+        assert res.status_code == 422
 
     def test_update_volume(self, client):
         res = client.put(

--- a/tests/core/test_signpost_vocab_setting.py
+++ b/tests/core/test_signpost_vocab_setting.py
@@ -69,13 +69,18 @@ class TestApiContract:
     def test_stale_per_user_copy_does_not_shadow_the_server_value(self, client, isolated_settings):
         """A user file written before the tier move still carries the key.
 
-        ``get_all`` layers the per-user cache over the server one, so without
-        the accessor read-through such a leftover would be reported by GET
-        while projection builds used the operator's value.
+        ``get_all`` layers the per-user cache over the server one, so such a
+        leftover would be reported by GET while projection builds (which read
+        the accessor) used the operator's value. The load-time sanitizer drops
+        server-tier keys out of a per-user file, so the stale copy never
+        reaches the cache in the first place (issue #3413).
         """
-        from vtsearch.auth import get_current_user
+        import json as _json
 
         settings_mod.set_browse_signpost_vocab({"audio": ["rain"]})
-        with settings_mod._settings_lock:
-            settings_mod._user_caches.setdefault(get_current_user(), {})["browse_signpost_vocab"] = {"audio": ["stale"]}
+        isolated_settings._user.parent.mkdir(parents=True, exist_ok=True)
+        isolated_settings._user.write_text(_json.dumps({"browse_signpost_vocab": {"audio": ["stale"]}}) + "\n")
+        settings_mod.reset()  # re-read both tiers from disk
+
         assert client.get("/api/settings").get_json()["browse_signpost_vocab"] == {"audio": ["rain"]}
+        assert settings_mod.get_browse_signpost_vocab() == {"audio": ["rain"]}

--- a/vtsearch/schemas/settings.py
+++ b/vtsearch/schemas/settings.py
@@ -12,11 +12,10 @@ the schema is flat to match what the frontend sends and receives.
 
 from __future__ import annotations
 
-from marshmallow import Schema, fields, pre_load, validate
+from marshmallow import Schema, fields, validate
 
 from vtsearch.settings_models import (
     VALID_ANIMATION_MODES,
-    coerce_animation_mode,
     VALID_BROWSE_GRAPHICS,
     VALID_FOCUS_MODES,
     VALID_GRID_ICON_SIZES,
@@ -256,21 +255,6 @@ class SettingsUpdateSchema(Schema):
     show_animations = fields.String(validate=validate.OneOf(VALID_ANIMATION_MODES))
     show_metadata = fields.Boolean()
     label_hint_dismissed = fields.Boolean()
-
-    @pre_load
-    def _migrate_legacy_show_animations(self, data, **kwargs):
-        """Fold pre-enum boolean ``show_animations`` values into the enum.
-
-        Settings files written before the 3-way pulldown (a3a37106) stored a
-        boolean; a client that fetched such a value re-sends it verbatim on
-        the next save, and without this hook the ``OneOf`` validator rejects
-        the entire update (every settings save 422s until the value is fixed
-        by hand).  See ``vtsearch.settings_models.coerce_animation_mode``.
-        """
-        if isinstance(data, dict) and "show_animations" in data:
-            data = dict(data)
-            data["show_animations"] = coerce_animation_mode(data["show_animations"])
-        return data
 
     grid_icon_size_left = fields.Raw()
     grid_icon_size_right = fields.Raw()

--- a/vtsearch/settings.py
+++ b/vtsearch/settings.py
@@ -265,10 +265,11 @@ _SERVER_KEYS: frozenset[str] = frozenset(ServerSettings.model_fields.keys())
 #: These are the Auto-Find knobs: per-user in multi-user deployments, but the
 #: single-user GUI (everyone is "default") and the CLI ``--settings`` flat file
 #: still expect a value placed in ``settings.json`` to take effect. The
-#: read-through (see :func:`_read_value`) makes that work without the
-#: destructive legacy migration moving them out of the server file (see
-#: ``UserSettingsStore._maybe_migrate_legacy_settings``, which skips
-#: these keys).
+#: read-through (see :func:`_read_value`) is what makes that documented
+#: flat-file workflow work; it is a live tier exception, not a migration.
+#: :func:`_sanitize_tier` therefore keeps these keys in the server file
+#: (validating them against ``UserSettings``, which owns them) and drops only
+#: the reverse direction: a server key stranded in a per-user file.
 _DEFAULT_USER_FALLBACK_KEYS: frozenset[str] = frozenset(
     {"autofind_detectors", "autofind_exporter", "autofind_exporter_field_values"}
 )
@@ -571,9 +572,6 @@ def get_user_settings() -> dict[str, Any]:
     user_copy = snapshot_user(get_current_user())
     result = dict(_user_defaults())
     result.update(user_copy)
-    # Same legacy migration as ``get_all`` so settings exports carry a value
-    # a fresh import will accept.
-    result["show_animations"] = get_show_animations()
     result["grid_icon_size_left"] = get_grid_icon_size_left()
     result["grid_icon_size_right"] = get_grid_icon_size_right()
     result["focus_mode_left"] = get_focus_mode_left()
@@ -610,20 +608,8 @@ def get_all() -> dict[str, Any]:
     result["panel_pct_right"] = get_panel_pct_right()
     # Auto-Find keys go through their accessors so the default-user read-through
     # (and per-user isolation for named users) is applied consistently: the
-    # plain ``result.update(server_copy)`` above would otherwise leak a legacy
-    # server-file Auto-Find list to every named user.
-    # ``show_animations`` goes through its accessor so pre-enum settings
-    # files (boolean ``True``/``"True"``; see ``coerce_animation_mode``) are
-    # migrated on read - the raw merge above would leak the legacy value to
-    # GET, and the frontend would echo it into a PUT that 422s.
-    result["show_animations"] = get_show_animations()
-    # ``browse_signpost_vocab`` was a per-user key until it became a server-tier
-    # operator setting, so user files written before the move still carry a copy
-    # that the ``result.update(user_copy)`` above would layer over the server
-    # value - GET would report a stale vocabulary while projection builds
-    # (which read the accessor) used the operator's. The accessor is the tier
-    # router, so going through it drops the shadowing copy.
-    result["browse_signpost_vocab"] = get_browse_signpost_vocab()
+    # plain ``result.update(server_copy)`` above would otherwise leak the
+    # server file's Auto-Find list to every named user, not just "default".
     result["autofind_detectors"] = get_autofind_detectors()
     result["autofind_exporter"] = get_autofind_exporter()
     result["autofind_exporter_field_values"] = get_autofind_exporter_field_values()
@@ -696,6 +682,57 @@ def _validate_field(model: type, key: str, value: Any) -> Any:
     except ValidationError as exc:
         first = exc.errors()[0] if exc.errors() else {"msg": str(exc)}
         raise ValueError(f"Invalid {key}: {first.get('msg', exc)}") from None
+
+
+def _sanitize_tier(data: dict[str, Any], tier: str) -> dict[str, Any]:
+    """Return *data* with values the tier's model would reject removed.
+
+    Applied by :class:`~vtsearch.settings_store.UserSettingsStore` to every
+    dict on its way into a cache, so the raw caches that ``get_all`` merges
+    hold only values the API can serialise. Two things are dropped:
+
+    * **Uncoercible typed values.** A settings file can carry a value from
+      before a field changed shape - a boolean ``show_animations`` from
+      before it became a three-way enum, a scalar ``browse_colormap`` from
+      before it became a per-media-type dict - or simply a hand-edit that
+      is out of range. Dropping it makes the field read as unset, so the
+      pydantic default applies (per the "break persisted data freely"
+      policy in ``CLAUDE.md``); keeping it used to leak the stale value
+      straight out of ``GET /api/settings``, which the frontend then echoed
+      back into a ``PUT`` that 422'd.
+    * **Server-tier keys stranded in a per-user file**, left behind when a
+      key moved tiers (``browse_signpost_vocab`` did). ``get_all`` layers
+      the user cache over the server one, so a stale copy would shadow the
+      operator's real value.
+
+    The reverse direction is deliberately *not* dropped: per-user keys in the
+    server file are the documented Auto-Find read-through (see
+    :data:`_DEFAULT_USER_FALLBACK_KEYS`), so those keys are kept - but checked
+    against ``UserSettings``, the model that will actually read them, so the
+    tier exception is not a hole in the value check. Unknown keys are
+    preserved in both tiers - both models set ``extra="allow"`` so a
+    forward-compatible or hand-added key round-trips rather than being
+    silently deleted.
+
+    This is a read-side view only; nothing here is written back to disk.
+    """
+    server_tier = tier == "server"
+    model = ServerSettings if server_tier else UserSettings
+    drop_wrong_tier = frozenset() if server_tier else _SERVER_KEYS
+    clean: dict[str, Any] = {}
+    for key, value in data.items():
+        if key in drop_wrong_tier:
+            continue
+        # The Auto-Find trio is read out of the server file by the "default"
+        # user, so validate it there against the model that owns it.
+        against = UserSettings if server_tier and key in _DEFAULT_USER_FALLBACK_KEYS else model
+        if key in against.model_fields:
+            try:
+                _validate_field(against, key, value)
+            except ValueError:
+                continue
+        clean[key] = value
+    return clean
 
 
 def _make_scalar_accessors(model: type, key: str):
@@ -1683,7 +1720,7 @@ _store = UserSettingsStore(
     apply_settings=_apply_settings,
     server_default_source=_server_default_settings_source,
     server_keys=_SERVER_KEYS,
-    fallback_keys=_DEFAULT_USER_FALLBACK_KEYS,
+    sanitize=_sanitize_tier,
     exclude_from_source_export=_EXCLUDE_FROM_SOURCE_EXPORT,
     freshness_check_interval=_FRESHNESS_CHECK_INTERVAL,
 )

--- a/vtsearch/settings_models.py
+++ b/vtsearch/settings_models.py
@@ -42,7 +42,6 @@ __all__ = [
     "Theme",
     "UserSettings",
     "VALID_ANIMATION_MODES",
-    "coerce_animation_mode",
     "VALID_BROWSE_COLORMAPS",
     "VALID_BROWSE_GRAPHICS",
     "VALID_BROWSE_ICON_SIZES",
@@ -54,30 +53,6 @@ __all__ = [
 
 
 Theme = Literal["dark", "light", "highviz", "system"]
-
-
-def coerce_animation_mode(value: Any) -> Any:
-    """Map legacy boolean ``show_animations`` values onto the mode enum.
-
-    The setting was a checkbox boolean until 2026-06-30 (a3a37106 made it a
-    three-way ``AnimationMode``), so settings files written before then (and
-    stale clients echoing an unmigrated GET back into PUT) still carry
-    ``True`` / ``"True"`` / ``"false"``-style values.  True-ish maps to
-    ``"show"``, False-ish to ``"hide"``; canonical modes pass through (case
-    folded), and anything else is returned unchanged so it still fails
-    validation loudly instead of being silently rewritten.
-    """
-    if isinstance(value, bool):
-        return "show" if value else "hide"
-    if isinstance(value, str):
-        folded = value.strip().lower()
-        if folded in ("true", "1", "yes", "on"):
-            return "show"
-        if folded in ("false", "0", "no", "off"):
-            return "hide"
-        if folded in VALID_ANIMATION_MODES:
-            return folded
-    return value
 
 
 # Decorative-motion master switch. ``"show"`` forces animations on even when the
@@ -355,7 +330,7 @@ class UserSettings(BaseModel):
     # request, ``"hide"`` always suppresses it, and ``"os"`` follows the
     # platform ``prefers-reduced-motion`` preference. See the "Show Animations"
     # pulldown in the appearance settings.
-    show_animations: Annotated[AnimationMode, BeforeValidator(coerce_animation_mode)] = "show"
+    show_animations: AnimationMode = "show"
     show_metadata: bool = False
     # Set to True once the user dismisses the zero-votes "Use ← / → or click"
     # hint that overlays the Good/Bad buttons when a fresh labeling session

--- a/vtsearch/settings_store.py
+++ b/vtsearch/settings_store.py
@@ -308,6 +308,12 @@ class UserSettingsStore:
     mutable containers passed in (``settings_lock``, ``user_caches``,
     ``sync_state``, ``syncing``) are shared by reference with
     :mod:`vtsearch.settings` so external importers see one set of objects.
+
+    ``sanitize(data, tier)`` is applied to every dict on its way *into* a
+    cache (``tier`` is ``"server"`` or ``"user"``); it is the store's only
+    view of the settings schema.  It runs on the read side only - what is
+    written back to disk is always the raw dict, so hiding a value the
+    models reject never deletes it from the file.
     """
 
     def __init__(
@@ -322,7 +328,7 @@ class UserSettingsStore:
         apply_settings: Callable[[dict[str, Any], Container[str] | None], None],
         server_default_source: Callable[[], dict[str, Any] | None],
         server_keys: frozenset[str],
-        fallback_keys: frozenset[str],
+        sanitize: Callable[[dict[str, Any], str], dict[str, Any]],
         exclude_from_source_export: set[str],
         freshness_check_interval: float = 1.0,
     ) -> None:
@@ -338,13 +344,12 @@ class UserSettingsStore:
         self._apply_settings = apply_settings
         self._server_default_source = server_default_source
         self._server_keys = server_keys
-        self._fallback_keys = fallback_keys
+        self._sanitize = sanitize
         self._exclude_from_source_export = exclude_from_source_export
         self._freshness_check_interval = freshness_check_interval
 
         # Store-only state (no external references).
         self._server_cache: dict[str, Any] | None = None
-        self._legacy_migrated: bool = False
         self._user_sync_locks: dict[str, threading.RLock] = {}
         self._user_sync_locks_guard = threading.Lock()
         # Thread-scoped import context: the set of usernames *this* thread is
@@ -421,32 +426,30 @@ class UserSettingsStore:
     # -- cache loaders ---------------------------------------------------
 
     def ensure_server_loaded(self) -> dict[str, Any]:
-        """Load the server-tier cache on first access and migrate legacy keys.
+        """Load the server-tier cache on first access.
 
-        The first load runs under the cross-process *server* file lock so the
-        one-shot legacy migration's ``_atomic_write`` calls are protected
-        against another process migrating the same files concurrently (H28
-        residual follow-up). The file lock is taken *before* ``settings_lock``
-        (the canonical file-lock -> settings-lock order), so this must never
-        be called while already holding ``settings_lock``: callers that need
-        the server tier loaded before touching a user cache (see
-        :meth:`ensure_user_loaded`) invoke it *outside* the lock.
+        The read runs under the cross-process *server* file lock, so a
+        sibling process rewriting the file cannot be observed mid-write. The
+        file lock is taken *before* ``settings_lock`` (the canonical
+        file-lock -> settings-lock order), so this must never be called while
+        already holding ``settings_lock``: callers that need the server tier
+        loaded before touching a user cache (see :meth:`ensure_user_loaded`)
+        invoke it *outside* the lock.
         """
         with self._lock:
             if self._server_cache is not None:
                 return self._server_cache
-        self._load_and_migrate_server()
+        self._load_server()
         with self._lock:
             assert self._server_cache is not None
             return self._server_cache
 
-    def _load_and_migrate_server(self) -> None:
-        """Read the server settings file and run the one-shot legacy migration.
+    def _load_server(self) -> None:
+        """Read the server settings file into the cache.
 
         Runs under the cross-process server file lock. The freshly-read dict
-        is migrated *before* it is published to ``self._server_cache`` so no
-        concurrent reader ever observes the intermediate (pre-migration)
-        shape.
+        is sanitized *before* it is published to ``self._server_cache`` so no
+        reader ever observes a value the model would reject.
         """
         server_path = self._server_path()
         with file_lock(server_path):
@@ -455,8 +458,7 @@ class UserSettingsStore:
                     # A sibling thread completed the load while we waited
                     # for the file lock.
                     return
-            fresh = _load_path(server_path)
-            self._maybe_migrate_legacy_settings(fresh, server_path)
+            fresh = self._sanitize(_load_path(server_path), "server")
             with self._lock:
                 self._server_cache = fresh
 
@@ -476,17 +478,15 @@ class UserSettingsStore:
         sync, so a concurrent thread B saw the marker and returned the
         pre-sync local cache.
         """
-        # Ensure the server tier is loaded (and the one-shot legacy migration
-        # has run) *before* we take ``settings_lock``: ``ensure_server_loaded``
-        # acquires the server file lock, and taking a file lock while holding
-        # ``settings_lock`` would invert the canonical file -> settings order.
-        # The migration may populate ``_user_caches["default"]``; we pick that
-        # up below.
+        # Ensure the server tier is loaded *before* we take ``settings_lock``:
+        # ``ensure_server_loaded`` acquires the server file lock, and taking a
+        # file lock while holding ``settings_lock`` would invert the canonical
+        # file -> settings order.
         self.ensure_server_loaded()
         with self._lock:
             cache = self._user_caches.get(username)
             if cache is None:
-                cache = _load_path(self._user_path(username))
+                cache = self._sanitize(_load_path(self._user_path(username)), "user")
                 self._user_caches[username] = cache
             # Re-entrance guard: a setter inside ``_apply_settings`` re-enters
             # this function while the outer call holds the sync lock.  Skip
@@ -768,79 +768,6 @@ class UserSettingsStore:
         # can skip its own first load while the source stays at this version.
         _write_sync_marker(self._user_path(username), new_version)
 
-    def _maybe_migrate_legacy_settings(self, server_cache: dict[str, Any], server_path: Path) -> None:
-        """Move per-user keys from a legacy ``data/settings.json`` into the
-        default user's per-user file (one-shot, idempotent).
-
-        Called from :meth:`_load_and_migrate_server` with the **server file
-        lock** held. Operates on *server_cache* - the freshly-read,
-        not-yet-published dict - in place, so the migrated shape is what gets
-        published to ``self._server_cache``. The default user's file write
-        takes that file's own cross-process ``file_lock`` (server-then-user
-        ordering; no other path acquires both, so no deadlock), giving both
-        ``_atomic_write`` calls full multi-process protection - previously
-        they wrote without any cross-process lock (H28 residual follow-up).
-        """
-        with self._lock:
-            if self._legacy_migrated:
-                return
-            self._legacy_migrated = True
-        # ``fallback_keys`` legitimately live in the server file (the
-        # default user reads through to them), so they are NOT "orphaned per-user"
-        # keys; leave them in place rather than moving them into the default user's
-        # file (which would also rewrite a CLI ``--settings`` file under the user).
-        legacy_user_entries = {
-            k: v for k, v in server_cache.items() if k not in self._server_keys and k not in self._fallback_keys
-        }
-        if not legacy_user_entries:
-            return
-
-        # Migrate into the "default" user's file. The default user is the one
-        # the single-user provider returns, and is also the safe target for
-        # multi-user upgrades (admins can copy it into other users' files).
-        default_user = "default"
-        user_path = self._user_path(default_user)
-        with file_lock(user_path):
-            if user_path.exists():
-                existing = _load_path(user_path)
-                # Existing per-user values win - never clobber a real user file.
-                merged: dict[str, Any] = {**legacy_user_entries, **existing}
-            else:
-                merged = dict(legacy_user_entries)
-            try:
-                _atomic_write(user_path, merged)
-            except Exception as exc:
-                logger.warning("Legacy settings migration to %s failed: %s", user_path, exc)
-                return
-
-            # Build the server-tier shape first; a failure here must not mutate
-            # the fresh dict, or the published server_cache and disk would
-            # silently diverge. Keep the default-user fallback keys in the
-            # server file (they are read through there, not migrated out).
-            new_server = {k: v for k, v in server_cache.items() if k in self._server_keys or k in self._fallback_keys}
-            try:
-                _atomic_write(server_path, new_server)
-            except Exception as exc:
-                logger.warning("Failed to rewrite server settings after legacy migration: %s", exc)
-                return
-
-            # Mutate the not-yet-published dict in place to the migrated shape.
-            for k in list(server_cache.keys()):
-                if k not in self._server_keys and k not in self._fallback_keys:
-                    server_cache.pop(k, None)
-
-            # Refresh the default user's cache if it was already materialised.
-            with self._lock:
-                self._user_caches[default_user] = _load_path(user_path)
-        logger.info(
-            "Migrated %d legacy per-user setting(s) from %s into %s",
-            len(legacy_user_entries),
-            server_path,
-            user_path,
-        )
-
-    # -- save helpers ----------------------------------------------------
-
     def mutate_server_locked(self, mutator: Callable[[dict[str, Any]], None]) -> None:
         """Apply *mutator* to a fresh-from-disk server cache, atomically.
 
@@ -850,9 +777,10 @@ class UserSettingsStore:
         atomically writes the result back. This is the only correct way to
         mutate a multi-writer settings file from a Python process.
 
-        The legacy migration is left to ``ensure_server_loaded`` and never
-        fires from inside the lock - by the time any setter runs the cache
-        has been loaded at least once.
+        The dict written back to disk is the *unsanitized* one: a value the
+        models reject is hidden from readers (see ``sanitize``) but never
+        deleted from the user's file by an unrelated setting change. Only the
+        in-memory cache carries the sanitized view.
 
         File I/O (``_load_path``, ``_atomic_write``) runs under the
         cross-process file lock only; ``settings_lock`` is acquired briefly
@@ -865,8 +793,9 @@ class UserSettingsStore:
             fresh = _load_path(path)
             mutator(fresh)
             _atomic_write(path, fresh)
+            clean = self._sanitize(fresh, "server")
             with self._lock:
-                self._server_cache = fresh
+                self._server_cache = clean
 
     def mutate_user_locked(
         self,
@@ -924,16 +853,20 @@ class UserSettingsStore:
             fresh = _load_path(path)
             mutator(fresh)
             _atomic_write(path, fresh)
+            # Disk keeps the raw dict; only the cache (and the snapshot pushed
+            # to the sync source) carries the sanitized view, so an unrelated
+            # write never deletes a key from the user's file.
+            clean = self._sanitize(fresh, "user")
             touched = list(resolve_keys(fresh)) if resolve_keys is not None else named
             with self._lock:
-                self._user_caches[username] = fresh
+                self._user_caches[username] = clean
                 if username in self._syncing:
                     return None
                 exportable = [k for k in touched if k not in self._exclude_from_source_export]
                 if exportable:
                     state = self._sync_state.setdefault(username, UserSyncState())
                     state.dirty_keys.update(exportable)
-                return dict(fresh)
+                return dict(clean)
 
     # -- sync to source --------------------------------------------------
 
@@ -1051,13 +984,12 @@ class UserSettingsStore:
     # -- lifecycle -------------------------------------------------------
 
     def invalidate_server_cache(self) -> None:
-        """Drop the server cache and re-arm the one-shot legacy migration.
+        """Drop the server cache so the next read re-loads it.
 
         Used when the server settings path is repointed (CLI ``--settings``).
         Caller already holds ``settings_lock``.
         """
         self._server_cache = None
-        self._legacy_migrated = False
 
     def drop_sync_state(self, username: str) -> None:
         """Forget *username*'s sync bookkeeping (e.g. when the source is cleared)."""
@@ -1079,6 +1011,5 @@ class UserSettingsStore:
             self._user_caches.clear()
             self._sync_state.clear()
             self._syncing.clear()
-            self._legacy_migrated = False
         with self._user_sync_locks_guard:
             self._user_sync_locks.clear()


### PR DESCRIPTION
CLAUDE.md's backwards-compatibility policy lets saved data break freely and explicitly forbids migration shims for it. Three lived in the settings tier; this deletes them and replaces the behavior they propped up with one generic load-time sanitizer.

## What's gone

- **`UserSettingsStore._maybe_migrate_legacy_settings`** — the one-shot rewrite that split a pre-tier-split `data/settings.json` across the two files. Took two `_atomic_write` calls under a server-then-user cross-process lock dance, plus a `_legacy_migrated` latch to stay one-shot.
- **`coerce_animation_mode`** — mapped a pre-enum boolean `show_animations` onto `"show"` / `"hide"`.
- **The `@pre_load` hook in `SettingsUpdateSchema`** — duplicated that coercion on the API's input side.
- **The two legacy re-routes in `get_all()`** (`show_animations`, `browse_signpost_vocab`), which existed only to keep an unmigrated value from leaking out of `GET /api/settings`.

## What replaces it

`_sanitize_tier`, applied by the store to every dict on its way *into* a cache: a value the tier's model rejects is dropped, so the field reads as unset and the pydantic default applies.

That's the issue's own "drop on load, let defaults apply" direction, but generic — it covers every typed key rather than the two that happened to have hand-written re-routes. The caches `get_all()` merges now hold only values the API can serialise, so no future shape change needs its own re-route. It also drops a server-tier key stranded in a per-user file, which is what made the `browse_signpost_vocab` re-route deletable.

**Sanitizing is a read-side view only** — `mutate_*_locked` still writes the raw dict to disk. Otherwise the migration we just deleted would come back in another form: silently rewriting the user's file on whatever unrelated setting they changed next.

## Where I disagree with the issue

The issue's fourth item — `_DEFAULT_USER_FALLBACK_KEYS` and the `_read_value` read-through, "which exist only to serve the unmigrated shape" — is **not** a migration shim, and it stays.

The Auto-Find trio falling through to `data/settings.json` for the built-in `default` user is a live, documented feature: it is what makes the CLI's `--settings` flat-file workflow work. `docs/CLI.md`'s "Which user's Auto-Find list runs" specifies it ("the `default` user … reads its list from the `--settings` file, so the flat-file workflow above is unchanged"), `docs/DEPLOYMENT.md` calls it "the one deliberate exception", and ~20 `--autodetect` examples in `docs/CLI.md` depend on it. Deleting it would break headless auto-detect for every deployment that follows the docs.

It is now validated against `UserSettings` where it sits, so the tier exception isn't also a hole in the value check.

The other `get_all()` re-routes the issue's framing swept in are likewise not migrations and stay: `grid_icon_size_*` / `focus_mode_*` / `panel_pct_*` expand to per-media-type dicts, and the `autofind_*` re-routes exist *because* the read-through does — they keep the server file's list from leaking to named users.

## Persisted-data break

Per policy, mentioned rather than shimmed:

- A boolean `show_animations` now reads as the default `"show"` rather than mapping True-ish → `"show"` and False-ish → `"hide"`. `PUT /api/settings` rejects it with a 422 instead of silently rewriting it.
- Per-user keys sitting in `data/settings.json` are inert rather than migrated into the default user's file.
- No file is rewritten either way, so nothing is lost: fix the value and it takes effect on the next start.

Documented in `CHANGELOG.md`, `docs/DEPLOYMENT.md` (settings-file schema) and `docs/ARCHITECTURE.md`.

## Testing

Full `./run-tests.sh` on the current `dev`: **RUN PASSED**, 10138 passed / 6 skipped, all heavy gates (pyright, pip-audit, vulture whitelist, npm audit, Vitest) green.

The migration test classes were rewritten to assert the new contract rather than deleted: an unmigrated mixed file is inert and untouched on disk, a stranded server key doesn't shadow, an unrelated write doesn't eat dropped keys, the Auto-Find read-through still works (and a bad value in it is still dropped), and the concurrent-first-load / file-lock coverage is retained without the migration.

## Note on the branch history

The first push of this branch carried a bad squash: a `git reset --soft origin/dev` re-parented a stale working tree onto a `dev` that had moved on, so the commit silently reverted three merged PRs (198 lines deleted from `tests/datasets/test_parallel_loading.py`, `vtscore/datasets/load_pipeline.py` reverted) — exactly what `scripts/check-phantom-base.py` exists to catch. The branch has been rebuilt from current `dev` carrying only this change's ten files; `check-phantom-base.py` is clean and the suite is green on the new base. An earlier version of this PR also claimed a `frontend/package.json` duplicate-key fix; `dev` landed a byte-identical fix independently, so it is no longer part of this diff.

Closes #3413

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXrse2Wit3gP8BbWUEAquk