### PR TITLE
Give a vg_scale class's review rule one home

### DIFF
--- a/docs/experiments/2026-08-25-vg-scale/DATASHEET.md
+++ b/docs/experiments/2026-08-25-vg-scale/DATASHEET.md
@@ -84,6 +84,18 @@ published cells predate that**, so any per-class reading of `bicycle` in the
 #3156 grid carries it. The other eleven classes have not been measured for the
 same defect.
 
+**A class's definition is part of its label, and it now has a home.** A reviewer
+votes on bare images — files are named by image id — so the dataset name is the
+whole brief, and for a class whose plain English name does not settle the
+question that name is where the rule has to live. `book` is what taught this:
+COCO has no magazine class and annotates magazines as `book`, the human pass
+applied the narrower English reading, and 21 verdicts landed on one definition
+against 49 on another. The wordings now live in
+`pile_config.SCALE_CLASS_RULES` and every slate maker builds its dataset name
+from them, so a first pass and a re-review of one class ask the same question
+(#3612). Only `book` of the twelve carries a rule; the published cells were
+reviewed before the table existed.
+
 **The small band is at the limit of verification, and this is a property of the
 data, not a defect to hide.** A sub-patch object is under 1/196 of the frame;
 reviewing bare thumbnails rejected 43% of small-band positives against 10% of

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -67,6 +67,28 @@ because "no spelling is listed" and "no spelling exists" are the same empty
 table. A build names the classes that have not, since a rebuild is the moment
 the fix is cheap.
 
+**A class's review rule is part of its definition, so it lives in the config
+too.** A reviewer votes on bare images — the slates name files by image id
+alone — which makes the dataset name the entire brief. For a class whose plain
+English name does not settle the question, `pile_config.SCALE_CLASS_RULES`
+carries both halves of the rule, and `review_name(cls, pass)` is what every
+slate maker builds its `detector` column from:
+
+| field | meaning |
+|---|---|
+| `name` | the few words the reviewer reads (`cell phone not landlines`) |
+| `test` | what that abbreviates — the near-misses two words cannot settle |
+
+Both are recorded because a name is not a definition. `book` split on the half
+that was never written down: COCO annotates magazines as `book`, the human pass
+read it narrowly, and 21 verdicts landed on one meaning against 49 on another.
+`cell phone`'s first slate then split on the `test` rather than the `name` — it
+read "anything with a cord or a base station is Bad", which discriminates on a
+base being *present* when what it means is that the handset is not itself the
+whole device, and so rejected a mobile phone sitting in a charging dock (#3612).
+A class absent from the table is its own definition and keeps the bare class
+name, which is what the manifests held before the table existed.
+
 ## Why this exists
 
 Before it, each study embedded its own datadir and then later studies

--- a/scripts/experiments/pile/make_audit_pass.py
+++ b/scripts/experiments/pile/make_audit_pass.py
@@ -101,7 +101,7 @@ def main() -> int:
                     "reference": "absent",  # every one of these is a current negative
                     "exhaustive": "no",
                     "n_boxes": 0,
-                    "detector": f"{cls} audit",
+                    "detector": pc.review_name(cls, "audit"),
                 }
             )
         with (cdir / "manifest.csv").open("w", newline="") as fh:
@@ -109,7 +109,7 @@ def main() -> int:
             w.writeheader()
             w.writerows(written)
         n_flag = sum(1 for r in written if r["stratum"] == "flag")
-        index.append({"class": cls, "dir": str(cdir), "n": len(written), "detector": f"{cls} audit"})
+        index.append({"class": cls, "dir": str(cdir), "n": len(written), "detector": pc.review_name(cls, "audit")})
         log(f"  {cls:<12}{len(written):4d} images  ({n_flag} flags + {len(written) - n_flag} audit)")
 
     (out_root / "slates.json").write_text(json.dumps(index, indent=1) + "\n")

--- a/scripts/experiments/pile/make_audit_slate.py
+++ b/scripts/experiments/pile/make_audit_slate.py
@@ -29,6 +29,12 @@ where the answer is already known. Reviewing those corrects nothing, but it
 into a bounded number. The reviewer cannot tell them apart: files are named by
 image id alone.
 
+**The dataset name is the only thing the reviewer meets besides the images**, so
+for a class whose plain English name is not the whole question it carries the
+rule: the manifest's ``detector`` column is ``pile_config.review_name``, which
+is the class name unless ``SCALE_CLASS_RULES`` gives it one (`cell phone not
+landlines`). An unstated convention is what split `book`.
+
 Each class becomes a folder of JPEGs plus a manifest, ready for VTSearch's
 ``server_folder`` importer. Vote Good/Bad, export with ``server_json_file``, and
 feed the export to ``ingest_slate.py``.
@@ -179,13 +185,19 @@ def main() -> int:
                         "reference": "present" if cell else "absent",
                         "exhaustive": "yes" if medias[i].get("labels_exhaustive") else "no",
                         "n_boxes": len(medias[i].get("regions") or []) if cell else 0,
+                        # The dataset/detector this slate is voted under, and
+                        # for a class with a rule the only place the reviewer
+                        # meets it. Equal to the class name where there is no
+                        # rule, which is what `ingest_slate.py` assumed before
+                        # this column existed.
+                        "detector": pc.review_name(c),
                     }
                 )
         with (cdir / "manifest.csv").open("w", newline="") as fh:
             w = csv.DictWriter(fh, fieldnames=list(rows[0]))
             w.writeheader()
             w.writerows(rows)
-        index.append({"class": c, "dir": str(cdir), "n": len(rows)})
+        index.append({"class": c, "dir": str(cdir), "n": len(rows), "detector": pc.review_name(c)})
         log(f"  {c:<12} {len(rows):3d} images -> {cdir}")
 
     (out_root / "slates.json").write_text(json.dumps(index, indent=1) + "\n")

--- a/scripts/experiments/pile/make_definition_reslate.py
+++ b/scripts/experiments/pile/make_definition_reslate.py
@@ -12,10 +12,14 @@ positive stays positive under a widened definition. Everything else stands.
 
 The rule travels in the dataset name (`book incl magazines`) because a reviewer
 cannot see a manifest while voting, and an unstated convention is what produced
-the split in the first place.
+the split in the first place. The wording lives in
+`pile_config.SCALE_CLASS_RULES` rather than in whoever runs this, so a
+re-review is issued under the corrected rule instead of the one that produced
+the disputed verdicts (#3612).
 
 Usage::
 
+    python make_definition_reslate.py --class book
     python make_definition_reslate.py --class book --name "book incl magazines"
 """
 
@@ -42,7 +46,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     base = pc.PILE.parent / "vgscale-3156"
     ap.add_argument("--class", dest="klass", default="book")
-    ap.add_argument("--name", default="", help="dataset name carrying the rule (default: <class> reviewed)")
+    ap.add_argument(
+        "--name",
+        default="",
+        help="dataset name carrying the rule (default: the class's SCALE_CLASS_RULES name + ' reviewed')",
+    )
     ap.add_argument(
         "--verdicts",
         default="/exp/sgreenberg/vgscale-3156-labelsets/verdicts_final_20260824.json,"
@@ -62,7 +70,16 @@ def main() -> int:
     from build_pile import _vg_image_paths  # noqa: PLC0415
 
     cls = args.klass
-    name = args.name or f"{cls} reviewed"
+    # The corrected wording, not whichever one the last slate happened to use:
+    # a re-review issued under the rule that produced the disputed verdicts
+    # would just reproduce them (#3612).
+    # `reviewed` keeps this pass's detector distinct from the first pass's:
+    # `ingest_slate.py` keys a manifest row by (image, class, detector), so two
+    # slates of one class sharing a name would overwrite each other's rows.
+    name = args.name or pc.review_name(cls, "reviewed")
+    rule = pc.SCALE_CLASS_RULES.get(cls)
+    if rule:
+        log(f"rule: {rule.test}")
 
     verdicts = []
     for p in args.verdicts.split(","):

--- a/scripts/experiments/pile/make_positive_slate.py
+++ b/scripts/experiments/pile/make_positive_slate.py
@@ -149,7 +149,7 @@ def main() -> int:
                         "reference": "present",
                         "exhaustive": "yes" if media.get("labels_exhaustive") else "no",
                         "n_boxes": len(boxes),
-                        "detector": f"{cls} positives",
+                        "detector": pc.review_name(cls, "positives"),
                     }
                 )
         if not written:
@@ -159,7 +159,7 @@ def main() -> int:
             w = csv.DictWriter(fh, fieldnames=list(written[0]))
             w.writeheader()
             w.writerows(written)
-        index.append({"class": cls, "dir": str(cdir), "n": len(written), "detector": f"{cls} positives"})
+        index.append({"class": cls, "dir": str(cdir), "n": len(written), "detector": pc.review_name(cls, "positives")})
         log(f"  {cls:<12} {len(written):3d} boxed positives -> {cdir}")
 
     (out_root / "slates.json").write_text(json.dumps(index, indent=1) + "\n")

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import NamedTuple
 
 USER = os.environ.get("USER", "sgreenberg")
 
@@ -370,6 +371,81 @@ SCALE_VG_AMBIGUOUS: dict[str, tuple[str, ...]] = {
 #: :func:`pilebuild.loaders.vg_scale.load` names the unaudited classes on every
 #: build, because the rebuild is when this stops being cheap to fix (#3605).
 SCALE_VG_NAMES_AUDITED: frozenset[str] = frozenset({"bicycle"})
+
+
+class ClassRule(NamedTuple):
+    """One class's review definition: the ``name`` a reviewer sees, and the ``test``."""
+
+    #: What the slate's dataset/detector is called. This is the ONLY thing a
+    #: reviewer sees while voting -- files are named by image id alone -- so it
+    #: has to carry the discrimination on its own, in a few words.
+    name: str
+    #: The full wording the name abbreviates: what counts as Good, what counts
+    #: as Bad, and the near-miss the short name does not settle. Read by whoever
+    #: builds the slate and whoever adjudicates it, so both apply one definition.
+    test: str
+
+
+#: Per-class review definitions, for the classes whose plain English name is not
+#: the whole question.
+#:
+#: A class whose meaning differs between the halves of a dataset is not noisy, it
+#: is two classes wearing one name (``make_definition_reslate.py``). The rule
+#: that separates them travels in the **dataset name**, because a reviewer
+#: cannot see a manifest while voting -- and until this table existed the rule
+#: was typed by hand at slate time and written down nowhere, so the wording a
+#: re-review used was whatever the next person remembered.
+#:
+#: Two things are therefore recorded, not one. The ``name`` is what the reviewer
+#: reads; the ``test`` is what the name abbreviates, and is what settles the
+#: near-misses a two-word name cannot. A rule whose ``test`` lives only in a
+#: session transcript is a rule that will be re-derived differently.
+#:
+#: Classes absent from this table are their own definition, and
+#: :func:`review_name` falls back to the bare class name for them. A class need
+#: not be in :data:`SCALE_CLASSES` to appear here: `cell phone` is a #3588
+#: candidate whose first slate is already voted.
+SCALE_CLASS_RULES: dict[str, ClassRule] = {
+    # COCO has no magazine class, so its annotators put magazines in `book`
+    # while the human pass applied the narrower English reading -- leaving 21
+    # verdicts on one definition and 49 on another. The dataset takes COCO's,
+    # since that is the half with an exhaustive reference.
+    "book": ClassRule(
+        name="book incl magazines",
+        test=(
+            "Good: a bound book, and also a magazine -- COCO has no magazine class and "
+            "annotates magazines as `book`, which is the reading this dataset uses. "
+            "Bad: newspapers, loose paper, a screen showing text."
+        ),
+    ),
+    # The class's whole risk is landlines: VG `phone` lands on no COCO class
+    # 46.2% of the time, worse than `book`'s 43.3%. The first slate's test read
+    # "anything with a cord or a base station is Bad", which discriminates on a
+    # base being PRESENT when what it means is that the handset is not itself
+    # the whole device -- so it rejected 2387021, a mobile phone in a charging
+    # dock (#3612).
+    "cell phone": ClassRule(
+        name="cell phone not landlines",
+        test=(
+            "Bad if the handset needs the base to work -- landline handsets, desk phones, "
+            "payphones, wall phones, intercoms. A mobile phone resting in a charging dock "
+            "or cradle is still Good."
+        ),
+    ),
+}
+
+
+def review_name(cls: str, suffix: str = "") -> str:
+    """The dataset/detector name a slate of *cls* is reviewed under.
+
+    The class's rule name where it has one, else the bare class name, plus an
+    optional *suffix* naming the pass (``positives``, ``audit``). Every slate
+    maker builds its ``detector`` column from this, so a class's rule reaches
+    the reviewer whichever pass they are voting -- the first pass included,
+    which is where a definition split does its damage.
+    """
+    rule = SCALE_CLASS_RULES.get(cls)
+    return f"{rule.name if rule else cls}{f' {suffix}' if suffix else ''}"
 
 
 def scale_vg_wanted() -> set[str]:

--- a/tests_lib/meta/test_pile_class_rules.py
+++ b/tests_lib/meta/test_pile_class_rules.py
@@ -1,0 +1,116 @@
+"""A class's review rule reaches the reviewer, and lives in one place (#3612).
+
+`vg_scale`'s slates are voted on bare images: files are named by image id, and
+the reviewer never sees a manifest. So for a class whose plain English name is
+not the whole question, the **dataset name is the entire brief**, and until
+`pile_config.SCALE_CLASS_RULES` existed that name was typed by hand at slate
+time and recorded nowhere.
+
+Two failures follow from that, and both have happened:
+
+* `book` split -- COCO annotates magazines as `book`, the human pass applied the
+  narrower reading, and 21 verdicts landed on one definition against 49 on
+  another.
+* `cell phone`'s first slate was voted under a test that read "anything with a
+  cord or a base station is Bad". That discriminates on a base being *present*
+  when what it means is that the handset is not itself the whole device, so it
+  rejected image 2387021 -- a mobile phone in a charging dock.
+
+These pin the properties that stop the second one recurring: the wording is
+recorded, it is what a re-review is issued under, and every slate maker builds
+its detector name from it rather than from a format string of its own.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+#: Every script that names a dataset a human votes in.
+_SLATE_MAKERS = (
+    "make_audit_slate.py",
+    "make_positive_slate.py",
+    "make_audit_pass.py",
+    "make_definition_reslate.py",
+)
+
+
+@pytest.fixture(scope="module")
+def pc():
+    """``pile_config``, which is constants only -- ``setup_env()`` is explicit."""
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pile_config
+
+    return pile_config
+
+
+def test_review_name_falls_back_to_the_bare_class(pc):
+    """A class without a rule is its own definition, and keeps the old name."""
+    assert "clock" not in pc.SCALE_CLASS_RULES
+    assert pc.review_name("clock") == "clock"
+    assert pc.review_name("clock", "positives") == "clock positives"
+
+
+def test_review_name_carries_the_rule_through_every_pass(pc):
+    """The suffix names the pass; the rule survives it."""
+    assert pc.review_name("cell phone") == "cell phone not landlines"
+    assert pc.review_name("cell phone", "audit") == "cell phone not landlines audit"
+
+
+def test_rule_names_are_usable_as_a_detector_and_a_folder(pc):
+    """The name becomes a directory (``name.replace(" ", "_")``) and an API path."""
+    for cls, rule in pc.SCALE_CLASS_RULES.items():
+        assert rule.name == rule.name.strip() and rule.name
+        assert not set(rule.name) & set("/\\"), f"{cls}: path separator in {rule.name!r}"
+        assert re.fullmatch(r"[a-z0-9 ]+", rule.name), f"{cls}: {rule.name!r} is not plain lowercase"
+        # `ingest_slate.py` attributes an export by matching the slate folder in
+        # the origin path, and a human has to recognise the class at a glance.
+        assert rule.name.startswith(cls), f"{cls}: {rule.name!r} does not name its class"
+
+
+def test_no_two_passes_of_one_class_share_a_detector(pc):
+    """``ingest_slate.py`` keys a manifest row by (image, class, detector).
+
+    Two slates of one class under one name would overwrite each other's rows,
+    silently dropping a whole review pass. The suffixes are what separate them,
+    so a rule name must not collide with another class's bare name either.
+    """
+    seen: dict[str, str] = {}
+    classes = set(pc.SCALE_CLASSES) | set(pc.SCALE_CLASS_RULES)
+    for cls in sorted(classes):
+        for suffix in ("", "positives", "audit", "reviewed"):
+            name = pc.review_name(cls, suffix)
+            assert name not in seen, f"{cls}/{suffix!r} collides with {seen[name]}"
+            seen[name] = f"{cls}/{suffix!r}"
+
+
+def test_the_cell_phone_rule_admits_a_docked_mobile(pc):
+    """The clause that rejected 2387021, stated as the dependency it means.
+
+    "A base is present" and "the handset needs the base" are the same sentence
+    about a desk phone and opposite sentences about a phone on a charger, which
+    is the whole of #3612.
+    """
+    test = pc.SCALE_CLASS_RULES["cell phone"].test.lower()
+    assert "needs the base" in test, "the Bad clause must turn on dependency, not presence"
+    assert "dock" in test and "cradle" in test, "the near-miss must be settled explicitly"
+    assert "landline" in test, "the clause still has to exclude landlines"
+
+
+def test_every_slate_maker_names_its_detector_from_the_table():
+    """No script may format a detector name of its own.
+
+    A pass that builds ``f"{cls} positives"`` inline is a pass the rule never
+    reaches -- which is exactly how the first `cell phone` slate was voted.
+    """
+    for script in _SLATE_MAKERS:
+        src = (_PILE_DIR / script).read_text()
+        assert "pc.review_name(" in src, f"{script} does not use pile_config.review_name"
+        stray = re.findall(r'f"\{cls\}[^"]*"|f"\{c\}[^"]*"', src)
+        assert not stray, f"{script} formats a detector name inline: {stray}"


### PR DESCRIPTION
A reviewer votes on bare images — the slates name files by image id alone — so the **dataset name is the entire brief**. For a class whose plain English name does not settle the question, that name is where the rule has to live, and until now it was typed by hand at slate time and recorded nowhere in the repo.

Two failures follow from that, and both have happened:

- **`book` split on a definition nobody wrote down.** COCO has no magazine class and annotates magazines as `book`; the human pass applied the narrower English reading. 21 verdicts landed on one meaning against 49 on another.
- **`cell phone`'s first slate split on the *test* rather than the name.** It read *"anything with a cord or a base station is Bad"*, which discriminates on a base being **present** when what it means is that **the handset is not itself the whole device** — so it rejected image 2387021, a mobile phone sitting in a charging dock. The base-station clause is doing real work (three of the five rejected pre-boxed positives are unambiguous landlines, and VG `phone` lands on no COCO class 46.2% of the time), so the fix is to restate it, not drop it.

## What changed

`pile_config.SCALE_CLASS_RULES` records **both halves**, because a name is not a definition:

| field | meaning |
|---|---|
| `name` | the few words the reviewer reads (`cell phone not landlines`) |
| `test` | what those abbreviate — the near-misses two words cannot settle |

`cell phone`'s `test` is the corrected wording: *Bad if the handset needs the base to work — landline handsets, desk phones, payphones, wall phones, intercoms. A mobile phone resting in a charging dock or cradle is still Good.*

`review_name(cls, pass)` is what all four slate makers now build their `detector` column from — `make_audit_slate.py`, `make_positive_slate.py`, `make_audit_pass.py`, `make_definition_reslate.py`. Wiring only the re-review would deliver the rule *after* the verdicts it exists to prevent, which is exactly what happened here.

Behaviour for a class with no rule is unchanged: `review_name` returns the bare class name, which is what the manifests already held. The pass suffixes (`positives`, `audit`, `reviewed`) stay distinct, since `ingest_slate.py` keys a manifest row by `(image, class, detector)` and two passes of one class sharing a name would overwrite each other's rows. Slate **folder** names are untouched — only the reviewer-facing dataset/detector name moves.

`tests_lib/meta/test_pile_class_rules.py` pins the fallback, the name/folder constraints, the no-collision property, the corrected `cell phone` clause, and — statically — that no slate maker formats a detector name of its own again.

Docs: a section in `scripts/experiments/pile/README.md` and a caveat in the `vg_scale` datasheet noting that the published cells were reviewed before the table existed.

## Testing

Full `./run-tests.sh`: **RUN PASSED**, 10489 passed / 6 skipped. (A first run tripped `npm audit` on a transient registry error — npm falling back to its retired quick-audit endpoint; it passes standalone and on the re-run, and this diff touches no JS.)

Closes #3612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX71UYENmcUpiRn4YFnKtZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SX71UYENmcUpiRn4YFnKtZ)_