### PR TITLE
DocMarks: audit the audit's descriptor — ask the similarity questions with siglip2_l

### DIFF
--- a/scripts/experiments/docmarks/GRID-RUNBOOK.md
+++ b/scripts/experiments/docmarks/GRID-RUNBOOK.md
@@ -166,6 +166,21 @@ bash launch_docmarks.sh slate           # ~minutes, CPU, no refetch
 scp $GRID:$VTS_DOCMARKS_OUT/audit/docmarks-audit-<date>.tar.gz .
 ```
 
+**Then the second opinion, on a GPU**, which re-renders both similarity passes
+against a semantic embedder (see README's *The descriptor the audit asks with is
+not the one it was built with*):
+
+```bash
+bash launch_docmarks.sh siglip          # ~minutes, GPU, embeds ~1.3k crops once
+scp $GRID:$VTS_DOCMARKS_OUT/audit/docmarks-audit-siglip-<date>.tar.gz .
+```
+
+It re-numbers the slate, so a `merges.txt` written against the `phash` sheets no
+longer refers to the same classes — the job keeps the old answer beside the new
+one as `merges.phash.txt` rather than overwriting it. Work the `phash` slate
+only if no GPU is available; the appendix it produces spends most of its 120
+pairs on classes that are not confusable (#3600).
+
 Rendering happens on the GRID because that is where the pages are: the sheets
 crop from full-resolution scans that live under `$VTS_DOCMARKS_OUT`, and pulling
 200k pages to a laptop to make four contact sheets is the wrong direction. The

--- a/scripts/experiments/docmarks/README.md
+++ b/scripts/experiments/docmarks/README.md
@@ -308,6 +308,53 @@ scanning and not a guarantee. The guarantee is `pairs_*.png`: the
 `MERGE_SLATE_NEAR_PAIRS` closest pairs, explicitly side by side, so no pair
 where a wrong call costs anything depends on the layout having been kind.
 
+### The descriptor the audit asks with is not the one it was built with
+
+`phash` clusters 200k pages for nothing and is the reason the corpus exists at
+this size. It is a poor judge of its own output. Measured on v2 (#3600): the one
+literal duplicate on the slate — two classes of the same `DY.Secretary` rubber
+stamp — ranked **83rd of 120** in the near-pair appendix, behind 82 pairs of
+stamps nobody would confuse, while two internally-mixed classes took 37% of the
+appendix between them. A perceptual hash of blue ink on white paper measures ink
+layout, and two different stamps in the same typeface at the same size have
+nearly the same ink layout. The identical failure is on record for UCSF
+letterhead bands, where no threshold produced classes at all.
+
+The audit can afford what the build cannot — it runs over ~1,300 crops, not
+200k pages — so `siglip_audit.py --embed` embeds every class instance once with
+`siglip2_l` and caches the vectors. Only that step needs a card; the slate
+render, the analysis and every re-render afterwards read the cache on `cpu`:
+
+```bash
+bash launch_docmarks.sh siglip                                   # GPU, ~7 min
+python make_audit_slate.py --task merge   --descriptor siglip2_l # re-ordered slate
+python make_audit_slate.py --task cluster --descriptor siglip2_l # split proposals
+```
+
+Three questions get better answers, and each was checked against a human verdict
+before being trusted rather than after:
+
+- **Which classes are nearest** — by class *centroid*, not by one query crop, so
+  an unrepresentative exemplar cannot place a whole class (#3599). On v2 the
+  closest pair went from 0.11 (two unrelated stamps) to 0.030 (two scans of the
+  same B&W wordmark).
+- **Which classes hold more than one mark** — each class's own instances
+  clustered by average linkage, swept over `AUDIT_SPLIT_SWEEP` and reported as a
+  sweep, never as a single verdict. Average linkage rather than single: single
+  linkage's failure mode is one ambiguous crop bridging two marks, which is the
+  defect the pass exists to find. On v2 it proposed `15 / 8 / 1` for the StaVer
+  class and `22 / 2` for `spods/stamp_00489_1` — both exactly the boundaries the
+  reviewer had already drawn by eye, and both found without being told.
+- **Whether a class's query crop retrieves its own class** — the question the
+  eval will ask, stated as the *rank* of the class's own centroid rather than a
+  distance whose scale nobody knows. It flags 3 of 59 on v2, including the one
+  `phash` scored second-*best* of 60.
+
+The proposals are hypotheses on a contact sheet. The verdict vocabulary does not
+change, `split` still means a person looked, and a false proposal is expected:
+on v2 two of the four proposed splits were scan quality varying more than the
+mark does, which is obvious on the sheet and invisible in the number.
+
 ### `REVIEWED-ALL` is the closed world, and it is deliberately narrow
 
 A partition asserts both directions at once: within a group is `same`, across

--- a/scripts/experiments/docmarks/audit_to_corrections.py
+++ b/scripts/experiments/docmarks/audit_to_corrections.py
@@ -502,6 +502,8 @@ def resplit_classes(
     *,
     backend: str,
     threshold: float,
+    corpus: Path,
+    min_mark_px: int = cfg.MIN_MARK_PX,
     factor: float = 0.5,
 ) -> list[str]:
     """Re-cluster each over-merged class alone, at a tighter threshold.
@@ -509,7 +511,17 @@ def resplit_classes(
     Only that class's own instances are touched, so re-splitting one class can
     never disturb another's already-confirmed membership.  The resulting pieces
     come back as fresh candidate classes for the next ``cluster`` sheet.
+
+    The pieces are **registered in** ``classes``, not merely written onto the
+    marks.  ``assign_class_ids`` relabels the manifest, but the slate, the
+    roster, the embedder and the report all read ``classes.json``; the only
+    other thing that writes it is ``build_corpus.py``, which rebuilds from the
+    sources and would discard this split along with every other audit verdict.
+    Popping the parent without adding its pieces therefore does not defer the
+    decision to the next sheet -- it deletes the class from everything
+    downstream while leaving its marks pointing at ids nothing knows.
     """
+    from build_corpus import admit_classes, write_query_crops
     from cluster_marks import assign_class_ids, describe_marks, distance_matrix, single_linkage
 
     notes: list[str] = []
@@ -528,7 +540,21 @@ def resplit_classes(
         provenance = "clustered_band" if meta.get("located_by") == "band" else "clustered"
         pieces = assign_class_ids(pages, refs, labels, source=source, provenance=provenance)
         classes.pop(class_id, None)
-        notes.append(f"{class_id}: re-clustered at {tighter:.3f} into {len(pieces)} piece(s)")
+
+        # `min_instances=1`: the reviewer said this class holds more than one
+        # mark, so every piece is a finding.  Sizing them out here would drop
+        # the small ones silently; the roster is where a piece too small to
+        # search gets excluded, and it can only exclude what it can see.
+        inventory = {cid: [(r.page_index, r.mark_index) for r in group] for cid, group in pieces.items()}
+        fresh, rejected = admit_classes(pages, inventory, min_instances=1, min_mark_px=min_mark_px, roster=None)
+        for cid, fresh_meta in fresh.items():
+            fresh_meta["audit"]["notes"] = f"re-clustered out of {class_id} at {tighter:.3f}"
+            classes[cid] = fresh_meta
+        write_query_crops(pages, inventory, fresh, corpus / "queries")
+        note = f"{class_id}: re-clustered at {tighter:.3f} into {len(pieces)} piece(s)"
+        if rejected:
+            note += f", {len(rejected)} not admitted ({'; '.join(sorted(rejected.values()))})"
+        notes.append(note)
     return notes
 
 
@@ -554,6 +580,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ap.add_argument("--apply", action="store_true", help="write the changes (default is a dry run)")
     ap.add_argument("--cluster-backend", default=cfg.CLUSTER_BACKEND, choices=("phash", "siglip"))
     ap.add_argument("--cluster-threshold", type=float, default=cfg.CLUSTER_THRESHOLD)
+    ap.add_argument("--min-mark-px", type=int, default=cfg.MIN_MARK_PX)
     args = ap.parse_args(argv)
 
     classes_path = args.corpus / "classes.json"
@@ -606,7 +633,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if resplit:
         for note in resplit_classes(
-            pages, classes, resplit, backend=args.cluster_backend, threshold=args.cluster_threshold
+            pages,
+            classes,
+            resplit,
+            backend=args.cluster_backend,
+            threshold=args.cluster_threshold,
+            corpus=args.corpus,
+            min_mark_px=args.min_mark_px,
         ):
             print(f"  {note}")
         print("  re-run make_audit_slate.py --task cluster to review the new pieces")

--- a/scripts/experiments/docmarks/cluster_marks.py
+++ b/scripts/experiments/docmarks/cluster_marks.py
@@ -172,9 +172,9 @@ def describe_marks(
         return np.array(rows, dtype=bool)
 
     if backend == "siglip":
-        from vtscore.media.image.embedder_siglip import SiglipEmbedder  # noqa: PLC0415
+        from vtscore.media.image.embedder_siglip import ImageSiglipEmbedder  # noqa: PLC0415
 
-        embedder = SiglipEmbedder()
+        embedder = ImageSiglipEmbedder()
         crops = []
         cache_path: Optional[str] = None
         cache_img: Any = None
@@ -183,7 +183,14 @@ def describe_marks(
             if page.path != cache_path:
                 cache_path, cache_img = page.path, Image.open(page.path).convert("RGB")
             crops.append(crop_mark(cache_img, ref.box))
-        vecs = np.asarray(embedder.embed_images(crops), dtype=np.float32)
+        # `embed_pil_image` is the embedder's only in-memory entry point, and it
+        # returns None for a crop the model declines.  A zero row keeps the
+        # matrix aligned with *refs* -- dropping the row would silently shift
+        # every later label onto the wrong mark -- and normalises to a vector at
+        # distance 1.0 from everything, so that mark simply clusters alone.
+        rows = [embedder.embed_pil_image(crop) for crop in crops]
+        dim = embedder.embedding_dim
+        vecs = np.asarray([row if row is not None else np.zeros(dim) for row in rows], dtype=np.float32)
         norms = np.linalg.norm(vecs, axis=1, keepdims=True)
         return vecs / np.clip(norms, 1e-8, None)
 

--- a/scripts/experiments/docmarks/docmarks_config.py
+++ b/scripts/experiments/docmarks/docmarks_config.py
@@ -370,3 +370,44 @@ MERGE_SLATE_NEAR_PAIRS = int(os.environ.get("VTS_DOCMARKS_MERGE_NEAR_PAIRS", "12
 
 #: Pairs per appendix sheet.
 MERGE_PAIRS_PER_SHEET = 12
+
+# --------------------------------------------------------------------------- #
+# The audit's second opinion
+# --------------------------------------------------------------------------- #
+#
+# `phash` is the right descriptor for *clustering* 200k pages and the wrong one
+# for *auditing* the result, and #3600 measured the gap: on corpus v2 the one
+# literal duplicate on the slate ranked 83rd of 120 in the near-pair appendix,
+# behind 82 pairs of stamps nobody would confuse, while two internally-mixed
+# classes took 37% of the appendix between them.  A perceptual hash of a blue
+# rubber stamp on white paper measures ink layout, and two different stamps of
+# the same size in the same typeface have nearly the same ink layout -- the
+# failure already on record for UCSF letterhead bands.
+#
+# The audit can afford what the build cannot: it runs over ~1.5k crops, not
+# 200k pages, so a GPU embedder is minutes.  Vectors are cached, so only the
+# embed step needs a card and every render afterwards stays on `cpu`.
+
+#: The embedder the audit's similarity questions are asked with.  Not the
+#: clustering's descriptor: changing that would change what the corpus *is*,
+#: and the roster's classes were admitted under `phash`.
+AUDIT_EMBEDDER = os.environ.get("VTS_DOCMARKS_AUDIT_EMBEDDER", "siglip2_l")
+
+#: Instances embedded per class.  A centroid stops moving long before a class's
+#: 30th instance, and the cap is recorded beside the vectors so a later reader
+#: knows the centroid is over a sample.
+AUDIT_MAX_PER_CLASS = int(os.environ.get("VTS_DOCMARKS_AUDIT_MAX_PER_CLASS", "24"))
+
+#: Cosine-distance thresholds the within-class split proposal is swept over.
+#: Reported as a sweep and never as a single verdict: the operating point is a
+#: property of this corpus and this embedder, and quietly picking one is how
+#: `CLUSTER_THRESHOLD`'s 0.16 outlived the mark decomposition it was measured
+#: on (#3366).
+AUDIT_SPLIT_SWEEP = (0.10, 0.15, 0.20, 0.25, 0.30, 0.40)
+
+#: Which descriptor the slate orders itself by.  `phash` stays the default so a
+#: slate renders with no cache and no card; `siglip2_l` requires
+#: `siglip_audit.py --embed` to have run, and refuses rather than silently
+#: falling back -- a slate whose ordering is not the one asked for is a slate
+#: whose appendix means something other than it says.
+SLATE_DESCRIPTOR = os.environ.get("VTS_DOCMARKS_SLATE_DESCRIPTOR", "phash")

--- a/scripts/experiments/docmarks/launch_docmarks.sh
+++ b/scripts/experiments/docmarks/launch_docmarks.sh
@@ -4,6 +4,7 @@
 #   bash launch_docmarks.sh probe          # can I reach every source?
 #   bash launch_docmarks.sh build          # stage 1: sources + clustering (CPU)
 #   bash launch_docmarks.sh slate          # stage 2: the human audit bundle (CPU)
+#   bash launch_docmarks.sh siglip         # stage 2b: the audit's second opinion (GPU)
 #   bash launch_docmarks.sh status         # queue + the real signal on disk
 #   bash launch_docmarks.sh embed s        # stage 5: cells for one tier (GPU)
 #
@@ -146,6 +147,56 @@ RUNNER_EOF
     --wrap="bash $RUNNER"
   ;;
 
+siglip)
+  # The audit's second opinion, on a semantic embedder (#3600).  One GPU job,
+  # because it is the only part of the audit that needs a card: it embeds every
+  # class instance once and caches the vectors, after which the re-render, the
+  # analysis and every later slate read the cache on `cpu`.
+  #
+  # ~1.5k crops of a few hundred pixels is minutes on any card here, so this
+  # does not get a type pin -- but VTS_GPU in the grid ~/.bashrc would silently
+  # supply one, so it is cleared for the same reason `embed` clears it.
+  if [ -n "${VTS_DOCMARKS_GPU:-}" ]; then
+    GRES="gpu:$VTS_DOCMARKS_GPU:1"
+  else
+    GRES="gpu:$(env -u VTS_GPU python3 "$WT/scripts/slurm/pick_gpu.py"):1"
+  fi
+  echo "gres: $GRES"
+  RUNNER="/exp/$USER/.docmarks-siglip.$$.sh"
+  cat > "$RUNNER" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -uo pipefail
+source "$WT/gridenv.sh"
+source "$WT/scripts/experiments/pile/pile_env.sh"
+export VTS_REPO="$WT"
+export VTS_DOCMARKS_OUT="$VTS_DOCMARKS_OUT"
+cd "$HERE"
+echo "node=\$(hostname) job=\$SLURM_JOB_ID start=\$(date -Is)"
+python -u siglip_audit.py --embed   --corpus "$VTS_DOCMARKS_OUT" || exit 1
+python -u siglip_audit.py --analyze --corpus "$VTS_DOCMARKS_OUT" || exit 1
+# Re-render both similarity passes against the cache, on the same node while it
+# is already warm.  The merge slate is re-ordered and re-numbered, so the old
+# merges.txt no longer refers to the same classes -- it is kept beside the new
+# one rather than overwritten.
+[ -f "$VTS_DOCMARKS_OUT/audit/merge/merges.txt" ] && \
+  cp "$VTS_DOCMARKS_OUT/audit/merge/merges.txt" "$VTS_DOCMARKS_OUT/audit/merge/merges.phash.txt"
+DESC="\${VTS_DOCMARKS_AUDIT_EMBEDDER:-siglip2_l}"
+python -u make_audit_slate.py --task merge   --corpus "$VTS_DOCMARKS_OUT" --descriptor "\$DESC" || exit 1
+python -u make_audit_slate.py --task cluster --corpus "$VTS_DOCMARKS_OUT" --descriptor "\$DESC" || exit 1
+cd "$VTS_DOCMARKS_OUT" && tar czf "audit/docmarks-audit-siglip-\$(date +%Y%m%d).tar.gz" \
+  audit/merge audit/cluster audit/siglip/pairs.json audit/siglip/splits.json audit/siglip/query_check.json
+echo "bundle: $VTS_DOCMARKS_OUT/audit/docmarks-audit-siglip-\$(date +%Y%m%d).tar.gz"
+echo "exit=\$? end=\$(date -Is)"
+RUNNER_EOF
+  chmod +x "$RUNNER"
+
+  sbatch --job-name="docmarks-siglip" --partition=gpu --gres="$GRES" \
+    --mem="${VTS_DOCMARKS_SIGLIP_MEM:-32G}" --cpus-per-task=4 \
+    --time="${VTS_DOCMARKS_SIGLIP_TIME:-02:00:00}" \
+    --output="$LOGS/siglip-%j.out" --error="$LOGS/siglip-%j.out" \
+    --wrap="bash $RUNNER"
+  ;;
+
 status)
   squeue -u "$USER" -n "$JOB_NAME" -o "%.10i %.16j %.8T %.12M %.12l %R"
   echo
@@ -193,5 +244,5 @@ RUNNER_EOF
   ;;
 
 *)
-  echo "usage: $0 {probe|build|slate|status|embed <tier>}" >&2; exit 2 ;;
+  echo "usage: $0 {probe|build|slate|siglip|status|embed <tier>}" >&2; exit 2 ;;
 esac

--- a/scripts/experiments/docmarks/make_audit_slate.py
+++ b/scripts/experiments/docmarks/make_audit_slate.py
@@ -8,6 +8,12 @@
     python make_audit_slate.py --task confusable   # are these two the same mark?
     python make_audit_slate.py --task distinctive  # is this a mark or a shape?
 
+Every task that ranks or groups by similarity takes ``--descriptor``.  The
+default ``phash`` is the corpus's own descriptor and needs nothing; naming the
+audit embedder instead reads the vector cache ``siglip_audit.py --embed``
+writes, which is what #3600 asks for -- ``phash`` ranked the slate's one literal
+duplicate 83rd of 120.
+
 Each task writes PNG sheets plus a ``verdicts.jsonl`` template into
 ``<out>/audit/<task>/``.  Fill in the verdict field, then fold the answers back
 with ``audit_to_corrections.py``.
@@ -68,6 +74,7 @@ instead prevented by construction — see ``CONTAMINATES`` in
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import random
 import re
@@ -125,33 +132,85 @@ def _crop(page: Page, box: tuple[int, int, int, int], pad_frac: float = 0.08) ->
         )
 
 
-def task_cluster(pages: list[Page], classes: dict[str, Any], out: Path, *, max_per_class: int = 24) -> list[dict]:
-    """One sheet per derived class: every instance, so a bad merge is obvious."""
+def subgroups(corpus: Path, descriptor: str, threshold: float) -> dict[str, dict[str, int]]:
+    """Where each class's instances fall apart, per the cached vectors.
+
+    Returns ``{class_id: {page_id: group}}``, groups numbered from 1 in
+    descending size.  ``phash`` returns nothing: the corpus was clustered with
+    it, so it has no second opinion to offer about its own output.
+    """
+    if descriptor == "phash":
+        return {}
+
+    import siglip_audit  # noqa: PLC0415  -- optional: only this path needs it
+
+    items, vecs = siglip_audit.load_cache(corpus)
+    by_class: dict[str, list[int]] = {}
+    for i, item in enumerate(items):
+        if item["kind"] == "instance":
+            by_class.setdefault(item["class_id"], []).append(i)
+
+    proposals: dict[str, dict[str, int]] = {}
+    for class_id, idx in by_class.items():
+        labels = siglip_audit.split_class(vecs[idx], threshold)
+        sizes = sorted(((int((labels == k).sum()), int(k)) for k in set(labels.tolist())), reverse=True)
+        rank = {raw: n + 1 for n, (_size, raw) in enumerate(sizes)}
+        proposals[class_id] = {items[i]["page_id"]: rank[int(label)] for i, label in zip(idx, labels)}
+    return proposals
+
+
+def task_cluster(
+    pages: list[Page],
+    classes: dict[str, Any],
+    out: Path,
+    *,
+    max_per_class: int = 24,
+    proposals: Optional[dict[str, dict[str, int]]] = None,
+) -> list[dict]:
+    """One sheet per derived class: every instance, so a bad merge is obvious.
+
+    With *proposals* the crops are grouped and captioned by the sub-group a
+    semantic descriptor puts them in, so the sheet says *where* the reviewer
+    thinks the boundary is instead of asking them to find it. The verdict
+    vocabulary is unchanged: the proposal is a hypothesis on a contact sheet,
+    and ``split`` still means a person looked.
+    """
     by_id = {p.page_id: p for p in pages}
     verdicts = []
     derived = {k: v for k, v in classes.items() if any(p.startswith("clustered") for p in v.get("provenance", []))}
+    proposals = proposals or {}
 
     for class_id, meta in sorted(derived.items(), key=lambda kv: -kv[1]["n_instances"]):
+        groups = proposals.get(class_id, {})
+        page_ids = meta["page_ids"][:max_per_class]
+        if groups:
+            page_ids = sorted(page_ids, key=lambda pid: (groups.get(pid, 99), pid))
         crops, caps = [], []
-        for page_id in meta["page_ids"][:max_per_class]:
+        for page_id in page_ids:
             page = by_id.get(page_id)
             if page is None:
                 continue
             for mark in page.marks:
                 if mark.class_id == class_id:
                     crops.append(_crop(page, mark.box))
-                    caps.append(page_id.split("/")[-1])
+                    tag = f"g{groups[page_id]} " if page_id in groups else ""
+                    caps.append(f"{tag}{page_id.split('/')[-1]}")
                     break
         if not crops:
             continue
+        proposed = sorted(collections.Counter(groups.values()).values(), reverse=True)
+        headline = f"{class_id}  —  {meta['n_instances']} instances  —  all one mark?"
+        if len(proposed) > 1:
+            headline += f"   [proposes {len(proposed)} groups: {', '.join(str(s) for s in proposed)}]"
         name = class_id.replace("/", "__")
-        _sheet(crops, f"{class_id}  —  {meta['n_instances']} instances  —  all one mark?", out / f"{name}.png", caps)
+        _sheet(crops, headline, out / f"{name}.png", caps)
         verdicts.append(
             {
                 "task": "cluster",
                 "class_id": class_id,
                 "n_instances": meta["n_instances"],
                 "sheet": f"{name}.png",
+                "proposed_groups": proposed,
                 # one of:
                 #   ok                     every crop on the sheet is one mark
                 #   merge_into:<class_id>  this and that class are the same mark
@@ -289,6 +348,56 @@ def seriate(dist: np.ndarray) -> list[int]:
     return order
 
 
+def phash_distances(exemplars: Sequence[Any]) -> np.ndarray:
+    """Normalised Hamming distance between the exemplars' perceptual hashes."""
+    desc = np.array([_cluster.phash(im) for im in exemplars], dtype=bool)
+    bits = desc.astype(np.uint8)
+    inv = 1 - bits
+    dist = (bits @ inv.T + inv @ bits.T).astype(float) / desc.shape[1]
+    np.fill_diagonal(dist, 0.0)
+    return dist
+
+
+def class_distances(class_ids: Sequence[str], exemplars: Sequence[Any], descriptor: str, corpus: Path) -> np.ndarray:
+    """The class-to-class distances the slate is ordered and paired by.
+
+    ``phash`` hashes each class's **query crop**, which is what the corpus was
+    clustered with and needs neither a card nor a cache.  Any other descriptor
+    reads the vector cache ``siglip_audit.py --embed`` writes and uses each
+    class's **centroid** over its instances -- centroids rather than exemplars
+    because #3599 is the case where one unrepresentative query crop placed a
+    whole class, and a semantic descriptor good enough to be worth running is
+    good enough to be worth pointing at the instances.
+
+    A missing or incomplete cache is an error, never a silent fall back to
+    ``phash``: the appendix's whole meaning is which pairs were ranked closest,
+    so a slate ordered by a descriptor other than the one asked for is a slate
+    whose ``REVIEWED-ALL`` records something nobody intended.
+    """
+    if descriptor == "phash":
+        return phash_distances(exemplars)
+
+    import siglip_audit  # noqa: PLC0415  -- optional: only this path needs it
+
+    items, vecs = siglip_audit.load_cache(corpus)
+    cached = json.loads((corpus / siglip_audit.ITEMS).read_text(encoding="utf-8"))
+    if cached.get("embedder") != descriptor:
+        raise SystemExit(
+            f"vector cache holds {cached.get('embedder')!r}, not {descriptor!r} — "
+            f"re-run siglip_audit.py --embed --embedder {descriptor}"
+        )
+    order, centroids = siglip_audit.class_centroids(items, vecs)
+    position = {class_id: i for i, class_id in enumerate(order)}
+    missing = [c for c in class_ids if c not in position]
+    if missing:
+        raise SystemExit(
+            f"{len(missing)} class(es) have no vectors in the cache (first: {missing[0]}) — "
+            "re-run siglip_audit.py --embed against this corpus"
+        )
+    rows = centroids[[position[c] for c in class_ids]]
+    return siglip_audit.cosine_distance(rows)
+
+
 def near_pairs(dist: np.ndarray, k: int) -> list[tuple[float, int, int]]:
     """The *k* closest class pairs, nearest first, ties broken by index."""
     n = dist.shape[0]
@@ -297,8 +406,13 @@ def near_pairs(dist: np.ndarray, k: int) -> list[tuple[float, int, int]]:
     return pairs[:k]
 
 
-def _cell(strip: Sequence[Any], index: int, label: str, *, thumb: int = 120) -> Any:
-    """One class as a numbered horizontal strip of its own instances."""
+def _cell(strip: Sequence[Any], index: int, label: str, *, thumb: int = 120, divide_after: Optional[int] = None) -> Any:
+    """One class as a numbered horizontal strip of its own instances.
+
+    *divide_after* draws a rule after that many thumbs, for the pair sheets,
+    where one cell carries instances of two different classes and the reader
+    has to be able to tell which are which without counting.
+    """
     from PIL import Image, ImageDraw
 
     slots = max(1, len(strip))
@@ -317,6 +431,10 @@ def _cell(strip: Sequence[Any], index: int, label: str, *, thumb: int = 120) -> 
         x = 4 + i * (thumb + 4) + (thumb - t.width) // 2
         y = head + 3 + (thumb - t.height) // 2
         cell.paste(t, (x, y))
+
+    if divide_after:
+        x = 2 + divide_after * (thumb + 4)
+        draw.line([x, head + 2, x, cell.height - 3], fill="#0b3d91", width=2)
     return cell
 
 
@@ -370,6 +488,8 @@ def task_merge(
     out: Path,
     *,
     top_pairs: int = cfg.MERGE_SLATE_NEAR_PAIRS,
+    descriptor: str = cfg.SLATE_DESCRIPTOR,
+    corpus: Optional[Path] = None,
 ) -> dict[str, Any]:
     """Every class on a few numbered sheets; the answer is a list of index sets.
 
@@ -405,6 +525,7 @@ def task_merge(
 
     by_id = {p.page_id: p for p in pages}
     pool = {k: v for k, v in classes.items() if v.get("on_roster")} or classes
+    corpus = corpus if corpus is not None else out.parent.parent
 
     exemplars: list[tuple[str, Any]] = []
     for class_id, meta in sorted(pool.items()):
@@ -414,20 +535,18 @@ def task_merge(
     if len(exemplars) < 2:
         return {"classes": [], "near_pairs": [], "sheets": []}
 
-    desc = np.array([_cluster.phash(im) for _cid, im in exemplars], dtype=bool)
-    bits = desc.astype(np.uint8)
-    inv = 1 - bits
-    dist = (bits @ inv.T + inv @ bits.T).astype(float) / desc.shape[1]
-    np.fill_diagonal(dist, 0.0)
+    dist = class_distances([cid for cid, _im in exemplars], [im for _cid, im in exemplars], descriptor, corpus)
 
     order = seriate(dist)
     slate_index = {orig: slot for slot, orig in enumerate(order)}
 
     cells, index_rows = [], []
+    strips: dict[int, list[Any]] = {}
     for slot, orig in enumerate(order):
         class_id, exemplar = exemplars[orig]
         meta = pool[class_id]
         strip = _class_strip(meta.get("page_ids", []), by_id, class_id, cfg.MERGE_SLATE_INSTANCES) or [exemplar]
+        strips[orig] = strip
         cells.append(_cell(strip, slot, f"{class_id}  ({int(meta.get('n_instances', len(strip)))}x)"))
         index_rows.append(
             {
@@ -472,7 +591,21 @@ def task_merge(
         pair_cells = []
         for d, i, j in chunk:
             li, ri = slate_index[i], slate_index[j]
-            pair_cells.append(_cell([exemplars[i][1], exemplars[j][1]], li, f"vs [{ri}]   distance {d:.3f}", thumb=150))
+            # Instances, not query crops, on both sides of the rule: the pair
+            # sheets are where a wrong call writes a permanent separation, and
+            # #3599 is the case where a class's query crop was a mark that
+            # appears nowhere in it.
+            left = strips.get(i, [exemplars[i][1]])[:2]
+            right = strips.get(j, [exemplars[j][1]])[:2]
+            pair_cells.append(
+                _cell(
+                    [*left, *right],
+                    li,
+                    f"vs [{ri}]   distance {d:.3f}",
+                    thumb=132,
+                    divide_after=len(left),
+                )
+            )
         _paste_grid(
             pair_cells,
             f"DocMarks — the {len(pairs)} closest pairs, {start}..{start + len(chunk) - 1} — "
@@ -702,6 +835,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         default=400,
         help="confusable: cap on pairs; a 24-class roster's full 276-pair matrix fits under the default",
     )
+    ap.add_argument(
+        "--descriptor",
+        default=cfg.SLATE_DESCRIPTOR,
+        help="merge: what the slate is ordered and paired by; cluster: what proposes the sub-groups. "
+        "'phash' is the corpus's own descriptor and needs nothing; anything else reads the vector "
+        "cache from siglip_audit.py --embed (see #3600)",
+    )
+    ap.add_argument(
+        "--split-threshold",
+        type=float,
+        default=cfg.AUDIT_SPLIT_SWEEP[len(cfg.AUDIT_SPLIT_SWEEP) // 2],
+        help="cluster: cosine distance at which a class's instances stop being one mark; "
+        "siglip_audit.py --analyze records the whole sweep to choose from",
+    )
     args = ap.parse_args(argv)
 
     pages = list(read_manifest(args.corpus / "corpus.jsonl"))
@@ -712,17 +859,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     out.mkdir(parents=True, exist_ok=True)
 
     if args.task == "merge":
-        payload = task_merge(pages, classes, out, top_pairs=args.near_pairs)
+        payload = task_merge(
+            pages, classes, out, top_pairs=args.near_pairs, descriptor=args.descriptor, corpus=args.corpus
+        )
         print(f"merge: {len(payload['classes'])} class(es) on {len(payload['sheets'])} slate sheet(s)")
         print(f"  slate    {out}/slate_*.png")
         print(f"  pairs    {out}/pairs_*.png   ({len(payload['near_pairs'])} nearest pairs)")
         print(f"  answer   {out}/merges.txt  (one line per group of same-mark indices)")
+        print(f"  ordered by {args.descriptor}")
         return 0
 
     if args.task == "membership":
         verdicts = task_membership(pages, classes, out)
     elif args.task == "cluster":
-        verdicts = task_cluster(pages, classes, out)
+        verdicts = task_cluster(
+            pages, classes, out, proposals=subgroups(args.corpus, args.descriptor, args.split_threshold)
+        )
     elif args.task == "confusable":
         verdicts = task_confusable(pages, classes, out, top_n=args.top_pairs)
     elif args.task == "distinctive":

--- a/scripts/experiments/docmarks/siglip_audit.py
+++ b/scripts/experiments/docmarks/siglip_audit.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python
+"""Re-run the DocMarks audit's similarity questions on a semantic embedder.
+
+    python siglip_audit.py --embed                      # GPU: cache one vector per crop
+    python siglip_audit.py --analyze                    # CPU: pairs, splits, query check
+    python make_audit_slate.py --task merge --descriptor siglip2_l   # CPU: re-order the slate
+
+``phash`` is the right descriptor for *clustering* marks: it is cheap, it runs
+on 200k pages, and the corpus was built with it.  It is the wrong descriptor for
+the questions the **audit** asks, and #3600 measured how wrong -- on corpus v2
+the one literal duplicate on the slate (the ``DY.Secretary`` stamp, since
+merged) ranked **83rd of 120** in the near-pair appendix, behind 82 pairs of
+stamps nobody would confuse, while two internally-mixed classes took 37% of the
+appendix between them.  The cause is not a threshold: a perceptual hash of a
+blue rubber stamp on white paper measures ink layout, and two different stamps
+of the same size in the same typeface have nearly the same ink layout.  The same
+failure is already on record for UCSF letterhead bands.
+
+So this module asks the audit's three similarity questions with ``siglip2_l``
+instead, and asks them of the *instances* rather than of one exemplar:
+
+``pairs``
+    Which classes are nearest each other, ranked by the cosine distance between
+    class **centroids**.  This is the near-pair appendix, re-derived.  A centroid
+    is what makes it robust: the phash ranking read a single query crop, so one
+    unrepresentative exemplar moved a whole class (#3599).
+
+``splits``
+    Which classes hold more than one mark, by clustering each class's own
+    instances.  ``--task cluster`` already renders every instance for a human to
+    look at; this proposes *where* the boundary falls, so the answer is a
+    confirmation rather than a search.  The threshold is not invented: it is
+    swept, and the sweep is recorded beside the answer.
+
+``query check``
+    Does a class's query crop retrieve its own class?  The eval searches with
+    that crop, so this is the question the eval will ask.  It is stated as the
+    **rank of the class's own centroid** among all centroids, which is a
+    property of the retrieval rather than of a distance whose scale nobody
+    knows.  The phash version of this screen does not work -- #3599 records it
+    scoring the one confirmed-wrong crop second-best of 60 -- and a screen that
+    ranks a known defect near the top of the healthy pile is worse than none.
+
+Vectors are cached to ``audit/siglip/vectors.npz`` so that only ``--embed``
+needs a card: the slate render, the analysis and every re-render afterwards read
+the cache and stay on the ``cpu`` partition, which is where the audit's own
+launcher runs them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import docmarks_config as cfg  # noqa: E402
+from sources._common import Page, read_manifest  # noqa: E402
+
+#: Where the cache lives, relative to the corpus root.
+VECTORS = Path("audit") / "siglip" / "vectors.npz"
+ITEMS = Path("audit") / "siglip" / "items.json"
+
+
+# --------------------------------------------------------------------------- #
+# embedding
+# --------------------------------------------------------------------------- #
+
+
+def _crop_bytes(page: Page, box: tuple[int, int, int, int], pad_frac: float = 0.08) -> bytes:
+    """One mark, cropped and PNG-encoded, ready to hand to the embedder."""
+    import io
+
+    from PIL import Image
+
+    x, y, w, h = box
+    pad = int(round(max(w, h) * pad_frac))
+    with Image.open(page.path) as im:
+        crop = im.convert("RGB").crop(
+            (max(0, x - pad), max(0, y - pad), min(im.width, x + w + pad), min(im.height, y + h + pad))
+        )
+    buf = io.BytesIO()
+    crop.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def collect_items(pages: Sequence[Page], classes: dict[str, Any], *, max_per_class: int) -> list[dict[str, Any]]:
+    """Every instance of every class, plus each class's query crop.
+
+    Capped per class because the cost of a class is linear in its instances and
+    the marginal instance stops moving a centroid quickly; the cap is recorded
+    in the items file so a later reader knows a centroid is over a sample.
+    """
+    by_id = {p.page_id: p for p in pages}
+    items: list[dict[str, Any]] = []
+    for class_id, meta in sorted(classes.items()):
+        for page_id in meta.get("page_ids", [])[:max_per_class]:
+            page = by_id.get(page_id)
+            if page is None:
+                continue
+            for mark in page.marks:
+                if mark.class_id == class_id and mark.area() > 0:
+                    items.append({"class_id": class_id, "page_id": page_id, "kind": "instance", "box": list(mark.box)})
+                    break
+        query = meta.get("query_crop")
+        if query and Path(query).exists():
+            items.append(
+                {"class_id": class_id, "page_id": meta.get("query_page_id", ""), "kind": "query", "path": query}
+            )
+    return items
+
+
+def embed_items(items: Sequence[dict[str, Any]], pages: Sequence[Page], embedder: str) -> np.ndarray:
+    """Embed each item's pixels, returning one L2-normalised row per item."""
+    from vtscore.datasets.stages.embedding import embed_missing
+    from vtscore.embedding.media_vectors import media_embedding
+
+    by_id = {p.page_id: p for p in pages}
+    medias: dict[int, dict[str, Any]] = {}
+    for index, item in enumerate(items):
+        if item["kind"] == "query":
+            raw = Path(item["path"]).read_bytes()
+            name = Path(item["path"]).name
+        else:
+            page = by_id[item["page_id"]]
+            raw = _crop_bytes(page, tuple(item["box"]))
+            name = f"{item['page_id'].replace('/', '__')}.png"
+        medias[index] = {
+            "id": index,
+            "media_type": "image",
+            "embedder": embedder,
+            "duration": 0,
+            "file_size": len(raw),
+            "md5": "",
+            "embeddings": {},
+            "media_bytes": raw,
+            "media_string": None,
+            "filename": name,
+            "category": item["class_id"],
+            "categories": [item["class_id"]],
+            "regions": [],
+            "origin": {"importer": "docmarks_audit", "params": {"embedder": embedder}},
+            "origin_name": f"{item['class_id']}:{item['kind']}:{item['page_id']}",
+        }
+
+    embed_missing(medias, embedder)
+
+    vecs = []
+    for index in range(len(items)):
+        vec = media_embedding(medias[index], embedder)
+        if vec is None:
+            raise SystemExit(f"embedder {embedder!r} returned no vector for item {index} ({items[index]})")
+        vecs.append(np.asarray(vec, dtype=np.float32))
+    matrix = np.vstack(vecs)
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+    return matrix / np.maximum(norms, 1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# analysis
+# --------------------------------------------------------------------------- #
+
+
+def class_centroids(items: Sequence[dict[str, Any]], vecs: np.ndarray) -> tuple[list[str], np.ndarray]:
+    """One L2-normalised centroid per class, over its *instance* vectors."""
+    order: list[str] = []
+    rows: list[np.ndarray] = []
+    by_class: dict[str, list[int]] = {}
+    for i, item in enumerate(items):
+        if item["kind"] == "instance":
+            by_class.setdefault(item["class_id"], []).append(i)
+    for class_id in sorted(by_class):
+        mean = vecs[by_class[class_id]].mean(axis=0)
+        rows.append(mean / max(float(np.linalg.norm(mean)), 1e-12))
+        order.append(class_id)
+    return order, np.vstack(rows) if rows else np.zeros((0, vecs.shape[1]), dtype=np.float32)
+
+
+def cosine_distance(matrix: np.ndarray) -> np.ndarray:
+    """Pairwise cosine distance for L2-normalised rows, diagonal zeroed."""
+    dist = 1.0 - matrix @ matrix.T
+    np.fill_diagonal(dist, 0.0)
+    return np.clip(dist, 0.0, 2.0)
+
+
+def split_class(vectors: np.ndarray, threshold: float) -> np.ndarray:
+    """Average-linkage sub-groups of one class's instances, at *threshold*.
+
+    Average linkage rather than single: single linkage's failure mode is exactly
+    the one this pass exists to catch -- one ambiguous crop bridging two marks
+    into a chain -- and using it here would reproduce the defect while claiming
+    to detect it.
+    """
+    from scipy.cluster.hierarchy import fcluster, linkage
+    from scipy.spatial.distance import squareform
+
+    if len(vectors) < 2:
+        return np.ones(len(vectors), dtype=int)
+    condensed = squareform(cosine_distance(vectors), checks=False)
+    return fcluster(linkage(condensed, method="average"), t=threshold, criterion="distance")
+
+
+def split_report(
+    items: Sequence[dict[str, Any]], vecs: np.ndarray, thresholds: Sequence[float]
+) -> list[dict[str, Any]]:
+    """For every class: how it breaks up, at each threshold in the sweep.
+
+    Reported as a sweep rather than a verdict because the operating point is a
+    property of this corpus and this embedder, and picking one silently is how
+    ``CLUSTER_THRESHOLD``'s 0.16 outlived the decomposition it was measured on.
+    """
+    by_class: dict[str, list[int]] = {}
+    for i, item in enumerate(items):
+        if item["kind"] == "instance":
+            by_class.setdefault(item["class_id"], []).append(i)
+
+    rows = []
+    for class_id in sorted(by_class):
+        idx = by_class[class_id]
+        sub = vecs[idx]
+        within = cosine_distance(sub)
+        sweep = {}
+        for t in thresholds:
+            labels = split_class(sub, t)
+            sizes = sorted((int((labels == k).sum()) for k in set(labels.tolist())), reverse=True)
+            sweep[f"{t:.2f}"] = sizes
+        rows.append(
+            {
+                "class_id": class_id,
+                "n": len(idx),
+                "median_within": round(float(np.median(within[np.triu_indices(len(idx), k=1)])), 3)
+                if len(idx) > 1
+                else 0.0,
+                "max_within": round(float(within.max()), 3),
+                "sweep": sweep,
+            }
+        )
+    rows.sort(key=lambda r: -r["max_within"])
+    return rows
+
+
+def query_check(
+    items: Sequence[dict[str, Any]], vecs: np.ndarray, order: Sequence[str], centroids: np.ndarray
+) -> list[dict[str, Any]]:
+    """Does each class's query crop retrieve its own class?
+
+    The number that matters is the **rank** of the class's own centroid, because
+    that is what the eval does with the crop.  A distance alone cannot say
+    whether 0.30 is fine, and #3599 is the case where a distance said fine.
+    """
+    position = {class_id: i for i, class_id in enumerate(order)}
+    rows = []
+    for i, item in enumerate(items):
+        if item["kind"] != "query" or item["class_id"] not in position:
+            continue
+        sims = centroids @ vecs[i]
+        ranking = np.argsort(-sims)
+        own = position[item["class_id"]]
+        rank = int(np.where(ranking == own)[0][0])
+        rows.append(
+            {
+                "class_id": item["class_id"],
+                "query_page_id": item["page_id"],
+                "rank_of_own_class": rank,
+                "distance_to_own": round(float(1.0 - sims[own]), 3),
+                "nearest_class": order[int(ranking[0])],
+                "distance_to_nearest": round(float(1.0 - sims[int(ranking[0])]), 3),
+            }
+        )
+    rows.sort(key=lambda r: (-r["rank_of_own_class"], -r["distance_to_own"]))
+    return rows
+
+
+def pair_report(order: Sequence[str], centroids: np.ndarray, top: int) -> list[dict[str, Any]]:
+    """The closest class pairs by centroid distance, nearest first."""
+    dist = cosine_distance(centroids)
+    n = len(order)
+    pairs = [(float(dist[i, j]), i, j) for i in range(n) for j in range(i + 1, n)]
+    pairs.sort(key=lambda t: (t[0], t[1], t[2]))
+    return [
+        {"rank": r, "left": order[i], "right": order[j], "distance": round(d, 4)}
+        for r, (d, i, j) in enumerate(pairs[:top])
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# entry point
+# --------------------------------------------------------------------------- #
+
+
+def load_cache(corpus: Path) -> tuple[list[dict[str, Any]], np.ndarray]:
+    vec_path, item_path = corpus / VECTORS, corpus / ITEMS
+    if not vec_path.exists() or not item_path.exists():
+        raise SystemExit(f"no vector cache at {vec_path} — run siglip_audit.py --embed first")
+    items = json.loads(item_path.read_text(encoding="utf-8"))["items"]
+    return items, np.load(vec_path)["vecs"]
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--corpus", type=Path, default=cfg.OUT)
+    ap.add_argument("--embed", action="store_true", help="GPU: embed every crop and cache the vectors")
+    ap.add_argument("--analyze", action="store_true", help="CPU: pairs, split proposals and the query check")
+    ap.add_argument("--embedder", default=cfg.AUDIT_EMBEDDER)
+    ap.add_argument("--max-per-class", type=int, default=cfg.AUDIT_MAX_PER_CLASS)
+    ap.add_argument("--top-pairs", type=int, default=cfg.MERGE_SLATE_NEAR_PAIRS)
+    args = ap.parse_args(argv)
+
+    if not args.embed and not args.analyze:
+        ap.error("nothing to do: pass --embed, --analyze, or both")
+
+    pages = list(read_manifest(args.corpus / "corpus.jsonl"))
+    classes = json.loads((args.corpus / "classes.json").read_text(encoding="utf-8"))
+    out = args.corpus / "audit" / "siglip"
+    out.mkdir(parents=True, exist_ok=True)
+
+    if args.embed:
+        items = collect_items(pages, classes, max_per_class=args.max_per_class)
+        print(f"embedding {len(items)} crop(s) from {len(classes)} class(es) with {args.embedder}")
+        vecs = embed_items(items, pages, args.embedder)
+        np.savez_compressed(args.corpus / VECTORS, vecs=vecs)
+        (args.corpus / ITEMS).write_text(
+            json.dumps(
+                {"embedder": args.embedder, "max_per_class": args.max_per_class, "items": items},
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"  wrote {args.corpus / VECTORS}  {vecs.shape}")
+
+    if args.analyze:
+        items, vecs = load_cache(args.corpus)
+        order, centroids = class_centroids(items, vecs)
+        pairs = pair_report(order, centroids, args.top_pairs)
+        splits = split_report(items, vecs, cfg.AUDIT_SPLIT_SWEEP)
+        queries = query_check(items, vecs, order, centroids)
+
+        (out / "pairs.json").write_text(json.dumps(pairs, indent=2) + "\n", encoding="utf-8")
+        (out / "splits.json").write_text(json.dumps(splits, indent=2) + "\n", encoding="utf-8")
+        (out / "query_check.json").write_text(json.dumps(queries, indent=2) + "\n", encoding="utf-8")
+
+        print(
+            f"pairs:   {len(pairs)} closest of {len(order)} classes, "
+            f"{pairs[0]['distance']:.3f}–{pairs[-1]['distance']:.3f}"
+        )
+        print("  " + "\n  ".join(f"{p['distance']:.3f}  {p['left']}  vs  {p['right']}" for p in pairs[:5]))
+        misses = [q for q in queries if q["rank_of_own_class"] > 0]
+        print(f"query:   {len(misses)} of {len(queries)} query crop(s) do not retrieve their own class first")
+        for q in misses[:5]:
+            print(f"  rank {q['rank_of_own_class']:2d}  {q['class_id']}  (nearest: {q['nearest_class']})")
+        print("splits:  most spread classes (max within-class distance)")
+        for s in splits[:8]:
+            print(f"  {s['max_within']:.3f}  {s['class_id']:44s} n={s['n']:3d}  sweep={s['sweep']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -63,6 +63,7 @@ def mods(_on_path):
         "shortlist": importlib.import_module("shortlist"),
         "audit": importlib.import_module("audit_to_corrections"),
         "slate": importlib.import_module("make_audit_slate"),
+        "siglip": importlib.import_module("siglip_audit"),
         "report": importlib.import_module("make_report"),
     }
 
@@ -2237,3 +2238,152 @@ class TestUcsfBandsAreNotClustered:
         # and that was always 92% of what it was for.
         assert "ucsf" not in mods["cfg"].ANCHOR_SOURCES
         assert mods["cfg"].eligible_distractor("spods", "ucsf", "Opioids") is True
+
+
+class TestSiglipAuditVectors:
+    """The audit's second opinion, over cached vectors rather than a card."""
+
+    @staticmethod
+    def _cache(tmp_path, items, vecs, embedder="siglip2_l"):
+        import numpy as np
+
+        out = tmp_path / "audit" / "siglip"
+        out.mkdir(parents=True)
+        np.savez_compressed(tmp_path / "audit" / "siglip" / "vectors.npz", vecs=np.asarray(vecs, dtype=np.float32))
+        (out / "items.json").write_text(
+            json.dumps({"embedder": embedder, "max_per_class": 24, "items": items}), encoding="utf-8"
+        )
+        return tmp_path
+
+    def test_a_missing_cache_is_an_error_not_an_empty_answer(self, mods, tmp_path):
+        with pytest.raises(SystemExit, match="--embed"):
+            mods["siglip"].load_cache(tmp_path)
+
+    def test_a_centroid_is_the_normalised_mean_of_its_instances(self, mods, tmp_path):
+        items = [
+            {"class_id": "a", "page_id": "p1", "kind": "instance"},
+            {"class_id": "a", "page_id": "p2", "kind": "instance"},
+            {"class_id": "b", "page_id": "p3", "kind": "instance"},
+            # A query crop must not move the centroid it is going to be judged
+            # against, or the check is comparing the crop with itself.
+            {"class_id": "a", "page_id": "p9", "kind": "query"},
+        ]
+        vecs = np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0], [-1.0, 0.0]], dtype=np.float32)
+        order, centroids = mods["siglip"].class_centroids(items, vecs)
+        assert order == ["a", "b"]
+        assert centroids[0] == pytest.approx([2**-0.5, 2**-0.5], abs=1e-6)
+        assert np.linalg.norm(centroids[1]) == pytest.approx(1.0, abs=1e-6)
+
+    def test_split_uses_average_linkage_so_one_crop_cannot_bridge_two_marks(self, mods):
+        # Two tight groups plus a crop halfway between them.  Single linkage
+        # chains all three together through the bridge -- which is the exact
+        # defect this pass exists to detect, so it must not be the linkage.
+        a, b = np.array([1.0, 0.0]), np.array([0.0, 1.0])
+        bridge = (a + b) / np.linalg.norm(a + b)
+        vecs = np.vstack([a, a, a, b, b, b, bridge]).astype(np.float32)
+        labels = mods["siglip"].split_class(vecs, 0.4)
+        assert len(set(labels.tolist())) >= 2
+        assert labels[0] == labels[1] == labels[2]
+        assert labels[3] == labels[4] == labels[5]
+        assert labels[0] != labels[3]
+
+    def test_one_tight_class_stays_one_group(self, mods):
+        vecs = np.tile(np.array([1.0, 0.0], dtype=np.float32), (5, 1))
+        assert len(set(mods["siglip"].split_class(vecs, 0.2).tolist())) == 1
+
+    def test_the_query_check_reports_the_rank_of_the_class_own_centroid(self, mods):
+        # The eval searches with the query crop, so the question is what that
+        # crop retrieves -- not how far it is, which is the screen #3599
+        # records failing.
+        items = [
+            {"class_id": "a", "page_id": "p1", "kind": "instance"},
+            {"class_id": "b", "page_id": "p2", "kind": "instance"},
+            {"class_id": "a", "page_id": "p9", "kind": "query"},
+        ]
+        vecs = np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 1.0]], dtype=np.float32)
+        order, centroids = mods["siglip"].class_centroids(items, vecs)
+        rows = mods["siglip"].query_check(items, vecs, order, centroids)
+        assert len(rows) == 1
+        assert rows[0]["class_id"] == "a"
+        assert rows[0]["rank_of_own_class"] == 1
+        assert rows[0]["nearest_class"] == "b"
+
+    def test_pairs_are_ranked_by_centroid_distance_nearest_first(self, mods):
+        order = ["a", "b", "c"]
+        centroids = np.array([[1.0, 0.0], [0.99, 0.141], [0.0, 1.0]], dtype=np.float32)
+        rows = mods["siglip"].pair_report(order, centroids, 3)
+        assert [(r["left"], r["right"]) for r in rows][0] == ("a", "b")
+        assert rows[0]["distance"] < rows[-1]["distance"]
+
+    def test_the_split_sweep_records_every_threshold_not_a_verdict(self, mods):
+        items = [{"class_id": "a", "page_id": f"p{i}", "kind": "instance"} for i in range(4)]
+        # Two pairs 0.5 apart: a tight threshold separates them, a loose one
+        # does not, and the file records both rather than choosing.
+        far = [0.5, 3**0.5 / 2]
+        vecs = np.array([[1.0, 0.0], [1.0, 0.0], far, far], dtype=np.float32)
+        rows = mods["siglip"].split_report(items, vecs, (0.1, 0.9))
+        assert rows[0]["sweep"]["0.10"] == [2, 2]
+        assert rows[0]["sweep"]["0.90"] == [4]
+
+
+class TestSlateDescriptorChoice:
+    """Which descriptor the slate is ordered by, and what it refuses."""
+
+    @staticmethod
+    def _items(class_ids):
+        return [{"class_id": c, "page_id": f"p{i}", "kind": "instance"} for i, c in enumerate(class_ids)]
+
+    def test_phash_needs_no_cache_and_is_the_default(self, mods, tmp_path):
+        from PIL import Image
+
+        images = [Image.new("RGB", (40, 40), c) for c in ("white", "black")]
+        dist = mods["slate"].class_distances(["a", "b"], images, "phash", tmp_path)
+        assert dist.shape == (2, 2)
+        assert dist[0, 0] == 0.0
+        assert mods["cfg"].SLATE_DESCRIPTOR == "phash"
+
+    def test_a_semantic_descriptor_orders_by_centroid_not_by_exemplar(self, mods, tmp_path):
+        from PIL import Image
+
+        TestSiglipAuditVectors._cache(
+            tmp_path,
+            self._items(["a", "a", "b"]),
+            [[1.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+        )
+        # Identical exemplars: a phash ordering would call these distance 0.
+        # The cache says the classes are orthogonal, and the cache is what a
+        # semantic descriptor is being asked for.
+        images = [Image.new("RGB", (40, 40), "white") for _ in range(2)]
+        dist = mods["slate"].class_distances(["a", "b"], images, "siglip2_l", tmp_path)
+        assert dist[0, 1] == pytest.approx(1.0, abs=1e-5)
+
+    def test_a_cache_from_another_embedder_is_refused_not_used(self, mods, tmp_path):
+        from PIL import Image
+
+        TestSiglipAuditVectors._cache(tmp_path, self._items(["a", "b"]), [[1.0, 0.0], [0.0, 1.0]], embedder="siglip")
+        images = [Image.new("RGB", (40, 40), "white") for _ in range(2)]
+        with pytest.raises(SystemExit, match="siglip2_l"):
+            mods["slate"].class_distances(["a", "b"], images, "siglip2_l", tmp_path)
+
+    def test_a_class_missing_from_the_cache_is_refused_not_dropped(self, mods, tmp_path):
+        from PIL import Image
+
+        TestSiglipAuditVectors._cache(tmp_path, self._items(["a"]), [[1.0, 0.0]])
+        images = [Image.new("RGB", (40, 40), "white") for _ in range(2)]
+        with pytest.raises(SystemExit, match="no vectors"):
+            mods["slate"].class_distances(["a", "b"], images, "siglip2_l", tmp_path)
+
+    def test_phash_proposes_no_subgroups_about_its_own_output(self, mods, tmp_path):
+        assert mods["slate"].subgroups(tmp_path, "phash", 0.2) == {}
+
+    def test_subgroups_are_numbered_largest_first(self, mods, tmp_path):
+        items = [
+            {"class_id": "a", "page_id": "p0", "kind": "instance"},
+            {"class_id": "a", "page_id": "p1", "kind": "instance"},
+            {"class_id": "a", "page_id": "p2", "kind": "instance"},
+            {"class_id": "a", "page_id": "p3", "kind": "instance"},
+        ]
+        TestSiglipAuditVectors._cache(tmp_path, items, [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        groups = mods["slate"].subgroups(tmp_path, "siglip2_l", 0.5)["a"]
+        assert groups["p0"] == groups["p1"] == groups["p2"] == 1
+        assert groups["p3"] == 2

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -1196,6 +1196,125 @@ class TestClustering:
 # ---------------------------------------------------------------- synthesis
 
 
+class TestResplitRegistersItsPieces:
+    """A ``split`` verdict must leave the pieces somewhere the corpus can see.
+
+    ``resplit_classes`` relabels the marks and pops the parent.  Everything
+    downstream -- the slate, the roster, the embedder, the report -- reads
+    ``classes.json``, and the only other writer is ``build_corpus.py``, which
+    rebuilds from the sources and would discard the split.  So a piece that is
+    not registered here is not "deferred to the next sheet"; it is gone, with
+    its marks pointing at an id nothing knows.
+    """
+
+    def _two_marks_one_class(self, mods, tmp_path):
+        """Two visibly different stamps sharing one class id, on real pages."""
+        from PIL import Image
+
+        pages = []
+        for i in range(6):
+            arr = np.full((_PAGE_H, _PAGE_W), 255, dtype=np.uint8)
+            if i < 4:
+                arr[200:260, 200:400] = 0  # a solid bar
+            else:
+                for k in range(12):  # a comb, nothing like the bar
+                    arr[200:260, 200 + k * 16 : 204 + k * 16] = 0
+            path = tmp_path / f"p{i}.png"
+            Image.fromarray(arr).save(path)
+            pages.append(
+                _page(
+                    mods,
+                    f"src/{i:05d}",
+                    "src",
+                    marks=[("stamp", (200, 200, 200, 60), "src/stamp_00000_0", "clustered")],
+                    path=str(path),
+                )
+            )
+        return pages
+
+    def test_every_piece_lands_in_classes_and_keeps_all_instances(self, mods, tmp_path):
+        pages = self._two_marks_one_class(mods, tmp_path)
+        inventory = mods["build"].class_inventory(pages)
+        classes, _ = mods["build"].admit_classes(pages, inventory, min_instances=1, min_mark_px=1)
+        assert set(classes) == {"src/stamp_00000_0"}
+
+        notes = mods["audit"].resplit_classes(
+            pages,
+            classes,
+            ["src/stamp_00000_0"],
+            backend="phash",
+            threshold=0.20,
+            corpus=tmp_path,
+            min_mark_px=1,
+        )
+
+        # A piece takes its id from its own smallest page id, so the parent's id
+        # comes back as the id of whichever piece kept page 00000 -- what must
+        # not survive is the parent's *entry*, with all six instances on it.
+        assert len(classes) >= 2, f"pieces were not registered: {notes}"
+        assert classes["src/stamp_00000_0"]["n_instances"] == 4
+        assert sum(m["n_instances"] for m in classes.values()) == 6
+        assert sorted(m["n_instances"] for m in classes.values()) == [2, 4]
+        # Every relabelled mark resolves to a registered class.
+        for page in pages:
+            for mark in page.marks:
+                assert mark.class_id in classes
+
+    def test_a_singleton_piece_is_registered_rather_than_sized_out(self, mods, tmp_path):
+        # The reviewer already said this class holds more than one mark, so a
+        # one-instance piece is a finding.  Dropping it here would hide it from
+        # the roster, which is the only place that should decide it is too
+        # small to search.
+        pages = self._two_marks_one_class(mods, tmp_path)
+        pages = pages[:4] + pages[4:5]  # 4 bars, 1 comb
+        inventory = mods["build"].class_inventory(pages)
+        classes, _ = mods["build"].admit_classes(pages, inventory, min_instances=1, min_mark_px=1)
+        mods["audit"].resplit_classes(
+            pages,
+            classes,
+            ["src/stamp_00000_0"],
+            backend="phash",
+            threshold=0.20,
+            corpus=tmp_path,
+            min_mark_px=1,
+        )
+        sizes = sorted(m["n_instances"] for m in classes.values())
+        assert sizes == [1, 4], sizes
+
+
+class TestSiglipClusterBackend:
+    """The ``siglip`` cluster backend named symbols that do not exist.
+
+    It imported ``SiglipEmbedder`` (the class is ``ImageSiglipEmbedder``) and
+    then called ``embed_images`` (the in-memory entry point is
+    ``embed_pil_image``), so ``--cluster-backend siglip`` raised ImportError on
+    every path that reached it, from the corpus builder's first commit onward.
+    Both names are checked here rather than the clustering itself, because the
+    failure was never in the maths -- it was in code no test had executed.
+    """
+
+    def test_the_backend_names_the_embedder_that_exists(self, mods):
+        import inspect
+
+        src = inspect.getsource(mods["cluster"].describe_marks)
+        assert "ImageSiglipEmbedder" in src
+        assert "import SiglipEmbedder" not in src
+
+    def test_the_embedder_exposes_the_method_the_backend_calls(self, mods):
+        import inspect
+
+        from vtscore.media.image.embedder_siglip import ImageSiglipEmbedder
+
+        src = inspect.getsource(mods["cluster"].describe_marks)
+        assert "embed_pil_image" in src
+        assert hasattr(ImageSiglipEmbedder, "embed_pil_image")
+        assert not hasattr(ImageSiglipEmbedder, "embed_images")
+
+    def test_an_unknown_backend_still_says_so(self, mods):
+        with pytest.raises(ValueError, match="unknown cluster backend"):
+            mods["cluster"].describe_marks([], [], backend="nope")
+
+
 class TestSynthesis:
     def _artwork(self, size=(120, 60)):
         from PIL import Image, ImageDraw


### PR DESCRIPTION
Answers #3600 by fixing what it measured, and gives #3599's screen a version that works.

## The problem, restated as a number

`phash` clusters 200k pages for nothing, and it is a poor judge of its own output. On corpus v2 the merge slate's one literal duplicate — two classes of the same `DY.Secretary` rubber stamp — ranked **83rd of 120** in the near-pair appendix, behind 82 pairs of stamps nobody would confuse, while two internally-mixed classes took **37%** of the appendix between them. Had the reviewer worked only the appendix, `REVIEWED-ALL` would have recorded those two classes as permanently **different**: the exact failure separations exist to prevent, committed by the mechanism meant to prevent it.

This is not a threshold. A perceptual hash of blue ink on white paper measures ink layout, and two different stamps in the same typeface at the same size have nearly the same ink layout. The identical failure is already on record for UCSF letterhead bands, where no threshold produced classes at all.

#3599 is the same weakness on the other axis. The obvious query-crop screen — hash each crop against its own members — scores the one **confirmed-wrong** crop *second-best of 60*, and the three-mark StaVer class best of all. A screen that ranks a known defect near the top of the healthy pile is worse than no screen.

## What this does

The audit can afford what the build cannot: ~1,300 crops, not 200k pages. `siglip_audit.py --embed` embeds every class instance once with `siglip2_l` and caches the vectors, so **only that step needs a card** — the slate render, the analysis and every re-render afterwards read the cache on `cpu`, which is where the audit's own launcher runs them.

Three questions get better answers:

- **Which classes are nearest** — by class *centroid*, not by one query crop, so an unrepresentative exemplar cannot place a whole class. v2's closest pair goes from 0.11 (two unrelated stamps) to **0.030** (two scans of one B&W wordmark).
- **Which classes hold more than one mark** — each class's instances clustered by **average** linkage, swept over `AUDIT_SPLIT_SWEEP` and reported as a sweep, never as one verdict. Average linkage because single linkage's failure mode is one ambiguous crop bridging two marks, which is the defect being looked for; a sweep because quietly picking an operating point is how `CLUSTER_THRESHOLD`'s 0.16 outlived the mark decomposition it was measured on (#3366).
- **Whether a query crop retrieves its own class** — the question the eval will ask, reported as the **rank** of the class's own centroid rather than a distance whose scale nobody knows.

The `cluster` sheets now sort and caption each class's crops by proposed sub-group, so the sheet says *where* the boundary is instead of asking the reviewer to find it. And both sides of an appendix pair cell now show **instances** rather than the single query crop, split by a rule — those sheets are where a wrong call writes a permanent separation, and #3599 is the case where a query crop was a mark that appears nowhere in its class.

## Validated against a human's verdicts, before being trusted

The reviewer had already worked the `phash` slate and ruled on four things. `siglip2_l` was scored against those rulings before any of its output was used:

| the reviewer's call | what the new pass proposed, unprompted | |
|---|---|---|
| the StaVer class holds three stamps: a mouse drawing, an empty form grid, a `DFKI Empfang` | `3 groups: 15 / 8 / 1` | exact |
| `spods/stamp_00489_1` holds two very different stamps, one red one blue | `2 groups: 22 / 2` | exact |
| the two Indian-chief engravings are different logos | kept apart, distance 0.155 | agrees |
| the three B&W leaf marks are all different | ranked them the three closest pairs in the corpus | **disagrees** |

The disagreement is the useful kind: those pairs are now *on* the appendix, so ruling them different records four permanent separations that `phash` never surfaced.

**And it is not magic.** Two of its four split proposals on v2 are false — 3 of 65 chief crops and 1 of 57 Philip Morris crests, where scan quality varies more than the mark does. That is obvious on the sheet and invisible in the number, which is why the proposal is a hypothesis on a contact sheet and `split` still means a person looked. The verdict vocabulary is unchanged.

## Nothing changes by default

`SLATE_DESCRIPTOR` stays `phash`, which needs neither cache nor card. Naming another descriptor without a cache is **refused rather than silently falling back** — a slate ordered by a descriptor other than the one asked for is a slate whose `REVIEWED-ALL` records something nobody intended — and a cache built by a different embedder, or missing a class, is refused the same way.

The **clustering** descriptor is untouched. Changing it would change what the corpus *is*, and v2's 59 classes were admitted under `phash`.

## Testing

`./run-tests.sh` on the GRID: **10,463 passed**, 6 skipped, every gate green (pyright, pip-audit, vulture whitelist). 21 new tests cover centroids over instances only, average linkage against the bridging crop that would defeat single linkage, the sweep, the query-crop rank, and each refusal.

Verified end to end on corpus v2 — job 613680, **7 minutes** on one L40S for 1,258 crops, then both passes re-rendered from the cache on CPU.

Refs #3561. Closes #3600. Gives #3599 its screen; the selection rule that issue asks for is not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJpMmTjyJraaECsv4fAxUP
