### PR TITLE
Record vote surfacing provenance in LabeledElement.metadata

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1215,7 +1215,8 @@ full materialization rather than lazy resolution.
 A `LabelSet` extends the dataset concept: each element carries its origin,
 its name within that origin, its label (`"good"` / `"bad"`), and optional
 `metadata` (arbitrary key-value dict for round-tripping extra data like
-`contentID`, `mediaID`, etc.).
+`contentID`, `mediaID`, etc., plus the reserved `"vt:provenance"` key —
+see below).
 
 ```python
 from vtscore.datasets.labelset import LabelSet
@@ -1230,6 +1231,37 @@ ls = LabelSet.from_results(results_dict, medias=medias)
 data = ls.to_dict()   # {"labels": [{"md5": ..., "label": ..., "origin": ..., ...}]}
 ls2 = LabelSet.from_dict(data)
 ```
+
+#### Vote surfacing provenance (`"vt:provenance"`)
+
+One key inside `metadata` is reserved: `"vt:provenance"` records **how each
+vote was surfaced** — which UI flow drove it, which autopilot phase (if any),
+how the item was drawn off the ranking, which ranking that was, and the item's
+rank and score at click time. `vtscore/datasets/vote_provenance.py` owns the
+vocabulary and the validation; `DetectorContext.vote_provenance` carries it in
+memory, threaded exactly like `vote_region_boxes`.
+
+It is recorded at click time because it is **not re-derivable later**: the
+ranking is client-side ephemeral state and the model behind the score is
+overwritten by the next retrain. Scalars only — the no-persisted-vectors rule
+is untouched.
+
+The four categorical fields are independent axes, not one fused enum, because
+the calibration bias this exists to measure tracks *how the item was drawn*
+(`select_mode`) rather than *who was driving* (`flow`). The two come apart at
+both edges: a user can pick the `hard` select mode by hand and get autopilot's
+exact margin-sampled draw, and autopilot's own `good` phase is mechanically a
+top-of-list draw.
+
+Recording only — nothing reads these values back to change behaviour. The
+consumer (partitioning the conformal calibration set by trustworthy surfacing
+context) is gated on the experiment pre-registered in
+[`docs/plans/provenance-partitioned-calibration.md`](plans/provenance-partitioned-calibration.md).
+Two rules keep the record honest: it is written **only on a vote-state change**
+(an idempotent re-apply keeps what the original click recorded, so a stale tab
+cannot rewrite it), and `restore_labels_from_detector` carries it back into
+vote state on load — without that, the next vote's labelset resync would erase
+every recorded vote's provenance, the bug `region_box` shipped with.
 
 The `GET /api/labels/export` endpoint returns a `LabelSet` serialised
 as JSON.  The format is backward-compatible: old consumers that only

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -204,6 +204,40 @@ cells on the fly). The box is dropped when the vote is removed
 {"target": "good", "region_box": [0.2, 0.3, 0.55, 0.7]}
 ```
 
+**Optional `provenance`**: how the item came to be in front of the user.
+Recorded per vote, read by nothing — the recording exists because the
+surfacing context is *not re-derivable later*: the ranking is client-side
+state and the model behind the score is overwritten by the next retrain, so a
+vote not annotated at click time is annotated never. It is stored in the
+element's labelset `metadata` under `"vt:provenance"` and round-trips through
+label export/import.
+
+Six optional fields, four of them independent categorical axes rather than one
+fused enum (the bias this recording exists to measure tracks *how the item was
+drawn*, not *who was driving*, and the two come apart — a user can pick the
+`hard` select mode by hand and get autopilot's exact margin-sampled draw):
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `flow` | `autopilot`, `list_review`, `find_verify`, `labelset_review`, `seed_example`, `import`, `bulk`, `undo`, `unknown` | Which UI flow drove the vote. |
+| `phase` | `good`, `bad`, `hard`, `new` | Autopilot phase; ignored unless `flow` is `autopilot`. |
+| `select_mode` | `top`, `hard`, `new` | How the item was drawn off the ranking. |
+| `sort_kind` | `learned`, `text`, `load` | Which ranking the user was looking at. |
+| `rank_at_vote` | integer ≥ 0 | The item's position in that ranking. |
+| `score_at_vote` | float | The item's model score when it was surfaced. |
+
+Recorded **only when the call actually changes the vote state**, so an
+idempotent re-send from a stale tab cannot overwrite what the original click
+recorded. An unrecognised *value* for any of these fields is rejected (422); a
+payload carrying nothing beyond `{"flow": "unknown"}` is dropped rather than
+stored.
+
+```json
+{"target": "good", "provenance": {"flow": "autopilot", "phase": "hard",
+                                  "select_mode": "hard", "sort_kind": "learned",
+                                  "rank_at_vote": 12, "score_at_vote": 0.44}}
+```
+
 →
 ```json
 {"ok": true, "state": "good", "click_time": 17}
@@ -222,7 +256,7 @@ Unknown body fields are silently dropped, so a client may attach advisory keys
 |--------|-------|
 | `400` | `region_box` on a `"bad"` / `"none"` target; `region_box` outside `[0, 1]`, not a 4-element list, or non-numeric. |
 | `404` | Media not found. |
-| `422` | Missing `target`, or a `target` outside `good` / `bad` / `none` (marshmallow validation envelope). |
+| `422` | Missing `target`, a `target` outside `good` / `bad` / `none`, or an unrecognised `provenance` value (marshmallow validation envelope). |
 | `500` | The vote was applied in memory but the detector labelset could not be persisted. |
 
 ### Bulk vote
@@ -231,7 +265,9 @@ Unknown body fields are silently dropped, so a client may attach advisory keys
 POST /api/medias/vote-bulk
 ```
 
-**Body:** `{"ids": [1, 2, 3], "target": "good"}`
+**Body:** `{"ids": [1, 2, 3], "target": "good"}`, plus an optional
+`provenance` block (same shape as the per-media vote) applied to every id in
+the batch. It defaults to `{"flow": "bulk"}` when omitted.
 
 Applies one absolute vote `target` (`"good"` / `"bad"` / `"none"`) to many
 medias in a single request, with the same idempotent semantics as the
@@ -244,7 +280,7 @@ the Marathoner streak.
 → `{"ok": true, "changed": 2, "missing": [3]}` — `changed` counts only ids
 whose state actually moved (idempotent re-applies don't count); ids not in the
 loaded dataset are reported in `missing`.
-400 if no ids supplied.
+400 if no ids supplied; 422 on an unrecognised `provenance` value.
 
 ### Thumbnail
 

--- a/docs/plans/provenance-partitioned-calibration.md
+++ b/docs/plans/provenance-partitioned-calibration.md
@@ -33,15 +33,27 @@ surfacing context the study measured as trustworthy.
 
 ## Design decisions (settled)
 
-- **Provenance taxonomy.** `surfaced_by ∈ {autopilot:good, autopilot:bad,
-  autopilot:hard, autopilot:new, list_review, seed_example, unknown}` plus
-  context scalars (`score_at_vote`, `rank_at_vote`, `sort_kind`). Recorded per
-  vote at click time — the surfacing model is gone by the next retrain, so this
-  is *not re-derivable* and must be persisted (scalars only; the No Persisted
-  Vectors rule is untouched). Storage: a namespaced key in
-  `LabeledElement.metadata`, which already round-trips through labelset
-  export/import. Recording is issue #2850 and ships independently of everything
-  below.
+- **Provenance taxonomy.** Recorded per vote at click time — the surfacing
+  model is gone by the next retrain, so this is *not re-derivable* and must be
+  persisted (scalars only; the No Persisted Vectors rule is untouched).
+  Storage: `"vt:provenance"` in `LabeledElement.metadata`, which already
+  round-trips through labelset export/import. **Shipped as separate axes, not
+  the single fused `surfaced_by` enum this plan first proposed:** `flow ∈
+  {autopilot, list_review, find_verify, labelset_review, seed_example, import,
+  bulk, undo, unknown}`, `phase ∈ {good, bad, hard, new}` (autopilot only),
+  `select_mode ∈ {top, hard, new}`, `sort_kind ∈ {learned, text, load}`, plus
+  `rank_at_vote` and `score_at_vote`. The fused enum labelled votes by *who was
+  driving* while the bias this plan exists to repair tracks *how the item was
+  drawn*, and the two come apart at both edges — a user can pick the `hard`
+  select mode by hand and get autopilot's exact margin-sampled draw, and
+  autopilot's own `good` phase is mechanically a top-of-list draw. See
+  `vtscore/datasets/vote_provenance.py`.
+
+  **Consequence for the arms below:** eligibility is a predicate over these
+  axes, not a membership test on a flow list. The measurement should partition
+  on `select_mode` (with `flow` available as a covariate) rather than on
+  "autopilot vs. list review", and the mixed-stream harness must tag simulated
+  votes in the shipped shape.
 - **Eligibility default for unattributed votes.** Legacy votes and imported
   labelsets carry no provenance (`unknown`) and stay **calibration-eligible**.
   The partition only bites when a session demonstrably mixes flows; it must not
@@ -107,11 +119,6 @@ fraction of cells where the starvation fallback engaged.
    `docs/experiments/provenance-calibration/REPORT.md` with the paired tables.
 
 ## Open work
-
-<!-- item-sep -->
-
-- [ ] #2850 — Record vote surfacing provenance in `LabeledElement.metadata`
-  (Sonnet 5)
 
 <!-- item-sep -->
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2340,8 +2340,12 @@
         "type": "object"
       },
       "DetectorLabelVoteRequest": {
-        "additionalProperties": false,
         "properties": {
+          "provenance": {
+            "$ref": "#/components/schemas/VoteProvenance",
+            "description": "Optional surfacing context; see :class:`VoteProvenanceSchema`.",
+            "nullable": true
+          },
           "target": {
             "enum": [
               "good",
@@ -4864,6 +4868,11 @@
             },
             "type": "array"
           },
+          "provenance": {
+            "$ref": "#/components/schemas/VoteProvenance",
+            "description": "Optional surfacing context applied to every id in the batch. Defaults to ``{\"flow\": \"bulk\"}`` when omitted.",
+            "nullable": true
+          },
           "target": {
             "description": "Absolute target state applied to every id: ``good``, ``bad``, or ``none``. Idempotent.",
             "enum": [
@@ -4907,6 +4916,11 @@
       },
       "MediaVoteRequest": {
         "properties": {
+          "provenance": {
+            "$ref": "#/components/schemas/VoteProvenance",
+            "description": "Optional surfacing context for this vote. Recorded only when the call actually changes the vote state, so an idempotent re-send from a stale tab cannot overwrite what the original click recorded.",
+            "nullable": true
+          },
           "region_box": {
             "description": "Optional 4-element ``[x0, y0, x1, y1]`` in normalised image coordinates ``[0, 1]``. Only valid when ``target`` is ``good``.",
             "items": {
@@ -6117,6 +6131,73 @@
         "required": [
           "version"
         ],
+        "type": "object"
+      },
+      "VoteProvenance": {
+        "properties": {
+          "flow": {
+            "description": "Which UI flow drove the vote.",
+            "enum": [
+              "autopilot",
+              "bulk",
+              "find_verify",
+              "import",
+              "labelset_review",
+              "list_review",
+              "seed_example",
+              "undo",
+              "unknown",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "phase": {
+            "description": "Autopilot phase at click time. Ignored unless ``flow`` is ``autopilot``.",
+            "enum": [
+              "bad",
+              "good",
+              "hard",
+              "new",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "rank_at_vote": {
+            "description": "Zero-based position of the item in the sort the user was looking at.",
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "score_at_vote": {
+            "description": "The item's model score when it was surfaced, if the client has one.",
+            "nullable": true,
+            "type": "number"
+          },
+          "select_mode": {
+            "description": "How the item was drawn off the ranking: ``top`` (head of the sort), ``hard`` (margin sampling near the cutoff), or ``new`` (diverse exploration).",
+            "enum": [
+              "hard",
+              "new",
+              "top",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "sort_kind": {
+            "description": "Which ranking the user was looking at.",
+            "enum": [
+              "learned",
+              "load",
+              "text",
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "VotesResponse": {
@@ -10779,7 +10860,7 @@
         }
       ],
       "post": {
-        "description": "Body: ``{\"target\": \"good\"}``, ``{\"target\": \"bad\"}``, or\n``{\"target\": \"remove\"}``.\n\nAbsolute-target semantics mirror :func:`~vtsearch.state.set_vote`:\n``\"good\"`` / ``\"bad\"`` set the element's label (a re-assert of the\ncurrent label is an idempotent no-op), ``\"remove\"`` drops the element.\nWhen the element resolves into the active dataset, the detector's\nin-memory ``good_votes`` / ``bad_votes`` are kept in sync so MLP\nretraining and learned-sort see the change.",
+        "description": "Body: ``{\"target\": \"good\"}``, ``{\"target\": \"bad\"}``, or\n``{\"target\": \"remove\"}``.\n\nAbsolute-target semantics mirror :func:`~vtsearch.state.set_vote`:\n``\"good\"`` / ``\"bad\"`` set the element's label (a re-assert of the\ncurrent label is an idempotent no-op), ``\"remove\"`` drops the element.\nWhen the element resolves into the active dataset, the detector's\nin-memory ``good_votes`` / ``bad_votes`` are kept in sync so MLP\nretraining and learned-sort see the change.\n\nAn optional ``provenance`` block records how the element was surfaced,\ndefaulting to ``{\"flow\": \"labelset_review\"}`` - this route is the\ndashboard's review of already-saved labels, not a draw off any ranking.\nIt is written only when the label actually flips.",
         "operationId": "vote_detector_label",
         "requestBody": {
           "content": {
@@ -10801,6 +10882,9 @@
               }
             },
             "description": "OK"
+          },
+          "400": {
+            "description": "provenance is malformed."
           },
           "404": {
             "description": "Detector or label element not found."
@@ -12649,7 +12733,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "No ids supplied."
+            "description": "No ids supplied, or provenance is malformed."
           },
           "422": {
             "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
@@ -13054,7 +13138,7 @@
         }
       ],
       "post": {
-        "description": "``target`` is one of:\n\n- ``\"good\"``: set to good (overrides ``bad`` if present).\n- ``\"bad\"``: set to bad (overrides ``good`` if present).\n- ``\"none\"``: un-vote (remove any existing vote).\n\nBehaviour is **idempotent**: sending the current state is a no-op\nthat does not append to ``label_history``, does not credit\nachievements, and returns the existing click-time.  This is the\nfix for logical-bug-audit H1; two stale-view tabs that race the\nsame media no longer alternate ADD/REMOVE on the server, so the\nachievement counter no longer inflates beyond the number of real\nlabeling decisions.\n\nYes-targets may carry ``\"region_box\": [x0, y0, x1, y1]`` (normalised\nimage coords in ``[0, 1]``) to designate the good region.\n``\"bad\"`` and ``\"none\"`` targets must not include ``region_box``; by\ndesign no-votes are image-level always (patch-embedder v2).\n\nReturns ``{\"ok\": true, \"state\": <new state>, \"click_time\": <int|null>}``\nso the client can reconcile its optimistic view directly from the\nresponse.",
+        "description": "``target`` is one of:\n\n- ``\"good\"``: set to good (overrides ``bad`` if present).\n- ``\"bad\"``: set to bad (overrides ``good`` if present).\n- ``\"none\"``: un-vote (remove any existing vote).\n\nBehaviour is **idempotent**: sending the current state is a no-op\nthat does not append to ``label_history``, does not credit\nachievements, and returns the existing click-time.  This is the\nfix for logical-bug-audit H1; two stale-view tabs that race the\nsame media no longer alternate ADD/REMOVE on the server, so the\nachievement counter no longer inflates beyond the number of real\nlabeling decisions.\n\nYes-targets may carry ``\"region_box\": [x0, y0, x1, y1]`` (normalised\nimage coords in ``[0, 1]``) to designate the good region.\n``\"bad\"`` and ``\"none\"`` targets must not include ``region_box``; by\ndesign no-votes are image-level always (patch-embedder v2).\n\nAn optional ``provenance`` block records how the item was surfaced\n(flow / autopilot phase / select mode / sort / rank / score).  It is\nstored only when the call actually changes the vote state, so an\nidempotent re-send from a stale tab cannot overwrite what the original\nclick recorded.  See :mod:`vtscore.datasets.vote_provenance`.\n\nReturns ``{\"ok\": true, \"state\": <new state>, \"click_time\": <int|null>}``\nso the client can reconcile its optimistic view directly from the\nresponse.",
         "operationId": "vote_media",
         "requestBody": {
           "content": {
@@ -13078,7 +13162,7 @@
             "description": "OK"
           },
           "400": {
-            "description": "region_box is malformed, or a non-good target carries a region_box."
+            "description": "region_box or provenance is malformed, or a non-good target carries a region_box."
           },
           "404": {
             "description": "Media not found."

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,6 @@
     "fast-uri": "^3.1.7",
     "postcss": "^8.5.10",
     "qs": "^6.16.0",
-    "fast-uri": "^3.1.7",
     "@angular/build": {
       "undici": "^7.29.0"
     }

--- a/frontend/src/app/components/browse-view/browse-view.component.ts
+++ b/frontend/src/app/components/browse-view/browse-view.component.ts
@@ -1336,7 +1336,7 @@ export class BrowseViewComponent implements OnInit, OnDestroy {
     const ids = this.selection.ids();
     if (ids.length === 0) return;
     this.mediasApi
-      .voteBulk(ids, target)
+      .voteBulk(ids, target, { flow: 'bulk' })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => this.dropFromBrowse(ids, target),

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -9,6 +9,7 @@ import { ANIMATIONS_OFF_CLASS, ANIMATIONS_ON_CLASS } from '../../utils/reduced-m
 import { configureZoneless } from '../../testing/zoneless-testbed';
 import { settleZoneless } from '../../testing/settle-resource';
 import { provideHttpTesting } from '../../testing/test-providers';
+import { voteBodyWithoutProvenance } from '../../testing/mocks';
 
 /**
  * Zoneless staleness canary for the center panel.
@@ -235,7 +236,7 @@ describe('CenterPanelComponent', () => {
     // server's response reconciles the optimistic local view directly (no
     // follow-up GET /api/votes).
     const voteReq = httpMock.expectOne('/api/medias/1/vote');
-    expect(voteReq.request.body).toEqual({ target: 'good' });
+    expect(voteBodyWithoutProvenance(voteReq)).toEqual({ target: 'good' });
     voteReq.flush({ state: 'good', click_time: 1 });
 
     expect(emitted).toEqual({ id: 1, vote: 'good' });
@@ -367,7 +368,7 @@ describe('CenterPanelComponent', () => {
       component.onRegionBoxChange(box);
       component.castVote('good');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.5, 0.6] });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.5, 0.6] });
       req.flush({ state: 'good', click_time: 1 });
     });
 
@@ -375,7 +376,7 @@ describe('CenterPanelComponent', () => {
       setup();
       component.castVote('good');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good' });
       req.flush({ state: 'good', click_time: 1 });
     });
 
@@ -389,7 +390,7 @@ describe('CenterPanelComponent', () => {
       // Second ← throws the box away and votes no.
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'bad' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'bad' });
       req.flush({ state: 'bad', click_time: 1 });
     });
 
@@ -397,7 +398,7 @@ describe('CenterPanelComponent', () => {
       setup();
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'bad' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'bad' });
       expect(component.pendingBadConfirm()).toBe(false);
       req.flush({ state: 'bad', click_time: 1 });
     });
@@ -428,7 +429,7 @@ describe('CenterPanelComponent', () => {
 
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'bad' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'bad' });
       expect(component.pendingBadConfirm()).toBe(false);
       req.flush({ state: 'bad', click_time: 1 });
     });
@@ -475,7 +476,7 @@ describe('CenterPanelComponent', () => {
       setup();
       component.castVote('bad');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'bad' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'bad' });
       expect(component.pendingBadConfirm()).toBe(false);
       req.flush({ state: 'bad', click_time: 1 });
     });
@@ -486,7 +487,7 @@ describe('CenterPanelComponent', () => {
       // Without arming first: yes-vote attaches the box immediately.
       component.castVote('good');
       const req = httpMock.expectOne('/api/medias/1/vote');
-      expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.5, 0.6] });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.5, 0.6] });
       req.flush({ state: 'good', click_time: 1 });
     });
   });

--- a/frontend/src/app/components/find-view/find-view.component.ts
+++ b/frontend/src/app/components/find-view/find-view.component.ts
@@ -546,7 +546,9 @@ export class FindViewComponent implements OnInit, AfterViewInit, OnDestroy {
     const m = this.mediaState.getMedia(event.id);
     const name = m?.filename || m?.origin_name || `#${event.id}`;
     this.voteState
-      .submitToggleVoteAndRecord(event.id, event.vote, name)
+      // Find is its own surfacing flow: the item was put here by a scoring
+      // pass, not by the Train window's sort.
+      .submitToggleVoteAndRecord(event.id, event.vote, name, null, 'find_verify')
       .pipe(this.pairScope.scoped())
       .subscribe({
         next: () => {

--- a/frontend/src/app/services/medias-api.service.ts
+++ b/frontend/src/app/services/medias-api.service.ts
@@ -11,6 +11,7 @@ import type { MediaVoteRequest } from '../generated/api-client/models/media-vote
 import type { MediaVoteResponse } from '../generated/api-client/models/media-vote-response';
 import type { MediaAddToPileResponse } from '../generated/api-client/models/media-add-to-pile-response';
 import type { PayloadVariant } from '../models/api.models';
+import type { VoteProvenance } from './vote-provenance.service';
 import { listMediaIds } from '../generated/api-client/fn/medias/list-media-ids';
 import { batchMedias } from '../generated/api-client/fn/medias/batch-medias';
 import { mediaParagraphGet2 } from '../generated/api-client/fn/medias/media-paragraph-get-2';
@@ -58,14 +59,21 @@ export class MediasApiService {
    * Returns the server-confirmed new state and click-time so the optimistic
    * local view can be reconciled directly from the response without a
    * follow-up ``GET /api/votes``.
+   *
+   * ``provenance`` records how the item was surfaced. The server stores it
+   * only when the call actually changes the vote state, so sending it on a
+   * call that turns out to be idempotent cannot overwrite what the original
+   * click recorded.
    */
   vote(
     id: number,
     target: 'good' | 'bad' | 'none',
     regionBox?: readonly number[] | null,
+    provenance?: VoteProvenance | null,
   ): Observable<MediaVoteResponse> {
     const body: MediaVoteRequest = { target };
     if (regionBox && regionBox.length === 4) body.region_box = [...regionBox];
+    if (provenance) body.provenance = provenance;
     return voteMedia(this.http, this.config.rootUrl, { media_id: id, body }).pipe(
       map((r) => r.body),
     );
@@ -84,10 +92,11 @@ export class MediasApiService {
   voteBulk(
     ids: number[],
     target: 'good' | 'bad' | 'none',
+    provenance?: VoteProvenance | null,
   ): Observable<{ ok: boolean; changed: number; missing: number[] }> {
     return this.http.post<{ ok: boolean; changed: number; missing: number[] }>(
       '/api/medias/vote-bulk',
-      { ids, target },
+      { ids, target, ...(provenance ? { provenance } : {}) },
     );
   }
 

--- a/frontend/src/app/services/vote-provenance.service.spec.ts
+++ b/frontend/src/app/services/vote-provenance.service.spec.ts
@@ -1,0 +1,112 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AutopilotStateService } from './autopilot-state.service';
+import { SortStateService } from './sort-state.service';
+import { VoteProvenanceService } from './vote-provenance.service';
+import { provideHttpTesting } from '../testing/test-providers';
+
+/**
+ * The provenance assembler is the one place in the client that decides what a
+ * vote's surfacing context *was*, so its job is to read the state already on
+ * screen rather than to be told. These tests pin the two derivations that are
+ * easy to get subtly wrong: which flow autopilot actually owns, and that the
+ * rank recorded is the item's real position in the ranking.
+ */
+describe('VoteProvenanceService', () => {
+  let service: VoteProvenanceService;
+  let sortState: SortStateService;
+  let autopilot: AutopilotStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [...provideHttpTesting()] });
+    service = TestBed.inject(VoteProvenanceService);
+    sortState = TestBed.inject(SortStateService);
+    autopilot = TestBed.inject(AutopilotStateService);
+  });
+
+  afterEach(() => autopilot.clear());
+
+  it('records list_review when autopilot is idle', () => {
+    expect(service.forVote(1).flow).toBe('list_review');
+  });
+
+  it('records the autopilot phase while autopilot is surfacing items', () => {
+    autopilot.activate();
+    autopilot.checkPhaseTransition(3, 4, 100);
+    expect(autopilot.state.phase).toBe('hard');
+
+    const p = service.forVote(1);
+    expect(p.flow).toBe('autopilot');
+    expect(p.phase).toBe('hard');
+  });
+
+  it('records the initial good phase, which is a top-of-list draw', () => {
+    // The other case a fused enum gets wrong: autopilot's `good` phase reads
+    // as "autopilot, therefore safe" while being mechanically the same
+    // top-of-list draw as manual review.
+    autopilot.activate();
+    autopilot.checkPhaseTransition(0, 0, 100);
+
+    const p = service.forVote(1);
+    expect(p.flow).toBe('autopilot');
+    expect(p.phase).toBe('good');
+  });
+
+  it('does not claim autopilot in its terminal phases', () => {
+    // `exhausted` (and `done`) leave the user labelling off the last sort by
+    // hand, which is list review whatever the panel still says.
+    autopilot.activate();
+    autopilot.checkPhaseTransition(3, 4, 7); // nothing left unlabeled
+    expect(autopilot.state.phase).toBe('exhausted');
+
+    const p = service.forVote(1);
+    expect(p.flow).toBe('list_review');
+    expect(p.phase).toBeUndefined();
+  });
+
+  it('records the sort and select modes as independent axes', () => {
+    // The case a fused `autopilot:hard` enum could not express: a user picking
+    // the margin-sampled draw by hand, outside autopilot.
+    sortState.setSortMode('learned');
+    sortState.setSelectMode('hard');
+    const p = service.forVote(1);
+    expect(p.flow).toBe('list_review');
+    expect(p.select_mode).toBe('hard');
+    expect(p.sort_kind).toBe('learned');
+  });
+
+  it('records the item rank and score from the ranking on screen', () => {
+    sortState.setSortResults(
+      [
+        { id: 7, score: 0.9 },
+        { id: 3, score: 0.5 },
+        { id: 9, score: 0.1 },
+      ],
+      0.4,
+    );
+    const p = service.forVote(3);
+    expect(p.rank_at_vote).toBe(1);
+    expect(p.score_at_vote).toBe(0.5);
+  });
+
+  it('omits rank and score for an item absent from the ranking', () => {
+    sortState.setSortResults([{ id: 7, score: 0.9 }], 0.4);
+    const p = service.forVote(999);
+    expect(p.rank_at_vote).toBeUndefined();
+    expect(p.score_at_vote).toBeUndefined();
+  });
+
+  it('omits rank and score when no sort has run', () => {
+    const p = service.forVote(1);
+    expect(p.rank_at_vote).toBeUndefined();
+    expect(p.score_at_vote).toBeUndefined();
+  });
+
+  it('lets a caller override the flow it knows better than the state does', () => {
+    autopilot.activate();
+    autopilot.checkPhaseTransition(3, 4, 100);
+    const p = service.forVote(1, 'find_verify');
+    expect(p.flow).toBe('find_verify');
+    expect(p.phase).toBeUndefined();
+  });
+});

--- a/frontend/src/app/services/vote-provenance.service.ts
+++ b/frontend/src/app/services/vote-provenance.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, inject } from '@angular/core';
+import { AutopilotStateService } from './autopilot-state.service';
+import { SortStateService } from './sort-state.service';
+
+/**
+ * Which UI flow drove a vote. Mirrors `FLOWS` in
+ * `vtscore/datasets/vote_provenance.py`; the server rejects anything else.
+ *
+ * The values the client can originate are here; `import`, `seed_example` and
+ * `unknown` are stamped server-side on paths that have no client at all.
+ */
+export type VoteFlow =
+  | 'autopilot'
+  | 'list_review'
+  | 'find_verify'
+  | 'labelset_review'
+  | 'bulk'
+  | 'undo';
+
+/**
+ * How a voted-on item came to be in front of the user, captured at click time.
+ *
+ * Recorded, never read back: nothing in the app changes behaviour on these
+ * values. They exist because the surfacing context is *not re-derivable* —
+ * `sortOrder` is ephemeral client state and the model behind `score` is
+ * overwritten by the next retrain — so a vote not annotated now is annotated
+ * never. See `docs/plans/provenance-partitioned-calibration.md`.
+ *
+ * Deliberately narrower than the generated `VoteProvenance` model, which
+ * carries every value the wire format allows including the ones only the
+ * server ever originates (`import`, `seed_example`, `unknown`). Structural
+ * typing bridges the two where a request body is built.
+ */
+export interface VoteProvenance {
+  flow?: VoteFlow;
+  /** Autopilot phase; only meaningful when `flow` is `autopilot`. */
+  phase?: 'good' | 'bad' | 'hard' | 'new';
+  /** How the item was drawn off the ranking. */
+  select_mode?: 'top' | 'hard' | 'new';
+  /** Which ranking the user was looking at. */
+  sort_kind?: 'learned' | 'text' | 'load';
+  /** Zero-based position in that ranking. */
+  rank_at_vote?: number;
+  /** The item's model score when it was surfaced. */
+  score_at_vote?: number;
+}
+
+/**
+ * Assembles the {@link VoteProvenance} for a vote from the state that already
+ * describes it.
+ *
+ * This is a single chokepoint on purpose. Every component vote funnels through
+ * `VoteStateService`, which calls this — so no vote surface has to remember to
+ * describe itself, and a new one is annotated correctly by default rather than
+ * silently recording `unknown`.
+ *
+ * The four categorical fields are independent axes rather than one fused enum
+ * (see the Python module for why): `flow` says who was driving, `select_mode`
+ * says how the item was drawn off the ranking, and those two genuinely come
+ * apart — a user can pick the `hard` select mode by hand and get autopilot's
+ * exact margin-sampled draw.
+ */
+@Injectable({ providedIn: 'root' })
+export class VoteProvenanceService {
+  private readonly autopilot = inject(AutopilotStateService);
+  private readonly sortState = inject(SortStateService);
+
+  /**
+   * Describe how *mediaId* was surfaced.
+   *
+   * @param mediaId  The media being voted on; used to look up its rank and
+   *                 score in the ranking currently on screen.
+   * @param flow     Overrides the derived flow for a surface that knows better
+   *                 than the autopilot/sort state can tell (a Find-mode
+   *                 verify, a bulk action, an undo replay).
+   */
+  forVote(mediaId: number, flow?: VoteFlow): VoteProvenance {
+    const provenance: VoteProvenance = {};
+
+    const phase = this.autopilot.state.phase;
+    const labelingPhase =
+      phase === 'good' || phase === 'bad' || phase === 'hard' || phase === 'new' ? phase : null;
+
+    // Autopilot only claims the vote while it is actually surfacing items. Its
+    // `done` / `exhausted` states leave the user labeling off the last sort by
+    // hand, which is list review whatever the panel still says.
+    provenance.flow = flow ?? (labelingPhase ? 'autopilot' : 'list_review');
+    if (provenance.flow === 'autopilot' && labelingPhase) provenance.phase = labelingPhase;
+
+    provenance.select_mode = this.sortState.selectMode;
+    provenance.sort_kind = this.sortState.sortMode;
+
+    const order = this.sortState.sortOrder;
+    if (order) {
+      // The loaded window always starts at rank 0 and grows by appending
+      // pages, so the index into it is the true rank in the full ranking.
+      const rank = order.findIndex((item) => item.id === mediaId);
+      if (rank >= 0) {
+        provenance.rank_at_vote = rank;
+        const score = order[rank].score;
+        if (Number.isFinite(score)) provenance.score_at_vote = score;
+      }
+    }
+
+    return provenance;
+  }
+}

--- a/frontend/src/app/services/vote-state.service.spec.ts
+++ b/frontend/src/app/services/vote-state.service.spec.ts
@@ -3,6 +3,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 
 import { VoteStateService } from './vote-state.service';
 import { provideHttpTesting } from '../testing/test-providers';
+import { voteBodyWithoutProvenance } from '../testing/mocks';
 
 describe('VoteStateService', () => {
   let service: VoteStateService;
@@ -237,11 +238,52 @@ describe('VoteStateService', () => {
     });
   });
 
+  describe('vote surfacing provenance', () => {
+    /**
+     * Every component vote funnels through this service, which is why the
+     * provenance is attached here rather than at each call site: a new vote
+     * surface is annotated correctly by default instead of silently
+     * recording nothing.
+     */
+    it('attaches provenance to every vote', () => {
+      service.submitToggleVote(5, 'good').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body.provenance).toEqual(
+        expect.objectContaining({ flow: 'list_review' }),
+      );
+      req.flush({ ok: true, state: 'good', click_time: 1 });
+    });
+
+    it('lets a caller override the flow', () => {
+      service.submitToggleVote(5, 'good', null, 'find_verify').subscribe();
+      const req = httpMock.expectOne('/api/medias/5/vote');
+      expect(req.request.body.provenance.flow).toBe('find_verify');
+      req.flush({ ok: true, state: 'good', click_time: 1 });
+    });
+
+    it('marks undo and redo as replays, not fresh surfacings', () => {
+      // Recording the live sort position on an undo would attribute the
+      // restored state to a ranking that had nothing to do with it.
+      service.recordVote(5, 'good', 'a.wav');
+      service.applyOptimisticState(5, 'good');
+
+      service.undo();
+      const undoReq = httpMock.expectOne('/api/medias/5/vote');
+      expect(undoReq.request.body.provenance).toEqual({ flow: 'undo' });
+      undoReq.flush({ ok: true, state: 'none', click_time: null });
+
+      service.redo();
+      const redoReq = httpMock.expectOne('/api/medias/5/vote');
+      expect(redoReq.request.body.provenance).toEqual({ flow: 'undo' });
+      redoReq.flush({ ok: true, state: 'good', click_time: 2 });
+    });
+  });
+
   describe('submitToggleVote (the H1 fix surface)', () => {
     it('posts absolute target=good when clicking good on an unvoted media', () => {
       service.submitToggleVote(5, 'good').subscribe();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good' });
       req.flush({ ok: true, state: 'good', click_time: 1 });
       expect(service.goodVotes.has(5)).toBe(true);
     });
@@ -250,7 +292,7 @@ describe('VoteStateService', () => {
       service.applyOptimisticState(5, 'good');
       service.submitToggleVote(5, 'good').subscribe();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'none' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'none' });
       req.flush({ ok: true, state: 'none', click_time: null });
       expect(service.goodVotes.has(5)).toBe(false);
       expect(service.clickTimes['5']).toBeUndefined();
@@ -260,7 +302,7 @@ describe('VoteStateService', () => {
       service.applyOptimisticState(5, 'good');
       service.submitToggleVote(5, 'bad').subscribe();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'bad' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'bad' });
       req.flush({ ok: true, state: 'bad', click_time: 2 });
       expect(service.badVotes.has(5)).toBe(true);
       expect(service.goodVotes.has(5)).toBe(false);
@@ -269,13 +311,13 @@ describe('VoteStateService', () => {
     it('honours region_box only when the computed target is good', () => {
       service.submitToggleVote(5, 'good', [0.1, 0.2, 0.3, 0.4]).subscribe();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
       req.flush({ ok: true, state: 'good', click_time: 1 });
 
       // Click good again → target=none, region_box must be omitted.
       service.submitToggleVote(5, 'good', [0.1, 0.2, 0.3, 0.4]).subscribe();
       const req2 = httpMock.expectOne('/api/medias/5/vote');
-      expect(req2.request.body).toEqual({ target: 'none' });
+      expect(voteBodyWithoutProvenance(req2)).toEqual({ target: 'none' });
       req2.flush({ ok: true, state: 'none', click_time: null });
     });
 
@@ -337,7 +379,7 @@ describe('VoteStateService', () => {
       // state lines up with the server.
       service.submitToggleVote(5, 'good').subscribe();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good' });
       req.flush({ ok: true, state: 'good', click_time: 42 });
 
       expect(service.goodVotes.has(5)).toBe(true);
@@ -461,7 +503,7 @@ describe('VoteStateService', () => {
       service.undo();
       // The inverse target is the saved previousPolarity ('good').
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good' });
       req.flush({ ok: true, state: 'good', click_time: 1 });
 
       expect(service.canRedo()).toBe(true);
@@ -474,7 +516,7 @@ describe('VoteStateService', () => {
 
       service.undo();
       const req = httpMock.expectOne('/api/medias/7/vote');
-      expect(req.request.body).toEqual({ target: 'none' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'none' });
       req.flush({ ok: true, state: 'none', click_time: null });
     });
 
@@ -489,7 +531,7 @@ describe('VoteStateService', () => {
 
       service.redo();
       const req = httpMock.expectOne('/api/medias/7/vote');
-      expect(req.request.body).toEqual({ target: 'bad' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'bad' });
       req.flush({ ok: true, state: 'bad', click_time: 2 });
 
       expect(service.canRedo()).toBe(false);
@@ -595,7 +637,7 @@ describe('VoteStateService', () => {
       // flood-filled 'good' as a human label (issue #2922).
       service.undo();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'none' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'none' });
       req.flush({ ok: true, state: 'none', click_time: null });
 
       // ...and the left/right split follows immediately, without a poll.
@@ -622,7 +664,7 @@ describe('VoteStateService', () => {
       // previousPolarity that was really the detector's presumption.
       service.redo();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good' });
       req.flush({ ok: true, state: 'good', click_time: 2 });
       expect(service.verifiedIds.has(5)).toBe(true);
     });
@@ -634,14 +676,14 @@ describe('VoteStateService', () => {
       // Clicking Good again un-votes it, which un-verifies it too.
       service.submitToggleVoteAndRecord(5, 'good', 'foo.wav').subscribe();
       const off = httpMock.expectOne('/api/medias/5/vote');
-      expect(off.request.body).toEqual({ target: 'none' });
+      expect(voteBodyWithoutProvenance(off)).toEqual({ target: 'none' });
       off.flush({ ok: true, state: 'none', click_time: null });
       verifyLikeFindView(5);
       expect(service.verifiedIds.has(5)).toBe(false);
 
       service.undo();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good' });
       req.flush({ ok: true, state: 'good', click_time: 2 });
       expect(service.verifiedIds.has(5)).toBe(true);
     });
@@ -703,7 +745,7 @@ describe('VoteStateService', () => {
       // the click, NOT the polarity that the optimistic flip put us in).
       service.undo();
       const undoReq = httpMock.expectOne('/api/medias/5/vote');
-      expect(undoReq.request.body).toEqual({ target: 'good' });
+      expect(voteBodyWithoutProvenance(undoReq)).toEqual({ target: 'good' });
       undoReq.flush({ ok: true, state: 'good', click_time: 3 });
     });
 
@@ -745,7 +787,7 @@ describe('VoteStateService', () => {
         .submitToggleVoteAndRecord(5, 'good', 'foo.wav', [0.1, 0.2, 0.3, 0.4])
         .subscribe();
       const req = httpMock.expectOne('/api/medias/5/vote');
-      expect(req.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
+      expect(voteBodyWithoutProvenance(req)).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
       req.flush({ ok: true, state: 'good', click_time: 1 });
     });
 
@@ -765,7 +807,7 @@ describe('VoteStateService', () => {
       // Redo must restore the original crop, not POST a box-less good vote.
       service.redo();
       const redoReq = httpMock.expectOne('/api/medias/5/vote');
-      expect(redoReq.request.body).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
+      expect(voteBodyWithoutProvenance(redoReq)).toEqual({ target: 'good', region_box: [0.1, 0.2, 0.3, 0.4] });
       redoReq.flush({ ok: true, state: 'good', click_time: 2 });
       expect(service.goodRegionBoxes['5']).toEqual([0.1, 0.2, 0.3, 0.4]);
     });
@@ -786,7 +828,7 @@ describe('VoteStateService', () => {
       // Undo must restore the prior crop, not drop it.
       service.undo();
       const undoReq = httpMock.expectOne('/api/medias/5/vote');
-      expect(undoReq.request.body).toEqual({ target: 'good', region_box: [0.5, 0.6, 0.7, 0.8] });
+      expect(voteBodyWithoutProvenance(undoReq)).toEqual({ target: 'good', region_box: [0.5, 0.6, 0.7, 0.8] });
       undoReq.flush({ ok: true, state: 'good', click_time: 2 });
       expect(service.goodRegionBoxes['5']).toEqual([0.5, 0.6, 0.7, 0.8]);
     });

--- a/frontend/src/app/services/vote-state.service.ts
+++ b/frontend/src/app/services/vote-state.service.ts
@@ -7,6 +7,7 @@ import { VotesResponse } from '../generated/api-client/models/votes-response';
 import { adaptivePoll } from './adaptive-poll';
 import { MediasApiService } from './medias-api.service';
 import { SortingApiService } from './sorting-api.service';
+import { VoteFlow, VoteProvenanceService } from './vote-provenance.service';
 
 /**
  * One vote captured for Cmd/Ctrl-Z undo.  `previousPolarity` is the polarity
@@ -63,6 +64,7 @@ const UNDO_STACK_MAX = 20;
 export class VoteStateService implements OnDestroy {
   private sortingApi = inject(SortingApiService);
   private mediasApi = inject(MediasApiService);
+  private provenance = inject(VoteProvenanceService);
 
   private readonly _goodVotes = signal<Set<number>>(new Set());
   private readonly _badVotes = signal<Set<number>>(new Set());
@@ -306,17 +308,26 @@ export class VoteStateService implements OnDestroy {
    *
    * @param regionBox  Optional good-vote region.  Honoured only when the
    *                   computed target is ``'good'``.
+   * @param flow       Overrides the derived surfacing flow for a caller that
+   *                   knows better than autopilot/sort state can tell (a Find
+   *                   verify, an undo replay).  Every other surface gets a
+   *                   correct annotation for free by funnelling through here.
    */
   submitToggleVote(
     id: number,
     clickedDirection: 'good' | 'bad',
     regionBox?: readonly number[] | null,
+    flow?: VoteFlow,
   ): Observable<MediaVoteResponse> {
     const target = this.toggleTargetFor(id, clickedDirection);
     this.applyOptimisticState(id, target);
     const effectiveBox = target === 'good' && regionBox && regionBox.length === 4 ? regionBox : null;
     this.applyOptimisticRegionBox(id, effectiveBox);
-    return this.mediasApi.vote(id, target, effectiveBox).pipe(
+    // Read before the request goes out: the sort the user was looking at can
+    // be replaced by a retrain while the POST is in flight, and the rank we
+    // want is the one that was on screen when they clicked.
+    const provenance = this.provenance.forVote(id, flow);
+    return this.mediasApi.vote(id, target, effectiveBox, provenance).pipe(
       tap({
         next: (resp) => this.reconcileVoteResponse(id, resp),
         // A failed POST means the server never saw the vote. Without the
@@ -361,12 +372,13 @@ export class VoteStateService implements OnDestroy {
     clickedDirection: 'good' | 'bad',
     mediaName: string,
     regionBox?: readonly number[] | null,
+    flow?: VoteFlow,
   ): Observable<MediaVoteResponse> {
     const { previousPolarity, previousRegionBox } = this.capturePrevious(id);
     const target = this.toggleTargetFor(id, clickedDirection);
     const clickedRegionBox =
       target === 'good' && regionBox && regionBox.length === 4 ? [...regionBox] : null;
-    return this.submitToggleVote(id, clickedDirection, regionBox).pipe(
+    return this.submitToggleVote(id, clickedDirection, regionBox, flow).pipe(
       tap(() => {
         this.past.push({
           mediaId: id,
@@ -603,7 +615,10 @@ export class VoteStateService implements OnDestroy {
     this.applyOptimisticState(entry.mediaId, target);
     this.applyOptimisticRegionBox(entry.mediaId, box);
     this.mirrorVerified(entry.mediaId, target);
-    this.mediasApi.vote(entry.mediaId, target, box).subscribe({
+    // An undo is a correction, not a fresh surfacing: recording the current
+    // sort position would attribute the restored state to a ranking that had
+    // nothing to do with it.
+    this.mediasApi.vote(entry.mediaId, target, box, { flow: 'undo' }).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       // rollbackOptimistic (not a bare loadVotes): the pending entries set
       // by the optimistic apply above would override the reloaded server
@@ -628,7 +643,8 @@ export class VoteStateService implements OnDestroy {
     this.applyOptimisticState(entry.mediaId, target);
     this.applyOptimisticRegionBox(entry.mediaId, box);
     this.mirrorVerified(entry.mediaId, target);
-    this.mediasApi.vote(entry.mediaId, target, box).subscribe({
+    // See undo(): a replay off the stack is not a surfacing event.
+    this.mediasApi.vote(entry.mediaId, target, box, { flow: 'undo' }).subscribe({
       next: (resp) => this.reconcileVoteResponse(entry.mediaId, resp),
       // See undo(): drop the pending entries before reloading server state.
       error: () => this.rollbackOptimistic(entry.mediaId),

--- a/frontend/src/app/testing/mocks.ts
+++ b/frontend/src/app/testing/mocks.ts
@@ -53,3 +53,22 @@ export function makeSettingsStateStub(overrides: Partial<SettingsStateService> =
   };
   return { stub, settings };
 }
+
+
+/**
+ * A vote request's body with its ``provenance`` block removed.
+ *
+ * Every vote now carries surfacing provenance assembled by
+ * ``VoteProvenanceService`` from whatever sort/autopilot state is live, so a
+ * spec asserting *which target was sent* would otherwise have to restate that
+ * whole block — and would then be re-edited every time an unrelated default
+ * moved. The provenance itself is asserted on its own, in
+ * ``vote-provenance.service.spec.ts`` and the vote-state provenance tests;
+ * everything else stays as strict as it was, including "no ``region_box`` was
+ * sent".
+ */
+export function voteBodyWithoutProvenance(req: { request: { body: unknown } }): unknown {
+  const body = req.request.body as Record<string, unknown>;
+  const { provenance: _provenance, ...rest } = body;
+  return rest;
+}

--- a/tests/api/test_vote_provenance_api.py
+++ b/tests/api/test_vote_provenance_api.py
@@ -14,7 +14,13 @@ exactly like a legacy vote to any later analysis.
 
 from __future__ import annotations
 
+import shutil
+
+import pytest
+
+from tests import load_detector_and_wait
 from vtscore.datasets.vote_provenance import METADATA_KEY
+from vtscore.detectors.store import _detector_path, _read_detector
 from vtsearch.state import bad_votes, good_votes
 
 FULL = {
@@ -213,3 +219,88 @@ class TestDetectorLabelVoteRoute:
             assert resp.status_code == 422
         finally:
             path.unlink(missing_ok=True)
+
+
+class TestPersistenceThroughTheLoadedDetector:
+    """The real write chain: vote -> ``sync_labels_to_loaded_detector`` -> disk.
+
+    The per-route tests above stop at in-memory vote state. This one goes the
+    whole way, because the in-memory half is not the part that can silently
+    fail: the labelset is *rebuilt from live votes on every vote*, so a break
+    anywhere in the compose/restore chain shows up as provenance that looks
+    recorded and is gone by the next click.
+    """
+
+    @pytest.fixture(autouse=True)
+    def clean_detectors_dir(self):
+        """Detectors live on disk, so each test starts and ends with none."""
+        from vtsearch.settings import get_detectors_dir
+
+        def _wipe():
+            d = get_detectors_dir()
+            if d.is_dir():
+                shutil.rmtree(d)
+
+        _wipe()
+        yield
+        _wipe()
+
+    def _loaded_detector(self, client, name: str) -> str:
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": name, "media_type": "audio", "text_query": "t"},
+        )
+        assert res.status_code in (200, 201), res.get_data(as_text=True)
+        detector_id = res.get_json()["detector"]["id"]
+        load_detector_and_wait(client, detector_id)
+        return detector_id
+
+    def _labels(self, name: str) -> list[dict]:
+        data = _read_detector(_detector_path(name))
+        assert data is not None
+        return data["labelset"]["labels"]
+
+    def test_a_vote_writes_its_provenance_into_the_detector_json(self, client):
+        from vtsearch.state import medias
+
+        if not medias:
+            pytest.skip("No medias loaded")
+        media_id = next(iter(medias))
+        self._loaded_detector(client, "ProvSync")
+
+        resp = client.post(
+            f"/api/medias/{media_id}/vote",
+            json={"target": "good", "provenance": FULL},
+        )
+        assert resp.status_code == 200
+
+        labels = self._labels("ProvSync")
+        assert len(labels) == 1
+        assert labels[0]["metadata"][METADATA_KEY] == {"v": 1, **FULL}
+
+    def test_a_second_vote_does_not_erase_the_first_ones_record(self, client):
+        """The erasure hazard, end to end.
+
+        Voting media B rewrites the whole labelset from live vote state, so if
+        anything in the chain dropped A's provenance, A's record would vanish
+        on B's click while looking perfectly fine until then.
+        """
+        from vtsearch.state import medias
+
+        if len(medias) < 2:
+            pytest.skip("Need two medias")
+        first, second = list(medias)[:2]
+        self._loaded_detector(client, "ProvSync2")
+
+        client.post(
+            f"/api/medias/{first}/vote",
+            json={"target": "good", "provenance": {"flow": "autopilot", "phase": "hard"}},
+        )
+        client.post(
+            f"/api/medias/{second}/vote",
+            json={"target": "bad", "provenance": {"flow": "list_review", "rank_at_vote": 2}},
+        )
+
+        by_md5 = {el["md5"]: el for el in self._labels("ProvSync2")}
+        assert by_md5[medias[first]["md5"]]["metadata"][METADATA_KEY]["phase"] == "hard"
+        assert by_md5[medias[second]["md5"]]["metadata"][METADATA_KEY]["rank_at_vote"] == 2

--- a/tests/api/test_vote_provenance_api.py
+++ b/tests/api/test_vote_provenance_api.py
@@ -1,0 +1,203 @@
+"""API surface for vote surfacing provenance (issue #2850).
+
+The three vote routes accept an optional ``provenance`` block, validate it
+against the closed vocabulary in :mod:`vtscore.datasets.vote_provenance`, and
+persist it into the detector's labelset.  Nothing reads it back to change
+behaviour — this is the recording slice only.
+
+The schemas use ``unknown = "exclude"``, so an unrecognised *key* is silently
+dropped by design (the frontend is allowed to attach advisory keys).  An
+unrecognised *value* for a key we do declare is a different matter and must be
+rejected: a typo'd ``surfaced_by`` silently stored as nothing would look
+exactly like a legacy vote to any later analysis.
+"""
+
+from __future__ import annotations
+
+from vtscore.datasets.vote_provenance import METADATA_KEY
+from vtsearch.state import bad_votes, good_votes
+
+FULL = {
+    "flow": "list_review",
+    "select_mode": "hard",
+    "sort_kind": "learned",
+    "rank_at_vote": 12,
+    "score_at_vote": 0.44,
+}
+
+
+def _recorded(media_id: int) -> dict | None:
+    from vtscore.state import get_active_detector_context
+
+    return get_active_detector_context().vote_provenance.get(media_id)
+
+
+class TestSingleVoteRoute:
+    """``POST /api/medias/<id>/vote``."""
+
+    def test_provenance_is_recorded(self, client):
+        resp = client.post("/api/medias/1/vote", json={"target": "good", "provenance": FULL})
+        assert resp.status_code == 200
+        assert 1 in good_votes
+        assert _recorded(1) == {"v": 1, **FULL}
+
+    def test_vote_without_provenance_still_works(self, client):
+        """Every existing client keeps working, and records nothing."""
+        resp = client.post("/api/medias/1/vote", json={"target": "good"})
+        assert resp.status_code == 200
+        assert _recorded(1) is None
+
+    def test_unknown_flow_value_is_rejected(self, client):
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "provenance": {"flow": "toplist"}},
+        )
+        assert resp.status_code == 422
+        assert 1 not in good_votes
+
+    def test_unknown_select_mode_is_rejected(self, client):
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "provenance": {"select_mode": "margin"}},
+        )
+        assert resp.status_code == 422
+
+    def test_negative_rank_is_rejected(self, client):
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "provenance": {"rank_at_vote": -3}},
+        )
+        assert resp.status_code == 422
+
+    def test_idempotent_revote_does_not_overwrite(self, client):
+        """A stale tab re-asserting the current target made no surfacing
+        event, so it must not rewrite the first click's record."""
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "provenance": {"flow": "autopilot", "phase": "hard"}},
+        )
+        resp = client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "provenance": {"flow": "list_review"}},
+        )
+        assert resp.status_code == 200
+        assert _recorded(1)["flow"] == "autopilot"
+
+    def test_a_flip_records_the_new_context(self, client):
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "good", "provenance": {"flow": "autopilot", "phase": "hard"}},
+        )
+        client.post(
+            "/api/medias/1/vote",
+            json={"target": "bad", "provenance": {"flow": "list_review"}},
+        )
+        assert 1 in bad_votes
+        assert _recorded(1)["flow"] == "list_review"
+
+    def test_unvote_clears_the_record(self, client):
+        client.post("/api/medias/1/vote", json={"target": "good", "provenance": FULL})
+        client.post("/api/medias/1/vote", json={"target": "none"})
+        assert _recorded(1) is None
+
+    def test_provenance_reaches_the_exported_labelset(self, client):
+        client.post("/api/medias/1/vote", json={"target": "good", "provenance": FULL})
+        resp = client.get("/api/labels/export")
+        assert resp.status_code == 200
+        labels = resp.get_json()["labels"]
+        recorded = [el for el in labels if (el.get("metadata") or {}).get(METADATA_KEY)]
+        assert len(recorded) == 1
+        assert recorded[0]["metadata"][METADATA_KEY]["rank_at_vote"] == 12
+
+
+class TestBulkVoteRoute:
+    """``POST /api/medias/vote-bulk``."""
+
+    def test_defaults_to_the_bulk_flow(self, client):
+        """A batch action over a hand-selected set is its own surfacing flow,
+        and the client never has to say so."""
+        resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 2], "target": "good"})
+        assert resp.status_code == 200
+        assert _recorded(1)["flow"] == "bulk"
+        assert _recorded(2)["flow"] == "bulk"
+
+    def test_explicit_provenance_overrides_the_default(self, client):
+        resp = client.post(
+            "/api/medias/vote-bulk",
+            json={"ids": [1], "target": "good", "provenance": {"flow": "bulk", "sort_kind": "learned"}},
+        )
+        assert resp.status_code == 200
+        assert _recorded(1)["sort_kind"] == "learned"
+
+    def test_unknown_value_is_rejected(self, client):
+        resp = client.post(
+            "/api/medias/vote-bulk",
+            json={"ids": [1], "target": "good", "provenance": {"flow": "nope"}},
+        )
+        assert resp.status_code == 422
+        assert 1 not in good_votes
+
+
+class TestDetectorLabelVoteRoute:
+    """``POST /api/detectors/<name>/labels/<element_id>/vote``."""
+
+    def _detector_with_one_label(self, client):
+        from vtscore.datasets.labelset import LabeledElement, LabelSet
+        from vtscore.detectors.labelset_elements import stable_element_id
+        from vtscore.detectors.store import _detector_path, _write_detector
+
+        from vtsearch.state import medias
+
+        media = medias[1]
+        el = LabeledElement(
+            md5=media["md5"],
+            label="good",
+            origin=media.get("origin"),
+            origin_name=media.get("origin_name", ""),
+            filename=media.get("filename", ""),
+        )
+        path = _detector_path("prov-test")
+        _write_detector(path, {"name": "prov-test", "labelset": LabelSet([el]).to_dict()})
+        return "prov-test", stable_element_id(el), path
+
+    def test_a_flip_defaults_to_labelset_review(self, client):
+        """This surface reviews already-saved labels; it is not a draw off any
+        ranking, so it gets its own flow rather than borrowing ``list_review``."""
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.store import _read_detector
+
+        name, element_id, path = self._detector_with_one_label(client)
+        try:
+            resp = client.post(f"/api/detectors/{name}/labels/{element_id}/vote", json={"target": "bad"})
+            assert resp.status_code == 200
+            assert resp.get_json()["action"] == "flipped"
+
+            stored = LabelSet.from_dict(_read_detector(path)["labelset"]).elements[0]
+            assert stored.label == "bad"
+            assert stored.metadata[METADATA_KEY]["flow"] == "labelset_review"
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_an_unchanged_reassert_writes_nothing(self, client):
+        from vtscore.datasets.labelset import LabelSet
+        from vtscore.detectors.store import _read_detector
+
+        name, element_id, path = self._detector_with_one_label(client)
+        try:
+            resp = client.post(f"/api/detectors/{name}/labels/{element_id}/vote", json={"target": "good"})
+            assert resp.get_json()["action"] == "unchanged"
+            stored = LabelSet.from_dict(_read_detector(path)["labelset"]).elements[0]
+            assert stored.metadata is None
+        finally:
+            path.unlink(missing_ok=True)
+
+    def test_unknown_value_is_rejected(self, client):
+        name, element_id, path = self._detector_with_one_label(client)
+        try:
+            resp = client.post(
+                f"/api/detectors/{name}/labels/{element_id}/vote",
+                json={"target": "bad", "provenance": {"phase": "idle"}},
+            )
+            assert resp.status_code == 422
+        finally:
+            path.unlink(missing_ok=True)

--- a/tests/api/test_vote_provenance_api.py
+++ b/tests/api/test_vote_provenance_api.py
@@ -32,6 +32,13 @@ def _recorded(media_id: int) -> dict | None:
     return get_active_detector_context().vote_provenance.get(media_id)
 
 
+def _must_record(media_id: int) -> dict:
+    """:func:`_recorded` narrowed to a non-``None`` result."""
+    out = _recorded(media_id)
+    assert out is not None, f"no provenance recorded for media {media_id}"
+    return out
+
+
 class TestSingleVoteRoute:
     """``POST /api/medias/<id>/vote``."""
 
@@ -81,7 +88,7 @@ class TestSingleVoteRoute:
             json={"target": "good", "provenance": {"flow": "list_review"}},
         )
         assert resp.status_code == 200
-        assert _recorded(1)["flow"] == "autopilot"
+        assert _must_record(1)["flow"] == "autopilot"
 
     def test_a_flip_records_the_new_context(self, client):
         client.post(
@@ -93,7 +100,7 @@ class TestSingleVoteRoute:
             json={"target": "bad", "provenance": {"flow": "list_review"}},
         )
         assert 1 in bad_votes
-        assert _recorded(1)["flow"] == "list_review"
+        assert _must_record(1)["flow"] == "list_review"
 
     def test_unvote_clears_the_record(self, client):
         client.post("/api/medias/1/vote", json={"target": "good", "provenance": FULL})
@@ -118,8 +125,8 @@ class TestBulkVoteRoute:
         and the client never has to say so."""
         resp = client.post("/api/medias/vote-bulk", json={"ids": [1, 2], "target": "good"})
         assert resp.status_code == 200
-        assert _recorded(1)["flow"] == "bulk"
-        assert _recorded(2)["flow"] == "bulk"
+        assert _must_record(1)["flow"] == "bulk"
+        assert _must_record(2)["flow"] == "bulk"
 
     def test_explicit_provenance_overrides_the_default(self, client):
         resp = client.post(
@@ -127,7 +134,7 @@ class TestBulkVoteRoute:
             json={"ids": [1], "target": "good", "provenance": {"flow": "bulk", "sort_kind": "learned"}},
         )
         assert resp.status_code == 200
-        assert _recorded(1)["sort_kind"] == "learned"
+        assert _must_record(1)["sort_kind"] == "learned"
 
     def test_unknown_value_is_rejected(self, client):
         resp = client.post(
@@ -172,8 +179,11 @@ class TestDetectorLabelVoteRoute:
             assert resp.status_code == 200
             assert resp.get_json()["action"] == "flipped"
 
-            stored = LabelSet.from_dict(_read_detector(path)["labelset"]).elements[0]
+            payload = _read_detector(path)
+            assert payload is not None
+            stored = LabelSet.from_dict(payload["labelset"]).elements[0]
             assert stored.label == "bad"
+            assert stored.metadata is not None
             assert stored.metadata[METADATA_KEY]["flow"] == "labelset_review"
         finally:
             path.unlink(missing_ok=True)
@@ -186,7 +196,9 @@ class TestDetectorLabelVoteRoute:
         try:
             resp = client.post(f"/api/detectors/{name}/labels/{element_id}/vote", json={"target": "good"})
             assert resp.get_json()["action"] == "unchanged"
-            stored = LabelSet.from_dict(_read_detector(path)["labelset"]).elements[0]
+            payload = _read_detector(path)
+            assert payload is not None
+            stored = LabelSet.from_dict(payload["labelset"]).elements[0]
             assert stored.metadata is None
         finally:
             path.unlink(missing_ok=True)

--- a/tests_lib/detectors/test_vote_provenance.py
+++ b/tests_lib/detectors/test_vote_provenance.py
@@ -41,6 +41,26 @@ FULL = {
 }
 
 
+def _norm(raw) -> dict:
+    """:func:`normalize_provenance` narrowed to a non-``None`` result."""
+    out = normalize_provenance(raw)
+    assert out is not None
+    return out
+
+
+def _read(metadata) -> dict:
+    """:func:`read_provenance` narrowed to a non-``None`` result."""
+    out = read_provenance(metadata)
+    assert out is not None
+    return out
+
+
+def _meta(element) -> dict:
+    """An element's metadata, narrowed to a non-``None`` dict."""
+    assert element is not None and element.metadata is not None
+    return element.metadata
+
+
 def _media(cid: int) -> dict:
     return {"md5": f"md5-{cid}", "filename": f"m{cid}.wav", "origin_name": f"m{cid}.wav"}
 
@@ -71,7 +91,7 @@ class TestVocabulary:
         manual_hard = normalize_provenance({"flow": "list_review", "select_mode": "hard"})
         assert manual_hard == {"v": 1, "flow": "list_review", "select_mode": "hard"}
 
-        autopilot_top = normalize_provenance({"flow": "autopilot", "phase": "good", "select_mode": "top"})
+        autopilot_top = _norm({"flow": "autopilot", "phase": "good", "select_mode": "top"})
         assert autopilot_top["phase"] == "good"
         assert autopilot_top["select_mode"] == "top"
 
@@ -80,7 +100,7 @@ class TestVocabulary:
             assert normalize_provenance(raw) is None
 
     def test_phase_is_dropped_off_a_non_autopilot_flow(self):
-        out = normalize_provenance({"flow": "list_review", "phase": "hard"})
+        out = _norm({"flow": "list_review", "phase": "hard"})
         assert "phase" not in out
 
     def test_absent_fields_are_omitted_not_stored_as_null(self):
@@ -117,6 +137,7 @@ class TestVocabulary:
 
     def test_attach_preserves_importer_metadata(self):
         merged = attach_provenance({"contentID": "x"}, {"flow": "autopilot", "phase": "new"})
+        assert merged is not None
         assert merged["contentID"] == "x"
         assert merged[METADATA_KEY]["phase"] == "new"
 
@@ -220,8 +241,8 @@ class TestLabelsetRoundTrip:
             vote_provenance={1: {"v": 1, "flow": "autopilot", "phase": "hard"}, 2: {"v": 1, "flow": "bulk"}},
         )
         by_label = {el.label: el for el in ls.elements}
-        assert by_label["good"].metadata[METADATA_KEY]["phase"] == "hard"
-        assert by_label["bad"].metadata[METADATA_KEY]["flow"] == "bulk"
+        assert _meta(by_label["good"])[METADATA_KEY]["phase"] == "hard"
+        assert _meta(by_label["bad"])[METADATA_KEY]["flow"] == "bulk"
 
     def test_votes_without_provenance_get_no_metadata_key(self):
         ls = LabelSet.from_clips_and_votes({1: _media(1)}, {1: None}, {})
@@ -230,7 +251,7 @@ class TestLabelsetRoundTrip:
     def test_survives_json_round_trip(self):
         ls = LabelSet.from_clips_and_votes({1: _media(1)}, {1: None}, {}, vote_provenance={1: {"v": 1, **FULL}})
         restored = LabelSet.from_dict(ls.to_dict())
-        assert read_provenance(restored.elements[0].metadata) == {"v": SCHEMA_VERSION, **FULL}
+        assert _read(restored.elements[0].metadata) == {"v": SCHEMA_VERSION, **FULL}
 
     def test_dupe_set_members_share_the_representatives_record(self):
         """Same rule as ``region_box``: the representative is what the user was
@@ -250,12 +271,12 @@ class TestLabelsetRoundTrip:
             {1: rep}, {1: None}, {}, vote_provenance={1: {"v": 1, "flow": "autopilot", "phase": "new"}}
         )
         assert len(ls.elements) == 2
-        assert all(read_provenance(el.metadata)["phase"] == "new" for el in ls.elements)
+        assert all(_read(el.metadata)["phase"] == "new" for el in ls.elements)
 
     def test_provenance_does_not_displace_importer_custom_metadata(self):
         media = {**_media(1), "custom_metadata": {"contentID": "abc"}}
         ls = LabelSet.from_clips_and_votes({1: media}, {1: None}, {}, vote_provenance={1: {"v": 1, "flow": "bulk"}})
-        meta = ls.elements[0].metadata
+        meta = _meta(ls.elements[0])
         assert meta["contentID"] == "abc"
         assert meta[METADATA_KEY]["flow"] == "bulk"
 
@@ -263,7 +284,7 @@ class TestLabelsetRoundTrip:
 class TestElementVoteFlip:
     """``apply_element_vote_in_data`` (the dashboard's labelset review)."""
 
-    def _data(self, label: str = "good") -> dict:
+    def _data(self, label: str = "good") -> tuple[dict, str]:
         from vtscore.detectors.labelset_elements import stable_element_id
 
         el = LabeledElement(md5="abc", label=label, origin_name="a.wav", filename="a.wav")
@@ -277,7 +298,8 @@ class TestElementVoteFlip:
             data, eid, "bad", provenance={"v": 1, "flow": "labelset_review"}
         )
         assert (changed, action) == (True, "flipped")
-        assert read_provenance(updated.metadata)["flow"] == "labelset_review"
+        assert updated is not None
+        assert _read(updated.metadata)["flow"] == "labelset_review"
 
     def test_an_idempotent_reassert_leaves_the_record_alone(self):
         from vtscore.detectors.labelset_elements import apply_element_vote_in_data
@@ -337,8 +359,8 @@ class TestRestorationCycle:
             vote_provenance=dict(det.vote_provenance),
         )
         by_md5 = {el.md5: el for el in resynced.elements}
-        assert read_provenance(by_md5[snap[1]["md5"]].metadata)["phase"] == "hard"
-        assert read_provenance(by_md5[snap[2]["md5"]].metadata)["flow"] == "list_review"
+        assert _read(by_md5[snap[1]["md5"]].metadata)["phase"] == "hard"
+        assert _read(by_md5[snap[2]["md5"]].metadata)["flow"] == "list_review"
 
     def test_a_legacy_labelset_restores_without_provenance(self):
         """Elements written before this feature carry none, and must restore

--- a/tests_lib/detectors/test_vote_provenance.py
+++ b/tests_lib/detectors/test_vote_provenance.py
@@ -1,0 +1,291 @@
+"""Vote surfacing provenance: the vocabulary, the state threading, the round-trip.
+
+Recording-only feature (issue #2850): nothing here asserts a behaviour change,
+because there is none.  What these tests protect is that the record is
+*written* and *survives* — the two ways a provenance feature dies silently.
+
+The load-bearing cases:
+
+* an idempotent re-vote must not overwrite an existing record (a stale tab
+  rewriting the context of a click it did not make), and
+* a detector-load restore must carry the record back into vote state, because
+  the labelset is rebuilt from live votes on every single vote — so a restore
+  that dropped it would erase every recorded vote's provenance on the user's
+  next click.  That is exactly the bug ``region_box`` had.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vtscore.datasets.labelset import LabeledElement, LabelSet
+from vtscore.datasets.vote_provenance import (
+    FLOWS,
+    METADATA_KEY,
+    SCHEMA_VERSION,
+    attach_provenance,
+    coerce_provenance,
+    normalize_provenance,
+    read_provenance,
+)
+from vtscore.state import get_active_detector_context
+from vtscore.state.core import get_active_context
+from vtscore.state.votes import apply_label, set_vote
+
+FULL = {
+    "flow": "list_review",
+    "select_mode": "hard",
+    "sort_kind": "learned",
+    "rank_at_vote": 37,
+    "score_at_vote": 0.512,
+}
+
+
+def _media(cid: int) -> dict:
+    return {"md5": f"md5-{cid}", "filename": f"m{cid}.wav", "origin_name": f"m{cid}.wav"}
+
+
+@pytest.fixture
+def one_media():
+    """Register a single media in the active dataset and return its id."""
+    ctx = get_active_context()
+    cid = (max(ctx.medias) if ctx.medias else 0) + 1
+    ctx.medias[cid] = _media(cid)
+    try:
+        yield cid
+    finally:
+        ctx.medias.pop(cid, None)
+
+
+class TestVocabulary:
+    """:mod:`vtscore.datasets.vote_provenance` normalisation."""
+
+    def test_full_payload_round_trips_with_a_schema_version(self):
+        assert normalize_provenance(FULL) == {"v": SCHEMA_VERSION, **FULL}
+
+    def test_axes_are_independent(self):
+        """The whole point of the shape: a hand-picked ``hard`` select mode
+        outside autopilot is recordable, and so is autopilot's top-of-list
+        ``good`` phase.  A fused ``autopilot:hard`` enum could express
+        neither."""
+        manual_hard = normalize_provenance({"flow": "list_review", "select_mode": "hard"})
+        assert manual_hard == {"v": 1, "flow": "list_review", "select_mode": "hard"}
+
+        autopilot_top = normalize_provenance({"flow": "autopilot", "phase": "good", "select_mode": "top"})
+        assert autopilot_top["phase"] == "good"
+        assert autopilot_top["select_mode"] == "top"
+
+    def test_empty_and_contentless_payloads_are_dropped(self):
+        for raw in (None, {}, {"flow": "unknown"}):
+            assert normalize_provenance(raw) is None
+
+    def test_phase_is_dropped_off_a_non_autopilot_flow(self):
+        out = normalize_provenance({"flow": "list_review", "phase": "hard"})
+        assert "phase" not in out
+
+    def test_absent_fields_are_omitted_not_stored_as_null(self):
+        out = normalize_provenance({"flow": "bulk"})
+        assert out == {"v": SCHEMA_VERSION, "flow": "bulk"}
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            {"flow": "nope"},
+            {"phase": "idle"},
+            {"select_mode": "toplist"},
+            {"sort_kind": "cosine"},
+            {"surfaced_by": "autopilot:hard"},
+            {"rank_at_vote": -1},
+            {"rank_at_vote": 1.5},
+            {"rank_at_vote": True},
+            {"score_at_vote": float("nan")},
+            {"score_at_vote": float("inf")},
+            "not a dict",
+        ],
+    )
+    def test_malformed_payloads_are_rejected(self, raw):
+        with pytest.raises(ValueError):
+            normalize_provenance(raw)
+
+    def test_coerce_never_raises(self):
+        """Payloads off disk get dropped, not repaired: a half-understood
+        record is worse than none, because a calibration partition would
+        trust it."""
+        assert coerce_provenance({"flow": "nope"}) is None
+        assert coerce_provenance("garbage") is None
+        assert coerce_provenance(FULL) == {"v": SCHEMA_VERSION, **FULL}
+
+    def test_attach_preserves_importer_metadata(self):
+        merged = attach_provenance({"contentID": "x"}, {"flow": "autopilot", "phase": "new"})
+        assert merged["contentID"] == "x"
+        assert merged[METADATA_KEY]["phase"] == "new"
+
+    def test_attach_is_a_no_op_without_provenance(self):
+        """A build that records nothing must emit a byte-identical labelset."""
+        assert attach_provenance({"contentID": "x"}, None) == {"contentID": "x"}
+        assert attach_provenance(None, None) is None
+
+    def test_attach_does_not_mutate_the_callers_dict(self):
+        """``hit_custom_metadata`` output is shared across every element built
+        from one media, so mutating it would leak one vote's context onto
+        another's element."""
+        original = {"contentID": "x"}
+        attach_provenance(original, {"flow": "bulk"})
+        assert original == {"contentID": "x"}
+
+    def test_read_provenance_tolerates_missing_metadata(self):
+        assert read_provenance(None) is None
+        assert read_provenance({}) is None
+        assert read_provenance({METADATA_KEY: {"flow": "bogus"}}) is None
+
+    def test_flow_vocabulary_is_closed(self):
+        """A new flow value is a wire-format change; adding one should be a
+        deliberate edit here as well as in the module."""
+        assert FLOWS == {
+            "autopilot",
+            "list_review",
+            "find_verify",
+            "labelset_review",
+            "seed_example",
+            "import",
+            "bulk",
+            "undo",
+            "unknown",
+        }
+
+
+class TestVoteStateThreading:
+    """``set_vote`` / ``apply_label`` record into ``ctx.vote_provenance``."""
+
+    def test_set_vote_records_provenance(self, one_media):
+        set_vote(one_media, "good", provenance=FULL)
+        assert get_active_detector_context().vote_provenance[one_media] == {
+            "v": SCHEMA_VERSION,
+            **FULL,
+        }
+
+    def test_bad_votes_carry_provenance_too(self, one_media):
+        """The surfacing context is just as real for a no-vote, and the
+        calibration set the recording exists for is built from both sides."""
+        set_vote(one_media, "bad", provenance={"flow": "autopilot", "phase": "hard"})
+        assert get_active_detector_context().vote_provenance[one_media]["phase"] == "hard"
+
+    def test_idempotent_revote_does_not_overwrite(self, one_media):
+        """The audit-H1 rule extended to provenance: a stale tab re-sending the
+        target a media already holds made no surfacing event, so it must not
+        rewrite the record the original click left."""
+        set_vote(one_media, "good", provenance={"flow": "autopilot", "phase": "hard"})
+        set_vote(one_media, "good", provenance={"flow": "list_review"})
+        recorded = get_active_detector_context().vote_provenance[one_media]
+        assert recorded["flow"] == "autopilot"
+        assert recorded["phase"] == "hard"
+
+    def test_a_real_flip_does_overwrite(self, one_media):
+        """A good→bad flip *is* a new surfacing event."""
+        set_vote(one_media, "good", provenance={"flow": "autopilot", "phase": "hard"})
+        set_vote(one_media, "bad", provenance={"flow": "list_review"})
+        assert get_active_detector_context().vote_provenance[one_media]["flow"] == "list_review"
+
+    def test_unvote_clears_provenance(self, one_media):
+        set_vote(one_media, "good", provenance=FULL)
+        set_vote(one_media, "none")
+        assert one_media not in get_active_detector_context().vote_provenance
+
+    def test_a_vote_without_provenance_clears_a_stale_record(self, one_media):
+        """The new vote was surfaced somehow; keeping the previous vote's
+        context would attribute it to a flow that did not produce it."""
+        set_vote(one_media, "good", provenance={"flow": "autopilot", "phase": "hard"})
+        set_vote(one_media, "bad")
+        assert one_media not in get_active_detector_context().vote_provenance
+
+    def test_malformed_provenance_is_dropped_not_raised(self, one_media):
+        """The state layer coerces; rejection belongs at the request boundary."""
+        set_vote(one_media, "good", provenance={"flow": "nope"})
+        assert one_media not in get_active_detector_context().vote_provenance
+
+    def test_apply_label_records_provenance(self, one_media):
+        apply_label(one_media, "good", provenance={"flow": "seed_example"})
+        assert get_active_detector_context().vote_provenance[one_media]["flow"] == "seed_example"
+
+
+class TestLabelsetRoundTrip:
+    """Provenance survives composition, serialisation, and re-parse."""
+
+    def test_from_clips_and_votes_writes_the_namespaced_key(self):
+        medias = {1: _media(1), 2: _media(2)}
+        ls = LabelSet.from_clips_and_votes(
+            medias,
+            {1: None},
+            {2: None},
+            vote_provenance={1: {"v": 1, "flow": "autopilot", "phase": "hard"}, 2: {"v": 1, "flow": "bulk"}},
+        )
+        by_label = {el.label: el for el in ls.elements}
+        assert by_label["good"].metadata[METADATA_KEY]["phase"] == "hard"
+        assert by_label["bad"].metadata[METADATA_KEY]["flow"] == "bulk"
+
+    def test_votes_without_provenance_get_no_metadata_key(self):
+        ls = LabelSet.from_clips_and_votes({1: _media(1)}, {1: None}, {})
+        assert ls.elements[0].metadata is None
+
+    def test_survives_json_round_trip(self):
+        ls = LabelSet.from_clips_and_votes({1: _media(1)}, {1: None}, {}, vote_provenance={1: {"v": 1, **FULL}})
+        restored = LabelSet.from_dict(ls.to_dict())
+        assert read_provenance(restored.elements[0].metadata) == {"v": SCHEMA_VERSION, **FULL}
+
+    def test_dupe_set_members_share_the_representatives_record(self):
+        """Same rule as ``region_box``: the representative is what the user was
+        actually shown, so it is what was surfaced."""
+        rep = {
+            "md5": "rep",
+            "filename": "rep.wav",
+            "origin": {
+                "importer": "dupe_set",
+                "members": [
+                    {"md5": "a", "origin_name": "a.wav", "filename": "a.wav"},
+                    {"md5": "b", "origin_name": "b.wav", "filename": "b.wav"},
+                ],
+            },
+        }
+        ls = LabelSet.from_clips_and_votes(
+            {1: rep}, {1: None}, {}, vote_provenance={1: {"v": 1, "flow": "autopilot", "phase": "new"}}
+        )
+        assert len(ls.elements) == 2
+        assert all(read_provenance(el.metadata)["phase"] == "new" for el in ls.elements)
+
+    def test_provenance_does_not_displace_importer_custom_metadata(self):
+        media = {**_media(1), "custom_metadata": {"contentID": "abc"}}
+        ls = LabelSet.from_clips_and_votes({1: media}, {1: None}, {}, vote_provenance={1: {"v": 1, "flow": "bulk"}})
+        meta = ls.elements[0].metadata
+        assert meta["contentID"] == "abc"
+        assert meta[METADATA_KEY]["flow"] == "bulk"
+
+
+class TestElementVoteFlip:
+    """``apply_element_vote_in_data`` (the dashboard's labelset review)."""
+
+    def _data(self, label: str = "good") -> dict:
+        from vtscore.detectors.labelset_elements import stable_element_id
+
+        el = LabeledElement(md5="abc", label=label, origin_name="a.wav", filename="a.wav")
+        return {"labelset": LabelSet([el]).to_dict()}, stable_element_id(el)
+
+    def test_a_flip_stamps_the_new_provenance(self):
+        from vtscore.detectors.labelset_elements import apply_element_vote_in_data
+
+        data, eid = self._data("good")
+        changed, updated, action = apply_element_vote_in_data(
+            data, eid, "bad", provenance={"v": 1, "flow": "labelset_review"}
+        )
+        assert (changed, action) == (True, "flipped")
+        assert read_provenance(updated.metadata)["flow"] == "labelset_review"
+
+    def test_an_idempotent_reassert_leaves_the_record_alone(self):
+        from vtscore.detectors.labelset_elements import apply_element_vote_in_data
+
+        data, eid = self._data("good")
+        changed, _updated, action = apply_element_vote_in_data(
+            data, eid, "good", provenance={"v": 1, "flow": "labelset_review"}
+        )
+        assert (changed, action) == (False, "unchanged")
+        stored = LabelSet.from_dict(data["labelset"]).elements[0]
+        assert read_provenance(stored.metadata) is None

--- a/tests_lib/detectors/test_vote_provenance.py
+++ b/tests_lib/detectors/test_vote_provenance.py
@@ -289,3 +289,67 @@ class TestElementVoteFlip:
         assert (changed, action) == (False, "unchanged")
         stored = LabelSet.from_dict(data["labelset"]).elements[0]
         assert read_provenance(stored.metadata) is None
+
+
+class TestRestorationCycle:
+    """The erasure hazard: vote -> compose -> restore -> recompose.
+
+    ``sync_labels_to_loaded_detector`` rebuilds the entire labelset from live
+    vote state on *every* vote.  So if a detector load restores votes without
+    their recorded provenance, the user's very next click rewrites the whole
+    labelset with the context stripped out.  ``region_box`` shipped with
+    exactly this bug; this is the test that says provenance did not.
+    """
+
+    def test_provenance_survives_a_detector_load_and_the_next_resync(self):
+        from vtscore.detectors.label_restoration import restore_labels_from_detector
+
+        det = get_active_detector_context()
+        snap = get_active_context().medias
+        set_vote(1, "good", provenance={"flow": "autopilot", "phase": "hard"})
+        set_vote(2, "bad", provenance={"flow": "list_review", "rank_at_vote": 4})
+
+        # What the detector JSON would hold after the vote-triggered sync.
+        on_disk = LabelSet.from_clips_and_votes(
+            snap,
+            dict(det.good_votes),
+            dict(det.bad_votes),
+            expand_dupes=False,
+            vote_provenance=dict(det.vote_provenance),
+        ).to_dict()
+
+        # Loading the detector afresh (as a dataset switch would).
+        det.good_votes.clear()
+        det.bad_votes.clear()
+        det.vote_provenance.clear()
+        restore_labels_from_detector({"labelset": on_disk})
+
+        assert det.vote_provenance[1]["phase"] == "hard"
+        assert det.vote_provenance[2]["rank_at_vote"] == 4
+
+        # The next vote resyncs the whole labelset from live state; the
+        # restored records must still be in what it writes.
+        resynced = LabelSet.from_clips_and_votes(
+            snap,
+            dict(det.good_votes),
+            dict(det.bad_votes),
+            expand_dupes=False,
+            vote_provenance=dict(det.vote_provenance),
+        )
+        by_md5 = {el.md5: el for el in resynced.elements}
+        assert read_provenance(by_md5[snap[1]["md5"]].metadata)["phase"] == "hard"
+        assert read_provenance(by_md5[snap[2]["md5"]].metadata)["flow"] == "list_review"
+
+    def test_a_legacy_labelset_restores_without_provenance(self):
+        """Elements written before this feature carry none, and must restore
+        cleanly rather than raising or inventing a record."""
+        from vtscore.detectors.label_restoration import restore_labels_from_detector
+
+        snap = get_active_context().medias
+        legacy = LabelSet.from_clips_and_votes(snap, {1: None}, {}, expand_dupes=False)
+        restored = restore_labels_from_detector({"labelset": legacy.to_dict()})
+
+        det = get_active_detector_context()
+        assert restored == 1
+        assert 1 in det.good_votes
+        assert det.vote_provenance == {}

--- a/vtscore/datasets/labelset.py
+++ b/vtscore/datasets/labelset.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterator
 
+from vtscore.datasets.vote_provenance import attach_provenance
 from vtscore.utils.hits import hit_custom_metadata
 
 
@@ -47,6 +48,10 @@ class LabeledElement:
             present.  Built from the media's ``custom_metadata`` through
             :func:`vtscore.utils.hits.hit_custom_metadata`, so the
             pre-computed-vector channel never lands in a persisted labelset.
+            The reserved key
+            :data:`~vtscore.datasets.vote_provenance.METADATA_KEY`
+            (``"vt:provenance"``) namespaces the vote's surfacing context
+            when one was recorded; see that module.
         region_box: Normalised ``(x0, y0, x1, y1)`` box on the source
             image when the user drew a region as part of a yes-vote;
             ``None`` for image-level votes (the perpetual default for
@@ -154,6 +159,7 @@ class LabelSet:
         *,
         expand_dupes: bool = True,
         vote_region_boxes: dict[int, tuple[float, float, float, float]] | None = None,
+        vote_provenance: dict[int, dict[str, Any]] | None = None,
         detector_meta: dict[str, Any] | None = None,
     ) -> LabelSet:
         """Build a ``LabelSet`` from the current media and vote state.
@@ -173,6 +179,13 @@ class LabelSet:
                 box is attached to the corresponding good vote's
                 :class:`LabeledElement`.  Ignored for bad votes (no-votes
                 are always image-level - see the patch-embedder v2 design).
+            vote_provenance: Optional ``media_id -> provenance dict`` map
+                recording how each vote was surfaced (which flow / autopilot
+                phase / sort / rank).  Written into the element's ``metadata``
+                under :data:`~vtscore.datasets.vote_provenance.METADATA_KEY`.
+                Applies to good and bad votes alike - the surfacing context is
+                what a later calibration partition needs, and it is just as
+                real for a no-vote.
             detector_meta: Optional detector-level metadata block to attach
                 to the labelset (e.g. ``{"media_type": ..., "input_spec":
                 ..., "threshold": ...}``).  Lets the labelset carry the
@@ -184,6 +197,7 @@ class LabelSet:
             voted media, in vote-insertion order (good votes first, then bad).
         """
         region_boxes = vote_region_boxes or {}
+        provenance = vote_provenance or {}
         elements: list[LabeledElement] = []
         for cid in good_votes:
             media = medias.get(cid)
@@ -194,12 +208,20 @@ class LabelSet:
                         "good",
                         expand_dupes=expand_dupes,
                         region_box=region_boxes.get(cid),
+                        provenance=provenance.get(cid),
                     )
                 )
         for cid in bad_votes:
             media = medias.get(cid)
             if media:
-                elements.extend(_clip_to_elements(media, "bad", expand_dupes=expand_dupes))
+                elements.extend(
+                    _clip_to_elements(
+                        media,
+                        "bad",
+                        expand_dupes=expand_dupes,
+                        provenance=provenance.get(cid),
+                    )
+                )
         return cls(elements, detector_meta=detector_meta)
 
     @classmethod
@@ -446,6 +468,7 @@ def _clip_to_elements(
     *,
     expand_dupes: bool = True,
     region_box: tuple[float, float, float, float] | None = None,
+    provenance: dict[str, Any] | None = None,
 ) -> list[LabeledElement]:
     """Convert a media dict into one or more :class:`LabeledElement` instances.
 
@@ -464,6 +487,12 @@ def _clip_to_elements(
     good in *this* image" and the representative is what the user actually
     saw, so cloning the box across structurally-identical members is the
     right default.
+
+    *provenance*, when given, is merged into every emitted element's metadata
+    under :data:`~vtscore.datasets.vote_provenance.METADATA_KEY`.  Dupe-set
+    members share the representative's record for the same reason they share
+    its box: the representative is what the user was actually shown, so it is
+    what was surfaced.
     """
     origin = media.get("origin")
     # Sanitised, not read straight off the media: ``custom_metadata_map`` lets
@@ -471,7 +500,7 @@ def _clip_to_elements(
     # dict is persisted verbatim into the detector JSON.  A numpy array there
     # is both a hard ``json.dump`` failure and exactly the vector persistence
     # the no-persisted-vectors rule forbids.
-    cm = hit_custom_metadata(media) or None
+    cm = attach_provenance(hit_custom_metadata(media) or None, provenance)
     if expand_dupes and isinstance(origin, dict) and origin.get("importer") == "dupe_set":
         members = origin.get("members", [])
         if members:

--- a/vtscore/datasets/vote_provenance.py
+++ b/vtscore/datasets/vote_provenance.py
@@ -1,0 +1,239 @@
+"""Vote surfacing provenance - how a label came to be in front of the user.
+
+Every vote is a *sample*, and the sampler is the detector's own sort: the
+most biased one available.  The selection-bias study
+(``docs/experiments/2026-07-27-inclusion-knob/SELECTION-BIAS.md``) measured
+what that costs and found it splits by *how the item was drawn*, not by who
+was labeling - a margin-sampled draw calibrates safely while a
+top-of-the-list draw poisons the conformal threshold.  Deciding which votes
+a future calibration may trust therefore needs to know each vote's surfacing
+context, and that context is **not re-derivable**: the ranking that surfaced
+the item is client-side ephemeral state and the model that produced its score
+is overwritten by the next retrain.  So it is recorded at click time, here.
+
+This module owns the vocabulary and the validation.  Recording only - nothing
+in the codebase reads these values back to change behaviour yet; consuming
+them is gated on the experiment pre-registered in
+``docs/plans/provenance-partitioned-calibration.md``.
+
+Storage
+-------
+
+A vote's provenance rides in :attr:`~vtscore.datasets.labelset.LabeledElement.metadata`
+under the :data:`METADATA_KEY` namespace, so it round-trips through labelset
+JSON export/import with no format change.  Scalars only: the
+no-persisted-vectors rule is untouched.
+
+Axes
+----
+
+The three questions "which ranking?", "which draw off that ranking?" and
+"who was driving?" are **independent**, and each is recorded in its own
+field rather than fused into one enum:
+
+* :data:`FLOWS` - which UI flow drove the vote (``autopilot``, ``manual``, ...).
+* :data:`PHASES` - the autopilot phase, when autopilot was driving.
+* :data:`SELECT_MODES` - how the item was drawn off the ranking
+  (``top`` / ``hard`` / ``new``).
+* :data:`SORT_KINDS` - which ranking the user was looking at.
+
+Keeping them separate matters because the bias lives on the *selection*
+axis while the flow axis is what a user notices.  The two come apart at both
+edges: a user can set the left panel's select mode to ``hard`` by hand and
+get exactly the margin-sampled draw autopilot's Hard phase uses, and
+autopilot's own ``good`` phase is mechanically a top-of-list draw.  A single
+fused ``autopilot:hard`` / ``list_review`` enum would label both of those
+cases by their flow and discard the variable that actually predicts the bias.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+#: Namespace key under which provenance is stored in ``LabeledElement.metadata``.
+#: Prefixed so it can never collide with an importer's ``custom_metadata``,
+#: which shares the same dict.
+METADATA_KEY = "vt:provenance"
+
+#: Schema version of the recorded payload, stored as ``"v"``.  Bump when the
+#: field set changes in a way a reader must branch on.
+SCHEMA_VERSION = 1
+
+#: Which UI flow drove the vote.
+#:
+#: ``autopilot``       - the guided Train loop was driving item selection.
+#: ``list_review``     - the user was voting down a sorted result list they
+#:                       steered themselves.  This is the flow the
+#:                       selection-bias study's ``toplist`` arm models and
+#:                       found unsafe for calibration.
+#: ``find_verify``     - verifying a Find pass's scored results.
+#: ``labelset_review`` - correcting an already-saved label from the detector's
+#:                       own labelset, not a fresh draw off any ranking.
+#: ``seed_example``    - a user-supplied exemplar: example media seeded on
+#:                       detector load, or an add-to-pile upload.  Never
+#:                       surfaced by a sort at all.
+#: ``import``          - applied by a label import that carried no provenance
+#:                       of its own.
+#: ``bulk``            - a batch action over a set (Browser verify-good/bad,
+#:                       fill-from-sort).
+#: ``undo``            - replayed from the undo/redo stack; not a fresh
+#:                       surfacing event.
+#: ``unknown``         - unattributed; the default for legacy votes.
+FLOWS = frozenset(
+    {
+        "autopilot",
+        "list_review",
+        "find_verify",
+        "labelset_review",
+        "seed_example",
+        "import",
+        "bulk",
+        "undo",
+        "unknown",
+    }
+)
+
+#: Autopilot phase at click time; ``None`` outside autopilot.  Mirrors the
+#: frontend's ``AutopilotPhase`` minus its non-labeling states (``idle``,
+#: ``done``, ``exhausted`` never surface an item to vote on).
+PHASES = frozenset({"good", "bad", "hard", "new"})
+
+#: How the item was drawn off the ranking.  Mirrors the frontend's
+#: ``SelectMode``: ``top`` is the head of the sort, ``hard`` is margin
+#: sampling near the decision boundary, ``new`` is atlas-diverse exploration.
+SELECT_MODES = frozenset({"top", "hard", "new"})
+
+#: Which ranking the user was looking at.  Mirrors the frontend's ``SortMode``.
+SORT_KINDS = frozenset({"learned", "text", "load"})
+
+_ENUM_FIELDS: dict[str, frozenset[str]] = {
+    "flow": FLOWS,
+    "phase": PHASES,
+    "select_mode": SELECT_MODES,
+    "sort_kind": SORT_KINDS,
+}
+
+#: Every key a recorded payload may carry, in serialisation order.
+FIELDS = ("v", "flow", "phase", "select_mode", "sort_kind", "rank_at_vote", "score_at_vote")
+
+
+def _clean_int(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be an integer")
+    ivalue = int(value)
+    if ivalue != value or ivalue < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return ivalue
+
+
+def _clean_float(value: Any, field: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    fvalue = float(value)
+    if not math.isfinite(fvalue):
+        raise ValueError(f"{field} must be finite")
+    return fvalue
+
+
+def _clean_enums(raw: dict[str, Any]) -> dict[str, str]:
+    """Validate every enum-valued field present in *raw*, dropping absent ones."""
+    out: dict[str, str] = {}
+    for field, allowed in _ENUM_FIELDS.items():
+        value = raw.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, str) or value not in allowed:
+            raise ValueError(f"{field} must be one of: {', '.join(sorted(allowed))}")
+        out[field] = value
+    return out
+
+
+def normalize_provenance(raw: Any) -> dict[str, Any] | None:
+    """Validate *raw* into a canonical provenance payload.
+
+    Returns ``None`` for ``None`` or for a payload that carries no
+    information (no ``flow`` and no context scalars) - there is nothing worth
+    persisting in an empty record, and storing one would inflate every
+    labelset with a dict that says only "unknown".
+
+    Absent optional fields are omitted rather than stored as ``None``, so the
+    serialised form stays small; a reader treats a missing key as unknown.
+
+    Raises:
+        ValueError: on an unrecognised enum value, an unknown key, or a
+            malformed scalar.  Callers at a request boundary let this become
+            a 400; callers reading from disk should use
+            :func:`coerce_provenance` instead.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise ValueError("provenance must be an object")
+
+    unknown_keys = set(raw) - set(FIELDS)
+    if unknown_keys:
+        raise ValueError(f"unknown provenance field(s): {', '.join(sorted(unknown_keys))}")
+
+    out: dict[str, Any] = {"v": SCHEMA_VERSION}
+    out.update(_clean_enums(raw))
+
+    rank = _clean_int(raw.get("rank_at_vote"), "rank_at_vote")
+    if rank is not None:
+        out["rank_at_vote"] = rank
+    score = _clean_float(raw.get("score_at_vote"), "score_at_vote")
+    if score is not None:
+        out["score_at_vote"] = score
+
+    # A phase only means something under autopilot, and a bare "unknown" flow
+    # says exactly what an absent record says.
+    if out.get("flow") not in (None, "autopilot"):
+        out.pop("phase", None)
+    if len(out) == 1 or (len(out) == 2 and out.get("flow") == "unknown"):
+        return None
+    return out
+
+
+def coerce_provenance(raw: Any) -> dict[str, Any] | None:
+    """Best-effort :func:`normalize_provenance` that never raises.
+
+    For payloads arriving from outside our own request validation - an
+    imported labelset, a detector JSON hand-edited or written by an older
+    build.  A record we cannot make sense of is dropped, not repaired: a
+    half-understood provenance is worse than none, because a future
+    calibration partition would trust it.
+    """
+    try:
+        return normalize_provenance(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def read_provenance(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Extract the provenance payload from a ``LabeledElement.metadata`` dict."""
+    if not isinstance(metadata, dict):
+        return None
+    return coerce_provenance(metadata.get(METADATA_KEY))
+
+
+def attach_provenance(
+    metadata: dict[str, Any] | None,
+    provenance: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return *metadata* with *provenance* written into :data:`METADATA_KEY`.
+
+    Copies rather than mutating: the caller's dict is typically an importer's
+    ``custom_metadata``, shared across every element built from that media.
+    Returns *metadata* unchanged when there is no provenance to attach, so a
+    labelset from a build that never recorded any is byte-identical to before.
+    """
+    cleaned = coerce_provenance(provenance)
+    if cleaned is None:
+        return metadata
+    merged = dict(metadata) if metadata else {}
+    merged[METADATA_KEY] = cleaned
+    return merged

--- a/vtscore/detectors/dataset_sync.py
+++ b/vtscore/detectors/dataset_sync.py
@@ -418,7 +418,7 @@ class VoteSnapshot(NamedTuple):
 
     ``safe`` reports whether the vote dicts could be proved to be keyed in
     the snapshot's medias' cid space.  When ``safe`` is False, ``good_votes``
-    / ``bad_votes`` / ``vote_region_boxes`` are returned empty (so read paths
+    / ``bad_votes`` / ``vote_region_boxes`` / ``vote_provenance`` are returned empty (so read paths
     that just compose with ``medias`` degrade to an empty result instead of
     leaking cross-dataset cids).  Write paths that would replace on-disk
     state must check ``safe`` and skip the write; otherwise an empty
@@ -429,6 +429,10 @@ class VoteSnapshot(NamedTuple):
     good_votes: dict[int, None]
     bad_votes: dict[int, None]
     vote_region_boxes: dict[int, tuple[float, float, float, float]]
+    # Per-vote surfacing provenance, captured under the same lock so a
+    # composed labelset can't pair one vote's label with another snapshot's
+    # context.  See :mod:`vtscore.datasets.vote_provenance`.
+    vote_provenance: dict[int, dict[str, Any]]
     safe: bool
     # Find-mode: ids the human has explicitly verified this session, captured
     # under the same lock so verified/unverified export filters stay atomic
@@ -495,12 +499,13 @@ def validated_vote_snapshot() -> VoteSnapshot:
         # match the active dataset) is the race / stale-state scenario and
         # is the only one we refuse to compose for.
         if det_ctx.detector_id and det_ctx.votes_dataset_id and det_ctx.votes_dataset_id != ds_ctx.dataset_id:
-            return VoteSnapshot(snap, {}, {}, {}, safe=False, verified_ids={})
+            return VoteSnapshot(snap, {}, {}, {}, {}, safe=False, verified_ids={})
         return VoteSnapshot(
             snap,
             dict(det_ctx.good_votes),
             dict(det_ctx.bad_votes),
             dict(det_ctx.vote_region_boxes),
+            dict(det_ctx.vote_provenance),
             safe=True,
             verified_ids=dict(det_ctx.verified_ids),
         )

--- a/vtscore/detectors/label_restoration.py
+++ b/vtscore/detectors/label_restoration.py
@@ -23,6 +23,7 @@ def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> in
     """
     import logging
 
+    from vtscore.datasets.vote_provenance import read_provenance
     from vtscore.detectors.resolver import resolve_file_context
     from vtscore.state import apply_label
 
@@ -48,7 +49,13 @@ def _resolve_unmatched(unresolved: list, md5_lookup: dict[str, list[int]]) -> in
             cids = md5_lookup.get(resolved_md5, [])
             if cids:
                 for cid in cids:
-                    apply_label(cid, elem.label, silent=True, region_box=elem.region_box)
+                    apply_label(
+                        cid,
+                        elem.label,
+                        silent=True,
+                        region_box=elem.region_box,
+                        provenance=read_provenance(elem.metadata),
+                    )
                 restored += 1
             else:
                 _log.debug(
@@ -74,14 +81,18 @@ def restore_labels_from_detector(det_data: dict) -> int:
     votes.  The good/bad counts still reflect restored labels, so autopilot's
     initial Find Goods / Find Bads gates can skip ahead.
 
-    A Good element's ``region_box`` rides along into ``vote_region_boxes``.
-    Dropping it here used to erase the drawn region the moment the next vote
-    resynced the labelset back to disk - the restored vote was image-level, so
-    the element it re-emitted was too.
+    A Good element's ``region_box`` rides along into ``vote_region_boxes``,
+    and any recorded surfacing provenance rides along into ``vote_provenance``.
+    Dropping either here erases it the moment the next vote resyncs the
+    labelset back to disk - the restored vote would be image-level and
+    context-free, so the element it re-emits would be too.  (That is exactly
+    the bug ``region_box`` had; provenance shares the hazard because the sync
+    rebuilds the whole labelset from live vote state on every vote.)
 
     Returns the number of labels successfully restored.
     """
     from vtscore.datasets.labelset import LabeledElement, LabelSet
+    from vtscore.datasets.vote_provenance import read_provenance
     from vtscore.state import (
         apply_label,
         cached_media_lookups,
@@ -111,7 +122,13 @@ def restore_labels_from_detector(det_data: dict) -> int:
         cids = resolve_media_ids(elem.to_dict(), origin_lookup, md5_lookup, name_lookup)
         if cids:
             for cid in cids:
-                apply_label(cid, elem.label, silent=True, region_box=elem.region_box)
+                apply_label(
+                    cid,
+                    elem.label,
+                    silent=True,
+                    region_box=elem.region_box,
+                    provenance=read_provenance(elem.metadata),
+                )
             restored += 1
         else:
             unresolved.append(elem)

--- a/vtscore/detectors/label_sync.py
+++ b/vtscore/detectors/label_sync.py
@@ -189,6 +189,7 @@ def _sync_labels_to_loaded_detector_locked() -> None:
         vote_snap.bad_votes,
         expand_dupes=False,
         vote_region_boxes=vote_snap.vote_region_boxes,
+        vote_provenance=vote_snap.vote_provenance,
     )
     existing_ls = LabelSet.from_dict(data.get("labelset") or {})
 

--- a/vtscore/detectors/labelset_elements.py
+++ b/vtscore/detectors/labelset_elements.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Iterator, Mapping
 
 from vtscore.datasets.labelset import LabeledElement, LabelSet, element_key
+from vtscore.datasets.vote_provenance import attach_provenance
 from vtscore.utils.hashing import content_sha1
 
 
@@ -193,6 +194,8 @@ def apply_element_vote_in_data(
     detector_data: dict[str, Any],
     target_id: str,
     target: str,
+    *,
+    provenance: dict[str, Any] | None = None,
 ) -> tuple[bool, LabeledElement | None, str]:
     """Set the label on the element with stable id *target_id* to *target*.
 
@@ -213,6 +216,10 @@ def apply_element_vote_in_data(
     already-good element is an ``"unchanged"`` no-op rather than a removal.
     A stale-view tab can no longer flip an element off the labelset by
     re-asserting its current label (logical-bug-audit H1).
+
+    *provenance* replaces the element's recorded surfacing context, but only
+    on an actual flip - an idempotent re-assert returns before it is read, so
+    a stale tab cannot rewrite the context of a decision it did not make.
     """
     if target not in ("good", "bad", "remove"):
         return False, None, "unchanged"
@@ -232,5 +239,6 @@ def apply_element_vote_in_data(
         return False, el, "unchanged"
 
     el.label = target
+    el.metadata = attach_provenance(el.metadata, provenance)
     detector_data["labelset"] = labelset.to_dict()
     return True, el, "flipped"

--- a/vtscore/detectors/media_seeding.py
+++ b/vtscore/detectors/media_seeding.py
@@ -169,7 +169,7 @@ def _insert_example_media(
             "origin_name": origin_name,
         }
 
-    apply_label(new_id, "good", record_achievement=False)
+    apply_label(new_id, "good", record_achievement=False, provenance={"flow": "seed_example"})
 
 
 def labeled_elements_from_examples(examples: list[dict]) -> list["LabeledElement"]:
@@ -302,7 +302,7 @@ def _seed_one_example(
             # System-driven seeding from a detector's saved examples, not a
             # user vote action, so don't credit achievement counters.
             for cid in cids:
-                apply_label(cid, "good", record_achievement=False)
+                apply_label(cid, "good", record_achievement=False, provenance={"flow": "seed_example"})
             return 1, embedder
 
         # Example is NOT in the dataset - embed and insert as new media.

--- a/vtscore/detectors/workflow.py
+++ b/vtscore/detectors/workflow.py
@@ -43,6 +43,7 @@ def apply_and_retrain(  # noqa: C901
 
     Returns ``(resolved_count, trained_bool)``.
     """
+    from vtscore.datasets.vote_provenance import read_provenance
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
     from vtscore.state import (
         apply_label,
@@ -61,15 +62,16 @@ def apply_and_retrain(  # noqa: C901
 
         # 1) Resolve every entry into concrete (cid, label) pairs without
         #    touching any state yet.
-        resolved_pairs: list[tuple[int, str]] = []
+        resolved_pairs: list[tuple[int, str, dict | None]] = []
         resolved = 0
         for entry in new_entries:
             label = entry.get("label", "")
             if label not in ("good", "bad"):
                 continue
+            prov = read_provenance(entry.get("metadata")) or {"flow": "import"}
             cids = resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup)
             for cid in cids:
-                resolved_pairs.append((cid, label))
+                resolved_pairs.append((cid, label, prov))
             if cids:
                 resolved += 1
 
@@ -78,7 +80,7 @@ def apply_and_retrain(  # noqa: C901
         #    via dict; new opposite-side labels supersede the old ones.
         proposed_good = dict(det_ctx.good_votes)
         proposed_bad = dict(det_ctx.bad_votes)
-        for cid, label in resolved_pairs:
+        for cid, label, _prov in resolved_pairs:
             if label == "good":
                 proposed_bad.pop(cid, None)
                 proposed_good[cid] = None
@@ -128,12 +130,13 @@ def apply_and_retrain(  # noqa: C901
         saved_good_votes = dict(det_ctx.good_votes)
         saved_bad_votes = dict(det_ctx.bad_votes)
         saved_region_boxes = dict(det_ctx.vote_region_boxes)
+        saved_provenance = dict(det_ctx.vote_provenance)
         saved_history = list(det_ctx.label_history)
         saved_click_times = dict(det_ctx.vote_click_times)
         saved_click_counter = det_ctx.click_counter
 
-        for cid, label in resolved_pairs:
-            apply_label(cid, label)
+        for cid, label, prov in resolved_pairs:
+            apply_label(cid, label, provenance=prov)
 
         try:
             sync_labels_to_loaded_detector()
@@ -145,6 +148,8 @@ def apply_and_retrain(  # noqa: C901
                 det_ctx.bad_votes.update(saved_bad_votes)
                 det_ctx.vote_region_boxes.clear()
                 det_ctx.vote_region_boxes.update(saved_region_boxes)
+                det_ctx.vote_provenance.clear()
+                det_ctx.vote_provenance.update(saved_provenance)
                 det_ctx.label_history.clear()
                 det_ctx.label_history.extend(saved_history)
                 det_ctx.vote_click_times.clear()

--- a/vtscore/labels/sync.py
+++ b/vtscore/labels/sync.py
@@ -244,6 +244,7 @@ def _push_to_labelset_source() -> None:
                 vote_snap.good_votes,
                 vote_snap.bad_votes,
                 vote_region_boxes=vote_snap.vote_region_boxes,
+                vote_provenance=vote_snap.vote_provenance,
                 detector_meta=detector_meta or None,
             )
             source.save(labelset, field_values)
@@ -321,6 +322,7 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
     with _sync_lock:
         _syncing = True
         try:
+            from vtscore.datasets.vote_provenance import read_provenance
             from vtscore.state.core import get_active_context, override_detector_context
             from vtscore.state.votes import apply_label
 
@@ -346,7 +348,12 @@ def sync_from_labelset_source(detector_id: str | None = None) -> list[dict[str, 
                             # ``record_detector_import`` call below covers the
                             # achievement credit instead of crediting each
                             # imported label as a user vote.
-                            apply_label(mid, label, record_achievement=False)
+                            apply_label(
+                                mid,
+                                label,
+                                record_achievement=False,
+                                provenance=read_provenance(entry.get("metadata")),
+                            )
                             applied_any = True
                             break
         finally:

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -897,6 +897,12 @@ class DetectorContext:
         "label_history",
         "vote_click_times",
         "vote_region_boxes",
+        # Per-vote surfacing provenance (which flow / phase / sort / rank
+        # surfaced the item).  Recorded at click time because none of it is
+        # re-derivable later: the ranking is client-side ephemeral state and
+        # the score's model is overwritten by the next retrain.  See
+        # ``vtscore/datasets/vote_provenance.py``.
+        "vote_provenance",
         "click_counter",
         # True when this detector's in-memory votes are find/scoring output
         # (set by /api/find-label) rather than genuine training labels.  While
@@ -1039,6 +1045,9 @@ class DetectorContext:
         # the user drew a region as part of a yes-vote; absent for image-level
         # yes-votes and for every no-vote.  Patch-embedder v2.
         self.vote_region_boxes: dict[int, tuple[float, float, float, float]] = {}
+        # Per-vote surfacing provenance, keyed by media id.  See the slot
+        # comment and :mod:`vtscore.datasets.vote_provenance`.
+        self.vote_provenance: dict[int, dict[str, object]] = {}
         self.click_counter: int = 0
         # See the slot comment: True while these votes are find/scoring output.
         self.find_mode: bool = False

--- a/vtscore/state/votes.py
+++ b/vtscore/state/votes.py
@@ -45,6 +45,7 @@ def clear_votes() -> None:
         ctx.textsort_suggestions.clear()
         ctx.vote_click_times.clear()
         ctx.vote_region_boxes.clear()
+        ctx.vote_provenance.clear()
         ctx.click_counter = 0
         ctx.last_learned_scores.clear()
         ctx.find_initial_labels.clear()
@@ -316,6 +317,25 @@ def _record_vote_locked(count_streak: bool = True) -> None:
     record_achievement("vote", det_ctx.detector_id, media_type=det_ctx.media_type, count_streak=count_streak)
 
 
+def _store_provenance(ctx, media_id: int, provenance: dict[str, Any] | None) -> None:
+    """Record (or clear) *media_id*'s surfacing provenance under ``_state_lock``.
+
+    Called only on a transition that produces a labeled state, never on an
+    idempotent re-apply - see the comment in :func:`_set_vote_locked`.  A
+    caller with nothing to record clears the slot rather than leaving the
+    previous vote's record in place: the new vote was surfaced *somehow*, and
+    keeping the old context would attribute it to a flow that did not produce
+    it.
+    """
+    from vtscore.datasets.vote_provenance import coerce_provenance
+
+    cleaned = coerce_provenance(provenance)
+    if cleaned is None:
+        ctx.vote_provenance.pop(media_id, None)
+    else:
+        ctx.vote_provenance[media_id] = cleaned
+
+
 def _current_label_locked(ctx, media_id: int) -> str:
     """Return ``"good"`` / ``"bad"`` / ``"none"`` for *media_id* (lock held)."""
     if media_id in ctx.good_votes:
@@ -331,6 +351,7 @@ def _set_vote_locked(
     region_box: tuple[float, float, float, float] | None = None,
     *,
     count_streak: bool = True,
+    provenance: dict[str, Any] | None = None,
 ) -> tuple[str, str, int | None]:
     """Set *media_id*'s vote to *target* under an already-held ``_state_lock``.
 
@@ -365,6 +386,11 @@ def _set_vote_locked(
         # ``region_box`` on an idempotent call leaves the existing one alone.
         if target == "good" and region_box is not None:
             ctx.vote_region_boxes[media_id] = region_box
+        # Provenance is deliberately *not* refreshed here.  It records the
+        # surfacing event that produced the vote, and an idempotent call
+        # produced no such event - it is a stale tab replaying a target the
+        # media already holds.  Overwriting would let whichever tab spoke
+        # last rewrite history that the first click already recorded.
         existing_click = ctx.vote_click_times.get(media_id) if target != "none" else None
         return (old, old, existing_click)
 
@@ -375,6 +401,7 @@ def _set_vote_locked(
             ctx.vote_region_boxes[media_id] = region_box
         else:
             ctx.vote_region_boxes.pop(media_id, None)
+        _store_provenance(ctx, media_id, provenance)
         click_time = assign_click_time(media_id)
         add_label_to_history(media_id, "good")
         coverage_atlas_label(media_id, good=True)
@@ -382,6 +409,7 @@ def _set_vote_locked(
         ctx.good_votes.pop(media_id, None)
         ctx.vote_region_boxes.pop(media_id, None)
         ctx.bad_votes[media_id] = None
+        _store_provenance(ctx, media_id, provenance)
         click_time = assign_click_time(media_id)
         add_label_to_history(media_id, "bad")
         coverage_atlas_label(media_id, good=False)
@@ -389,6 +417,7 @@ def _set_vote_locked(
         ctx.good_votes.pop(media_id, None)
         ctx.bad_votes.pop(media_id, None)
         ctx.vote_region_boxes.pop(media_id, None)
+        ctx.vote_provenance.pop(media_id, None)
         remove_click_time(media_id)
         add_label_to_history(media_id, "unlabel")
         coverage_atlas_unlabel(media_id)
@@ -440,6 +469,7 @@ def set_vote(
     region_box: tuple[float, float, float, float] | None = None,
     *,
     count_streak: bool = True,
+    provenance: dict[str, Any] | None = None,
 ) -> tuple[str, str, int | None]:
     """Atomically set a media's vote to an absolute target state.
 
@@ -470,6 +500,11 @@ def set_vote(
             achievement but does not inflate the Marathoner streak, which only
             counts consecutive *individual* hand-clicks.  Defaults to True (the
             single-item vote path).
+        provenance: Optional surfacing context for this vote (which flow /
+            autopilot phase / sort / rank put the item in front of the user);
+            see :mod:`vtscore.datasets.vote_provenance`.  Recorded only on a
+            state *change* - an idempotent re-apply keeps whatever the
+            original click recorded, so a stale tab cannot rewrite it.
 
     Returns:
         ``(old_label, new_label, click_time)``.  ``click_time`` is the
@@ -477,7 +512,13 @@ def set_vote(
         idempotent calls.
     """
     with _state_lock:
-        result = _set_vote_locked(media_id, target, region_box=region_box, count_streak=count_streak)
+        result = _set_vote_locked(
+            media_id,
+            target,
+            region_box=region_box,
+            count_streak=count_streak,
+            provenance=provenance,
+        )
         _mark_verified_if_find_mode(get_active_detector_context(), media_id, result[1])
     # Progress-cache invalidation runs *after* ``_state_lock`` is released so
     # we never establish a ``_state_lock → _progress_lock`` ordering across
@@ -542,6 +583,7 @@ def apply_label(
     region_box: tuple[float, float, float, float] | None = None,
     record_achievement: bool = True,
     count_streak: bool = True,
+    provenance: dict[str, Any] | None = None,
 ) -> None:
     """Atomically apply a label to a media (for imports).
 
@@ -574,6 +616,11 @@ def apply_label(
             such as label import, which credit the other vote achievements but
             must not build a Marathoner streak out of one import.  Defaults to
             True (e.g. a single add-to-pile upload is an individual vote).
+        provenance: Optional surfacing context to record for this label; see
+            :mod:`vtscore.datasets.vote_provenance`.  The label-restoration
+            path passes the element's *recorded* provenance straight back
+            through, which is what keeps the next labelset resync from
+            erasing it (the same hazard ``region_box`` had).
     """
     with _state_lock:
         ctx = get_active_detector_context()
@@ -585,6 +632,7 @@ def apply_label(
                 ctx.vote_region_boxes[media_id] = region_box
             else:
                 ctx.vote_region_boxes.pop(media_id, None)
+            _store_provenance(ctx, media_id, provenance)
             if not silent:
                 add_label_to_history(media_id, "good")
         else:
@@ -592,6 +640,7 @@ def apply_label(
             ctx.good_votes.pop(media_id, None)
             ctx.vote_region_boxes.pop(media_id, None)
             ctx.bad_votes[media_id] = None
+            _store_provenance(ctx, media_id, provenance)
             if not silent:
                 add_label_to_history(media_id, "bad")
         if not silent:
@@ -600,7 +649,12 @@ def apply_label(
                 _record_vote_locked(count_streak=count_streak)
 
 
-def apply_label_with_click_time(media_id: int, label: str) -> None:
+def apply_label_with_click_time(
+    media_id: int,
+    label: str,
+    *,
+    provenance: dict[str, Any] | None = None,
+) -> None:
     """Atomically apply a label with click-time assignment (for fill-from-sort).
 
     Same as :func:`apply_label` but also assigns a click-time ordinal so the
@@ -614,6 +668,11 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
     Args:
         media_id: Integer ID of the media to label.
         label: ``"good"`` or ``"bad"``.
+        provenance: Optional surfacing context; see
+            :mod:`vtscore.datasets.vote_provenance`.  Fill-from-sort is the
+            purest top-of-list draw in the app - it labels a whole sort window
+            at once - so the caller records it as such rather than leaving it
+            unattributed.
     """
     with _state_lock:
         ctx = get_active_detector_context()
@@ -627,6 +686,7 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
             ctx.vote_region_boxes.pop(media_id, None)
             ctx.bad_votes[media_id] = None
             add_label_to_history(media_id, "bad")
+        _store_provenance(ctx, media_id, provenance)
         assign_click_time(media_id)
         coverage_atlas_label(media_id, good=label == "good")
         # Bulk fill-from-sort: credit votes_cast/days/hours/types but never the
@@ -635,7 +695,7 @@ def apply_label_with_click_time(media_id: int, label: str) -> None:
 
 
 def _purge_vote_state_outside(ctx: Any, kept: set[int]) -> None:
-    """Drop every vote / click-time / region box / verified marker outside *kept*.
+    """Drop every vote / click-time / region box / provenance / verified marker outside *kept*.
 
     The ``replace_all`` half of :func:`apply_labels_bulk_with_click_time`.  The
     verified markers go with the votes they described: a marker whose vote was
@@ -651,6 +711,8 @@ def _purge_vote_state_outside(ctx: Any, kept: set[int]) -> None:
         ctx.vote_click_times.pop(cid, None)
     for cid in [c for c in ctx.vote_region_boxes if c not in kept]:
         ctx.vote_region_boxes.pop(cid, None)
+    for cid in [c for c in ctx.vote_provenance if c not in kept]:
+        ctx.vote_provenance.pop(cid, None)
     for cid in [c for c in ctx.verified_ids if c not in kept]:
         ctx.verified_ids.pop(cid, None)
     ctx.find_initial_labels.clear()
@@ -675,6 +737,10 @@ def apply_labels_bulk_with_click_time(
     When *record_achievement* is True, the credited votes still never touch the
     Marathoner ``vote_streak``: this applies a whole batch at once, which is
     not the consecutive-individual-hand-click effort the streak measures.
+
+    These are the detector's own machine calls, not a surfacing event, so any
+    recorded vote provenance for the affected ids is cleared: the human's
+    later verify vote is what stamps a fresh one.
 
     When *replace_all* is True, any pre-existing votes/click-times for IDs
     outside *labels* are cleared first.  This is what ``/api/find-label``
@@ -708,6 +774,7 @@ def apply_labels_bulk_with_click_time(
         bad_votes = ctx.bad_votes
         vote_click_times = ctx.vote_click_times
         vote_region_boxes = ctx.vote_region_boxes
+        vote_provenance = ctx.vote_provenance
         verified_ids = ctx.verified_ids
         label_history = ctx.label_history
         atlas = get_active_context().coverage_atlas
@@ -726,11 +793,13 @@ def apply_labels_bulk_with_click_time(
                 bad_votes.pop(media_id, None)
                 good_votes[media_id] = None
                 vote_region_boxes.pop(media_id, None)
+                vote_provenance.pop(media_id, None)
                 label_history.append((media_id, "good", _time.time()))
             else:
                 already = media_id in bad_votes
                 good_votes.pop(media_id, None)
                 vote_region_boxes.pop(media_id, None)
+                vote_provenance.pop(media_id, None)
                 bad_votes[media_id] = None
                 label_history.append((media_id, "bad", _time.time()))
             ctx.click_counter += 1

--- a/vtsearch/routes/detectors/labels.py
+++ b/vtsearch/routes/detectors/labels.py
@@ -48,6 +48,7 @@ from pathlib import Path
 from flask import jsonify, send_file
 from flask_smorest import Blueprint, abort
 
+from vtscore.datasets.vote_provenance import normalize_provenance
 from vtscore.detectors.store import (
     _detector_path,
     _read_detector,
@@ -159,6 +160,7 @@ def save_detector_labels(name: str):
             snap.bad_votes,
             expand_dupes=False,
             vote_region_boxes=snap.vote_region_boxes,
+            vote_provenance=snap.vote_provenance,
         )
 
         # Existing labelset entries that resolve into the active dataset are
@@ -643,6 +645,7 @@ def thumbnail_detector_label(name: str, element_id: str):
 )
 @detectors_labels_bp.arguments(DetectorLabelVoteRequestSchema)
 @detectors_labels_bp.response(200, DetectorLabelVoteResponseSchema)
+@detectors_labels_bp.alt_response(400, description="provenance is malformed.")
 @detectors_labels_bp.alt_response(404, description="Detector or label element not found.")
 def vote_detector_label(body: dict, name: str, element_id: str):
     """Set a saved labelset element's label to an absolute target.
@@ -656,6 +659,11 @@ def vote_detector_label(body: dict, name: str, element_id: str):
     When the element resolves into the active dataset, the detector's
     in-memory ``good_votes`` / ``bad_votes`` are kept in sync so MLP
     retraining and learned-sort see the change.
+
+    An optional ``provenance`` block records how the element was surfaced,
+    defaulting to ``{"flow": "labelset_review"}`` - this route is the
+    dashboard's review of already-saved labels, not a draw off any ranking.
+    It is written only when the label actually flips.
     """
     from vtscore.detectors.labelset_elements import (
         apply_element_vote_in_data,
@@ -663,6 +671,11 @@ def vote_detector_label(body: dict, name: str, element_id: str):
     )
 
     target = body["target"]
+
+    try:
+        provenance = normalize_provenance(body.get("provenance") or {"flow": "labelset_review"})
+    except ValueError as exc:
+        abort(400, message=str(exc))
 
     from vtscore.datasets.labelset import LabelSet
     from vtscore.detectors.labelset_elements import find_element_by_id
@@ -684,7 +697,7 @@ def vote_detector_label(body: dict, name: str, element_id: str):
 
         cid_before = resolve_current_dataset_cid(pre_elem)
 
-        changed, _updated, action = apply_element_vote_in_data(data, element_id, target)
+        changed, _updated, action = apply_element_vote_in_data(data, element_id, target, provenance=provenance)
         if not changed:
             return {"ok": True, "action": action}
 
@@ -697,7 +710,7 @@ def vote_detector_label(body: dict, name: str, element_id: str):
     if cid_before is not None:
         from vtsearch.state import set_vote
 
-        set_vote(cid_before, "none" if target == "remove" else target)
+        set_vote(cid_before, "none" if target == "remove" else target, provenance=provenance)
 
     from vtscore.detectors.registry import find_by_name, update_detector
 

--- a/vtsearch/routes/detectors/scoring.py
+++ b/vtsearch/routes/detectors/scoring.py
@@ -794,6 +794,7 @@ def find_corrections_to_detector():
             corr_bad,
             expand_dupes=False,
             vote_region_boxes=snap.vote_region_boxes,
+            vote_provenance=snap.vote_provenance,
         )
 
         # Merge: a correction supersedes any prior entry for the same source media

--- a/vtsearch/routes/labels/importers.py
+++ b/vtsearch/routes/labels/importers.py
@@ -65,6 +65,7 @@ from flask_smorest import Blueprint
 
 logger = logging.getLogger(__name__)
 
+from vtscore.datasets.vote_provenance import read_provenance
 from vtscore.labels.importers import get_label_importer, list_label_importers
 from vtsearch.errors import error_response
 from vtsearch.routes._shared import (
@@ -130,7 +131,11 @@ def _apply_labels(
 
         try:
             for cid in cids:
-                apply_label(cid, label)
+                apply_label(
+                    cid,
+                    label,
+                    provenance=read_provenance(entry.get("metadata")) or {"flow": "import"},
+                )
         except Exception as exc:
             logger.exception("Failed to apply label for entry %r", entry)
             failed.append({"entry": entry, "error": str(exc) or exc.__class__.__name__})

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -28,6 +28,7 @@ from vtsearch.state import (
     get_active_detector_context,
     resolve_media_ids,
 )
+from vtscore.datasets.vote_provenance import read_provenance
 from vtscore.utils.hits import build_media_hit, hit_custom_metadata
 
 logger = logging.getLogger(__name__)
@@ -368,6 +369,7 @@ def export_labels(query: dict):
         goods,
         bads,
         vote_region_boxes=snap.vote_region_boxes,
+        vote_provenance=snap.vote_provenance,
     )
 
     fallback_entries = _origin_only_fallback_entries(labelset, all_medias, label_filter, query["goods_only"])
@@ -466,7 +468,13 @@ def import_labels(body: dict):
             # Importing a labelset is a bulk action, not consecutive individual
             # hand-clicks: credit the other vote achievements but not the
             # Marathoner streak.
-            apply_label(cid, label, region_box=region_box, count_streak=False)
+            apply_label(
+                cid,
+                label,
+                region_box=region_box,
+                count_streak=False,
+                provenance=read_provenance(entry.get("metadata")) or {"flow": "import"},
+            )
         applied += 1
 
     from vtscore.detectors.label_sync import sync_labels_to_loaded_detector
@@ -573,16 +581,28 @@ def fill_labels_from_sort(body: dict):
     saved_good_votes = dict(det_ctx.good_votes)
     saved_bad_votes = dict(det_ctx.bad_votes)
     saved_region_boxes = dict(det_ctx.vote_region_boxes)
+    saved_provenance = dict(det_ctx.vote_provenance)
     saved_history = list(det_ctx.label_history)
     saved_click_times = dict(det_ctx.vote_click_times)
     saved_click_counter = det_ctx.click_counter
 
     # Apply labels
+    # Fill-from-sort takes a whole window off the head of the current sort -
+    # the top-of-list draw the selection-bias study measured as the unsafe
+    # one - so it is recorded as such, with each item's own sort score.
     for entry in good_candidates:
-        apply_label_with_click_time(entry["id"], "good")
+        apply_label_with_click_time(
+            entry["id"],
+            "good",
+            provenance={"flow": "bulk", "select_mode": "top", "score_at_vote": entry["score"]},
+        )
 
     for entry in bad_candidates:
-        apply_label_with_click_time(entry["id"], "bad")
+        apply_label_with_click_time(
+            entry["id"],
+            "bad",
+            provenance={"flow": "bulk", "select_mode": "top", "score_at_vote": entry["score"]},
+        )
 
     # Persist labels to disk BEFORE building the response.  Letting a
     # silent disk-write failure here fall through to ``return {...}`` is
@@ -603,6 +623,8 @@ def fill_labels_from_sort(body: dict):
             det_ctx.bad_votes.update(saved_bad_votes)
             det_ctx.vote_region_boxes.clear()
             det_ctx.vote_region_boxes.update(saved_region_boxes)
+            det_ctx.vote_provenance.clear()
+            det_ctx.vote_provenance.update(saved_provenance)
             det_ctx.label_history.clear()
             det_ctx.label_history.extend(saved_history)
             det_ctx.vote_click_times.clear()

--- a/vtsearch/routes/media/list.py
+++ b/vtsearch/routes/media/list.py
@@ -28,6 +28,7 @@ from vtscore.media.audio.ffmpeg import get_ffmpeg_exe
 from vtscore.media.base import MediaResponse
 from vtscore.security.path_validation import resolve_media_file_path
 from vtscore.utils.hashing import content_md5
+from vtscore.datasets.vote_provenance import normalize_provenance
 from vtscore.utils.hits import hit_custom_metadata
 from vtsearch.schemas.media import (
     MediaAddToPileResponseSchema,
@@ -946,7 +947,9 @@ def media_generic(query: dict, media_id: int):
 @medias_bp.route("/api/medias/<int:media_id>/vote", methods=["POST"])
 @medias_bp.arguments(MediaVoteRequestSchema)
 @medias_bp.response(200, MediaVoteResponseSchema)
-@medias_bp.alt_response(400, description="region_box is malformed, or a non-good target carries a region_box.")
+@medias_bp.alt_response(
+    400, description="region_box or provenance is malformed, or a non-good target carries a region_box."
+)
 @medias_bp.alt_response(404, description="Media not found.")
 @require_dataset_header
 @require_detector_header
@@ -972,6 +975,12 @@ def vote_media(body: dict, media_id: int):
     ``"bad"`` and ``"none"`` targets must not include ``region_box``; by
     design no-votes are image-level always (patch-embedder v2).
 
+    An optional ``provenance`` block records how the item was surfaced
+    (flow / autopilot phase / select mode / sort / rank / score).  It is
+    stored only when the call actually changes the vote state, so an
+    idempotent re-send from a stale tab cannot overwrite what the original
+    click recorded.  See :mod:`vtscore.datasets.vote_provenance`.
+
     Returns ``{"ok": true, "state": <new state>, "click_time": <int|null>}``
     so the client can reconcile its optimistic view directly from the
     response.
@@ -988,7 +997,12 @@ def vote_media(body: dict, media_id: int):
     if target != "good" and region_box is not None:
         abort(400, message="region_box is only valid on 'good' targets")
 
-    _old, new_state, click_time = set_vote(media_id, target, region_box=region_box)
+    try:
+        provenance = normalize_provenance(body.get("provenance"))
+    except ValueError as exc:
+        abort(400, message=str(exc))
+
+    _old, new_state, click_time = set_vote(media_id, target, region_box=region_box, provenance=provenance)
 
     # Persist the resulting labelset.  A failure here (e.g. ``os.replace``
     # EBUSY/ENOSPC under ``_write_detector``) used to bubble as an
@@ -1024,7 +1038,7 @@ def vote_media(body: dict, media_id: int):
 @medias_bp.route("/api/medias/vote-bulk", methods=["POST"])
 @medias_bp.arguments(MediaVoteBulkRequestSchema)
 @medias_bp.response(200, MediaVoteBulkResponseSchema)
-@medias_bp.alt_response(400, description="No ids supplied.")
+@medias_bp.alt_response(400, description="No ids supplied, or provenance is malformed.")
 @require_dataset_header
 @require_detector_header
 def vote_media_bulk(body: dict):
@@ -1047,6 +1061,14 @@ def vote_media_bulk(body: dict):
     if not ids:
         abort(400, message="No ids supplied")
 
+    # A batch action over a hand-selected set is its own surfacing flow; the
+    # client may refine it (with the sort it was selecting from), but never
+    # has to.
+    try:
+        provenance = normalize_provenance(body.get("provenance") or {"flow": "bulk"})
+    except ValueError as exc:
+        abort(400, message=str(exc))
+
     changed = 0
     missing: list[int] = []
     for media_id in ids:
@@ -1056,7 +1078,7 @@ def vote_media_bulk(body: dict):
         # Bulk "Verified Good/Bad" over a hand-selected set is not an
         # individual hand-click, so it must not build a Marathoner streak;
         # count_streak=False still credits the other vote achievements.
-        old, new, _click_time = set_vote(media_id, target, count_streak=False)
+        old, new, _click_time = set_vote(media_id, target, count_streak=False, provenance=provenance)
         if old != new:
             changed += 1
 
@@ -1241,7 +1263,7 @@ def add_media_to_pile():
 
     if existing_cids:
         for cid in existing_cids:
-            apply_label(cid, label)
+            apply_label(cid, label, provenance={"flow": "seed_example"})
         _sync_pile_label_to_storage()
         return {"ok": True, "media_id": existing_cids[0], "is_new": False}
 
@@ -1285,7 +1307,7 @@ def add_media_to_pile():
     target_cids, target_id, is_new = _insert_or_collide(new_media, file_md5)
 
     for cid in target_cids:
-        apply_label(cid, label)
+        apply_label(cid, label, provenance={"flow": "seed_example"})
     _sync_pile_label_to_storage()
 
     if is_new:

--- a/vtsearch/schemas/detectors.py
+++ b/vtsearch/schemas/detectors.py
@@ -72,7 +72,7 @@ from marshmallow import Schema, fields, validate
 
 from vtsearch.schemas.common import PluginExtrasSchema, list_of_strings
 from vtsearch.schemas.labels import LabeledElementSchema
-from vtsearch.schemas.media import MediaEntrySchema, OriginSchema
+from vtsearch.schemas.media import MediaEntrySchema, OriginSchema, VoteProvenanceSchema
 
 #: Upper bound on user-supplied detector names.  A name this long is already
 #: past any reasonable display use, and capping it here keeps the derived
@@ -893,9 +893,23 @@ class DetectorLabelVoteRequestSchema(Schema):
     direction: ``"good"`` / ``"bad"`` set the element's label, ``"remove"``
     drops it from the labelset. Sending an absolute target makes repeated
     requests from stale tabs idempotent (logical-bug-audit H1).
+
+    The optional ``provenance`` block records how the element came to be in
+    front of the user; it defaults to ``{"flow": "labelset_review"}``, which
+    is what this surface is - a correction to an already-saved label, not a
+    fresh draw off any ranking.  Recorded only when the label actually
+    flips.
     """
 
     target = fields.String(required=True, validate=validate.OneOf(["good", "bad", "remove"]))
+    provenance = fields.Nested(
+        VoteProvenanceSchema,
+        allow_none=True,
+        metadata={"description": "Optional surfacing context; see :class:`VoteProvenanceSchema`."},
+    )
+
+    class Meta:
+        unknown = "exclude"
 
 
 class DetectorLabelVoteResponseSchema(Schema):

--- a/vtsearch/schemas/media.py
+++ b/vtsearch/schemas/media.py
@@ -7,6 +7,8 @@ Listing / per-media routes (``vtsearch/routes/media/list.py``):
                                 :class:`MediaBatchResponseSchema`
 * ``POST /api/medias/<id>/vote`` -> :class:`MediaVoteRequestSchema` ->
                                     :class:`MediaVoteResponseSchema`
+        (its optional ``provenance`` block is :class:`VoteProvenanceSchema`,
+        shared with the bulk and detector-label vote routes)
 * ``GET  /api/medias/<id>/paragraph`` and ``GET /api/medias/<id>/text`` ->
         :class:`MediaParagraphResponseSchema`
 * ``POST /api/medias/add-to-pile`` -> :class:`MediaAddToPileResponseSchema`
@@ -46,6 +48,8 @@ docstring there.
 from __future__ import annotations
 
 from marshmallow import Schema, fields, validate
+
+from vtscore.datasets import vote_provenance
 
 from vtsearch.schemas.datasets import ImporterPickerTabSchema
 
@@ -198,6 +202,75 @@ class MediaBatchResponseSchema(MediaEntrySchema):
 
 
 # ---------------------------------------------------------------------------
+# Vote surfacing provenance (shared by the vote request schemas)
+# ---------------------------------------------------------------------------
+
+
+class VoteProvenanceSchema(Schema):
+    """How the item being voted on came to be in front of the user.
+
+    Optional on every vote request.  Recording only - nothing reads these
+    values back to change behaviour yet; consuming them is gated on the
+    experiment in ``docs/plans/provenance-partitioned-calibration.md``.  The
+    context is recorded at click time because it is *not re-derivable*: the
+    ranking is client-side state and the model that produced the score is
+    overwritten by the next retrain.
+
+    The four categorical fields are deliberately **separate axes** rather
+    than one fused enum, because the calibration bias the recording exists to
+    measure tracks ``select_mode`` (how the item was drawn off the ranking),
+    not ``flow`` (who was driving).  The two come apart at both edges: a user
+    can pick the ``hard`` select mode by hand and get autopilot's exact
+    margin-sampled draw, and autopilot's own ``good`` phase is mechanically a
+    top-of-list draw.  See :mod:`vtscore.datasets.vote_provenance`, which owns
+    the vocabulary these validators are built from.
+
+    Every field is optional: a client that knows only some of the axes sends
+    what it has.  A payload that carries nothing beyond ``flow="unknown"`` is
+    dropped rather than stored.
+    """
+
+    flow = fields.String(
+        allow_none=True,
+        validate=validate.OneOf(sorted(vote_provenance.FLOWS)),
+        metadata={"description": "Which UI flow drove the vote."},
+    )
+    phase = fields.String(
+        allow_none=True,
+        validate=validate.OneOf(sorted(vote_provenance.PHASES)),
+        metadata={"description": "Autopilot phase at click time. Ignored unless ``flow`` is ``autopilot``."},
+    )
+    select_mode = fields.String(
+        allow_none=True,
+        validate=validate.OneOf(sorted(vote_provenance.SELECT_MODES)),
+        metadata={
+            "description": (
+                "How the item was drawn off the ranking: ``top`` (head of the "
+                "sort), ``hard`` (margin sampling near the cutoff), or ``new`` "
+                "(diverse exploration)."
+            )
+        },
+    )
+    sort_kind = fields.String(
+        allow_none=True,
+        validate=validate.OneOf(sorted(vote_provenance.SORT_KINDS)),
+        metadata={"description": "Which ranking the user was looking at."},
+    )
+    rank_at_vote = fields.Integer(
+        allow_none=True,
+        validate=validate.Range(min=0),
+        metadata={"description": "Zero-based position of the item in the sort the user was looking at."},
+    )
+    score_at_vote = fields.Float(
+        allow_none=True,
+        metadata={"description": "The item's model score when it was surfaced, if the client has one."},
+    )
+
+    class Meta:
+        unknown = "exclude"
+
+
+# ---------------------------------------------------------------------------
 # /api/medias/<id>/vote
 # ---------------------------------------------------------------------------
 
@@ -237,6 +310,18 @@ class MediaVoteRequestSchema(Schema):
             "description": (
                 "Optional 4-element ``[x0, y0, x1, y1]`` in normalised image "
                 "coordinates ``[0, 1]``. Only valid when ``target`` is ``good``."
+            ),
+        },
+    )
+    provenance = fields.Nested(
+        VoteProvenanceSchema,
+        allow_none=True,
+        metadata={
+            "description": (
+                "Optional surfacing context for this vote. Recorded only when "
+                "the call actually changes the vote state, so an idempotent "
+                "re-send from a stale tab cannot overwrite what the original "
+                "click recorded."
             ),
         },
     )
@@ -299,6 +384,16 @@ class MediaVoteBulkRequestSchema(Schema):
         validate=validate.OneOf(["good", "bad", "none"]),
         metadata={
             "description": "Absolute target state applied to every id: ``good``, ``bad``, or ``none``. Idempotent.",
+        },
+    )
+    provenance = fields.Nested(
+        VoteProvenanceSchema,
+        allow_none=True,
+        metadata={
+            "description": (
+                "Optional surfacing context applied to every id in the batch. "
+                'Defaults to ``{"flow": "bulk"}`` when omitted.'
+            ),
         },
     )
 


### PR DESCRIPTION
Closes #2850

Records **how each vote was surfaced** — which UI flow drove it, which autopilot phase, how the item was drawn off the ranking, which ranking that was, and its rank and score at click time. Recording only: nothing reads these values back to change behaviour. Consuming them stays gated on the experiment pre-registered in `docs/plans/provenance-partitioned-calibration.md`.

## Why now

The context is **not re-derivable later**, which is verifiable in the code: `last_learned_scores` is overwritten on every retrain, sort order is client-side ephemeral state, and autopilot phase lives only in a frontend `BehaviorSubject`. Nothing persists any of it, so every vote cast before this ships is permanently `unknown`. That asymmetry — cheap to record, impossible to backfill — is what justifies shipping the recorder ahead of the experiment that consumes it, as decision rule 3 of the plan already says.

## Departure from the issue's spec: separate axes, not a fused enum

The issue specced a single `surfaced_by` string fusing flow and phase (`autopilot:hard`, `list_review`). Shipped instead as four independent fields, because the bias the recording exists to measure tracks **how the item was drawn** (`select_mode`) while the fused enum labels votes by **who was driving** (`flow`) — and the two come apart at both edges:

- A user can set the left panel's select mode to `hard` by hand and get exactly autopilot's margin-sampled draw. The fused enum records that as `list_review` (poison) when it is mechanically safe.
- Autopilot's own `good` phase is mechanically a top-of-list draw. The fused enum records it as `autopilot:good` (safe) when it is the same shape as the poison flow.

So the enum systematically mislabels both edges, discarding the discriminating variable. The three axes are already first-class and separate in the code (`SortMode`, `SelectMode`, `AutopilotPhase`), which is what made the conflation visible.

```json
"vt:provenance": {
  "v": 1, "flow": "list_review", "phase": null,
  "select_mode": "hard", "sort_kind": "learned",
  "rank_at_vote": 37, "score_at_vote": 0.512
}
```

`flow ∈ {autopilot, list_review, find_verify, labelset_review, seed_example, import, bulk, undo, unknown}`; `phase ∈ {good, bad, hard, new}` (autopilot only); `select_mode ∈ {top, hard, new}`; `sort_kind ∈ {learned, text, load}`.

## Storage

`vtscore/datasets/vote_provenance.py` owns the vocabulary and validation. The payload rides in `LabeledElement.metadata` under `"vt:provenance"`, so it round-trips through labelset export/import with no format change. Scalars only — the no-persisted-vectors rule is untouched. Threaded to mirror `vote_region_boxes` exactly: a `vote_provenance` map on `DetectorContext`, through `VoteSnapshot`, into `LabelSet.from_clips_and_votes`, and back out via `restore_labels_from_detector`.

## The two rules that keep the record honest

- **Idempotency is preserved.** Provenance is written only on a transition that changes the vote state; an idempotent re-apply returns before the write, so a stale tab cannot rewrite the context of a click it did not make. Same rule on `apply_element_vote_in_data`.
- **Restoration carries it back.** `sync_labels_to_loaded_detector` rebuilds the entire labelset from live vote state on *every* vote, so a detector load that dropped provenance would erase it on the user's next click — exactly the bug `region_box` shipped with. Both guards have regression tests that were verified to fail when the corresponding line is removed.

## Client

`VoteProvenanceService` assembles the payload from `AutopilotStateService` + `SortStateService` at a single chokepoint in `VoteStateService`, so a new vote surface is annotated correctly by default rather than silently recording nothing. Backend-inferable flows (example seeding, add-to-pile, label import, fill-from-sort, labelset review) are stamped server-side; a detector's machine calls in Find clear it, since they are not a surfacing event.

## Also fixed

A duplicate `"fast-uri"` key in `frontend/package.json`'s `overrides` was emitting two `▲ [WARNING]` lines from `build:prod` — a hard `run-tests.sh` failure. Both entries had the same value; removed the second.

## Testing

`./run-tests.sh` fully green: 9973 passed, 6 skipped, all gates OK (pyright, pip-audit, vulture whitelist, npm audit, Vitest). 56 new tests — the vocabulary, the state threading, the labelset round-trip, the three API routes, and an end-to-end vote → sync → disk assertion through a loaded detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M48Rezi1DsmKb9yLuDgbxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01M48Rezi1DsmKb9yLuDgbxm)_