### PR TITLE
tests: give every test fresh dataset-load concurrency gates

### DIFF
--- a/tests/datasets/test_parallel_loading.py
+++ b/tests/datasets/test_parallel_loading.py
@@ -628,42 +628,16 @@ class TestConcurrentModelLoading:
 
 
 class TestLoadingGates:
-    """Verify the download/embed gates serialise (or pipeline) concurrent loads."""
+    """Verify the download/embed gates serialise (or pipeline) concurrent loads.
 
-    @pytest.fixture(autouse=True)
-    def _isolate_loading_gates(self):
-        """Drain the dataset-load gates around each test in this class.
-
-        ``conftest.reset_state`` clears the loading-tasks dict between
-        tests but cannot stop worker threads from a prior test that are
-        still holding ``_download_gate`` / ``_embed_gate``. When the
-        suite is under load and a leaked thread is still draining when
-        this test starts, the assertions on ``gate.active`` see stale
-        counts and the test fails with a cryptic ``assert 1 == 0``.
-
-        This fixture cancels any in-flight loading tasks and waits for
-        both gates to settle at zero before yielding, then does the
-        same again on teardown so the next test starts clean.
-        """
-        from vtscore.datasets.load_pipeline import _download_gate, _embed_gate
-
-        def drain(timeout_s: float = 10.0) -> None:
-            loading_tasks.cancel_all()
-            deadline = time.time() + timeout_s
-            while time.time() < deadline:
-                if _download_gate.active == 0 and _embed_gate.active == 0 and not loading_tasks.has_active_tasks():
-                    return
-                time.sleep(0.05)
-
-        drain()
-        assert _download_gate.active == 0, (
-            "Download gate not clean at test start: a prior test leaked a thread that is still holding the gate."
-        )
-        assert _embed_gate.active == 0, (
-            "Embed gate not clean at test start: a prior test leaked a thread that is still holding the gate."
-        )
-        yield
-        drain()
+    These tests read ``_download_gate.active`` / ``_embed_gate.active`` as
+    absolute counts, which is only meaningful because the per-test reset in
+    ``tests_shared.state_reset`` hands every test freshly-constructed gates.
+    This class used to carry its own drain-and-assert fixture instead, and that
+    could only *detect* a gate another test had left dirty, never prevent it —
+    so it turned a leak elsewhere in the worker process into an error here
+    (issue #3613).
+    """
 
     def test_second_load_waits_for_first(self):
         """With the download limit at 1, a second load should show 'Waiting…'

--- a/tests_lib/datasets/test_load_gate_isolation.py
+++ b/tests_lib/datasets/test_load_gate_isolation.py
@@ -1,0 +1,134 @@
+"""Per-test isolation of the process-global dataset-load concurrency gates.
+
+``_download_gate`` / ``_embed_gate`` live at module scope in
+``vtscore.datasets.load_pipeline``, so every test landing in the same xdist
+worker shares them.  The tests here cover the two halves of what keeps that
+sharing invisible: the load-task registry stops the threads it forgets, and the
+gates themselves are rebound between tests so a thread it could not stop cannot
+be observed by — or corrupt the counts of — the next one (issue #3613).
+"""
+
+from __future__ import annotations
+
+import threading
+
+from vtscore.concurrency.progress import CancelledError, LoadingTasksTracker
+from vtscore.datasets import load_pipeline
+from vtscore.datasets.load_pipeline import _LoadGateController, reset_load_gates_for_tests
+
+
+class _NullTracker:
+    """The slice of ``ProgressTracker`` that ``_LoadGateController`` uses."""
+
+    def update(self, *args, **kwargs) -> None:
+        pass
+
+    def check_cancelled(self) -> None:
+        pass
+
+
+class TestGateRebinding:
+    def test_reset_hands_out_fresh_gates(self):
+        before_download = load_pipeline._download_gate
+        before_embed = load_pipeline._embed_gate
+        assert before_download.acquire(blocking=False)
+
+        reset_load_gates_for_tests()
+
+        assert load_pipeline._download_gate is not before_download
+        assert load_pipeline._embed_gate is not before_embed
+        assert load_pipeline._download_gate.active == 0
+        assert load_pipeline._embed_gate.active == 0
+
+        # The permit taken above is still outstanding — on the old gate.
+        assert before_download.active == 1
+        before_download.release()
+
+    def test_leaked_holder_releases_the_gate_it_acquired(self):
+        """A controller from before the reset must not decrement the new gate.
+
+        This is what makes rebinding safe in the presence of a thread the task
+        registry could not join: were the release to resolve the module global
+        at release time, it would drive the *current* test's gate negative and
+        silently let extra loads through.
+        """
+        controller = _LoadGateController(_NullTracker())
+        controller.acquire_download()
+        stale_gate = load_pipeline._download_gate
+        assert stale_gate.active == 1
+
+        reset_load_gates_for_tests()
+        fresh_gate = load_pipeline._download_gate
+
+        controller.release()
+
+        assert stale_gate.active == 0
+        assert fresh_gate.active == 0
+
+    def test_swap_to_embed_releases_the_download_gate_it_holds(self):
+        controller = _LoadGateController(_NullTracker())
+        controller.acquire_download()
+        download_gate = load_pipeline._download_gate
+
+        controller.swap_to_embed()
+
+        assert controller.held == "embed"
+        assert download_gate.active == 0
+        assert load_pipeline._embed_gate.active == 1
+
+        controller.release()
+        assert load_pipeline._embed_gate.active == 0
+
+
+class TestLoadingTasksReset:
+    def test_reset_cancels_and_joins_a_live_worker(self):
+        tracker_registry = LoadingTasksTracker()
+        tracker = tracker_registry.create_task("leaky", "Leaky DS")
+
+        running = threading.Event()
+        finished = threading.Event()
+
+        def body():
+            running.set()
+            try:
+                while True:
+                    tracker.check_cancelled()
+                    tracker.cancel_event.wait(timeout=0.05)
+            except CancelledError:
+                finished.set()
+
+        worker = threading.Thread(target=body, daemon=True)
+        tracker_registry.set_worker("leaky", worker)
+        worker.start()
+        assert running.wait(timeout=5)
+
+        tracker_registry.reset_for_tests()
+
+        assert finished.is_set(), "reset_for_tests returned before the worker unwound"
+        assert not worker.is_alive()
+        assert tracker_registry.list_tasks() == []
+
+    def test_reset_is_bounded_when_a_worker_will_not_stop(self):
+        """An unstoppable worker costs the budget once, not the whole run."""
+        tracker_registry = LoadingTasksTracker()
+        tracker_registry.create_task("wedged", "Wedged DS")
+
+        release = threading.Event()
+        running = threading.Event()
+
+        def body():
+            running.set()
+            release.wait(timeout=30)
+
+        worker = threading.Thread(target=body, daemon=True)
+        tracker_registry.set_worker("wedged", worker)
+        worker.start()
+        assert running.wait(timeout=5)
+
+        try:
+            tracker_registry.reset_for_tests(join_timeout=0.1)
+            assert worker.is_alive(), "worker was expected to outlast the join budget"
+            assert tracker_registry.list_tasks() == []
+        finally:
+            release.set()
+            worker.join(timeout=5)

--- a/tests_shared/state_reset.py
+++ b/tests_shared/state_reset.py
@@ -196,8 +196,20 @@ def reset_shared_state(medias_snapshot) -> None:
     find_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     sort_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
     eval_progress.update("idle", "", 0, 0, step=None, total_steps=None, error=None)
+    # Cancels each task and joins its worker before dropping the entry, so a
+    # load still running at the end of the previous test is stopped rather than
+    # orphaned.
     loading_tasks.reset_for_tests()
     detector_loading_tasks.reset_for_tests()
+
+    # ...and hand this test fresh load gates regardless, so a worker that
+    # outlived the join above holds a permit on a gate nothing will look at
+    # again.  Without this the gates' counts are whatever the previous test in
+    # the worker process left behind, which made the assertions in
+    # ``TestLoadingGates`` a lottery over xdist scheduling (issue #3613).
+    from vtscore.datasets.load_pipeline import reset_load_gates_for_tests
+
+    reset_load_gates_for_tests()
 
     # Cancel any debounced labelset-source push left over from the previous test
     # so its captured contexts don't fire after this test's reset has dropped

--- a/vtscore/concurrency/progress.py
+++ b/vtscore/concurrency/progress.py
@@ -814,8 +814,35 @@ class LoadingTasksTracker:
             entries = list(self._tasks.values())
         return any(e["tracker"].get()["status"] != "idle" for e in entries)
 
-    def reset_for_tests(self) -> None:
-        """Clear all tasks.  For test isolation."""
+    def reset_for_tests(self, join_timeout: float = 5.0) -> None:
+        """Cancel every task, wait for its worker, then clear the registry.
+
+        Clearing alone is not isolation: the entry it drops is the only handle
+        anything has on the worker thread, so a load still running at the end of
+        a test became an *unreachable* thread that carried on mutating shared
+        state — contexts, progress, the load concurrency gates — underneath the
+        next test (issue #3613).  Cancelling first gives the worker its
+        cooperative exit; the join then makes "the previous test's threads are
+        gone" true rather than hoped-for.
+
+        *join_timeout* is a budget for the whole sweep, not per worker, so a
+        thread parked on something no test will ever set costs a bounded delay
+        once instead of stalling the run.  It is spent only when a worker is
+        actually alive, which is the exceptional case.
+        """
+        with self._lock:
+            entries = list(self._tasks.values())
+
+        for entry in entries:
+            entry["tracker"].cancel()
+
+        deadline = time.monotonic() + join_timeout
+        for entry in entries:
+            worker = entry.get("worker")
+            if worker is None or not worker.is_alive():
+                continue
+            worker.join(timeout=max(0.0, deadline - time.monotonic()))
+
         with self._lock:
             self._tasks.clear()
 

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -73,6 +73,28 @@ _download_gate = ConcurrencyGate(lambda: CoreConfig.from_settings().max_concurre
 _embed_gate = ConcurrencyGate(lambda: CoreConfig.from_settings().max_concurrent_dataset_embeddings)
 
 
+def reset_load_gates_for_tests() -> None:
+    """Rebind both load gates to fresh instances.  For test isolation.
+
+    The gates are process globals, so under ``pytest -n auto`` every test in a
+    worker shares them.  A test that leaves a background load thread running
+    leaves that thread holding a permit, and the next test in the process sees
+    a gate that is already partly full — which is how ``TestLoadingGates``
+    became a lottery over xdist worker assignment (issue #3613).
+
+    Rebinding rather than zeroing the counters is what makes this safe in the
+    presence of a thread we could not stop: the leaked thread still holds — and
+    eventually releases — the *old* gate object, so it cannot drive the new
+    gate's count negative.  :class:`_LoadGateController` cooperates by
+    remembering the gate object it acquired instead of re-resolving these
+    globals at release time.
+    """
+    global _download_gate, _embed_gate
+
+    _download_gate = ConcurrencyGate(lambda: CoreConfig.from_settings().max_concurrent_dataset_downloads)
+    _embed_gate = ConcurrencyGate(lambda: CoreConfig.from_settings().max_concurrent_dataset_embeddings)
+
+
 # ---------------------------------------------------------------------------
 # App-side persistence hook
 # ---------------------------------------------------------------------------
@@ -350,6 +372,12 @@ class _LoadGateController:
         self._tracker = tracker
         self._total_steps = total_steps
         self._held: str | None = None
+        #: The gate object :meth:`acquire` last took a permit from.  Held as an
+        #: object rather than re-resolved from the module global at release
+        #: time so a controller always releases *the gate it acquired*, even if
+        #: the global has since been rebound (which is what
+        #: :func:`reset_load_gates_for_tests` does between tests).
+        self._held_gate: ConcurrencyGate | None = None
 
     @property
     def held(self) -> str | None:
@@ -358,11 +386,13 @@ class _LoadGateController:
     def acquire(self, gate: ConcurrencyGate, name: str, wait_msg: str) -> None:
         if gate.acquire(blocking=False):
             self._held = name
+            self._held_gate = gate
             return
         self._tracker.update("loading", wait_msg, 0, 0, step=1, total_steps=self._total_steps)
         while not gate.acquire(timeout=0.5):
             self._tracker.check_cancelled()
         self._held = name
+        self._held_gate = gate
 
     def acquire_download(self) -> None:
         self.acquire(_download_gate, "download", "Waiting for other datasets to finish downloading…")
@@ -371,16 +401,14 @@ class _LoadGateController:
         if self._held == "embed":
             return
         if self._held == "download":
-            _download_gate.release()
-            self._held = None
+            self.release()
         self.acquire(_embed_gate, "embed", "Waiting for other datasets to finish embedding…")
 
     def release(self) -> None:
-        if self._held == "download":
-            _download_gate.release()
-        elif self._held == "embed":
-            _embed_gate.release()
+        if self._held_gate is not None:
+            self._held_gate.release()
         self._held = None
+        self._held_gate = None
 
 
 def _make_stepped_progress(controller: _LoadGateController, pacer):


### PR DESCRIPTION
Fixes the `TestLoadingGates` flake by removing the shared state it depended on, rather than serialising the tests that touch it.

Closes #3613

## The problem

`_download_gate` / `_embed_gate` are module-level globals in `vtscore.datasets.load_pipeline`, so every test landing in the same xdist worker *process* shares them. `LoadingTasksTracker.reset_for_tests()` cleared the task dict without stopping anything — and that entry was the only handle anything held on a still-running load's worker thread. The thread became unreachable and carried on holding a gate permit under the next test.

`TestLoadingGates` reads `gate.active` as an absolute count, so it errored at setup whenever such a leak happened to land on its worker, and passed 58/58 when the file ran alone. Under `--dist loadgroup` that assignment is a lottery, which is why the same commit went 2-errors / 0-errors / 0-errors across three runs.

## The fix

Three changes; none of them need `xdist_group` pinning:

- **`LoadingTasksTracker.reset_for_tests()` stops what it forgets.** It now cancels each task and joins its worker before dropping the entry. The join has a bounded whole-sweep budget (not per worker), so a thread parked on something no test will ever set costs a delay once instead of stalling the run — and that budget is only spent when a worker is actually alive.
- **`load_pipeline.reset_load_gates_for_tests()`** rebinds both gates to fresh instances, called from `tests_shared.state_reset` alongside the other per-test global resets. Rebinding rather than zeroing the counters is what makes this safe against a worker the join could *not* stop: that thread still holds — and eventually releases — the **old** gate object, so it cannot drive the current test's gate negative.
- **`_LoadGateController` releases the gate it acquired.** It now remembers the gate object rather than re-resolving the module global at release time, which is what closes the rebinding hole above. This also collapses `swap_to_embed`'s hand-rolled download-gate release into a `release()` call.

## What that replaces

`TestLoadingGates`'s own drain-and-assert fixture is gone. It could only *detect* a gate another test had left dirty, never prevent it — so its effect was to convert a leak elsewhere in the worker process into an error in this class. The class docstring now records where its isolation actually comes from.

New regression coverage in `tests_lib/datasets/test_load_gate_isolation.py` pins all four behaviours: the reset hands out fresh gates, a pre-reset controller decrements the stale gate and not the fresh one, `swap_to_embed` releases the download gate it holds, and the task reset both stops a cancellable worker and stays bounded against one that will not stop.

## Testing

Full `./run-tests.sh`: **10488 passed, 6 skipped, 2 xpassed**; pyright, pip-audit, the vulture whitelist check, the Vitest suite and every stage-1 gate green.

The `npm audit` lane failed on `503 Service Unavailable` from `registry.npmjs.org` and did so again on a re-run. Running the same command directly in `frontend/` returns `found 0 vulnerabilities`, and this branch touches no frontend file, `package.json` or lockfile — the lane is hitting an npm-registry availability problem, not a dependency issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uuPSPoEvMwFd4aZNVbr1J

---
_Generated by [Claude Code](https://claude.ai/code/session_012uuPSPoEvMwFd4aZNVbr1J)_