### PR TITLE
eval: stopping point and stopping cost — measure where the app's rules fire, not the click budget

### DIFF
--- a/docs/EVAL.md
+++ b/docs/EVAL.md
@@ -280,6 +280,32 @@ Two columns make this visible in the output:
 
 Metrics are still recorded at every trainable step in both modes — fidelity changes the *vote order* and the `app_trained` flag, not measurement coverage.
 
+#### Stopping point and stopping cost (issue #3560)
+
+A study's headline number is its **final cost** — the metric at the last click of `CALIB_MAX_STEPS` (usually 150). Nobody in the app is asking that question. The app has *stopping rules*: when the Smart, Stable and Span indicators are all green the phase becomes `done` and the panel says *"All quality indicators are green. You can continue labeling or export your results."* The number a user leaves with is the metric **there**, at a click count they did not pick in advance. So every simulated-user study owes two more numbers:
+
+| | what it is | column it comes from |
+|---|---|---|
+| **stopping point** | the click at which the rules first fired — the *width* | first `t` where `phase == "done"` |
+| **stopping cost** | the metric at that click — the *height* | that row's `cost` (and `average_precision` beside it) |
+
+`phase` has been on every metric row since the harness adopted the app's phase machine, so **this needs no re-run**: a finished study's cells carry it already. Five columns beside it (added by #3560) say *which* rule was doing the holding, which `phase` alone cannot:
+
+- **`smart` / `stable` / `span`** — the three indicator lights that produced the phase, each `red` / `yellow` / `green`. `done` is all three green and `new` is Span alone short, so the phase already encodes those; what it cannot encode is whether Smart, Stable or both hold a run in `hard`.
+- **`span_level` / `span_depth`** — the raw atlas counts the Span light thresholds (`level >= min(autopilot_goal_diversity, depth)`), so a run can say how far short it fell rather than only that it did.
+
+All five are blank / `-1` where no phase machine ran (a non-`autopilot` strategy, `autopilot_fidelity=False`) and throughout a startup schedule's rounds, which own the phase without consulting the indicators — *not measured* is deliberately distinguishable from *not green*. They cost nothing: the phase machine already computed all three every step and threw them away.
+
+**Do not truncate the run at `done`.** The simulated user keeps clicking to the budget exactly as before, because the stretch past the stopping point is what says whether stopping there was the right call — and because arms can only be compared at a fixed `t`.
+
+[`scripts/experiments/calibration/stopping.py`](../scripts/experiments/calibration/stopping.py) is the one implementation of the derivation, and there are three reasons not to write it again by hand:
+
+- **The rules flap.** The phase is derived from the current labelset every step, never latched, so a run can go `done` on one vote and back to `hard` on the next. The app announces on the **first** fire and never re-announces, so first-fire is the faithful stopping point (`t_stop`); `t_sustained` reports the stricter reading, and `n_done_episodes` says how far apart the two are.
+- **They often never fire**, which makes every average a **censored** statistic. Averaging the runs that stopped excludes precisely the slow ones, so the mean flatters, and flatters harder the worse the arm is. `summarise()` leads with the fire *rate*, and its `km_t_stop` is a Kaplan–Meier median that carries the non-firing runs as censored at their own budget — returning `NaN`, honestly, when fewer than half of them ever fired.
+- **Cost at the stop and cost at the budget are different numbers, and the difference has a sign.** Report both, paired within run.
+
+Pass the result to `curves.quality_vs_clicks(..., stops=...)` and the mandatory averaged figure carries a `▽` at each arm's median stopping click, with the arms that mostly never stopped named in the caption rather than silently unmarked.
+
 #### The acquisition cut (`acq_inclusion_offset`, default: whatever `vtscore.training.thresholds` ships)
 
 The selector and the metrics read **different thresholds**. Reporting and every emitted metric stay at `inclusion`; the threshold handed to the picks is re-cut at `inclusion + acq_inclusion_offset` from the same fold-anchored fit. This mirrors production, which decoupled the two jobs in PR #2876 — see [`docs/ML.md`](ML.md#threshold-calibration) for the mechanism and the measured effect.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -52,6 +52,7 @@ to go stale. Keep the grouping in sync when you add or delete a plan — one lin
 - [`set-scorer-experiment.md`](set-scorer-experiment.md)
 - [`coverage-atlas.md`](coverage-atlas.md)
 - [`vg-scale-bands-and-corrections.md`](vg-scale-bands-and-corrections.md)
+- [`stopping-rules-in-eval.md`](stopping-rules-in-eval.md)
 
 ## Platform / CLI
 

--- a/docs/plans/stopping-rules-in-eval.md
+++ b/docs/plans/stopping-rules-in-eval.md
@@ -1,0 +1,107 @@
+# Reporting the app's stopping rules in eval studies (issue #3560)
+
+**Status:** the measurement layer has shipped; what is owed is the *reporting*
+— re-analysing the influential finished studies and adopting the convention.
+
+## Background
+
+Every simulated-user study quotes a **final cost**: the metric at the last click
+of a fixed budget (`CALIB_MAX_STEPS`, usually 150). The app has its own notion of
+finished — the Smart / Stable / Span indicators all green, at which point the
+phase becomes `done` and the panel offers the export hand-off. So "final" in
+every published report is a click count nobody chose, and it is not the click
+at which any user would actually stop.
+
+What already exists, and is therefore *not* owed:
+
+- The harness runs the app's phase machine on every autopilot-fidelity run and
+  has emitted **`phase`** on every metric row since 2026-07-31.
+- Since #3560 it also emits the three indicator lights (`smart` / `stable` /
+  `span`) and the raw span counts (`span_level` / `span_depth`), which say
+  *which* rule held a run short of stopping.
+- [`scripts/experiments/calibration/stopping.py`](../../scripts/experiments/calibration/stopping.py)
+  derives the stopping point and stopping cost from those columns, with the
+  censoring and flapping handled; `curves.quality_vs_clicks(..., stops=…)` marks
+  the stopping click on the mandatory averaged figure.
+- [`docs/EVAL.md`](../EVAL.md) documents the columns and the derivation.
+
+**The marginal compute cost of all of this is zero.** The phase machine's inputs
+— the Smart error-cost window, the Stable prediction flips, the Span atlas — are
+computed every step already, because the vote order depends on them; the lights
+were being discarded. A local measurement puts the whole Smart-window rescoring
+at 1–4% of a run's wall clock, and that 1–4% was already being paid before this
+issue. No study gets slower for reporting a stopping point.
+
+<!-- item-sep -->
+
+- **Re-analyse the influential finished studies** — no re-runs. `phase` is in
+  the cells of every study since 2026-07-31, so the enrichment is a read, not a
+  grid. In rough order of influence:
+  [#3156 vg-scale](../experiments/2026-08-25-vg-scale/REPORT.md) (the overview
+  everything else is read against),
+  [#2877 acquisition-inclusion](../experiments/2026-08-07-acquisition-inclusion/REPORT.md),
+  [#3267 good-mining](../experiments/2026-08-27-good-mining-3267/REPORT.md).
+  For each: `stopping.stopping_points` over the arm frames `_cells_io.load_arm`
+  already returns, `stopping.summarise`, `stopping.stopping_table` into the
+  report, and a re-generated `cost_vs_clicks.png` with `stops=` passed.
+
+  Two things to check before quoting a number off an old grid, both of which the
+  code will tell you rather than assume: that the cells are still on
+  `/expscratch` (nothing here can rebuild them), and that `phase` is actually
+  populated — a study run with `autopilot_fidelity=False` for byte-reproduction
+  of a pre-fidelity result has an empty column, and `stopping_points` returns an
+  empty frame rather than a table of zeros.
+
+  What the re-analysis **cannot** answer is which of Smart and Stable was
+  binding, since those cells predate the lights. `stopping.binding_note` says so
+  in as many words instead of guessing. That question needs a re-run, and is the
+  only thing here that does.
+
+<!-- item-sep -->
+
+- **Adopt the reporting convention.** Once one study has been through it and the
+  table has survived a reading, fold it into the mandatory set: the
+  `grid-experiments` skill already requires the quality-over-clicks pair and the
+  interactive viewer of every simulated-user study, and the stopping block
+  belongs in the same list. Proposed shape, which
+  `stopping.stopping_table` emits:
+
+  | arm | runs | fired | stop click (KM) | stop click (median of fired) | cost at stop | cost at budget | Δcost (paired) | clicks after stop |
+
+  The two qualifications are not optional decoration. **`fired`** comes before
+  every other column because each of them is conditional on it, and the runs it
+  excludes are systematically the slow ones. **Δcost** is paired within run and
+  keeps its sign: a positive Δ means the clicks spent past the app's advice made
+  the detector *worse*, which is a finding about the stopping rule and not a
+  wrinkle to average away.
+
+<!-- item-sep -->
+
+- **Then ask whether the rules are any good.** The measurement above is
+  descriptive: it says where the app's rules fire, not whether firing there was
+  right. The questions it makes askable, in the order they get cheaper to
+  answer:
+
+  - **Is the stopping cost near the run's own best?** Compare `cost_at_stop`
+    against `min(cost)` over the trajectory. A rule that fires 40 clicks after
+    the run's floor is a rule that costs users clicks; one that fires 40 clicks
+    before it is a rule that costs them quality. Both are readable off cells
+    that already exist.
+  - **Which indicator is binding, and is it the right one?** Needs the lights,
+    so it needs a re-run — but only of a grid small enough to answer it. A local
+    probe on synthetic data had Stable holding runs far more often than Smart or
+    Span, which if it reproduces means the stopping rule is in practice a
+    prediction-flip rule with two decorations.
+  - **Does the rule flap because the rule is noisy, or because the detector
+    is?** `n_done_episodes` above 1 is common. Whether the fix is hysteresis in
+    the app's indicator (a real product change, not an eval one) depends on
+    which.
+
+<!-- item-sep -->
+
+- **Do not truncate runs at `done`.** Recorded as a decision so it is not
+  re-litigated: the simulated user keeps clicking to the budget. The stretch
+  past the stopping point is what says whether stopping there was right, and
+  arms can only be compared at a fixed `t`. If a study ever wants the honest
+  end-to-end cost of a user who obeys the app, that is an opt-in arm, not a
+  change to the default.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/scripts/experiments/calibration/README.md
+++ b/scripts/experiments/calibration/README.md
@@ -47,6 +47,7 @@ a report's committed-figure requirement points at.
 | `prepare_data.py`, `run_cells.py`, `analyze.py`, `launch_all.sh`, `launch_cells.sh` | The three-stage pipeline (#2781). Every study launcher is a wrapper that flips pre-registered knobs over these and re-points `CALIB_EXP`. |
 | `noop.py` | The analyze step for a launcher whose analysis runs separately. |
 | `curves.py`, `selftest_curves.py` | The standard quality-over-clicks figure pair every simulated-user study owes. One implementation; do not write it again. |
+| `stopping.py`, `selftest_stopping.py` | **Stopping point and stopping cost** (#3560): where the app's own stopping rules fired on each trajectory, and what the detector cost there — the number a user actually leaves with, as against the "final cost" at a click budget nobody chose. Reads the `phase` column every run since 2026-07-31 already emits, so it enriches finished studies without a re-run. Handles the three things that make a naive average wrong: the rules **flap**, they **often never fire**, and the runs excluded by "average over the ones that stopped" are exactly the slow ones. |
 | `viewer.py`, `selftest_viewer.py` | The interactive `viewer.html` every study's report links to. `--reskin` pushes a template change onto committed pages. |
 | `make_bench_html.py` | A study's `report.html` reading copy, generated from its own `REPORT.md`. |
 | `bench_cells.py` | Pure-pandas reading and pairing of overview-benchmark cells, shared by the bench analyzers. |

--- a/scripts/experiments/calibration/curves.py
+++ b/scripts/experiments/calibration/curves.py
@@ -89,7 +89,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 import common
@@ -344,6 +344,46 @@ def _prevalence_norm(prevalence: dict[tuple[str, str], float] | None):
     return mcolors.LogNorm(vmin=min(vals), vmax=max(vals))
 
 
+def _stop_clicks(stops: pd.DataFrame | None, panels: Iterable[tuple[str, str]]) -> dict[tuple[str, str], float]:
+    """Median first-fire click per ``(dataset, arm)``, for the panels being drawn.
+
+    Only where **at least half** the arm's runs on that dataset ever fired.
+    Below that the median of the firers is a survivorship artefact — the runs it
+    leaves out are exactly the slow ones — and a marker drawn from it would put
+    an authoritative glyph on a number the sample cannot support.  Those arms
+    are named in the caption instead (see :func:`_stop_caption`), which is
+    itself the finding.
+    """
+    if stops is None or stops.empty or "t_stop" not in stops.columns:
+        return {}
+    want = set(panels)
+    out: dict[tuple[str, str], float] = {}
+    for (arm, ds), g in stops.groupby(["arm", "dataset"], dropna=False):
+        if (str(ds), str(arm)) not in want:
+            continue
+        fired = g[g["stopped"]] if "stopped" in g.columns else g[g["t_stop"].notna()]
+        if len(g) == 0 or len(fired) / len(g) < 0.5:
+            continue
+        med = float(pd.to_numeric(fired["t_stop"], errors="coerce").median())
+        if np.isfinite(med):
+            out[(str(ds), str(arm))] = med
+    return out
+
+
+def _stop_caption(stops: pd.DataFrame, stop_at: dict[tuple[str, str], float], panels: Iterable[tuple[str, str]]) -> str:
+    """The one line the stopping marker needs to be readable.
+
+    Says what the glyph is, and — the part that is easy to omit and expensive to
+    omit — names the arms that carry no glyph *because their runs mostly never
+    stopped*, so an absent marker cannot be read as an oversight.
+    """
+    drawn = "▽ = median click at which the app's stopping rules first fired"
+    missing = sorted({arm for (ds, arm) in set(panels) if (ds, arm) not in stop_at})
+    if not missing:
+        return drawn
+    return drawn + f"; no marker for {', '.join(missing)} — fewer than half those runs ever fired"
+
+
 def mean_figure(  # noqa: C901
     main: pd.DataFrame,
     outdir: Path,
@@ -357,6 +397,7 @@ def mean_figure(  # noqa: C901
     baseline_label: str = BASELINE_LABEL,
     stat: str = STAT,
     lower_is_better: bool = True,
+    stops: pd.DataFrame | None = None,
     dpi: int = FIG_DPI,
 ) -> tuple[str | None, pd.DataFrame]:
     """Per-dataset mean curves with an inter-quartile band.
@@ -365,6 +406,16 @@ def mean_figure(  # noqa: C901
     dashed/solid switch does not — see :func:`_strip_worth_drawing`; otherwise
     the panel takes the height and its title names the click from which every
     arm is fully measured.
+
+    *stops* is :func:`stopping.stopping_points`' output (issue #3560).  When
+    given, each arm's curve carries a marker at the click where the app's
+    stopping rules fired for **half** the runs that ever fired — the point on
+    this very axis past which the user was being told they could stop.  It is
+    drawn as a marker on the curve rather than a rule across the panel for the
+    same reason the click-0 anchor is: a rule implies a level that holds
+    everywhere, and this one holds at one click.  Arms where fewer than half
+    the runs ever fired get no marker and are named in the caption instead,
+    because there is no click to put one at.
 
     Returns ``(filename, curves)``; ``curves`` is the plotted numbers, long
     format, one row per ``(arm, dataset, t)``, and always carries ``coverage``.
@@ -426,6 +477,7 @@ def mean_figure(  # noqa: C901
                 }
             )
 
+    stop_at = _stop_clicks(stops, series.keys())
     strip = _strip_worth_drawing([sr["cov"] for sr in series.values()], t_index)
     fig = plt.figure(figsize=(6.6 * len(datasets), 5.4 if strip else 4.4), layout="constrained")
     gs = (
@@ -474,6 +526,24 @@ def mean_figure(  # noqa: C901
             # implied a level that holds at every click when it holds at one.
             if base and np.isfinite(y[0]):
                 ax.plot(0, y[0], marker="o", ms=4.5, color=palette[arm], zorder=5)
+            # Where the app told the user they could stop (#3560).  On the
+            # curve, at the median first-fire click, so it reads as a point on
+            # this arm rather than as a level across the panel.
+            ts = stop_at.get((ds, arm))
+            if ts is not None:
+                yi = np.interp(ts, t_index, y, left=np.nan, right=np.nan)
+                if np.isfinite(yi):
+                    ax.plot(
+                        ts,
+                        yi,
+                        marker="v",
+                        ms=7,
+                        mfc="none",
+                        mew=1.6,
+                        color=palette[arm],
+                        zorder=6,
+                        ls="none",
+                    )
             if axc is not None:
                 axc.plot(t_index[clicked], 100.0 * cov[clicked], color=palette[arm], lw=1.2)
                 if not clicked.all():
@@ -499,11 +569,13 @@ def mean_figure(  # noqa: C901
                 axc.set_ylabel("% of cells\nmeasured", fontsize=8)
     top_axes[0].legend(fontsize=7, ncol=2)
     better = "lower is better" if lower_is_better else "higher is better"
-    fig.suptitle(
+    caption = (
         f"Is the user's detector getting better as they click?  —  {metric} vs clicks ({better})\n"
-        f"dashed where fewer than {SOLID_COVERAGE:.0%} of that arm's cells are measured at that click",
-        fontsize=10,
+        f"dashed where fewer than {SOLID_COVERAGE:.0%} of that arm's cells are measured at that click"
     )
+    if stops is not None and not stops.empty:
+        caption += "\n" + _stop_caption(stops, stop_at, series.keys())
+    fig.suptitle(caption, fontsize=10)
     outdir.mkdir(parents=True, exist_ok=True)
     p = outdir / f"{metric}_vs_clicks.png"
     fig.savefig(p, dpi=dpi)
@@ -662,12 +734,16 @@ def quality_vs_clicks(
     stat: str = STAT,
     max_runs: int = 0,
     lower_is_better: bool = True,
+    stops: pd.DataFrame | None = None,
     dpi: int = FIG_DPI,
 ) -> list[str]:
     """Both standard figures (averaged, and per run) plus the curve CSV.
 
     The one call an analyzer needs: pass the main metric frame tagged with
     ``arm``, the cell list as *denominator*, and the text-sort *baseline*.
+    Pass *stops* (from ``stopping.stopping_points``) to mark where the app's
+    stopping rules fired on the averaged panel — the click past which every
+    further click on the axis was one the app had already said was optional.
     """
     written: list[str] = []
     name, _curves = mean_figure(
@@ -682,6 +758,7 @@ def quality_vs_clicks(
         baseline_label=baseline_label,
         stat=stat,
         lower_is_better=lower_is_better,
+        stops=stops,
         dpi=dpi,
     )
     if name:

--- a/scripts/experiments/calibration/selftest_curves.py
+++ b/scripts/experiments/calibration/selftest_curves.py
@@ -19,7 +19,10 @@ subset and said nothing".  Every check here is one of those:
   dashed rule above it does not — a healthy grid must not spend a quarter of
   the figure restating the crossing the line thickness already marks — while a
   starving, never-recovering, or falling-back denominator must keep it;
-* the per-run panel must **count** the runs that drew no line at all.
+* the per-run panel must **count** the runs that drew no line at all;
+* the stopping marker (#3560) must appear only where at least half an arm's runs
+  actually stopped, must name the arms it withheld itself from, and must not
+  move a single plotted number.
 
 Run: ``python selftest_curves.py``
 """
@@ -291,6 +294,48 @@ def main() -> int:  # noqa: C901
             f"{n_cells - n_trained}/{n_cells}",
         )
         ok &= _check("per-run figures written for every dataset", len(names) == 2, str(names))
+
+        # --- the stopping marker (#3560) -----------------------------------
+        # One arm whose runs all stop at click 30, one whose runs never do.
+        # The marker must land on the first and be withheld from the second,
+        # with the caption saying which - an absent glyph that is not explained
+        # reads as an oversight rather than as the finding it is.
+        stops = pd.DataFrame(
+            [
+                {
+                    "arm": a,
+                    "dataset": d,
+                    "category": c,
+                    "seed": sd,
+                    "stopped": a != "starver",
+                    "t_stop": 30.0 if a != "starver" else float("nan"),
+                    "t_budget": float(N_STEP),
+                }
+                for a in arms
+                for d in ("dsA", "dsB")
+                for c in range(N_CAT)
+                for sd in range(N_SEED)
+            ]
+        )
+        marked = C._stop_clicks(stops, [("dsA", a) for a in arms])
+        ok &= _check(
+            "a marker is placed only for arms where at least half the runs stopped",
+            all(marked.get(("dsA", a)) == 30.0 for a in arms if a != "starver") and ("dsA", "starver") not in marked,
+            str(marked),
+        )
+        cap = C._stop_caption(stops, marked, [("dsA", a) for a in arms])
+        ok &= _check(
+            "...and the caption names the arm that has none, and why",
+            "starver" in cap and "fewer than half" in cap,
+            cap,
+        )
+        kw = dict(arms=arms, denominator=cells, baseline=base)
+        ok &= _check(
+            "drawing the marker does not touch the plotted numbers",
+            C.mean_figure(main_df, tmp / "stops", stops=stops, **kw)[1].equals(
+                C.mean_figure(main_df, tmp / "nostops", **kw)[1]
+            ),
+        )
 
         # --- degrade gracefully with no baseline ---------------------------
         plain = C.mean_figure(main_df, tmp / "nobase", arms=arms, denominator=cells)[1]

--- a/scripts/experiments/calibration/selftest_stopping.py
+++ b/scripts/experiments/calibration/selftest_stopping.py
@@ -1,0 +1,207 @@
+"""Planted-answer self-test for ``stopping.py`` — the app's stopping rules, measured.
+
+Each planted trajectory is one way the `phase` column can lie to a careless
+reader, and each check is the corresponding refusal:
+
+* a **clean stopper** must report the click it *first* went green, not the last
+  one it stayed there — the app announces once, on the first;
+* a **flapper** that crosses and falls back four times must still report the
+  first crossing as ``t_stop`` (that is what the user saw) while reporting *no*
+  ``t_sustained`` and an episode count above 1, so the two are never confused;
+* a **never-stopper** must be counted as a run, not dropped: it is the run that
+  makes the conditional mean flattering, and it is carried into the
+  Kaplan-Meier fit as a censored observation rather than discarded;
+* with **most runs censored** the KM median must come back ``NaN`` rather than
+  quoting the median of the minority that finished;
+* the **stopping cost** must be read at the stopping click and not at the
+  budget, including when the extra clicks made the detector *worse* — the sign
+  of ``cost_delta`` is the finding, so it must not be absolute-valued anywhere;
+* the **binding indicator** must be named from the lights when a frame carries
+  them, and must say so rather than guessing when the frame predates them.
+
+Run: ``python selftest_stopping.py``
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import common
+
+common.setup_env()
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+sys.path.insert(0, str(Path(__file__).parent))
+import stopping as S  # noqa: E402
+
+BUDGET = 60
+
+#: One planted trajectory per shape.  ``phases`` is a function from click to
+#: phase; the metric is planted so that the value at click ``t`` is exactly
+#: ``t / 1000``, which makes every "was this read at the right click?" check a
+#: literal equality rather than a tolerance.
+PLANTED: dict[str, dict] = {
+    # Goes green at 20 and stays: t_stop == t_sustained == 20, one episode.
+    "clean": {"done_at": lambda t: t >= 20, "lights": "green"},
+    # Green at 15, then falls back four times, ending in `hard`: the app
+    # announced at 15 and the run never settled.
+    "flapper": {"done_at": lambda t: t in (15, 16, 25, 26, 35, 44), "lights": "green"},
+    # Never green: censored at the budget.
+    "never": {"done_at": lambda t: False, "lights": "amber-stable"},
+}
+
+
+def _frame() -> pd.DataFrame:
+    """Three arms x four seeds, each arm one planted shape."""
+    rows = []
+    for arm, spec in PLANTED.items():
+        for seed in range(4):
+            for t in range(1, BUDGET + 1):
+                done = bool(spec["done_at"](t))
+                if spec["lights"] == "green":
+                    smart, stable, span = ("green", "green", "green") if done else ("green", "yellow", "green")
+                else:
+                    # Stable is the culprit on every held step of this arm.
+                    smart, stable, span = "green", "yellow", "green"
+                rows.append(
+                    {
+                        "arm": arm,
+                        "dataset": "ds",
+                        "category": "cat",
+                        "seed": seed,
+                        "t": t,
+                        "phase": "done" if done else "hard",
+                        "smart": smart,
+                        "stable": stable,
+                        "span": span,
+                        "n_good": t // 2,
+                        "n_bad": t - t // 2,
+                        # Planted so cost(t) == t/1000: rising, so the budget's
+                        # extra clicks always make it WORSE and the delta's sign
+                        # is checkable.
+                        "cost": t / 1000.0,
+                        "average_precision": 1.0 - t / 1000.0,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def _check(label: str, cond: bool, detail: str = "") -> bool:
+    print(f"  {'PASS' if cond else 'FAIL'}  {label}{('  — ' + detail) if detail and not cond else ''}")
+    return bool(cond)
+
+
+def main() -> int:
+    ok = True
+    main_df = _frame()
+    stops = S.stopping_points(main_df, keys=("arm", "dataset", "category", "seed"))
+
+    by_arm = {a: g for a, g in stops.groupby("arm")}
+    clean, flap, never = by_arm["clean"], by_arm["flapper"], by_arm["never"]
+
+    # --- first fire is the app's announcement --------------------------------
+    ok &= _check(
+        "clean stopper fires at its first green click", set(clean["t_stop"]) == {20.0}, str(set(clean["t_stop"]))
+    )
+    ok &= _check("...and that is also where it settles", set(clean["t_sustained"]) == {20.0})
+    ok &= _check("...one episode", set(clean["n_done_episodes"]) == {1})
+
+    ok &= _check(
+        "flapper reports its FIRST crossing, not its last", set(flap["t_stop"]) == {15.0}, str(set(flap["t_stop"]))
+    )
+    ok &= _check("...and reports no sustained stop at all", flap["t_sustained"].isna().all())
+    ok &= _check(
+        "...with the episode count that says why",
+        set(flap["n_done_episodes"]) == {4},
+        str(set(flap["n_done_episodes"])),
+    )
+
+    ok &= _check("never-stopper is kept as a run", len(never) == 4 and not never["stopped"].any())
+    ok &= _check("...with no stopping click invented", never["t_stop"].isna().all())
+    ok &= _check("...and its budget recorded for censoring", set(never["t_budget"]) == {BUDGET})
+
+    # --- the stopping cost is read AT the stopping click ---------------------
+    ok &= _check("stopping cost is the metric at the stopping click", set(clean["cost_at_stop"]) == {0.020})
+    ok &= _check("...not the metric at the budget", set(clean["cost_final"]) == {BUDGET / 1000.0})
+    ok &= _check(
+        "...and the paired delta keeps its sign when the extra clicks hurt",
+        np.allclose(clean["cost_delta"], (BUDGET - 20) / 1000.0),
+        str(clean["cost_delta"].tolist()),
+    )
+    ok &= _check("clicks after the announcement are counted", set(clean["clicks_after_stop"]) == {float(BUDGET - 20)})
+    ok &= _check("labelset at the stop is carried through", set(clean["n_good_at_stop"]) == {10.0})
+
+    # --- censoring ------------------------------------------------------------
+    summary = S.summarise(stops)
+    srow = {r["arm"]: r for _, r in summary.iterrows()}
+    ok &= _check(
+        "fire rate leads, and is over ALL runs", srow["never"]["fire_rate"] == 0.0 and srow["clean"]["fire_rate"] == 1.0
+    )
+    ok &= _check("KM median equals the plain median when nothing is censored", srow["clean"]["km_t_stop"] == 20.0)
+    ok &= _check("KM median is NaN when no run ever fired", not np.isfinite(srow["never"]["km_t_stop"]))
+
+    # Pool all three shapes into one group: 8 of 12 runs fire, the other 4 are
+    # censored at the budget.  The two medians then disagree, which is the whole
+    # reason both are reported.
+    pooled = stops.copy()
+    pooled["arm"] = "pooled"
+    ps = S.summarise(pooled).iloc[0]
+    ok &= _check("...with the rate that qualifies it", np.isclose(ps["fire_rate"], 8 / 12))
+    ok &= _check("...the conditional median is the firers' own", ps["median_t_stop"] == 17.5, str(ps["median_t_stop"]))
+    # The whole point of carrying the censored runs: they push the survival
+    # curve out, so the honest median is LATER than the median of the runs that
+    # happened to finish.  Quoting the conditional number as "the stopping
+    # point" understates it, and understates it more the worse the arm is.
+    ok &= _check(
+        "...and the censored median is later than it, never earlier", ps["km_t_stop"] == 20.0, str(ps["km_t_stop"])
+    )
+
+    # --- direct KM checks ----------------------------------------------------
+    ok &= _check("KM: all events, odd n", S.km_median([1, 2, 3], []) == 2)
+    ok &= _check("KM: censoring past the median leaves it where it was", S.km_median([1, 2, 3], [99]) == 2)
+    ok &= _check(
+        "KM: a minority of firers returns NaN, not the survivors' median",
+        not np.isfinite(S.km_median([15] * 4, [60] * 8)),
+    )
+    ok &= _check(
+        "KM: heavy censoring returns NaN, not a survivors' median", not np.isfinite(S.km_median([1], [9, 9, 9]))
+    )
+
+    # --- which rule was binding ----------------------------------------------
+    ok &= _check("the held steps name Stable as the culprit", srow["never"]["blocked_stable"] == 1.0)
+    ok &= _check(
+        "...and clear Smart and Span", srow["never"]["blocked_smart"] == 0.0 and srow["never"]["blocked_span"] == 0.0
+    )
+    note = S.binding_note(summary)
+    ok &= _check("the binding note names it", "stable" in note and "binding rule" in note, note)
+
+    dark = main_df.drop(columns=list(S.LIGHT_COLUMNS))
+    dark_summary = S.summarise(S.stopping_points(dark, keys=("arm", "dataset", "category", "seed")))
+    ok &= _check(
+        "a pre-#3560 frame says the binding rule is unrecoverable rather than guessing",
+        "Re-run to answer it" in S.binding_note(dark_summary),
+        S.binding_note(dark_summary),
+    )
+    ok &= _check(
+        "...while still reporting the stopping point it CAN derive from `phase`",
+        dark_summary.loc[dark_summary["arm"] == "clean", "median_t_stop"].iloc[0] == 20.0,
+    )
+
+    # --- the table renders every group ---------------------------------------
+    table = S.stopping_table(summary)
+    ok &= _check("the table has a row per arm", all(a in table for a in PLANTED), table)
+    ok &= _check("...and quotes the fire rate beside every stopping click", "0%" in table and "100%" in table, table)
+    ok &= _check(
+        "an empty frame renders a sentence, not a broken table", "No stopping data" in S.stopping_table(pd.DataFrame())
+    )
+    ok &= _check("...and an empty frame in gives an empty frame out", S.stopping_points(pd.DataFrame()).empty)
+
+    print("\n" + ("SELFTEST PASSED" if ok else "SELFTEST FAILED"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/calibration/stopping.py
+++ b/scripts/experiments/calibration/stopping.py
@@ -1,0 +1,355 @@
+"""Where the app's stopping rules fired, and what the detector cost there.
+
+Every simulated-user study reports a **final cost**: the metric at the last
+click of a fixed budget (`CALIB_MAX_STEPS`, usually 150).  That number answers
+"how good is the detector after 150 clicks", which is a question nobody in the
+app is asking.  The app has stopping rules — the Smart / Stable / Span
+indicators, all three green — and when they fire it tells the user *"All quality
+indicators are green. You can continue labeling or export your results."*  The
+number a user actually leaves with is the cost **there**, at a click count they
+did not choose in advance.  Issue #3560.
+
+This module turns the `phase` column every run already emits into that pair:
+
+    stopping point  =  the click at which the rules first fired  (the width)
+    stopping cost   =  the metric at that click                  (the height)
+
+Nothing here needs a re-run.  `phase` has been on every metric row since the
+harness adopted the app's phase machine (2026-07-31), so any study whose cells
+are still on disk can be enriched by re-reading them.  What a *new* run adds is
+the three indicator lights beside the phase (`smart` / `stable` / `span`, plus
+`span_level` / `span_depth`), which say **which** rule held a run short of
+stopping; those are absent from older frames and every function here degrades to
+"unknown" rather than failing.
+
+Three properties of the data decide the shape of this API, and all three were
+measured before it was written:
+
+**The rule fires far short of the budget.**  Not a rounding difference — on the
+#3156 grid the `done` phase holds 24–37 of ~150 clicks per run, and a run that
+stops has spent a quarter of its budget past the point the app said to stop.
+
+**It flaps.**  The phase is *derived* from the current labelset every step, not
+latched, so a run can go `done` on one vote and back to `hard` on the next; a
+local probe saw up to five separate `done` episodes in one trajectory.  The app
+announces completion on the **first** one and never re-announces
+(`AutopilotStateService.completionAnnounced`), so *first fire* is the faithful
+definition and is what `t_stop` reports.  `t_sustained` reports the stricter
+one — the click from which it never goes back — and the gap between them is a
+real finding about the rules, not noise to be smoothed away.
+
+**It often never fires at all.**  Which makes every "average stopping point"
+a **censored** statistic.  Averaging over the runs that stopped is the classic
+survivorship error: the runs excluded are precisely the slow ones, so the mean
+comes out flattering and gets more flattering the worse the arm is.  So
+:func:`summarise` leads with the fire *rate*, quotes the conditional
+distribution only behind it, and computes the median through Kaplan–Meier with
+non-firing runs censored at their own budget — which returns `NaN`, honestly,
+when fewer than half the runs ever fired.
+
+Usage::
+
+    import stopping
+    stops = stopping.stopping_points(main, keys=curves.KEYS)
+    print(stopping.stopping_table(stopping.summarise(stops)))
+
+`selftest_stopping.py` is its planted-answer test.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from vtscore.eval.autopilot_flow import STOPPING_PHASE
+
+#: What identifies one trajectory in a pooled frame.  Mirrors ``curves.KEYS``
+#: with ``arm`` in front: a study tags each arm's frame with an ``arm`` column
+#: before concatenating, and two arms of the same cell are two trajectories.
+#: Filtered to the columns actually present, so a single-arm frame keys on the
+#: rest.
+RUN_KEYS: tuple[str, ...] = ("arm", "dataset", "embedder", "category", "seed")
+
+#: Metrics carried through to the stopping point by default: the one the ship
+#: decision reads and the ranking metric that sits beside it in every report.
+DEFAULT_METRICS: tuple[str, ...] = ("cost", "average_precision")
+
+#: The indicator columns a post-#3560 run emits.  Absent from every earlier
+#: frame, which is why every read of them is guarded.
+LIGHT_COLUMNS: tuple[str, ...] = ("smart", "stable", "span")
+
+
+def _present(df: pd.DataFrame, keys: Sequence[str]) -> list[str]:
+    return [k for k in keys if k in df.columns]
+
+
+def _episodes(is_done: np.ndarray) -> int:
+    """Number of maximal runs of consecutive ``done`` steps.
+
+    One episode is a trajectory that reached ``done`` and stayed; five is one
+    that crossed the line and fell back four times.  Reported because the two
+    are the same `stopped=True` and mean entirely different things about
+    whether the rules found a real convergence.
+    """
+    if is_done.size == 0:
+        return 0
+    return int(np.sum(is_done & ~np.concatenate(([False], is_done[:-1]))))
+
+
+def stopping_points(
+    main: pd.DataFrame,
+    *,
+    keys: Sequence[str] = RUN_KEYS,
+    metrics: Sequence[str] = DEFAULT_METRICS,
+) -> pd.DataFrame:
+    """One row per trajectory: where the stopping rules fired and what it cost.
+
+    *main* is a metric frame (base rows only — filter variants out first, as
+    ``_cells_io.load_arm`` does) carrying at least ``t`` and ``phase``.
+
+    Columns, per run:
+
+    ``stopped``
+        Whether the rules ever fired inside the budget.  **Read this first.**
+        Every other stopping column is conditional on it, and the runs where it
+        is ``False`` are systematically the slow ones.
+    ``t_stop`` / ``t_sustained``
+        First click at which the phase is ``done``, and the first from which it
+        never leaves — the app's own announcement, and the stricter reading.
+        Both ``NaN`` where they never happen.
+    ``n_done_episodes``
+        How many separate times the trajectory entered ``done``.
+    ``t_budget`` / ``clicks_after_stop``
+        The last click measured, and how many of them were spent past the
+        announcement.  ``clicks_after_stop`` is the waste the issue is about.
+    ``{metric}_at_stop`` / ``{metric}_final`` / ``{metric}_delta``
+        The **stopping cost** (height at the stopping point), the number
+        studies report today, and ``final - at_stop``.  For ``cost`` a positive
+        delta means the extra clicks made the detector *worse*.
+    ``n_good_at_stop`` / ``n_bad_at_stop``
+        The labelset the user would have left with.
+    ``blocked_smart`` / ``blocked_stable`` / ``blocked_span``
+        Fraction of the run's not-yet-``done`` steps at which each light was not
+        green — i.e. which rule was doing the holding.  ``NaN`` on a frame from
+        before the lights were emitted.
+    """
+    kk = _present(main, keys)
+    if main.empty or "phase" not in main.columns or "t" not in main.columns or not kk:
+        return pd.DataFrame()
+
+    metrics = [m for m in metrics if m in main.columns]
+    out: list[dict[str, Any]] = []
+    for run_key, g in main.groupby(kk, dropna=False, sort=True):
+        g = g.sort_values("t")
+        t = g["t"].to_numpy()
+        is_done = (g["phase"].astype(str) == STOPPING_PHASE).to_numpy()
+
+        first_i = int(np.argmax(is_done)) if is_done.any() else None
+        # Sustained: the first index from which every LATER measured step is
+        # also done.  A suffix scan, so it is the last falsification that
+        # decides - not the first success.
+        sust_i: int | None = None
+        if is_done.size and is_done[-1]:
+            k = is_done.size - 1
+            while k > 0 and is_done[k - 1]:
+                k -= 1
+            sust_i = k
+
+        row: dict[str, Any] = dict(zip(kk, run_key if isinstance(run_key, tuple) else (run_key,), strict=True))
+        row["n_steps"] = int(len(g))
+        row["t_budget"] = int(t[-1])
+        row["stopped"] = bool(first_i is not None)
+        row["t_stop"] = float(t[first_i]) if first_i is not None else float("nan")
+        row["t_sustained"] = float(t[sust_i]) if sust_i is not None else float("nan")
+        row["n_done_episodes"] = _episodes(is_done)
+        row["clicks_after_stop"] = float(t[-1] - t[first_i]) if first_i is not None else float("nan")
+
+        for m in metrics:
+            vals = pd.to_numeric(g[m], errors="coerce").to_numpy(dtype=float)
+            at_stop = float(vals[first_i]) if first_i is not None else float("nan")
+            final = float(vals[-1])
+            row[f"{m}_at_stop"] = at_stop
+            row[f"{m}_final"] = final
+            row[f"{m}_delta"] = final - at_stop
+        for col, name in (("n_good", "n_good_at_stop"), ("n_bad", "n_bad_at_stop")):
+            if col in g.columns and first_i is not None:
+                row[name] = float(pd.to_numeric(g[col], errors="coerce").to_numpy(dtype=float)[first_i])
+            else:
+                row[name] = float("nan")
+
+        # Which light held the run back, over the steps where it was held.  A
+        # run that never entered `done` is held at every step; one that did is
+        # held only up to its first fire, because what happens after the app
+        # said stop is a different question.
+        held = slice(0, first_i if first_i is not None else len(g))
+        for light in LIGHT_COLUMNS:
+            key = f"blocked_{light}"
+            if light not in g.columns:
+                row[key] = float("nan")
+                continue
+            vals = g[light].astype(str).to_numpy()[held]
+            # Blank = no phase machine ran (or a startup round owned the phase),
+            # which is "not measured" rather than "not green".
+            measured = vals[(vals != "") & (vals != "nan")]
+            row[key] = float(np.mean(measured != "green")) if measured.size else float("nan")
+        out.append(row)
+    return pd.DataFrame(out)
+
+
+def km_median(t_event: Sequence[float], t_censor: Sequence[float]) -> float:
+    """Kaplan-Meier median stopping click, censoring the runs that never fired.
+
+    *t_event* are the clicks at which the rules fired; *t_censor* are the
+    budgets of the runs that reached the end without firing — those runs are
+    **not** dropped, they are carried as "would have fired at some click > this
+    one", which is exactly what a censored observation is.
+
+    Returns the first click at which the survival function falls to 0.5 or
+    below, or ``NaN`` when it never does — the honest answer when most runs
+    never stopped, and the reason this returns a number rather than printing
+    a mean over the survivors.
+    """
+    ev = [float(x) for x in t_event if np.isfinite(x)]
+    ce = [float(x) for x in t_censor if np.isfinite(x)]
+    if not ev:
+        return float("nan")
+    at_risk = len(ev) + len(ce)
+    surv = 1.0
+    for tt in sorted(set(ev)):
+        d = sum(1 for x in ev if x == tt)
+        n = at_risk
+        if n <= 0:
+            break
+        surv *= 1.0 - d / n
+        if surv <= 0.5:
+            return tt
+        # Everyone who failed or was censored AT this click leaves the risk set.
+        at_risk -= d + sum(1 for x in ce if x == tt)
+    return float("nan")
+
+
+def _q(x: pd.Series, p: float) -> float:
+    x = pd.to_numeric(x, errors="coerce").dropna()
+    return float(x.quantile(p)) if len(x) else float("nan")
+
+
+def summarise(
+    stops: pd.DataFrame,
+    *,
+    by: Sequence[str] = ("arm",),
+    metrics: Sequence[str] = DEFAULT_METRICS,
+) -> pd.DataFrame:
+    """Reduce per-run stopping points to one row per group.
+
+    Leads with ``n_runs`` and ``fire_rate`` on purpose: every column after them
+    is conditional on the rules having fired, and quoting a median stopping
+    point without saying how many runs it describes is the survivorship error
+    this whole module exists to avoid.  ``km_t_stop`` is the censoring-aware
+    median — it uses the non-firing runs rather than dropping them, and is
+    ``NaN`` when fewer than half of them ever fired.
+    """
+    if stops.empty:
+        return pd.DataFrame()
+    gb = _present(stops, by)
+    groups: list[tuple[Any, pd.DataFrame]] = list(stops.groupby(gb, dropna=False, sort=True)) if gb else [((), stops)]
+    metrics = [m for m in metrics if f"{m}_at_stop" in stops.columns]
+
+    out: list[dict[str, Any]] = []
+    for key, g in groups:
+        fired = g[g["stopped"]]
+        row: dict[str, Any] = dict(zip(gb, key if isinstance(key, tuple) else (key,), strict=True))
+        row["n_runs"] = int(len(g))
+        row["n_fired"] = int(len(fired))
+        row["fire_rate"] = float(len(fired) / len(g)) if len(g) else float("nan")
+        row["km_t_stop"] = km_median(fired["t_stop"], g.loc[~g["stopped"], "t_budget"])
+        row["median_t_stop"] = _q(fired["t_stop"], 0.5)
+        row["q25_t_stop"] = _q(fired["t_stop"], 0.25)
+        row["q75_t_stop"] = _q(fired["t_stop"], 0.75)
+        row["median_t_sustained"] = _q(fired["t_sustained"], 0.5)
+        row["sustained_rate"] = (
+            float(np.mean(np.isfinite(pd.to_numeric(fired["t_sustained"], errors="coerce"))))
+            if len(fired)
+            else float("nan")
+        )
+        row["median_episodes"] = _q(fired["n_done_episodes"], 0.5)
+        row["median_clicks_after_stop"] = _q(fired["clicks_after_stop"], 0.5)
+        for m in metrics:
+            row[f"median_{m}_at_stop"] = _q(fired[f"{m}_at_stop"], 0.5)
+            row[f"median_{m}_final"] = _q(fired[f"{m}_final"], 0.5)
+            # Paired over the SAME runs (those that fired), so this is a
+            # within-run difference and not a difference of two medians over
+            # different denominators.
+            row[f"median_{m}_delta"] = _q(fired[f"{m}_delta"], 0.5)
+        for light in LIGHT_COLUMNS:
+            row[f"blocked_{light}"] = (
+                _q(g[f"blocked_{light}"], 0.5) if f"blocked_{light}" in g.columns else float("nan")
+            )
+        out.append(row)
+    return pd.DataFrame(out)
+
+
+def _fmt(v: Any, digits: int = 2) -> str:
+    """Two significant digits by default — the report rule, applied here once."""
+    if v is None:
+        return "—"
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return str(v)
+    if not math.isfinite(f):
+        return "—"
+    return f"{f:.{digits}f}"
+
+
+def stopping_table(summary: pd.DataFrame, *, metric: str = "cost") -> str:
+    """The stopping block of a REPORT.md, as markdown.
+
+    One row per group.  The columns are the issue's two questions — *where* the
+    rules fired and *what it cost there* — plus the two qualifications without
+    which neither number can be read: how many runs ever fired, and how much
+    the budget's extra clicks moved the metric afterwards.
+    """
+    if summary.empty:
+        return "_No stopping data: no run carried a `phase` column._"
+    ident = [c for c in summary.columns if c in ("arm", "dataset", "embedder", "category")]
+    head = [*ident, "runs", "fired", "stop click (KM)", "stop click (median of fired)"]
+    head += [f"{metric} at stop", f"{metric} at budget", f"Δ{metric} (paired)", "clicks after stop"]
+    lines = ["| " + " | ".join(head) + " |", "|" + "|".join(["---"] * len(head)) + "|"]
+    for _, r in summary.iterrows():
+        cells = [str(r[c]) for c in ident]
+        cells.append(str(int(r["n_runs"])))
+        cells.append(f"{int(r['n_fired'])} ({r['fire_rate']:.0%})")
+        cells.append(_fmt(r.get("km_t_stop"), 0))
+        iqr = f"{_fmt(r.get('median_t_stop'), 0)} [{_fmt(r.get('q25_t_stop'), 0)}–{_fmt(r.get('q75_t_stop'), 0)}]"
+        cells.append(iqr)
+        cells.append(_fmt(r.get(f"median_{metric}_at_stop")))
+        cells.append(_fmt(r.get(f"median_{metric}_final")))
+        cells.append(_fmt(r.get(f"median_{metric}_delta")))
+        cells.append(_fmt(r.get("median_clicks_after_stop"), 0))
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines)
+
+
+def binding_note(summary: pd.DataFrame) -> str:
+    """One sentence naming which rule held runs short of stopping, or why not.
+
+    Only answerable on a post-#3560 frame; on an older one it says so instead of
+    guessing, because the phase alone cannot separate Smart from Stable.
+    """
+    if summary.empty:
+        return ""
+    cols = [f"blocked_{c}" for c in LIGHT_COLUMNS]
+    if not all(c in summary.columns for c in cols) or summary[cols].isna().all().all():
+        return (
+            "The binding indicator is not recoverable from these cells: they predate the "
+            "`smart` / `stable` / `span` columns, and `phase` alone cannot tell Smart from "
+            "Stable inside `hard`. Re-run to answer it."
+        )
+    means = {c: float(summary[f"blocked_{c}"].mean(skipna=True)) for c in LIGHT_COLUMNS}
+    worst = max(means, key=lambda c: means[c] if math.isfinite(means[c]) else -1.0)
+    parts = ", ".join(f"{c} {means[c]:.0%}" if math.isfinite(means[c]) else f"{c} —" for c in LIGHT_COLUMNS)
+    return f"Share of held steps each indicator was not green: {parts}. **{worst}** is the binding rule."

--- a/tests_lib/detectors/test_stopping_columns.py
+++ b/tests_lib/detectors/test_stopping_columns.py
@@ -1,0 +1,172 @@
+"""The stopping-rule columns the harness emits beside ``phase`` (issue #3560).
+
+A study's "final cost" is the metric at a click budget nobody chose; the number
+a user actually leaves with is the metric at the click the app's stopping rules
+fired.  Deriving that needs two things from every row: the phase (already
+emitted), and the three indicator lights behind it — because ``hard`` cannot
+say whether Smart or Stable is what is holding a run there, and "why did this
+run never stop?" is exactly that question.
+
+What these pin:
+
+1. The lights are **on every row**, and are the ones that produced the phase —
+   ``done`` means all three green, ``new`` means Span alone is not, and nothing
+   else can claim to be ``done``.
+2. They are **blank rather than guessed** where no phase machine ran, so an
+   analysis can tell "not green" from "not measured".
+3. Emitting them does not perturb the trajectory: the same run with and without
+   a reader of them is the same run.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from vtscore.eval.autopilot_flow import STOPPING_PHASE, AutopilotFlow, stopping_rule_fired
+from vtscore.eval.voting_columns import IDENT_COLUMNS, VOTING_COLUMNS
+from vtscore.eval.voting_iterations import simulate_voting_iterations
+
+LIGHTS = ("smart", "stable", "span")
+
+
+def _clips(n=120, dim=16, seed=7):
+    """A separable two-class pool big enough to run a real trajectory."""
+    rng = np.random.default_rng(seed)
+    medias = {}
+    for i in range(n):
+        cat = "target" if i < n // 3 else "other"
+        emb = rng.standard_normal(dim).astype(np.float32) + (1.0 if cat == "target" else -1.0)
+        medias[i + 1] = {
+            "id": i + 1,
+            "embedder": "e5",
+            "embeddings": {"e5": (emb / np.linalg.norm(emb)).astype(np.float32)},
+            "category": cat,
+        }
+    return medias
+
+
+@pytest.fixture(scope="module")
+def rows():
+    return simulate_voting_iterations(
+        _clips(), "target", seed=3, dataset_name="synthetic", max_steps=40, calibrate_count=1
+    )
+
+
+class TestSchema:
+    def test_lights_are_declared_beside_the_phase(self):
+        for col in (*LIGHTS, "span_level", "span_depth"):
+            assert col in IDENT_COLUMNS, f"{col} must ride the identifying prefix, like `phase`"
+            assert col in VOTING_COLUMNS
+
+    def test_every_row_carries_them(self, rows):
+        assert rows
+        for r in rows:
+            assert set(r) == set(VOTING_COLUMNS)
+
+
+class TestLightsAgreeWithPhase:
+    """The phase is a function of the lights, so the two can be checked against
+    each other on real rows - which is what catches a light read off a stale
+    step, the one failure a schema test cannot see."""
+
+    def test_done_means_all_three_green(self, rows):
+        for r in rows:
+            if stopping_rule_fired(r["phase"]):
+                assert [r[k] for k in LIGHTS] == ["green"] * 3, r
+
+    def test_new_means_span_alone_is_short(self, rows):
+        for r in rows:
+            if r["phase"] == "new":
+                assert r["smart"] == "green" and r["stable"] == "green"
+                assert r["span"] != "green", r
+
+    def test_hard_means_smart_or_stable_is_short(self, rows):
+        for r in rows:
+            if r["phase"] == "hard":
+                assert not (r["smart"] == "green" and r["stable"] == "green"), r
+
+    def test_span_counts_are_consistent_with_the_light(self, rows):
+        for r in rows:
+            if r["span"] == "":
+                continue
+            assert r["span_depth"] >= 0 and r["span_level"] >= 0
+            if r["span"] == "green":
+                assert r["span_level"] >= min(40, r["span_depth"]) or r["span_depth"] == 0, r
+
+
+class TestNotMeasuredIsNotNotGreen:
+    def test_a_run_with_no_phase_machine_leaves_them_blank(self):
+        rows = simulate_voting_iterations(
+            _clips(),
+            "target",
+            seed=3,
+            dataset_name="synthetic",
+            max_steps=8,
+            calibrate_count=1,
+            autopilot_fidelity=False,
+        )
+        assert rows
+        for r in rows:
+            assert r["phase"] == ""
+            assert [r[k] for k in LIGHTS] == ["", "", ""]
+            assert r["span_level"] == -1 and r["span_depth"] == -1
+
+    def test_a_startup_schedules_own_rounds_leave_them_blank(self):
+        """A schedule owns the phase without consulting the indicators, so its
+        rounds are 'not measured' - and because a schedule is always a prefix of
+        the trajectory, blank is exactly the rounds and never a stale reading
+        carried forward into a step the machine did evaluate."""
+        medias = _clips()
+        # A schedule names positions on the seed sort, so it needs one: rank the
+        # pool by its own first coordinate, which is arbitrary but real.
+        seed_scores = {mid: float(m["embeddings"]["e5"][0]) for mid, m in medias.items()}
+        rows = simulate_voting_iterations(
+            medias,
+            "target",
+            seed=3,
+            dataset_name="synthetic",
+            max_steps=30,
+            calibrate_count=1,
+            seed_scores=seed_scores,
+            startup_schedule="n12@top",
+        )
+        assert rows
+        blank = [r["t"] for r in rows if r["smart"] == ""]
+        assert blank, "the schedule's own rounds should be in the frame"
+        assert all(r["phase"].startswith("s") for r in rows if r["smart"] == "")
+        # Blank is a prefix: once the machine starts evaluating, it never stops.
+        assert blank == sorted(blank) and max(blank) < min(
+            (r["t"] for r in rows if r["smart"] != ""), default=float("inf")
+        )
+
+    def test_a_fresh_flow_has_not_measured_anything_yet(self):
+        flow = AutopilotFlow()
+        assert [flow.smart, flow.stable, flow.span] == ["", "", ""]
+        assert flow.span_level == -1 and flow.span_depth == -1
+
+
+class TestObservationDoesNotPerturb:
+    def test_the_trajectory_is_unchanged_by_recording_the_lights(self, rows):
+        """Two identical runs agree on every non-timing column, lights included.
+
+        The lights are read off state the phase machine already computed, so
+        they cannot move a vote - but "cannot" is what a regression makes false
+        quietly, and the trajectory is the thing every study rests on.
+        """
+        again = simulate_voting_iterations(
+            _clips(), "target", seed=3, dataset_name="synthetic", max_steps=40, calibrate_count=1
+        )
+        assert len(again) == len(rows)
+        for a, b in zip(rows, again, strict=True):
+            for col in ("t", "phase", "n_good", "n_bad", "cost", *LIGHTS, "span_level", "span_depth"):
+                assert a[col] == b[col] or (isinstance(a[col], float) and np.isnan(a[col]) and np.isnan(b[col])), col
+
+
+class TestStoppingPhaseName:
+    def test_exhausted_is_not_a_stop(self):
+        """Running out of pool is the opposite result from converging, and
+        folding the two together would report a starved run as a stopped one."""
+        assert stopping_rule_fired(STOPPING_PHASE)
+        assert not stopping_rule_fired("exhausted")
+        assert not stopping_rule_fired("hard")

--- a/vtscore/eval/autopilot_flow.py
+++ b/vtscore/eval/autopilot_flow.py
@@ -200,6 +200,31 @@ def next_phase(
 TRAINED_PHASES: frozenset[str] = frozenset({"hard", "new", "done", "exhausted"})
 
 
+#: The phase in which the app has told the user it is done: all three quality
+#: indicators are green, and the panel reads "All quality indicators are green.
+#: You can continue labeling or export your results."  Spelled here so that
+#: analysis asking "where did the stopping rule fire?" compares against a name
+#: rather than a string literal.
+#:
+#: ``exhausted`` is deliberately **not** here.  It is the app running out of
+#: pool with the indicators still amber - the opposite result - and folding the
+#: two together would report a starved run as a converged one.
+STOPPING_PHASE: str = "done"
+
+
+def stopping_rule_fired(phase: str) -> bool:
+    """Whether *phase* is the one the app's stopping rules produce.
+
+    The app announces completion the **first** time this becomes true and never
+    re-announces it (``AutopilotStateService.completionAnnounced``), while the
+    phase itself is *derived* every step and can therefore go back to ``hard``
+    on the next vote.  So "where did the stopping rule fire" is the first step
+    this holds, not the last, and the two are routinely far apart - see
+    ``scripts/experiments/calibration/stopping.py``, which reports both.
+    """
+    return phase == STOPPING_PHASE
+
+
 def app_has_detector(phase: str) -> bool:
     """Whether the app would have a trained detector on screen in *phase*.
 
@@ -222,6 +247,11 @@ class AutopilotFlow:
     and the accumulated per-step prediction-flip counts (Stable) — and
     recomputes the phase after every vote.  The atlas span is read from the
     harness's atlas, which it labels in lock-step with the votes.
+
+    After every :meth:`update` the three indicator lights that produced the
+    phase are left on :attr:`smart` / :attr:`stable` / :attr:`span` (with the
+    raw :attr:`span_level` / :attr:`span_depth` behind the last of them), which
+    is what lets a run say *which* rule held it short of ``done``.
 
     Note the asymmetry between the two, which is the app's: Stable's flip counts
     are a genuine history (each entry compares two consecutive models and can
@@ -254,6 +284,25 @@ class AutopilotFlow:
         self.recent_error_costs: list[float] = []
         self.stability: list[dict[str, Any]] = []
         self._prev_predictions: Optional[dict[int, int]] = None
+        #: The three indicator lights behind the phase, as of the last
+        #: :meth:`update`.  The phase alone cannot say which of Smart and Stable
+        #: is holding a trajectory in ``hard`` - both gate that transition
+        #: together - so a study asking *why* a run never stopped needs the
+        #: lights themselves.  Computing them is already paid for by
+        #: :meth:`update`; keeping them costs three attribute writes.  Blank
+        #: until the first :meth:`update`, and left blank throughout a startup
+        #: schedule's rounds, which own the phase without consulting them.
+        self.smart: Status | str = ""
+        self.stable: Status | str = ""
+        self.span: Status | str = ""
+        #: The raw span counts the Span light is a threshold on: how many
+        #: consecutive BFS-order atlas nodes carry evidence, out of how many the
+        #: tree has.  ``-1`` where there is no atlas (a non-autopilot run) or no
+        #: update yet.  Reported alongside the light because "red" and "green"
+        #: cannot say how far short a run fell, and the gap is the actionable
+        #: number when Span turns out to be the binding rule.
+        self.span_level: int = -1
+        self.span_depth: int = -1
 
     def record_step(self, error_costs: list[float] | None, predictions: dict[int, int] | None) -> None:
         """Fold one step's model into the Smart / Stable inputs.
@@ -296,6 +345,9 @@ class AutopilotFlow:
         smart = smart_status(self.recent_error_costs, good_count, bad_count)
         stable = stable_status(self.stability, good_count, bad_count)
         sp: Status = span_status(int(span["level"]), int(span["depth"]), self.span_green) if span is not None else "red"
+        self.smart, self.stable, self.span = smart, stable, sp
+        self.span_level = int(span["level"]) if span is not None else -1
+        self.span_depth = int(span["depth"]) if span is not None else -1
         self.phase = next_phase(
             good_count,
             bad_count,

--- a/vtscore/eval/voting_columns.py
+++ b/vtscore/eval/voting_columns.py
@@ -86,6 +86,27 @@ IDENT_COLUMNS: tuple[str, ...] = (
     "n_haystack",
     "n_remainder",
     "phase",
+    #: The three quality indicators behind that phase (issue #3560), each
+    #: ``red`` / ``yellow`` / ``green``, plus the raw counts the Span light is a
+    #: threshold on.  Blank / ``-1`` on a run with no phase machine (a
+    #: non-autopilot strategy, ``autopilot_fidelity=False``) and throughout a
+    #: startup schedule's rounds, which own the phase without consulting them.
+    #:
+    #: The phase is *almost* a lossless encoding of the three - ``new`` means
+    #: Smart and Stable are green and Span is not, ``done`` means all three -
+    #: with one gap that matters: in ``hard`` it cannot say whether Smart,
+    #: Stable, or both are what is holding the run there.  That is exactly the
+    #: question "why did this run never stop?" asks, so the lights are emitted
+    #: beside the phase.  They cost three attribute writes: the phase machine
+    #: already computes all three every step and threw them away.
+    "smart",
+    "stable",
+    "span",
+    #: Consecutive evidence-bearing atlas nodes, out of the tree's total.  The
+    #: Span light is ``level >= min(autopilot_goal_diversity, depth)``, so these
+    #: two say *how far short* a run fell rather than merely that it did.
+    "span_level",
+    "span_depth",
     "app_trained",
     #: The parameterised opening this run took (issue #3267), verbatim - so a
     #: pooled frame says which arm each row came from without depending on the

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -2159,6 +2159,15 @@ def simulate_voting_iterations(  # noqa: C901
             "n_haystack": len(sim_ids),
             "n_remainder": 0,
             "phase": "",
+            # A skyline belongs to no step, so no phase ran and no indicator
+            # was ever read for it (#3560).  Blank / -1 is the "not measured"
+            # spelling every other unphased row uses; a `red` here would say
+            # the rules had looked and refused, which they never did.
+            "smart": "",
+            "stable": "",
+            "span": "",
+            "span_level": -1,
+            "span_depth": -1,
             "app_trained": 0,
             "startup_schedule": startup_schedule or "",
             "acq_threshold": float("nan"),

--- a/vtscore/eval/voting_iterations.py
+++ b/vtscore/eval/voting_iterations.py
@@ -1924,6 +1924,14 @@ def simulate_voting_iterations(  # noqa: C901
             "n_haystack": len(sim_ids),
             "n_remainder": len(pool),
             "phase": flow.phase if flow is not None else "",
+            # The three lights behind that phase (#3560).  Already computed by
+            # `flow.update` above and previously discarded; the phase alone
+            # cannot say whether Smart or Stable is what holds a run in `hard`.
+            "smart": flow.smart if flow is not None else "",
+            "stable": flow.stable if flow is not None else "",
+            "span": flow.span if flow is not None else "",
+            "span_level": flow.span_level if flow is not None else -1,
+            "span_depth": flow.span_depth if flow is not None else -1,
             "app_trained": 1 if (flow is None or app_has_detector(flow.phase)) else 0,
             "startup_schedule": startup_schedule or "",
             "acq_threshold": round(float(acq_threshold), 6),


### PR DESCRIPTION
Every simulated-user study quotes a **final cost**: the metric at the last click of a fixed budget (`CALIB_MAX_STEPS`, usually 150). The app has its own notion of finished — Smart, Stable and Span all green, at which point the phase becomes `done` and the panel offers the export hand-off. So "final" in every published report is a click count nobody chose, and it is not where any user would actually leave.

This adds the two numbers that close the gap, and the machinery to report them:

```
stopping point  =  the click at which the rules first fired   (the width)
stopping cost   =  the metric at that click                   (the height)
```

## The headline: this costs nothing, and needs no re-runs

`phase` has been on every metric row since the harness adopted the app's phase machine (2026-07-31), and the machine's three inputs — the Smart error-cost window, the Stable prediction flips, the Span atlas — are computed *every step already*, because the vote order depends on them. Locally, the whole Smart-window rescoring is 1–4% of a run's wall clock, and that 1–4% was being paid before this PR. **No study gets slower, and every finished study's cells can be enriched by re-reading them.**

## What the harness gains

Five columns beside `phase`, all previously computed and discarded: `smart` / `stable` / `span` (the three lights) and `span_level` / `span_depth` (the raw atlas counts the Span light thresholds). The phase already encodes `done` (all green) and `new` (Span alone short); what it cannot encode is whether Smart, Stable, or both hold a run in `hard` — which is exactly what "why did this run never stop?" asks. Blank / `-1` where no phase machine ran, so *not measured* stays distinguishable from *not green*.

## What the analysis layer gains

`scripts/experiments/calibration/stopping.py` is the one implementation of the derivation. Three properties of the data shape its API, and all three were measured before it was written:

- **The rules flap.** The phase is derived from the current labelset every step, never latched, so a run can go `done` on one vote and back to `hard` on the next — a local probe saw five separate `done` episodes in one trajectory. The app announces on the **first** fire and never re-announces (`AutopilotStateService.completionAnnounced`), so first-fire is the faithful stopping point; `t_sustained` and `n_done_episodes` say how far that is from settling.
- **They often never fire**, which makes every average a **censored** statistic. Averaging the runs that stopped drops precisely the slow ones, so the mean flatters — and flatters harder the worse the arm is. `summarise()` leads with the fire *rate*, and `km_t_stop` is a Kaplan–Meier median that carries the non-firers as censored at their own budget, returning `NaN` honestly when fewer than half ever fired.
- **Cost at the stop and cost at the budget are different numbers with a sign between them.** Reported paired within run; a positive Δcost means the clicks past the app's advice made the detector *worse*.

`curves.quality_vs_clicks(..., stops=…)` marks the median stopping click on the mandatory averaged figure and **names the arms it withheld a marker from** — an absent glyph that is not explained reads as an oversight rather than as the finding it is. Default `None` leaves every existing figure byte-identical.

## Decision recorded: runs are not truncated at `done`

The simulated user keeps clicking to the budget. The stretch past the stopping point is what says whether stopping there was right, and arms can only be compared at a fixed `t`. An opt-in truncation arm is a separate thing if a study ever wants it.

## Tests

- `tests_lib/detectors/test_stopping_columns.py` — the lights are on every row and **agree with the phase they produced** on real trajectories (the fixture exercises `bad`, `hard`, `new` and `done`); blank means not-measured, including throughout a startup schedule's rounds; observing them does not perturb the trajectory.
- `scripts/experiments/calibration/selftest_stopping.py` — planted-answer, one trajectory shape per way `phase` can mislead: a clean stopper, a flapper that crosses four times, a never-stopper carried as censored. Pins that the stopping cost is read at the stopping click, that Δcost keeps its sign, that KM returns `NaN` rather than a survivors' median, and that a pre-#3560 frame says the binding rule is unrecoverable instead of guessing.
- `selftest_curves.py` gains the marker's three checks.

Full `./run-tests.sh` green (9928 passed, all gates).

## Drive-by

`frontend/package.json` had `overrides.fast-uri` twice (added independently by 0342b296 and dfad4201). Same value, so nothing resolved differently — but esbuild emitted `duplicate-object-key` on every build and `run-tests.sh` treats any `▲ [WARNING]` as a hard failure, so the frontend gate was red for everyone.

## What's still owed

[`docs/plans/stopping-rules-in-eval.md`](docs/plans/stopping-rules-in-eval.md): re-analysing the influential finished studies (a read, not a grid — vg-scale, acquisition-inclusion, good-mining), adopting the reporting convention alongside the quality-over-clicks pair, and then the actual question — whether the rules fire in the *right place*.

Refs #3560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fWFUkjehqejaQ4jVAjkcx

---
_Generated by [Claude Code](https://claude.ai/code/session_015fWFUkjehqejaQ4jVAjkcx)_