### PR TITLE
DocMarks: screen for a mixed class, and stop sampling classes off their head

### DIFF
--- a/scripts/experiments/docmarks/README.md
+++ b/scripts/experiments/docmarks/README.md
@@ -344,11 +344,42 @@ before being trusted rather than after:
   linkage's failure mode is one ambiguous crop bridging two marks, which is the
   defect the pass exists to find. On v2 it proposed `15 / 8 / 1` for the StaVer
   class and `22 / 2` for `spods/stamp_00489_1` — both exactly the boundaries the
-  reviewer had already drawn by eye, and both found without being told.
+  reviewer had already drawn by eye, and both found without being told. A class
+  whose two most distant instances sit further apart than the loosest threshold
+  in the sweep (`AUDIT_MIXED_MAX_WITHIN`) is flagged `mixed`.
 - **Whether a class's query crop retrieves its own class** — the question the
   eval will ask, stated as the *rank* of the class's own centroid rather than a
   distance whose scale nobody knows. It flags 3 of 59 on v2, including the one
-  `phash` scored second-*best* of 60.
+  `phash` scored second-*best* of 60. Beside the rank, **how many of the class's
+  own instances that crop reaches** before the nearest other class's centroid,
+  which is the part a rank cannot see.
+
+#### A screen for a crop is not a screen for a class
+
+Both query-crop numbers are properties of one *crop*; `mixed` is a property of a
+*class*, and #3610 is the case that separates them.
+`staver/stamp_stampds-00156_0` holds **five** marks across 27 instances — a
+16-strong blue routing box, eight `DFKI Empfang`, and three singletons — and the
+rank scores it 0 at distance 0.078, the healthiest tier of all 59 classes. That
+score is *correct on its own terms*: its query crop is a good instance of the
+16-strong mark, so it retrieves its own class first, and nothing about a rank is
+sensitive to the class being five marks in a trench coat. Its `max_within` is
+0.433, second worst of 59. Gate on both, or the mixed classes the `cluster`
+sheets exist to adjudicate arrive pre-certified healthy.
+
+And the sample the questions are asked of is **spread** over the class, not
+taken off the head of its page-id list. Page ids sort by source and number, so a
+head sample is the scanner's order: the two classes #3610 was filed over are 27
+and 30 instances against `AUDIT_MAX_PER_CLASS` = 24, and between them five marks
+live only in the tail. Note that a plain `[::step]` stride does not fix this —
+`27 // 24` is 1, so the stride hands back the first 24 — which is why
+`sources/_common.spread` spaces indices over the whole range instead.
+
+One caveat for the reviewer working these sheets: a **wide crop catches
+neighbouring page furniture**, and at 150 px that is indistinguishable from a
+second mark. Two crops in the StaVer class show the routing box with a black
+`EINGEGANGEN AM 05. JAN. 2011` stamp above it; others catch `* Artikel mit 7%`
+or `Bankverbindung:`. Check at full size before splitting.
 
 The proposals are hypotheses on a contact sheet. The verdict vocabulary does not
 change, `split` still means a person looked, and a false proposal is expected:

--- a/scripts/experiments/docmarks/docmarks_config.py
+++ b/scripts/experiments/docmarks/docmarks_config.py
@@ -405,6 +405,21 @@ AUDIT_MAX_PER_CLASS = int(os.environ.get("VTS_DOCMARKS_AUDIT_MAX_PER_CLASS", "24
 #: on (#3366).
 AUDIT_SPLIT_SWEEP = (0.10, 0.15, 0.20, 0.25, 0.30, 0.40)
 
+#: The within-class spread at which a class is reported as internally **mixed**.
+#:
+#: The rank of a class's own centroid answers "is this query crop an outlier",
+#: and #3610 is the case where nothing answered "is this class more than one
+#: mark": `staver/stamp_stampds-00156_0` holds five marks and scores rank 0,
+#: distance 0.078 -- correctly, because its query crop is a good instance of the
+#: 16-strong mark it is drawn from.  A rank cannot see the other four.
+#:
+#: Not a fresh magic number: it is the loosest threshold in `AUDIT_SPLIT_SWEEP`,
+#: so "mixed" means *the class's two most distant instances sit further apart
+#: than the loosest cut we would ever call one mark*.  Tying it to the sweep is
+#: what stops it drifting away from the sweep the way `CLUSTER_THRESHOLD`'s 0.16
+#: drifted away from its decomposition (#3366).
+AUDIT_MIXED_MAX_WITHIN = float(os.environ.get("VTS_DOCMARKS_AUDIT_MIXED_MAX_WITHIN", str(max(AUDIT_SPLIT_SWEEP))))
+
 #: Which descriptor the slate orders itself by.  `phash` stays the default so a
 #: slate renders with no cache and no card; `siglip2_l` requires
 #: `siglip_audit.py --embed` to have run, and refuses rather than silently

--- a/scripts/experiments/docmarks/make_audit_slate.py
+++ b/scripts/experiments/docmarks/make_audit_slate.py
@@ -88,7 +88,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import cluster_marks as _cluster  # noqa: E402
 import docmarks_config as cfg  # noqa: E402
-from sources._common import Page, read_manifest  # noqa: E402
+from sources._common import Page, read_manifest, spread  # noqa: E402
 
 THUMB = 180
 COLS = 8
@@ -182,9 +182,15 @@ def task_cluster(
 
     for class_id, meta in sorted(derived.items(), key=lambda kv: -kv[1]["n_instances"]):
         groups = proposals.get(class_id, {})
-        page_ids = meta["page_ids"][:max_per_class]
         if groups:
-            page_ids = sorted(page_ids, key=lambda pid: (groups.get(pid, 99), pid))
+            # Render exactly the instances the proposal covers.  The proposal is
+            # what this sheet exists to adjudicate, and the two samples are
+            # drawn by different code paths -- showing a crop the clusterer
+            # never saw would put an untagged cell on the sheet and invite a
+            # verdict about it.
+            page_ids = sorted(groups, key=lambda pid: (groups[pid], pid))
+        else:
+            page_ids = spread(meta["page_ids"], max_per_class)
         crops, caps = [], []
         for page_id in page_ids:
             page = by_id.get(page_id)
@@ -463,17 +469,15 @@ def _paste_grid(cells: Sequence[Any], title: str, out_path: Path, *, cols: int) 
 def _class_strip(page_ids: Sequence[str], by_id: dict[str, Page], class_id: str, limit: int) -> list[Any]:
     """Up to *limit* instance crops of *class_id*, evenly spread over the class.
 
-    Spread rather than the first *limit*: page ids sort by source and number, so
-    the head of the list is whatever the scanner did first, and a class whose
-    later instances drifted (a re-inked stamp, a second printing) would look
-    homogeneous on the slate for no better reason than alphabetical order.
+    Spread rather than the first *limit*, via the shared ``spread`` — see its
+    docstring for why the head of a class is the wrong sample and why a plain
+    stride is not enough to avoid it.
     """
     crops: list[Any] = []
     resolved = [pid for pid in page_ids if pid in by_id]
     if not resolved:
         return crops
-    step = max(1, len(resolved) // max(1, limit))
-    for page_id in resolved[::step][:limit]:
+    for page_id in spread(resolved, limit):
         page = by_id[page_id]
         for mark in page.marks:
             if mark.class_id == class_id:

--- a/scripts/experiments/docmarks/siglip_audit.py
+++ b/scripts/experiments/docmarks/siglip_audit.py
@@ -30,16 +30,26 @@ instead, and asks them of the *instances* rather than of one exemplar:
     instances.  ``--task cluster`` already renders every instance for a human to
     look at; this proposes *where* the boundary falls, so the answer is a
     confirmation rather than a search.  The threshold is not invented: it is
-    swept, and the sweep is recorded beside the answer.
+    swept, and the sweep is recorded beside the answer.  One class-level flag is
+    read off it -- ``mixed``, for a class whose two most distant instances sit
+    further apart than the loosest threshold in the sweep.
 
 ``query check``
-    Does a class's query crop retrieve its own class?  The eval searches with
-    that crop, so this is the question the eval will ask.  It is stated as the
-    **rank of the class's own centroid** among all centroids, which is a
-    property of the retrieval rather than of a distance whose scale nobody
-    knows.  The phash version of this screen does not work -- #3599 records it
-    scoring the one confirmed-wrong crop second-best of 60 -- and a screen that
-    ranks a known defect near the top of the healthy pile is worse than none.
+    Does a class's query crop retrieve its own class, and how much of it?  The
+    eval searches with that crop, so these are the questions the eval will ask.
+    The first is stated as the **rank of the class's own centroid** among all
+    centroids, which is a property of the retrieval rather than of a distance
+    whose scale nobody knows.  The phash version of that screen does not work --
+    #3599 records it scoring the one confirmed-wrong crop second-best of 60 --
+    and a screen that ranks a known defect near the top of the healthy pile is
+    worse than none.  The second is **how many of the class's own instances the
+    crop reaches** before the nearest other class's centroid, which is what a
+    rank cannot see: #3610's five-mark StaVer class ranks 0 at distance 0.078
+    because its query crop is a good instance of the largest of its five marks.
+
+Both of those are screens for a *crop*.  ``mixed`` is the screen for a *class*,
+and the two are not substitutes: #3610 is the case where a class holds five
+marks and every crop-level number about it is healthy.
 
 Vectors are cached to ``audit/siglip/vectors.npz`` so that only ``--embed``
 needs a card: the slate render, the analysis and every re-render afterwards read
@@ -60,7 +70,7 @@ import numpy as np
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import docmarks_config as cfg  # noqa: E402
-from sources._common import Page, read_manifest  # noqa: E402
+from sources._common import Page, read_manifest, spread  # noqa: E402
 
 #: Where the cache lives, relative to the corpus root.
 VECTORS = Path("audit") / "siglip" / "vectors.npz"
@@ -95,11 +105,17 @@ def collect_items(pages: Sequence[Page], classes: dict[str, Any], *, max_per_cla
     Capped per class because the cost of a class is linear in its instances and
     the marginal instance stops moving a centroid quickly; the cap is recorded
     in the items file so a later reader knows a centroid is over a sample.
+
+    The sample is **spread** over the class rather than taken off its head.  A
+    head sample makes every split proposal a statement about a class's first
+    ``max_per_class`` page ids instead of about the class: the two classes #3610
+    was filed over are 27 and 30 instances against a cap of 24, and between them
+    five marks live only in the tail the head sample never reaches.
     """
     by_id = {p.page_id: p for p in pages}
     items: list[dict[str, Any]] = []
     for class_id, meta in sorted(classes.items()):
-        for page_id in meta.get("page_ids", [])[:max_per_class]:
+        for page_id in spread(meta.get("page_ids", []), max_per_class):
             page = by_id.get(page_id)
             if page is None:
                 continue
@@ -166,14 +182,26 @@ def embed_items(items: Sequence[dict[str, Any]], pages: Sequence[Page], embedder
 # --------------------------------------------------------------------------- #
 
 
-def class_centroids(items: Sequence[dict[str, Any]], vecs: np.ndarray) -> tuple[list[str], np.ndarray]:
-    """One L2-normalised centroid per class, over its *instance* vectors."""
-    order: list[str] = []
-    rows: list[np.ndarray] = []
+def instances_by_class(items: Sequence[dict[str, Any]]) -> dict[str, list[int]]:
+    """``{class_id: [row index, ...]}`` over the *instance* items only.
+
+    Query crops are excluded everywhere they would otherwise be counted as
+    members: a centroid a query crop helped build is a centroid partly compared
+    with itself, and an instance count that includes the query overstates what
+    a search would have to find.
+    """
     by_class: dict[str, list[int]] = {}
     for i, item in enumerate(items):
         if item["kind"] == "instance":
             by_class.setdefault(item["class_id"], []).append(i)
+    return by_class
+
+
+def class_centroids(items: Sequence[dict[str, Any]], vecs: np.ndarray) -> tuple[list[str], np.ndarray]:
+    """One L2-normalised centroid per class, over its *instance* vectors."""
+    order: list[str] = []
+    rows: list[np.ndarray] = []
+    by_class = instances_by_class(items)
     for class_id in sorted(by_class):
         mean = vecs[by_class[class_id]].mean(axis=0)
         rows.append(mean / max(float(np.linalg.norm(mean)), 1e-12))
@@ -206,18 +234,29 @@ def split_class(vectors: np.ndarray, threshold: float) -> np.ndarray:
 
 
 def split_report(
-    items: Sequence[dict[str, Any]], vecs: np.ndarray, thresholds: Sequence[float]
+    items: Sequence[dict[str, Any]],
+    vecs: np.ndarray,
+    thresholds: Sequence[float],
+    *,
+    mixed_at: float = cfg.AUDIT_MIXED_MAX_WITHIN,
 ) -> list[dict[str, Any]]:
     """For every class: how it breaks up, at each threshold in the sweep.
 
     Reported as a sweep rather than a verdict because the operating point is a
     property of this corpus and this embedder, and picking one silently is how
     ``CLUSTER_THRESHOLD``'s 0.16 outlived the decomposition it was measured on.
+
+    One flag *is* drawn from the sweep, because #3610 needed a screen and not
+    just a table: a class is ``mixed`` when its two most distant instances sit
+    further apart than ``mixed_at`` -- by default the loosest threshold in the
+    sweep, i.e. wider than any cut that would still be called one mark.  That is
+    the question the ``--task cluster`` sheets exist to adjudicate, and it is
+    the one the query-crop rank cannot ask: the rank scores a *crop*, and a
+    five-mark class whose query crop is a good instance of its largest mark
+    scores in the healthiest tier while being the second most mixed class in the
+    corpus.
     """
-    by_class: dict[str, list[int]] = {}
-    for i, item in enumerate(items):
-        if item["kind"] == "instance":
-            by_class.setdefault(item["class_id"], []).append(i)
+    by_class = instances_by_class(items)
 
     rows = []
     for class_id in sorted(by_class):
@@ -229,6 +268,7 @@ def split_report(
             labels = split_class(sub, t)
             sizes = sorted((int((labels == k).sum()) for k in set(labels.tolist())), reverse=True)
             sweep[f"{t:.2f}"] = sizes
+        max_within = float(within.max())
         rows.append(
             {
                 "class_id": class_id,
@@ -236,7 +276,9 @@ def split_report(
                 "median_within": round(float(np.median(within[np.triu_indices(len(idx), k=1)])), 3)
                 if len(idx) > 1
                 else 0.0,
-                "max_within": round(float(within.max()), 3),
+                "max_within": round(max_within, 3),
+                "mixed": bool(max_within >= mixed_at),
+                "mixed_at": mixed_at,
                 "sweep": sweep,
             }
         )
@@ -247,13 +289,32 @@ def split_report(
 def query_check(
     items: Sequence[dict[str, Any]], vecs: np.ndarray, order: Sequence[str], centroids: np.ndarray
 ) -> list[dict[str, Any]]:
-    """Does each class's query crop retrieve its own class?
+    """Does each class's query crop retrieve its own class -- and how much of it?
 
-    The number that matters is the **rank** of the class's own centroid, because
-    that is what the eval does with the crop.  A distance alone cannot say
-    whether 0.30 is fine, and #3599 is the case where a distance said fine.
+    Two numbers, because the eval asks two things of one crop.
+
+    ``rank_of_own_class``
+        The **rank** of the class's own centroid among all centroids, because
+        that is what the eval does with the crop.  A distance alone cannot say
+        whether 0.30 is fine, and #3599 is the case where a distance said fine.
+
+    ``own_instances_reached``
+        How many of the class's own instances are closer to the query crop than
+        the nearest **other** class's centroid is.  The rank is a statement
+        about one crop against 59 classes; this is a statement about that crop
+        against the class it is supposed to stand for, and it is what catches a
+        query crop that represents only part of its class.  #3610's five-mark
+        StaVer class is exactly that: rank 0, distance 0.078, healthiest tier --
+        and a crop of the 16-strong routing box says nothing about the other
+        eleven instances.
+
+        The cut-off is not invented either.  It is the distance to the nearest
+        foreign centroid, i.e. the point past which a retrieval is picking up
+        another class anyway, so "reached" means "would come back before the
+        confusion starts".
     """
     position = {class_id: i for i, class_id in enumerate(order)}
+    by_class = instances_by_class(items)
     rows = []
     for i, item in enumerate(items):
         if item["kind"] != "query" or item["class_id"] not in position:
@@ -262,6 +323,13 @@ def query_check(
         ranking = np.argsort(-sims)
         own = position[item["class_id"]]
         rank = int(np.where(ranking == own)[0][0])
+        others = [int(j) for j in ranking if int(j) != own]
+        nearest_other = others[0] if others else None
+
+        idx = by_class.get(item["class_id"], [])
+        own_sims = vecs[idx] @ vecs[i] if idx else np.zeros(0, dtype=np.float32)
+        reached = int((own_sims >= sims[nearest_other]).sum()) if nearest_other is not None else len(idx)
+
         rows.append(
             {
                 "class_id": item["class_id"],
@@ -270,9 +338,23 @@ def query_check(
                 "distance_to_own": round(float(1.0 - sims[own]), 3),
                 "nearest_class": order[int(ranking[0])],
                 "distance_to_nearest": round(float(1.0 - sims[int(ranking[0])]), 3),
+                "own_instances": len(idx),
+                "own_instances_reached": reached,
+                "nearest_other_class": order[nearest_other] if nearest_other is not None else "",
+                "distance_to_nearest_other": round(float(1.0 - sims[nearest_other]), 3)
+                if nearest_other is not None
+                else 0.0,
             }
         )
-    rows.sort(key=lambda r: (-r["rank_of_own_class"], -r["distance_to_own"]))
+    # Worst first, by both screens at once: a crop that does not retrieve its own
+    # class, then one that retrieves only part of it.
+    rows.sort(
+        key=lambda r: (
+            -r["rank_of_own_class"],
+            r["own_instances_reached"] / max(1, r["own_instances"]),
+            -r["distance_to_own"],
+        )
+    )
     return rows
 
 
@@ -355,9 +437,24 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"query:   {len(misses)} of {len(queries)} query crop(s) do not retrieve their own class first")
         for q in misses[:5]:
             print(f"  rank {q['rank_of_own_class']:2d}  {q['class_id']}  (nearest: {q['nearest_class']})")
-        print("splits:  most spread classes (max within-class distance)")
+
+        # The second half of the query screen: a crop can retrieve its own class
+        # first and still stand for only part of it (#3610).
+        partial = [
+            q for q in queries if q["rank_of_own_class"] == 0 and q["own_instances_reached"] < q["own_instances"]
+        ]
+        print(f"reach:   {len(partial)} query crop(s) rank their class first but reach only part of it")
+        for q in partial[:8]:
+            print(
+                f"  {q['own_instances_reached']:3d}/{q['own_instances']:<3d} {q['class_id']:44s}"
+                f" (cut at {q['distance_to_nearest_other']:.3f}, {q['nearest_other_class']})"
+            )
+
+        mixed = [s for s in splits if s["mixed"]]
+        print(f"mixed:   {len(mixed)} of {len(splits)} class(es) spread wider than {cfg.AUDIT_MIXED_MAX_WITHIN:.2f}")
         for s in splits[:8]:
-            print(f"  {s['max_within']:.3f}  {s['class_id']:44s} n={s['n']:3d}  sweep={s['sweep']}")
+            flag = "MIXED" if s["mixed"] else "     "
+            print(f"  {flag} {s['max_within']:.3f}  {s['class_id']:44s} n={s['n']:3d}  sweep={s['sweep']}")
     return 0
 
 

--- a/scripts/experiments/docmarks/sources/_common.py
+++ b/scripts/experiments/docmarks/sources/_common.py
@@ -126,6 +126,32 @@ def stable_rank(key: str, salt: str) -> float:
     return int.from_bytes(h[:8], "big") / float(1 << 64)
 
 
+def spread(items: Sequence[Any], limit: int) -> list[Any]:
+    """Up to *limit* of *items*, evenly spaced across the whole sequence.
+
+    Every pass that samples a class hits the same trap: page ids sort by source
+    and number, so the head of the list is whatever the scanner did first, and a
+    class whose later instances drifted (a re-inked stamp, a second printing, a
+    second mark that only appears late) looks homogeneous for no better reason
+    than alphabetical order.
+
+    Spaced by index rather than by a ``[::step]`` stride, because the stride
+    degenerates exactly where it is needed most: ``step = n // limit`` is 1 for
+    any class between ``limit`` and ``2 * limit`` instances, so a 27-instance
+    class sampled at 24 silently gets its first 24 — the head sample the stride
+    was reached for to avoid (#3610).  Spacing the indices over ``n - 1``
+    instead always reaches the tail.
+    """
+    n = len(items)
+    if limit <= 0 or n == 0:
+        return []
+    if n <= limit:
+        return list(items)
+    if limit == 1:
+        return [items[0]]
+    return [items[round(i * (n - 1) / (limit - 1))] for i in range(limit)]
+
+
 # --------------------------------------------------------------------------
 # Masks -> boxes
 # --------------------------------------------------------------------------

--- a/tests_lib/datasets/test_docmarks_corpus.py
+++ b/tests_lib/datasets/test_docmarks_corpus.py
@@ -2445,6 +2445,174 @@ class TestSiglipAuditVectors:
         assert rows[0]["sweep"]["0.90"] == [4]
 
 
+class TestClassSamplingIsSpread:
+    """Which instances of a class the audit actually looks at (#3610).
+
+    Every pass that samples a class capped the sample by taking the head of the
+    page-id list, so a split proposal for a class larger than the cap was a
+    statement about its first ``max_per_class`` pages.  Page ids sort by source
+    and number, so that is the scanner's order: the two classes #3610 was filed
+    over are 27 and 30 instances against a cap of 24, and five of their marks
+    live only in the tail.
+    """
+
+    def test_a_short_sequence_is_taken_whole(self, mods):
+        assert mods["common"].spread(list(range(5)), 24) == list(range(5))
+
+    def test_the_sample_always_reaches_the_tail(self, mods):
+        # The regression that matters.  A `[::step]` stride computes
+        # `step = 27 // 24 == 1` and hands back the first 24 -- the head sample
+        # it was reached for to avoid.
+        picked = mods["common"].spread(list(range(27)), 24)
+        assert len(picked) == 24
+        assert picked[0] == 0
+        assert picked[-1] == 26
+
+    def test_the_sample_is_spread_and_ordered_and_distinct(self, mods):
+        picked = mods["common"].spread(list(range(30)), 24)
+        assert len(set(picked)) == 24
+        assert picked == sorted(picked)
+        assert max(b - a for a, b in zip(picked, picked[1:])) <= 2
+
+    def test_degenerate_limits(self, mods):
+        assert mods["common"].spread([], 5) == []
+        assert mods["common"].spread([1, 2, 3], 0) == []
+        assert mods["common"].spread([1, 2, 3], 1) == [1]
+
+    def test_collect_items_spreads_over_the_class_not_its_head(self, mods):
+        pages = [
+            _page(
+                mods,
+                f"spods/p{i:03d}",
+                "spods",
+                marks=(("stamp", (10, 10, 20, 20), "spods/c", ("clustered",)),),
+            )
+            for i in range(27)
+        ]
+        classes = {"spods/c": {"page_ids": [p.page_id for p in pages], "n_instances": 27}}
+        items = mods["siglip"].collect_items(pages, classes, max_per_class=24)
+        sampled = [it["page_id"] for it in items if it["kind"] == "instance"]
+        assert len(sampled) == 24
+        assert "spods/p026" in sampled
+
+    def test_the_cluster_sheet_renders_exactly_what_the_proposal_covers(self, mods, tmp_path):
+        # The sheet exists to adjudicate the proposal, and the two samples are
+        # drawn by different code paths -- an untagged cell would invite a
+        # verdict about a crop the clusterer never saw.
+        from PIL import Image
+
+        img = tmp_path / "p.png"
+        Image.new("RGB", (200, 200), "white").save(img)
+        pages = [
+            _page(
+                mods,
+                f"spods/p{i:03d}",
+                "spods",
+                marks=(("stamp", (10, 10, 20, 20), "spods/c", ("clustered",)),),
+                path=str(img),
+            )
+            for i in range(6)
+        ]
+        classes = {
+            "spods/c": {
+                "page_ids": [p.page_id for p in pages],
+                "n_instances": 6,
+                "provenance": ["clustered"],
+            }
+        }
+        proposals = {"spods/c": {"spods/p000": 1, "spods/p005": 2}}
+        verdicts = mods["slate"].task_cluster(pages, classes, tmp_path, proposals=proposals)
+        assert verdicts[0]["proposed_groups"] == [1, 1]
+
+
+class TestMixedClassScreen:
+    """The screen for a mixed *class*, beside the screens for an odd *crop*.
+
+    #3610: `staver/stamp_stampds-00156_0` holds five marks, and the query-crop
+    rank scores it in the healthiest tier of all 59 classes -- correctly, since
+    its query crop is a good instance of the 16-strong mark it was drawn from.
+    A rank of a crop cannot see the other four marks; nothing did.
+    """
+
+    @staticmethod
+    def _mixed(n_close=3, n_far=3):
+        # Two tight groups a right angle apart: max within-class distance 1.0,
+        # wider than any threshold in the sweep.
+        near, far = [1.0, 0.0], [0.0, 1.0]
+        items = [{"class_id": "a", "page_id": f"p{i}", "kind": "instance"} for i in range(n_close + n_far)]
+        vecs = np.array([near] * n_close + [far] * n_far, dtype=np.float32)
+        return items, vecs
+
+    def test_a_class_wider_than_the_loosest_sweep_threshold_is_flagged(self, mods):
+        items, vecs = self._mixed()
+        (row,) = mods["siglip"].split_report(items, vecs, (0.1, 0.4))
+        assert row["max_within"] == pytest.approx(1.0, abs=1e-3)
+        assert row["mixed"] is True
+
+    def test_a_tight_class_is_not(self, mods):
+        items = [{"class_id": "a", "page_id": f"p{i}", "kind": "instance"} for i in range(3)]
+        vecs = np.tile(np.array([1.0, 0.0], dtype=np.float32), (3, 1))
+        (row,) = mods["siglip"].split_report(items, vecs, (0.1, 0.4))
+        assert row["mixed"] is False
+
+    def test_the_flag_defaults_to_the_loosest_threshold_in_the_sweep(self, mods):
+        # Tied to the sweep on purpose: an independent number is one that can
+        # drift away from the sweep, which is how CLUSTER_THRESHOLD's 0.16
+        # outlived its decomposition (#3366).
+        assert mods["cfg"].AUDIT_MIXED_MAX_WITHIN == max(mods["cfg"].AUDIT_SPLIT_SWEEP)
+
+    def test_the_flag_records_the_threshold_it_was_taken_at(self, mods):
+        items, vecs = self._mixed()
+        (row,) = mods["siglip"].split_report(items, vecs, (0.4,), mixed_at=1.5)
+        assert row["mixed"] is False
+        assert row["mixed_at"] == 1.5
+
+    def test_a_query_crop_can_rank_first_and_still_reach_only_part_of_its_class(self, mods):
+        # The #3610 case in miniature: the crop is a good instance of the
+        # majority mark, so the centroid rank is 0 and says nothing about the
+        # instances that are a different mark.
+        items = [
+            {"class_id": "a", "page_id": "p0", "kind": "instance"},
+            {"class_id": "a", "page_id": "p1", "kind": "instance"},
+            {"class_id": "a", "page_id": "p2", "kind": "instance"},
+            {"class_id": "b", "page_id": "p3", "kind": "instance"},
+            {"class_id": "a", "page_id": "q", "kind": "query"},
+        ]
+        # `other` sits half-way to the query, so the cut-off the reach is
+        # measured against falls between the two marks inside class "a".
+        near, far, other = [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.5, 0.0, 3**0.5 / 2]
+        vecs = np.array([near, near, far, other, near], dtype=np.float32)
+        order, centroids = mods["siglip"].class_centroids(items, vecs)
+        (row,) = mods["siglip"].query_check(items, vecs, order, centroids)
+        assert row["rank_of_own_class"] == 0
+        assert row["own_instances"] == 3
+        assert row["own_instances_reached"] == 2
+        assert row["nearest_other_class"] == "b"
+
+    def test_a_representative_query_crop_reaches_its_whole_class(self, mods):
+        items = [
+            {"class_id": "a", "page_id": "p0", "kind": "instance"},
+            {"class_id": "a", "page_id": "p1", "kind": "instance"},
+            {"class_id": "b", "page_id": "p2", "kind": "instance"},
+            {"class_id": "a", "page_id": "q", "kind": "query"},
+        ]
+        vecs = np.array([[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+        order, centroids = mods["siglip"].class_centroids(items, vecs)
+        (row,) = mods["siglip"].query_check(items, vecs, order, centroids)
+        assert row["own_instances_reached"] == row["own_instances"] == 2
+
+    def test_the_query_crop_is_not_counted_as_one_of_its_own_instances(self, mods):
+        items = [
+            {"class_id": "a", "page_id": "p0", "kind": "instance"},
+            {"class_id": "b", "page_id": "p1", "kind": "instance"},
+            {"class_id": "a", "page_id": "q", "kind": "query"},
+        ]
+        vecs = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+        order, centroids = mods["siglip"].class_centroids(items, vecs)
+        (row,) = mods["siglip"].query_check(items, vecs, order, centroids)
+        assert row["own_instances"] == 1
+
+
 class TestSlateDescriptorChoice:
     """Which descriptor the slate is ordered by, and what it refuses."""
 


### PR DESCRIPTION
Closes #3610.

## 1. A screen for a crop is not a screen for a class

The query-crop screen added in #3607 reports the **rank of a class's own centroid**, which is a statement about one *crop*. Nothing was a statement about the *class*, and `staver/stamp_stampds-00156_0` is the case that separates the two: **five marks across 27 instances** (16 routing box / 8 `DFKI Empfang` / three singletons), scored **rank 0, distance 0.078** — the healthiest tier of all 59 classes — because its query crop is a good instance of the 16-strong mark it was drawn from.

That score is *correct on its own terms*. A rank cannot see the other four marks. Its `max_within` is **0.433, second worst of 59**, and was already sitting in `splits.json` unread.

Two screens now, beside the rank:

- **`mixed`** on each `split_report` row — the class's two most distant instances sit further apart than `AUDIT_MIXED_MAX_WITHIN`. That knob defaults to `max(AUDIT_SPLIT_SWEEP)` rather than to a fresh constant: "wider than the loosest cut we would still call one mark" is a threshold that cannot drift away from the sweep, which is how `CLUSTER_THRESHOLD`'s 0.16 outlived its decomposition (#3366).
- **`own_instances_reached`** on each `query_check` row — how many of the class's own instances the query crop reaches before the nearest **other** class's centroid. The cut-off is the confusion boundary, not an invented number. This is the crop-side view of the same defect: a crop that stands for only part of its class.

Both are printed by `--analyze` (a `reach:` block and a `MIXED` column) and written to the JSON. The verdict vocabulary is unchanged — these are hypotheses on a contact sheet.

## 2. `collect_items` sampled the alphabetical head — and a stride would not have fixed it

Every pass that capped a class's sample took `page_ids[:max_per_class]`. Page ids sort by source and number, so that is the scanner's order, and every split proposal for a class larger than the cap was a statement about its alphabetical head. Three of the StaVer class's five marks, and all four `://NOT-DELIVERED//:` stamps in `spods/stamp_00489_1`, sort after the cap.

The issue proposes striding the way `_class_strip` already does. **That does not work here**, and it is worth stating why: `step = n // limit` is **1** for any class between one and two caps, so `resolved[::1][:24]` is the first 24 again. The two classes in the issue are 27 and 30 instances against a cap of 24 — precisely the range where the stride degenerates to the head sample it was reached for to avoid.

So `sources/_common.spread` spaces indices over the whole range (`round(i * (n-1) / (limit-1))`), always reaching the tail, and `collect_items`, `task_cluster` and `_class_strip` all use it. `_class_strip`'s picks shift slightly as a result and now include each class's last instance.

`task_cluster` additionally renders **exactly the instances the proposal covers** when there is one. The sheet exists to adjudicate that proposal, the two samples are drawn by different code paths, and an untagged cell invites a verdict about a crop the clusterer never saw.

## Also recorded

The README now carries the reviewer note from the issue: a wide crop catches neighbouring page furniture, and at 150 px that is indistinguishable from a second mark. Two crops in the StaVer class show the routing box with a black `EINGEGANGEN AM 05. JAN. 2011` stamp above it — check at full size before splitting. That misreading is what the issue's own correcting comment records.

## Testing

Full `./run-tests.sh`: **10,520 passed**, 6 skipped, every gate green (pyright, pip-audit, vulture whitelist, Vitest). `npm audit` returned a registry 503 on the first run and `found 0 vulnerabilities` on retry.

16 new tests: the spread's tail-reaching property and the 27-against-24 regression specifically, `collect_items` and `task_cluster` sampling, the `mixed` flag and its tie to the sweep, and the query-crop reach — including the #3610 case in miniature, where the crop ranks its class first and reaches only part of it.

Existing caches are stale under the new sampling; re-run `siglip_audit.py --embed` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013EHaa8c1cXEeV1ormfq7ZY

---
_Generated by [Claude Code](https://claude.ai/code/session_013EHaa8c1cXEeV1ormfq7ZY)_