### PR TITLE
Stop building a vg_scale class from one VG spelling (#3605)

### DIFF
--- a/docs/experiments/2026-08-25-vg-scale/DATASHEET.md
+++ b/docs/experiments/2026-08-25-vg-scale/DATASHEET.md
@@ -70,6 +70,20 @@ empty that plainly hold the object, and four adjudicated COCO errors among the
 twelve classes (two prohibition circles and a school-crossing paddle labelled
 `stop sign`; a box on a hedge labelled `umbrella`).
 
+**`bicycle` is built from one VG spelling, and the published pickle still is.**
+VG names objects in free text and the builder matched an object's primary name
+only, so a bicycle annotated `bike` was never a `bicycle` positive — and on the
+non-COCO half, where VG's silence is the only evidence of absence, it was a
+`bicycle` **negative**. Over the 51,411-image VG∩COCO overlap `bike` carries
+**638** of COCO's 3,683 `bicycle` boxes against the `bicycle` spelling's 775, so
+roughly half the class's positives on that half are missing and its negative pool
+holds the ones it missed (#3605). The builder now withholds `bike` images from
+both — `bike` cannot simply be merged, since only 40.1% of its boxes land on a
+COCO `bicycle` and it is a measured alias of `motorcycle` too — but **the
+published cells predate that**, so any per-class reading of `bicycle` in the
+#3156 grid carries it. The other eleven classes have not been measured for the
+same defect.
+
 **The small band is at the limit of verification, and this is a property of the
 data, not a defect to hide.** A sub-patch object is under 1/196 of the frame;
 reviewing bare thumbnails rejected 43% of small-band positives against 10% of

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -36,12 +36,36 @@ entirely intact. A new dataset kind therefore adds one module carrying both, and
 a kind with no module fails at dispatch instead of falling through to the demo
 loader. `tests_lib/meta/test_pile_loaders.py` pins that.
 
-The `vg_scale` build is six named passes rather than one long function, because
+The `vg_scale` build is eight named passes rather than one long function, because
 two of them are where this pile's expensive bugs have lived — `apply_corrections`
 (the single normalised→pixel crossing, #3281) and `designate_cells` (whether a
 rebuild keeps the images a human reviewed). Both are ordinary functions taking
 what they read and returning what they produce, so
 `tests_lib/meta/test_pile_vg_scale.py` exercises them without the VG source.
+
+**VG's vocabulary is free text, and the read matches an object's primary name
+only** — so a class is built from one spelling out of several, and on the ~52% of
+VG that COCO does not annotate the others become *negatives* for their own class,
+because there VG's silence is the only evidence of absence. `bicycle` shipped
+that way: the VG name `bike` carries 638 of COCO's 3,683 `bicycle` boxes against
+the `bicycle` spelling's 775 (#3605). Two config tables decide what happens to a
+spelling, and both are measured rather than drafted (`scan_name_overlap.py`,
+`coco_folds.py` — string similarity is not evidence about objects, which is how
+`bus` once matched 80 images annotated `bush`):
+
+| table | meaning | effect (`vg_scale.py`) |
+|---|---|---|
+| `SCALE_VG_NAMES` | measured alias — same object, other spelling | `canonicalise` folds the boxes onto the class name |
+| `SCALE_VG_AMBIGUOUS` | may be the class, may be something else | `lift_ambiguous` withholds the image from the class's bands **and** from the shared negative pool |
+
+Suppression applies only where the spelling is the last word: an image COCO
+annotates, or one a reviewer has ruled on, already answers the question. That is
+why `lift_ambiguous` runs after `anchor_to_coco` and `apply_corrections`.
+
+`SCALE_VG_NAMES_AUDITED` records which classes have actually had this measured,
+because "no spelling is listed" and "no spelling exists" are the same empty
+table. A build names the classes that have not, since a rebuild is the moment
+the fix is cheap.
 
 ## Why this exists
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -315,6 +315,77 @@ SCALE_CLASSES: tuple[str, ...] = (
     "stop sign",
 )
 
+#: VG spellings that ARE a class in *C*, beyond the class name itself.
+#:
+#: VG's vocabulary is free text and :func:`pilebuild.vgsource.vg_boxes_by_name`
+#: matches an object's PRIMARY name only, so a class built from one spelling
+#: silently drops every other. That is not merely a supply loss: on the ~52% of
+#: VG that COCO does not annotate, VG's silence is the only evidence of absence,
+#: so an instance annotated under an unlisted spelling becomes a **negative** for
+#: its own class (#3605).
+#:
+#: Only merges MEASURED as aliases belong here -- two names on the same pixels,
+#: both ways, at high IoU (``scan_name_overlap.py``). A name that merely looks
+#: related goes in :data:`SCALE_VG_AMBIGUOUS` or nowhere: `bus`/`bush` matched 80
+#: images by string containment and is the reason this table is measured rather
+#: than drafted.
+#:
+#: Empty for the current twelve. `bicycle`, the one class of the twelve whose
+#: names have been measured, has an alternate spelling that is NOT an alias --
+#: see :data:`SCALE_VG_AMBIGUOUS`.
+SCALE_VG_NAMES: dict[str, tuple[str, ...]] = {}
+
+#: VG spellings that MAY denote a class in *C* but also denote something else.
+#:
+#: `bike` is the case that named this table. Over the 51,411-image VG-COCO
+#: overlap it carries **638 of COCO's 3,683 `bicycle` boxes** against the
+#: `bicycle` spelling's 775 -- so `bicycle` built from one spelling is missing
+#: roughly half its positives on the non-COCO half. It cannot simply be merged:
+#: `bike` is a measured alias of `motorcycle` too (box IoU 0.38 over 388
+#: co-images), and fold-out puts only 40.1% of `bike` boxes on a COCO `bicycle`
+#: while 59.6% land on no COCO class at all (``coco_folds.py``, #3606).
+#:
+#: So a box under one of these names is treated as **evidence of neither
+#: presence nor absence**: it is not a positive (we cannot say the object is
+#: there) and it bars the image from the shared negative pool (we cannot say it
+#: is not). That is the ``excluded`` third state the construction already has --
+#: see :func:`pilebuild.loaders.vg_scale.lift_ambiguous`. It removes the
+#: contaminated negatives; recovering the missing positives needs a human pass.
+#:
+#: Suppression applies only where it is the sole evidence. On an image COCO
+#: annotates, or one a reviewer has ruled on, the answer is already known and
+#: the ambiguous spelling is ignored.
+SCALE_VG_AMBIGUOUS: dict[str, tuple[str, ...]] = {
+    "bicycle": ("bike",),
+}
+
+#: Classes in *C* whose VG-name coverage has actually been measured.
+#:
+#: Written down because "no alternate spelling is listed" and "no alternate
+#: spelling exists" are the same empty table, and the first is what shipped:
+#: `bicycle` was built from one spelling for the whole of #3156 with every
+#: structural check passing. A class is added here once ``coco_folds.py`` has
+#: been run against it and its fold-in column read.
+#:
+#: :func:`pilebuild.loaders.vg_scale.load` names the unaudited classes on every
+#: build, because the rebuild is when this stops being cheap to fix (#3605).
+SCALE_VG_NAMES_AUDITED: frozenset[str] = frozenset({"bicycle"})
+
+
+def scale_vg_wanted() -> set[str]:
+    """Every VG name the ``vg_scale`` read must match, spellings included.
+
+    The class names themselves plus both name tables. Read with this rather than
+    ``set(SCALE_CLASSES)``: a spelling absent from the read is invisible later,
+    since an image holding it then looks like an image holding nothing.
+    """
+    wanted = set(SCALE_CLASSES)
+    for table in (SCALE_VG_NAMES, SCALE_VG_AMBIGUOUS):
+        for names in table.values():
+            wanted.update(names)
+    return wanted
+
+
 #: Images per ``(class, band)`` cell, and the shared negative pool every cell
 #: draws from. The pool is the whole of VG, labelled by VG and repaired from
 #: COCO where an exhaustive reference exists, so the binding supply is the union

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -18,7 +18,16 @@ a paired contrast on one class rather than two datasets of different difficulty.
 VG's own annotation is not exhaustive and measurably fails this construction --
 see :func:`anchor_to_coco` and ``coco_anchor.py``.
 
-The build is six passes, and they are named rather than inlined because two of
+**On the other half, VG's vocabulary is the construction's weak point.** VG names
+objects in free text and the read matches an object's primary name only, so a
+class is built from one spelling out of several. What that costs is not supply:
+an instance annotated `bike` while the class is `bicycle` is not a missing
+positive, it is a *negative*, because on the non-COCO half VG's silence is the
+only evidence of absence (#3605). :func:`canonicalise` folds in the spellings
+measured to be the same object, and :func:`lift_ambiguous` withholds the ones
+that may not be -- from the bands and from the negative pool alike.
+
+The build is eight passes, and they are named rather than inlined because two of
 them are where this dataset's expensive bugs have lived: :func:`apply_corrections`
 is the single point at which a box crosses from normalised into pixel space
 (#3281), and :func:`designate_cells` is what decides whether a rebuild keeps the
@@ -57,6 +66,77 @@ def read_vg_labels(
             continue
         labels[iid] = vg_boxes_by_name(rec, wanted)
     return labels
+
+
+def canonicalise(
+    labels: dict[int, dict[str, list[list[float]]]], vg_names: dict[str, tuple[str, ...]]
+) -> dict[str, int]:
+    """Fold each class's alternate VG spellings onto the class name, in place.
+
+    ``vg_boxes_by_name`` matches VG's PRIMARY name only, so `hydrant` and
+    `fire hydrant` arrive as two categories of one object. Merging after the read
+    -- rather than aliasing during it -- keeps the merge visible and reversible,
+    and keeps it out of the shared reader every other VG build uses.
+
+    Returns ``{class: boxes folded in}``, which is the number the build reports:
+    a merge that folds nothing has either been mis-spelled or is not needed, and
+    both are worth seeing.
+    """
+    reverse = {n: cls for cls, names in vg_names.items() for n in names if n != cls}
+    folded: dict[str, int] = {c: 0 for c in vg_names}
+    for by_name in labels.values():
+        for vg_name in [n for n in by_name if n in reverse]:
+            cls = reverse[vg_name]
+            boxes = by_name.pop(vg_name)
+            by_name.setdefault(cls, []).extend(boxes)
+            folded[cls] += len(boxes)
+    return folded
+
+
+def lift_ambiguous(
+    labels: dict[int, dict[str, list[list[float]]]],
+    vg_names: dict[str, tuple[str, ...]],
+    exhaustive: set[int],
+) -> set[tuple[int, str]]:
+    """Take ambiguous spellings out of *labels*, and return the pairs they suppress.
+
+    A name in :data:`pile_config.SCALE_VG_AMBIGUOUS` may denote its class or
+    something else -- VG's `bike` sits on a COCO `bicycle` 40% of the time, and
+    59.6% of the time on no COCO class at all, because much of it is motorcycles
+    (#3605). It is therefore evidence in neither direction: too weak to band as a
+    positive, and far too strong to leave in the shared negative pool, where it
+    would score a detector wrong for finding the bicycle that is really there.
+
+    So the boxes are dropped, and the ``(image, class)`` pair joins the
+    ``unbanded`` set :func:`band_candidates` already keeps out of both. Three
+    things stop a pair being suppressed, and they are the whole judgment in this
+    pass:
+
+    * **The image is exhaustively labelled.** COCO annotates C exhaustively and a
+      reviewer has looked; either answers the question the spelling leaves open,
+      so the spelling is ignored and the image stays a usable negative. This is
+      why the pass runs after :func:`anchor_to_coco` and
+      :func:`apply_corrections` rather than straight off the read -- on the ~48%
+      of VG that is COCO-sourced the defect does not exist, and suppressing there
+      would throw away good negatives to fix nothing.
+    * **The class is already established on the image.** It is confirmed present
+      by a box we trust, and an ambiguous box can only make its extent less
+      certain -- a smaller question than this one, and not worth discarding a
+      confirmed positive over.
+    * The name is the class name itself, which is not ambiguous by definition.
+
+    The boxes are dropped either way: :func:`band_candidates` bands by category
+    name and has no cell to put a `bike` in.
+    """
+    reverse = {n: cls for cls, names in vg_names.items() for n in names if n != cls}
+    pairs: set[tuple[int, str]] = set()
+    for iid, by_name in labels.items():
+        for vg_name in [n for n in by_name if n in reverse]:
+            cls = reverse[vg_name]
+            by_name.pop(vg_name)
+            if cls not in by_name and iid not in exhaustive:
+                pairs.add((iid, cls))
+    return pairs
 
 
 def anchor_to_coco(
@@ -174,8 +254,11 @@ def band_candidates(
     """Sort every image into ``(class, band)`` supply, or into the clean pool.
 
     Returns ``(supply, boxes_for, clean)``. An image with no instance of any
-    class in C joins ``clean`` -- unless a reviewer said one *is* present without
-    drawing it, which makes it neither a positive nor a true negative.
+    class in C joins ``clean`` -- unless its ``(image, class)`` pair is in
+    *unbanded*, which makes it neither a positive nor a true negative. Two things
+    put a pair there: a reviewer who said one *is* present without drawing it (no
+    size was measured, and a band is a claim about size), and an ambiguous VG
+    spelling that may or may not be the class (:func:`lift_ambiguous`).
     """
     supply: dict[str, dict[str, list[int]]] = {c: {b: [] for b in pc.BOX_BANDS} for c in pc.SCALE_CLASSES}
     boxes_for: dict[tuple[int, str], list[list[float]]] = {}
@@ -356,10 +439,14 @@ def _emit_medias(
 
 
 def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
-    """Run the six passes over the VG source and write the designated medias."""
+    """Run the eight passes over the VG source and write the designated medias."""
     import coco_anchor as ca  # noqa: PLC0415
 
     wanted = set(pc.SCALE_CLASSES)
+    # The READ has to be wider than the class list: a VG spelling absent from it
+    # is invisible downstream, because an image holding only that spelling then
+    # looks like an image holding nothing -- i.e. like a negative (#3605).
+    wanted_vg = pc.scale_vg_wanted()
     cells = [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in pc.BOX_BANDS]
 
     paths = vg_image_paths()
@@ -373,13 +460,36 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     corrections = load_corrections()
     log(f"  {len(coco_of)} VG images carry a coco_id; {len(corrections)} human verdicts on file")
 
-    labels = read_vg_labels(records, paths, dims, wanted)
+    labels = read_vg_labels(records, paths, dims, wanted_vg)
+    folded = canonicalise(labels, pc.SCALE_VG_NAMES)
     box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
     unbanded = apply_corrections(labels, corrections, box_dims, exhaustive)
+    suppressed = lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)
+    unbanded |= suppressed
     log(
         f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, "
         f"{len(exhaustive)} with a verified pair, {n_reframed} skipped as re-framed copies"
     )
+    if folded:
+        log("  merged VG spellings: " + ", ".join(f"{c}+{n}" for c, n in sorted(folded.items())))
+    if suppressed:
+        by_class: dict[str, int] = defaultdict(int)
+        for _iid, c in suppressed:
+            by_class[c] += 1
+        log(
+            "  ambiguous spellings withheld from both bands and the pool: "
+            + ", ".join(f"{c}={n}" for c, n in sorted(by_class.items()))
+        )
+    unaudited = [c for c in pc.SCALE_CLASSES if c not in pc.SCALE_VG_NAMES_AUDITED]
+    if unaudited:
+        # Not a failure: the dataset this builds is the one #3156 published, and
+        # blocking a rebuild on unmeasured classes would strand it. But it is the
+        # one moment the fix is cheap, so it says so rather than passing quietly.
+        log(
+            f"  VG-NAME COVERAGE UNMEASURED for {len(unaudited)} of {len(pc.SCALE_CLASSES)} classes: "
+            + ", ".join(unaudited)
+        )
+        log("    run `coco_folds.py --classes <c>` and record the result in pile_config.SCALE_VG_NAMES_AUDITED (#3605)")
 
     supply, boxes_for, clean = band_candidates(labels, box_dims, unbanded)
 

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale_deep.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale_deep.py
@@ -47,6 +47,8 @@ from pilebuild.loaders.vg_scale import (
     anchor_to_coco,
     apply_corrections,
     band_candidates,
+    canonicalise,
+    lift_ambiguous,
     rank,
     read_vg_labels,
 )
@@ -141,7 +143,7 @@ def draw_negatives(clean: list[int], roster: dict) -> tuple[list[int], list[int]
 
 
 def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
-    """``vg_scale``'s six passes, with a band-free designation in the middle."""
+    """``vg_scale``'s eight passes, with a band-free designation in the middle."""
     import coco_anchor as ca  # noqa: PLC0415
 
     wanted = set(pc.SCALE_CLASSES)
@@ -158,9 +160,17 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     corrections = load_corrections()
     log(f"  {len(coco_of)} VG images carry a coco_id; {len(corrections)} human verdicts on file")
 
-    labels = read_vg_labels(records, paths, dims, wanted)
+    # Read wider than the class list, fold the measured spellings in, and
+    # withhold the ambiguous ones -- `vg_scale`'s passes, called unchanged, so
+    # the sibling cannot carry a defect the shallow cell has been repaired of
+    # (#3605). Leaving them out would put a VG `bike` image in this pool as a
+    # `bicycle` negative while `vg_scale` excludes it, which is precisely the
+    # "only depth changed" premise breaking.
+    labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
+    canonicalise(labels, pc.SCALE_VG_NAMES)
     box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
     unbanded = apply_corrections(labels, corrections, box_dims, exhaustive)
+    unbanded |= lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)
     log(
         f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, "
         f"{len(exhaustive)} with a verified pair, {n_reframed} skipped as re-framed copies"

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -1,6 +1,6 @@
 """The ``vg_scale`` build's passes, exercised without the 100 GB of VG source.
 
-``build_pile.py`` assembles this dataset in six passes over the Visual Genome
+``build_pile.py`` assembles this dataset in eight passes over the Visual Genome
 source. Two of them are where this pile's expensive bugs have actually lived:
 
 * :func:`apply_corrections` is the single point at which a human verdict's box
@@ -211,6 +211,119 @@ class TestBandCandidates:
         cls = pc.SCALE_CLASSES[0]
         _, _, clean = vgs.band_candidates({7: {}}, {7: (100, 100)}, {(7, cls)})
         assert clean == []
+
+
+class TestVgNameTables:
+    """#3605: a class built from one VG spelling turns its own instances into negatives."""
+
+    def test_the_read_set_covers_every_declared_spelling(self, pc):
+        """A spelling missing from the read is invisible, not merely unmatched."""
+        wanted = pc.scale_vg_wanted()
+        assert set(pc.SCALE_CLASSES) <= wanted
+        for table in (pc.SCALE_VG_NAMES, pc.SCALE_VG_AMBIGUOUS):
+            for names in table.values():
+                assert set(names) <= wanted
+
+    def test_both_tables_only_name_classes_in_c(self, pc):
+        for table in (pc.SCALE_VG_NAMES, pc.SCALE_VG_AMBIGUOUS, {c: () for c in pc.SCALE_VG_NAMES_AUDITED}):
+            assert set(table) <= set(pc.SCALE_CLASSES)
+
+    def test_a_spelling_is_never_both_an_alias_and_ambiguous(self, pc):
+        """The two tables mean opposite things; a name in both has no defined outcome."""
+        alias = {n for names in pc.SCALE_VG_NAMES.values() for n in names}
+        ambiguous = {n for names in pc.SCALE_VG_AMBIGUOUS.values() for n in names}
+        assert not (alias & ambiguous)
+
+    def test_bike_is_declared_ambiguous_for_bicycle(self, pc):
+        """Not merged: 59.6% of VG `bike` boxes land on no COCO class (#3605)."""
+        assert "bike" in pc.SCALE_VG_AMBIGUOUS["bicycle"]
+        assert "bike" not in pc.SCALE_VG_NAMES.get("bicycle", ())
+
+
+class TestCanonicalise:
+    def test_an_alternate_spelling_folds_onto_the_class_name(self, vgs):
+        labels = {7: {"hydrant": [[0.0, 0.0, 1.0, 1.0]]}}
+        folded = vgs.canonicalise(labels, {"fire hydrant": ("fire hydrant", "hydrant")})
+
+        assert labels[7] == {"fire hydrant": [[0.0, 0.0, 1.0, 1.0]]}
+        assert folded == {"fire hydrant": 1}
+
+    def test_boxes_under_both_spellings_are_kept_together(self, vgs):
+        labels = {7: {"fire hydrant": [[0.0, 0.0, 1.0, 1.0]], "hydrant": [[2.0, 2.0, 3.0, 3.0]]}}
+        vgs.canonicalise(labels, {"fire hydrant": ("fire hydrant", "hydrant")})
+
+        assert len(labels[7]["fire hydrant"]) == 2
+
+    def test_a_merge_that_folds_nothing_reports_zero(self, vgs):
+        """Reported rather than silent: a mis-spelled entry looks exactly like this."""
+        labels = {7: {"bus": [[0.0, 0.0, 1.0, 1.0]]}}
+        assert vgs.canonicalise(labels, {"fire hydrant": ("hydrant",)}) == {"fire hydrant": 0}
+
+    def test_an_empty_table_is_a_no_op(self, vgs):
+        labels = {7: {"bus": [[0.0, 0.0, 1.0, 1.0]]}}
+        assert vgs.canonicalise(labels, {}) == {}
+        assert labels == {7: {"bus": [[0.0, 0.0, 1.0, 1.0]]}}
+
+
+class TestLiftAmbiguous:
+    AMBIG = {"bicycle": ("bike",)}
+
+    def test_the_boxes_are_dropped_and_the_pair_returned(self, vgs):
+        labels = {7: {"bike": [[0.0, 0.0, 1.0, 1.0]]}}
+        assert vgs.lift_ambiguous(labels, self.AMBIG, set()) == {(7, "bicycle")}
+        assert labels[7] == {}
+
+    def test_the_lifted_pair_keeps_the_image_out_of_the_negative_pool(self, vgs):
+        """The whole point: a `bike` image is not evidence that there is no bicycle."""
+        labels = {7: {"bike": [[0.0, 0.0, 1.0, 1.0]]}}
+        pairs = vgs.lift_ambiguous(labels, self.AMBIG, set())
+        _, _, clean = vgs.band_candidates(labels, {7: (100, 100)}, pairs)
+
+        assert clean == []
+
+    def test_without_the_lift_that_image_would_be_a_negative(self, vgs):
+        """The defect, stated as a test: an unmatched spelling reads as an empty image."""
+        _, _, clean = vgs.band_candidates({7: {}}, {7: (100, 100)}, set())
+        assert clean == [7]
+
+    def test_an_ambiguous_box_never_becomes_a_positive(self, vgs, pc):
+        labels = {7: {"bike": [[0.0, 0.0, 50.0, 50.0]]}}
+        pairs = vgs.lift_ambiguous(labels, self.AMBIG, set())
+        supply, boxes_for, _ = vgs.band_candidates(labels, {7: (100, 100)}, pairs)
+
+        assert all(not ids for band in supply.values() for ids in band.values())
+        assert boxes_for == {}
+
+    def test_a_confirmed_class_on_the_same_image_is_not_discarded(self, vgs, pc):
+        """`bicycle` is there under a box we trust; the ambiguous one only blurs its extent."""
+        band, (lo, hi) = next(iter(pc.BOX_BANDS.items()))
+        side = (((lo + hi) / 2) * 10000) ** 0.5
+        labels = {7: {"bicycle": [[0.0, 0.0, side, side]], "bike": [[0.0, 0.0, 99.0, 99.0]]}}
+        pairs = vgs.lift_ambiguous(labels, self.AMBIG, set())
+        supply, _, _ = vgs.band_candidates(labels, {7: (100, 100)}, pairs)
+
+        assert pairs == set()
+        assert supply["bicycle"][band] == [7]
+
+    def test_it_touches_only_the_ambiguous_name(self, vgs):
+        labels = {7: {"bike": [[0.0, 0.0, 1.0, 1.0]], "bus": [[2.0, 2.0, 3.0, 3.0]]}}
+        vgs.lift_ambiguous(labels, self.AMBIG, set())
+        assert labels[7] == {"bus": [[2.0, 2.0, 3.0, 3.0]]}
+
+    def test_an_exhaustively_labelled_image_is_not_suppressed(self, vgs):
+        """COCO already answered; the image stays a usable negative."""
+        labels = {7: {"bike": [[0.0, 0.0, 1.0, 1.0]]}}
+        assert vgs.lift_ambiguous(labels, self.AMBIG, {7}) == set()
+        assert labels[7] == {}
+
+        _, _, clean = vgs.band_candidates(labels, {7: (100, 100)}, set())
+        assert clean == [7]
+
+    def test_the_boxes_go_either_way(self, vgs):
+        """`band_candidates` bands by category name and has no cell for a `bike`."""
+        labels = {7: {"bike": [[0.0, 0.0, 1.0, 1.0]]}}
+        vgs.lift_ambiguous(labels, self.AMBIG, {7})
+        assert "bike" not in labels[7]
 
 
 class TestDesignateCells:


### PR DESCRIPTION
Refs #3605.

## The defect

VG's vocabulary is free text and `pilebuild.vgsource.vg_boxes_by_name` matches an
object's **primary** name only, so `vg_scale` builds each class from one spelling
out of several.

What that costs is not supply. On the ~52% of VG that COCO does not annotate,
**VG's silence is the only evidence of absence** — so an instance annotated under
an unlisted spelling is not a missing positive, it is a **negative for its own
class**, and a detector is scored wrong for finding it.

`bicycle` shipped that way. Over the 51,411-image VG∩COCO overlap the VG name
`bike` carries **638** of COCO's 3,683 `bicycle` boxes against the `bicycle`
spelling's 775.

## The fix

Two tables in `pile_config`, both **measured rather than drafted** — string
similarity is not evidence about objects, which is how `bus` once matched 80
images annotated `bush`:

| table | meaning | effect |
|---|---|---|
| `SCALE_VG_NAMES` | measured alias — same object, other spelling | `canonicalise` folds the boxes onto the class name |
| `SCALE_VG_AMBIGUOUS` | may be the class, may be something else | `lift_ambiguous` withholds the image from the class's bands **and** from the shared negative pool |

`bike` is in the second table, not the first, because it **cannot be merged**:
only 40.1% of its boxes land on a COCO `bicycle`, 59.6% land on no COCO class at
all, and it is a measured alias of `motorcycle` (box IoU 0.38 over 388
co-images). Suppression uses the `excluded` third state the construction already
has — neither a positive nor a true negative — so it removes the contaminated
negatives without inventing a single positive.

Three things stop a pair being suppressed, and they are the whole judgment in the
pass:

- **The image is exhaustively labelled.** COCO annotates *C* exhaustively and a
  reviewer has looked; either answers the question the spelling leaves open. This
  is why `lift_ambiguous` runs *after* `anchor_to_coco` and `apply_corrections`
  rather than off the read — on the 48% of VG that is COCO-sourced the defect
  does not exist, and suppressing there would discard good negatives to fix
  nothing.
- **The class is already established on the image** by a box we trust. An
  ambiguous box can then only make its extent less certain, which is a smaller
  question and not worth discarding a confirmed positive over.
- The name is the class name itself.

## Two things beyond the one class

- **`vg_scale_deep` calls both passes too.** Its premise is that only *depth*
  changed from `vg_scale`; leaving them out would put a `bike` image in the deep
  pool as a `bicycle` negative while the shallow cell excludes it.
- **`SCALE_VG_NAMES_AUDITED`** records which classes have actually had their name
  coverage measured, because "no spelling is listed" and "no spelling exists" are
  the same empty table — and the first is what shipped, silently, for the whole
  of #3156. Only `bicycle` has. A build names the other eleven, since a rebuild
  is the moment the fix is cheap. Filed as #3618.

## What this does *not* do

- **It does not recover `bicycle`'s missing positives.** Splitting the suppressed
  `bike` images into bicycles and motorcycles needs a human pass, so **#3605
  stays open** and this PR references rather than closes it.
- **It does not rebuild anything.** The published `vg_scale` pickle predates all
  of this, so the #3156 grid's `bicycle` column still carries the defect; the
  datasheet now says so.
- **The audit of the other eleven classes is not done here** (#3618) — it needs
  `coco_folds.py` against the VG and COCO trees, which this container has no
  access to.

## Relationship to #3606

Branched off `dev`, per the branch policy, so this lands independently of the
open #3606. Two small things to reconcile when both are in:

- #3606 appends its own `SCALE_VG_NAMES` at the end of `pile_config.py` (keyed on
  its `SCALE_CANDIDATES_3588`, with `fire hydrant`/`hydrant` and `cell phone`/
  `phone`). This PR defines the same name beside `SCALE_CLASSES`. **Keep one
  table** — the entries merge cleanly, and the builder will then honour those
  candidate merges too, which today only `make_class_slate.py` does.
- #3606's `make_class_slate.canonicalise` and this PR's
  `vg_scale.canonicalise` are the same function. The slate builder should import
  the loader's, as it already does for `band_candidates` and `read_vg_labels`.

## Checks

- `./run-tests.sh` full: **RUN PASSED** — 10,483 passed, 6 skipped, every gate
  green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).
- `tests_lib/meta/test_pile_vg_scale.py` gains 15 tests over the two new passes
  and the table invariants, including the defect stated as a test
  (`test_without_the_lift_that_image_would_be_a_negative`) and the
  exhaustive-half exemption.
- The existing 25 tests are untouched and pass: `canonicalise` is a no-op on an
  empty `SCALE_VG_NAMES`, and `lift_ambiguous` only reaches `band_candidates`
  through the `unbanded` set it already honours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013E1uB78kcxoDqSRMt8AMn7
