### PR TITLE
Let a definitional rejection remove a small-band positive

### DIFF
--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -24,11 +24,21 @@ builder therefore drops it from every cell of that class: not a positive, and no
 longer a negative either. That is the whole point of the three-valued design --
 the alternative is inventing a box to keep the arithmetic tidy.
 
-**A rejection is not a deletion in the small band.** Boxed review confirms only
-~2/3 of sub-patch positives even when the box is drawn for the reviewer, and the
-same objects defeat the model, so "not confirmed" there is recorded as exactly
-that and the label stands. Above one patch a rejection backed by adjudication
-does remove the positive.
+**A rejection is not a deletion in the small band -- unless it is definitional.**
+Boxed review confirms only ~2/3 of sub-patch positives even when the box is drawn
+for the reviewer, and the same objects defeat the model, so "not confirmed" there
+is recorded as exactly that and the label stands. Above one patch a rejection
+backed by adjudication does remove the positive.
+
+That guard reads a small-band rejection as *"I cannot tell at this size"*, which
+is the right default and the wrong one when the adjudicator has named what the
+object actually is. Three of the ten ``bicycle@small`` positives are bicycle
+pictograms on road signs; they are not bicycles at any resolution, and the guard
+made them uncorrectable by a human rejection and an adjudicated one alike
+(#3614). An adjudication may therefore carry ``"reason": "definition"``
+alongside ``"claude": "absent"``, which removes the positive regardless of band.
+Use it only where the identity of the object is settled -- never to force through
+a rejection that is really about confirmability, which is what the guard is for.
 
 Usage::
 
@@ -140,7 +150,25 @@ def main() -> int:
                 continue
             # Rejected. Small band: not confirmed is not absent.
             a = adj.get(key)
-            if band == "small":
+            # ...unless the rejection is DEFINITIONAL. The band guard exists
+            # because a small object is hard to confirm, so a rejection there is
+            # ambiguous between "absent" and "I cannot tell at 26 px". That
+            # ambiguity does not arise when the adjudicator names *what the
+            # object is*: a bicycle pictogram on a road sign is not a bicycle at
+            # any size, and no amount of resolution would change the answer.
+            # Without this branch such a positive is uncorrectable -- the guard
+            # swallows the human rejection and the adjudicated one alike (#3614).
+            if a and a.get("claude") == "absent" and a.get("reason") == "definition":
+                out[key] = {
+                    "image_id": key[0],
+                    "class": key[1],
+                    "present": False,
+                    "boxes": [],
+                    "source": "human_reject+adjudicated_definition",
+                    "note": a.get("note", ""),
+                }
+                stats["positive_removed_definitional"] += 1
+            elif band == "small":
                 stats["small_unconfirmed"] += 1
             elif a and a["claude"] == "absent":
                 out[key] = {

--- a/tests_lib/meta/test_pile_definitional_rejection.py
+++ b/tests_lib/meta/test_pile_definitional_rejection.py
@@ -1,0 +1,158 @@
+"""A definitional rejection must remove a small-band positive (#3614).
+
+``verdicts_to_corrections.py`` guards the small band: a rejection there is read
+as "not confirmed" rather than "absent", because boxed review confirms only
+~2/3 of sub-patch positives and the failure tracks object *size*. That guard is
+right for confirmability and wrong for identity. Three of the ten
+``bicycle@small`` positives in the #3156 review are bicycle pictograms on road
+signs -- not bicycles at any resolution -- and the guard swallowed the human
+rejection and the adjudicated one alike, leaving them uncorrectable.
+
+These tests pin both halves: the guard still holds for an ordinary small-band
+rejection, and an adjudication carrying ``"reason": "definition"`` gets through
+it. The script is run in a subprocess because ``pile_config.setup_env()`` edits
+``os.environ`` and ``sys.meta_path`` at import.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+_CLASS = "bicycle"
+_SMALL = 2374765  # a bicycle pictogram on a road sign
+_MEDIUM = 2352009  # an ordinary rejected positive, above the guard
+
+
+def _slate(root: Path, rows: list[dict]) -> Path:
+    d = root / "slates" / _CLASS
+    d.mkdir(parents=True)
+    cols = ["image_id", "class", "stratum", "cell", "text_score", "reference", "exhaustive", "n_boxes", "detector"]
+    with (d / "manifest.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    return root / "slates"
+
+
+def _run(tmp_path: Path, adjudication: list[dict]) -> dict:
+    rows = [
+        {
+            "image_id": _SMALL,
+            "class": _CLASS,
+            "stratum": "positive_boxed",
+            "cell": f"{_CLASS}@small",
+            "text_score": "0.0",
+            "reference": "present",
+            "exhaustive": "yes",
+            "n_boxes": "1",
+            "detector": _CLASS,
+        },
+        {
+            "image_id": _MEDIUM,
+            "class": _CLASS,
+            "stratum": "positive_boxed",
+            "cell": f"{_CLASS}@medium",
+            "text_score": "0.0",
+            "reference": "present",
+            "exhaustive": "yes",
+            "n_boxes": "1",
+            "detector": _CLASS,
+        },
+    ]
+    slates = _slate(tmp_path, rows)
+
+    verdicts = [
+        {
+            "image_id": i,
+            "class": _CLASS,
+            "stratum": "positive_boxed",
+            "human": "absent",
+            "reference": "present",
+            "exhaustive": "yes",
+            "box": None,
+            "text_score": 0.0,
+            "export": "test",
+        }
+        for i in (_SMALL, _MEDIUM)
+    ]
+    vpath = tmp_path / "verdicts.json"
+    vpath.write_text(json.dumps(verdicts))
+    apath = tmp_path / "adjudication.json"
+    apath.write_text(json.dumps(adjudication))
+    out = tmp_path / "corrections.json"
+
+    proc = subprocess.run(  # noqa: S603  # interpreter + test-controlled args
+        [
+            sys.executable,
+            "verdicts_to_corrections.py",
+            "--verdicts",
+            str(vpath),
+            "--adjudication",
+            str(apath),
+            "--slates",
+            str(slates),
+            "--triage",
+            str(tmp_path / "absent.json"),
+            "--sheets",
+            str(tmp_path / "no_sheets"),
+            "--out",
+            str(out),
+        ],
+        cwd=_PILE_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return {(r["image_id"], r["class"]): r for r in json.loads(out.read_text())}
+
+
+def _adj(image_id: int, **extra) -> dict:
+    return {
+        "image_id": image_id,
+        "class": _CLASS,
+        "cell": f"{_CLASS}@small",
+        "claude": "absent",
+        "note": "bicycle pictogram on a road sign",
+        **extra,
+    }
+
+
+def test_small_band_rejection_is_still_guarded(tmp_path):
+    """Without a reason, the band guard stands: the positive is NOT removed."""
+    got = _run(tmp_path, [_adj(_SMALL)])
+    assert (_SMALL, _CLASS) not in got
+
+
+def test_definitional_rejection_removes_a_small_band_positive(tmp_path):
+    """``reason: definition`` names the object, so the guard must not apply."""
+    got = _run(tmp_path, [_adj(_SMALL, reason="definition")])
+    row = got[(_SMALL, _CLASS)]
+    assert row["present"] is False
+    assert row["boxes"] == []
+    assert row["source"] == "human_reject+adjudicated_definition"
+    assert "pictogram" in row["note"]
+
+
+def test_ordinary_adjudicated_rejection_above_the_band_still_works(tmp_path):
+    """The pre-existing path is untouched for a positive the guard never covered."""
+    got = _run(
+        tmp_path,
+        [
+            {
+                "image_id": _MEDIUM,
+                "class": _CLASS,
+                "cell": f"{_CLASS}@medium",
+                "claude": "absent",
+                "note": "not a bicycle",
+            }
+        ],
+    )
+    assert got[(_MEDIUM, _CLASS)]["source"] == "human_reject+adjudicated"


### PR DESCRIPTION
Closes #3614.

## The problem

`verdicts_to_corrections.py` guards the small band — a rejection there is recorded as
*"not confirmed"* rather than *"absent"*, because boxed review confirms only ~2/3 of
sub-patch positives and that failure tracks object **size** rather than truth. #3156
rejected 43% of small-band positives as a clean function of size, so the guard is doing
real work and should stay.

It is the wrong default when the rejection is about **identity**. Cropping every box the
#3156 review voted `present` for `bicycle` turned up three road-sign pictograms among the
ten `bicycle@small` positives:

| image | box | what it is |
|---|---|---|
| 2374765 | 26×24 | bicycle pictogram on a signboard |
| 2379908 | 29×14 | bicycle pictogram on a white sign |
| 2383865 | 42×40 | bicycle pictogram on a red/white warning sign |

Those are not bicycles at any resolution. But `band == "small"` short-circuited **before**
adjudication was consulted, so neither a human rejection nor an adjudicated one could
remove them. The positives were structurally uncorrectable — 30% of that band.

## The change

An adjudication may now carry `"reason": "definition"` alongside `"claude": "absent"`,
which removes the positive regardless of band. It still **requires an adjudication**, so a
bare human rejection cannot bypass the guard — that is the property protecting genuinely
small objects, and it is unchanged.

## Tests

Three, pinning both halves:

- an ordinary small-band rejection is *still* guarded (no correction written)
- `reason: "definition"` gets through the guard and writes `present: False`
- the pre-existing adjudicated path above the band is untouched

## Follow-on, not in this PR

`adjudication_20260903.json` on scratch carries the three entries, and the four disputed
images are re-slated for a human re-vote as `bicycle not signs or pictograms of bicycles`
(3819 is a boundary discovery and needs only the re-vote; the other three need the re-vote
*and* the adjudication). The corrections rebuild is deliberately left until Sam has voted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv