### PR TITLE
pile: report a rebox that changes band, and measure the same drift unreviewed

### DIFF
--- a/docs/plans/vg-scale-bands-and-corrections.md
+++ b/docs/plans/vg-scale-bands-and-corrections.md
@@ -183,3 +183,17 @@ Two measurements constrain what comes next:
   the label-noise effect is on the record rather than assumed. (Sonnet 5)
 
 <!-- item-sep -->
+
+- **Decide what the review guide tells a reviewer to do with a better example.**
+  `audit_band_drift.py` measures how often VG's boxes band an image below the
+  largest instance it actually holds; what to do about the ones a *reviewer*
+  spots is still open, and the guide currently says the opposite of the decision
+  taken in #3616. It was amended to "on a pre-boxed positive, judge the object in
+  the box and redraw only to correct the extent of the *same* object", which
+  makes the drift stop — by asking the reviewer to leave an annotation error in
+  place once they have seen it. That is the wrong trade if the mis-banding is
+  common, and the audit is what says whether it is. The guide is not in this
+  repo, so the amendment has to be reverted by hand once the rate is known.
+  (human)
+
+<!-- item-sep -->

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -218,6 +218,36 @@ labels with a perfectly healthy media count. It now stamps a digest of the
 parent's labels, `--verify` compares that against the live parent, and a run
 that rebuilds `vg_scale` pulls the derived dataset in with it.
 
+## A rebox can change the band, and that is a correction
+
+An image sits in `class@band` because of the box it arrived with, so a reviewer
+who redraws that box onto a different, more prominent instance of the same class
+moves it to another cell and vacates the one it was sampled to fill. Six of the
+first thirteen redrawn boxes did, two of them leaving `small` (#3616).
+
+The move is **kept**. VG's recall over *C* is 0.61, so an image holding a small
+annotated bowl and a large unannotated one was banded by the only box anyone had
+written down, and the reviewer is the first person to have seen the other one —
+the sampled band was the error, not the redraw. What was wrong is that it
+happened silently, so `verdicts_to_corrections.py` now prints every
+band-changing rebox with the band it left and the band it lands in.
+
+`audit_band_drift.py` asks how much of the same error the *un*-reviewed half is
+still hiding, without spending a human on it. The COCO-anchored half has both
+readings available — VG's boxes and COCO's exhaustive ones — so banding each
+anchored image twice and counting the disagreements measures the rate directly,
+and the roster says how many un-anchored seats that rate applies to:
+
+```
+python audit_band_drift.py                          # small + medium
+python audit_band_drift.py --bands small --out drift_small.json
+```
+
+Only the bottom bands are audited by default: the defect can only push an image
+*up* (a band can hide a larger instance), and `large` has nowhere to go. A
+disagreement in the other direction is an extent error in VG's box, which is a
+different problem and is counted separately.
+
 ## Voted-box scale bands (`--bands`)
 
 Orthogonal to the `_s`/`_m`/`_l` suffix, which is a **dataset size tier** (a

--- a/scripts/experiments/pile/audit_band_drift.py
+++ b/scripts/experiments/pile/audit_band_drift.py
@@ -103,9 +103,9 @@ def main() -> int:
     args = ap.parse_args()
 
     # Imported here, not at module scope: `coco_anchor` runs `setup_env()` at
-    # import, which edits `os.environ` and `sys.meta_path` process-wide. Keeping
-    # it inside `main` is what lets the banding helpers above be imported and
-    # tested without doing that to the caller (the loader does the same).
+    # import, which rewrites `os.environ` and the process-wide import machinery.
+    # Keeping it inside `main` is what lets the banding helpers above be imported
+    # and tested without doing that to the caller (the loader does the same).
     import coco_anchor as ca  # noqa: PLC0415
 
     order = list(pc.BOX_BANDS)

--- a/scripts/experiments/pile/audit_band_drift.py
+++ b/scripts/experiments/pile/audit_band_drift.py
@@ -1,0 +1,257 @@
+"""How often does VG's non-exhaustive annotation file an image in too small a band?
+
+A `vg_scale` image sits in `class@band` because of the box it arrived with. When
+a reviewer redraws that box onto a *different, more prominent* instance of the
+same class, the image moves to the band the new box implies and leaves the cell
+it was sampled to fill -- 6 of the first 13 redrawn boxes did (#3616).
+
+That is a correction, not a reviewer error. VG's recall over *C* is 0.61, so an
+image holding a small annotated bowl and a large unannotated one was banded
+`small` by the only box anyone had written down, and the reviewer is the first
+person to have seen the other one. The open question is not whether to accept
+the move but **how much of this the un-reviewed half is still hiding**, and
+review is far too expensive a way to find out.
+
+**COCO answers it for free.** 48% of VG's images are COCO images, COCO annotates
+*C* exhaustively, and `anchor_to_coco` already replaces VG's labels with COCO's
+on that half. So the anchored images are a control group with both readings
+available: band each one from VG's boxes *alone*, band it again from COCO's, and
+every disagreement is one instance of exactly the defect a reviewer catches by
+hand. The rate measured there is the rate to expect on the un-anchored half,
+where nothing but a human can see it.
+
+Which disagreements count::
+
+    UP          VG says small, COCO says medium/large -- an unannotated larger
+                instance. THE defect: the reviewer's rebox, found automatically.
+    scattered   COCO finds several instances too far apart to be one region, so
+                the image belongs in no cell of that class at all.
+    absent      COCO annotates the image and no instance is there; VG's box was
+                a false positive, which the boxed-positive review already covers.
+    down        COCO's box is SMALLER. Not this defect -- an extent error in VG's
+                box, or a differently-drawn instance -- and reported apart from it.
+
+Bands are audited from the bottom up (`--bands small,medium` by default) because
+the error only ever pushes an image *up*: a band can hide a larger instance, and
+`large` has nowhere left to go.
+
+Reads the VG source and COCO's instances; writes nothing but its report (and
+``--out``, the affected pairs, for a targeted re-slate). In particular it does
+NOT touch the roster.
+
+Usage::
+
+    python audit_band_drift.py                       # small + medium
+    python audit_band_drift.py --bands small --out drift_small.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+
+import pile_config as pc
+
+sys.path.insert(0, str(pc.Path(__file__).resolve().parent))
+
+from pilebuild.env import log  # noqa: E402
+from pilebuild.loaders.vg_scale import (  # noqa: E402
+    OVERSIZE,
+    SCATTERED,
+    anchor_to_coco,
+    band_for,
+    canonicalise,
+    lift_ambiguous,
+    read_vg_labels,
+)
+from pilebuild.vgsource import vg_image_paths, vg_source  # noqa: E402
+
+#: What a pair is when the source annotates the image and puts no instance in it.
+ABSENT = "absent"
+#: The verdict on one pair, in the order the report prints them. `up` and
+#: `scattered` are the defect; the rest are named so the total adds up.
+VERDICTS = ("up", SCATTERED, ABSENT, "down", OVERSIZE, "agrees")
+
+
+def _state(by_name: dict[str, list[list[float]]], cls: str, wh: tuple[int, int]) -> str:
+    """One source's reading of one ``(image, class)`` pair: a band, or why not."""
+    boxes = by_name.get(cls)
+    if not boxes:
+        return ABSENT
+    return band_for(boxes, *wh)
+
+
+def _verdict(vg_band: str, coco_state: str, order: list[str]) -> str:
+    """How COCO's reading of a pair differs from VG's, as one of :data:`VERDICTS`."""
+    if coco_state in (ABSENT, SCATTERED, OVERSIZE):
+        return coco_state
+    if coco_state == vg_band:
+        return "agrees"
+    return "up" if order.index(coco_state) > order.index(vg_band) else "down"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--bands",
+        default="small,medium",
+        help="VG-side bands to audit, comma-separated (default: small,medium; `large` cannot move up)",
+    )
+    ap.add_argument("--out", help="write the affected pairs here, for a targeted re-slate")
+    args = ap.parse_args()
+
+    # Imported here, not at module scope: `coco_anchor` runs `setup_env()` at
+    # import, which edits `os.environ` and `sys.meta_path` process-wide. Keeping
+    # it inside `main` is what lets the banding helpers above be imported and
+    # tested without doing that to the caller (the loader does the same).
+    import coco_anchor as ca  # noqa: PLC0415
+
+    order = list(pc.BOX_BANDS)
+    audited = [b.strip() for b in args.bands.split(",") if b.strip()]
+    unknown = [b for b in audited if b not in pc.BOX_BANDS]
+    if unknown:
+        raise SystemExit(f"unknown band(s): {', '.join(unknown)}; known: {', '.join(order)}")
+
+    wanted = set(pc.SCALE_CLASSES)
+    paths = vg_image_paths()
+    _, records, dims = vg_source()
+
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    truth = ca.coco_truth(instances, wanted)
+    with image_data.open() as fh:
+        coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
+
+    # The read is deliberately wider than the class list, exactly as the loader's
+    # is: a VG spelling absent from it makes an image holding only that spelling
+    # look like an image holding nothing (#3605).
+    labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
+    canonicalise(labels, pc.SCALE_VG_NAMES)
+
+    # VG's own reading, taken before `anchor_to_coco` replaces it. `lift_ambiguous`
+    # is applied with an EMPTY exhaustive set on purpose: that is what makes this
+    # copy the UN-ANCHORED treatment of these images, which is the population the
+    # measured rate is being carried over to. Applying the real exhaustive set
+    # would let COCO's presence answer the ambiguity here and nowhere else, and
+    # the control would flatter itself.
+    vg_labels = {iid: {n: list(bs) for n, bs in by_name.items()} for iid, by_name in labels.items()}
+    withheld = lift_ambiguous(vg_labels, pc.SCALE_VG_AMBIGUOUS, set())
+
+    box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    log(f"  labels: {len(labels)} VG images, {n_anchored} anchored to COCO, {n_reframed} skipped as re-framed")
+    if not exhaustive:
+        raise SystemExit("no image anchored to COCO; there is no control group to measure against")
+
+    # --- the control: band every anchored pair twice, once from each source
+    tally: dict[str, dict[str, Counter]] = {c: {b: Counter() for b in audited} for c in pc.SCALE_CLASSES}
+    n_withheld: Counter = Counter()
+    affected: list[dict] = []
+    for iid in sorted(exhaustive):
+        for cls in pc.SCALE_CLASSES:
+            if (iid, cls) in withheld:
+                n_withheld[cls] += 1
+                continue
+            vg_band = _state(vg_labels[iid], cls, dims[iid])
+            if vg_band not in audited:
+                continue
+            coco_state = _state(labels[iid], cls, box_dims[iid])
+            verdict = _verdict(vg_band, coco_state, order)
+            tally[cls][vg_band][verdict] += 1
+            if verdict in ("up", SCATTERED):
+                affected.append({"image_id": iid, "class": cls, "vg_band": vg_band, "coco_band": coco_state})
+
+    _report(tally, audited, n_withheld)
+    _project(audited, exhaustive, tally)
+
+    if args.out:
+        pc.Path(args.out).write_text(json.dumps(affected, indent=1) + "\n")
+        print(f"\n{len(affected)} affected pairs written to {args.out}")
+    return 0
+
+
+def _report(tally: dict[str, dict[str, Counter]], audited: list[str], n_withheld: Counter) -> None:
+    """Per class and per band: where VG's reading of an anchored pair goes wrong."""
+    print("\n=== VG-alone vs COCO on the anchored half, per (class, VG band) ===")
+    print("`up` and `scattered` are the #3616 defect: an instance VG never annotated.\n")
+    head = "%-12s %-7s %6s | " % ("class", "band", "n") + " ".join("%9s" % v for v in VERDICTS) + "   defect"
+    print(head)
+    print("-" * len(head))
+    totals: dict[str, Counter] = {b: Counter() for b in audited}
+    for cls in pc.SCALE_CLASSES:
+        for band in audited:
+            counts = tally[cls][band]
+            n = sum(counts.values())
+            if not n:
+                continue
+            totals[band].update(counts)
+            defect = counts["up"] + counts[SCATTERED]
+            print(
+                "%-12s %-7s %6d | " % (cls, band, n)
+                + " ".join("%9d" % counts[v] for v in VERDICTS)
+                + "   %5.1f%%" % (100.0 * defect / n)
+            )
+    print("-" * len(head))
+    for band in audited:
+        counts, n = totals[band], sum(totals[band].values())
+        if not n:
+            continue
+        defect = counts["up"] + counts[SCATTERED]
+        print(
+            "%-12s %-7s %6d | " % ("ALL", band, n)
+            + " ".join("%9d" % counts[v] for v in VERDICTS)
+            + "   %5.1f%%" % (100.0 * defect / n)
+        )
+    if n_withheld:
+        # Not a defect and not a clean pair: an ambiguous spelling means the
+        # un-anchored copy of this image would be in no cell and in no negative
+        # pool either, so it is outside the population above rather than a zero in it.
+        print(
+            "\nwithheld by an ambiguous VG spelling (in no band, so not audited): "
+            + ", ".join(f"{c}={n}" for c, n in sorted(n_withheld.items()))
+        )
+
+
+def _project(audited: list[str], exhaustive: set[int], tally: dict[str, dict[str, Counter]]) -> None:
+    """Carry the measured rate onto the cells no reference can check.
+
+    The roster is what says which images are actually *in* a cell, and the
+    un-anchored ones are the seats where this error is invisible: their band
+    rests on VG's word alone. Multiplying the two is the number that decides
+    whether a re-slate is worth a human's time.
+    """
+    if not pc.ROSTER.exists():
+        log(f"  no roster at {pc.ROSTER}; skipping the projection onto designated cells")
+        return
+    roster = json.loads(pc.ROSTER.read_text()).get("cells", {})
+    if not roster:
+        return
+    print("\n=== projected onto the designated cells (the seats no reference can check) ===")
+    print("%-12s %6s %10s %10s   %s" % ("band", "seats", "anchored", "un-anch.", "expected mis-banded"))
+    per_band: dict[str, Counter] = defaultdict(Counter)
+    for cell, members in roster.items():
+        band = cell.rsplit("@", 1)[1] if "@" in cell else ""
+        if band not in audited:
+            continue
+        per_band[band]["seats"] += len(members)
+        per_band[band]["anchored"] += sum(1 for i in members if i in exhaustive)
+    for band in audited:
+        counts = per_band.get(band)
+        if not counts:
+            continue
+        control: Counter = Counter()
+        for cls in pc.SCALE_CLASSES:
+            control.update(tally[cls][band])
+        n = sum(control.values())
+        unanchored = counts["seats"] - counts["anchored"]
+        rate = (control["up"] + control[SCATTERED]) / n if n else 0.0
+        print(
+            "%-12s %6d %10d %10d   %.1f%% of %d = %.0f images"
+            % (band, counts["seats"], counts["anchored"], unanchored, 100.0 * rate, unanchored, rate * unanchored)
+        )
+    print("\nThe anchored seats already carry COCO's band, so only the un-anchored ones")
+    print("are exposed. Reviewing them is the only way to find the rest (#3616).")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -246,6 +246,45 @@ def apply_corrections(
     return unbanded
 
 
+#: What :func:`band_for` returns for boxes that fall in no band. Named because
+#: they are two different facts about an image and an audit has to tell them
+#: apart: ``SCATTERED`` means several instances too far apart to be one region,
+#: ``OVERSIZE`` means one box bigger than :data:`pile_config.MAX_VOTED_AREA` --
+#: not a region, the image.
+SCATTERED = "scattered"
+OVERSIZE = "oversize"
+
+
+def band_for(boxes: list[list[float]], W: int, H: int) -> str:
+    """The band one class's boxes put an image in, or why they put it in none.
+
+    Returns a key of :data:`pile_config.BOX_BANDS`, or :data:`SCATTERED` /
+    :data:`OVERSIZE`. Split out of :func:`band_candidates` so that anything
+    asking "what band would these boxes imply?" -- the builder, and
+    ``audit_band_drift.py``, which re-bands the same images off a second
+    annotation source -- asks it of one implementation. A second copy of this
+    rule would answer a drift question with its own drift.
+
+    *boxes* must be non-empty and in the pixel space of ``(W, H)``.
+    """
+    area = float(W * H)
+    ux0 = min(b[0] for b in boxes)
+    uy0 = min(b[1] for b in boxes)
+    ux1 = max(b[2] for b in boxes)
+    uy1 = max(b[3] for b in boxes)
+    union = max(0.0, ux1 - ux0) * max(0.0, uy1 - uy0) / area
+    largest = max((b[2] - b[0]) * (b[3] - b[1]) for b in boxes) / area
+    # Scattered instances in *this* image: the union box describes the scatter
+    # rather than the object, so the image is excluded from every band of this
+    # class rather than banded by a box no user would drag.
+    if union > largest * pc.BAND_MAX_INFLATION:
+        return SCATTERED
+    for band, (lo, hi) in pc.BOX_BANDS.items():
+        if lo <= union < hi:
+            return band
+    return OVERSIZE
+
+
 def band_candidates(
     labels: dict[int, dict[str, list[list[float]]]],
     box_dims: dict[int, tuple[int, int]],
@@ -266,30 +305,17 @@ def band_candidates(
 
     for iid, by_name in labels.items():
         W, H = box_dims[iid]
-        area = float(W * H)
         if not by_name:
             # Only a true negative for every class in C may join the shared pool.
             if not any((iid, c) in unbanded for c in pc.SCALE_CLASSES):
                 clean.append(iid)
             continue
         for name, bs in by_name.items():
-            ux0 = min(b[0] for b in bs)
-            uy0 = min(b[1] for b in bs)
-            ux1 = max(b[2] for b in bs)
-            uy1 = max(b[3] for b in bs)
-            union = max(0.0, ux1 - ux0) * max(0.0, uy1 - uy0) / area
-            largest = max((b[2] - b[0]) * (b[3] - b[1]) for b in bs) / area
-            # Scattered instances in *this* image: the union box describes the
-            # scatter rather than the object, so the image is excluded from
-            # every band of this class rather than banded by a box no user
-            # would drag.
-            if union > largest * pc.BAND_MAX_INFLATION:
+            band = band_for(bs, W, H)
+            if band not in pc.BOX_BANDS:  # scattered, or bigger than a region
                 continue
-            for band, (lo, hi) in pc.BOX_BANDS.items():
-                if lo <= union < hi:
-                    supply[name][band].append(iid)
-                    boxes_for[(iid, pc.scale_cell(name, band))] = bs
-                    break
+            supply[name][band].append(iid)
+            boxes_for[(iid, pc.scale_cell(name, band))] = bs
     return supply, boxes_for, clean
 
 

--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -24,6 +24,17 @@ builder therefore drops it from every cell of that class: not a positive, and no
 longer a negative either. That is the whole point of the three-valued design --
 the alternative is inventing a box to keep the arithmetic tidy.
 
+**A rebox can move an image between bands, and that is reported, not refused.**
+An image entered a `class@band` cell because of the box it arrived with, so a
+reviewer who retargets the box to a different instance of the same class moves
+the image to the band the new box implies and vacates the cell it was sampled to
+fill -- 6 of the first 13 redrawn boxes did (#3616). The move is a *correction*,
+not a defect: VG is not exhaustive, so an image holding a small annotated bowl
+and a large unannotated one was mis-banded from the start, and the reviewer is
+the first person to have seen it. What was wrong is that it happened silently,
+so the run now prints every band-changing rebox. `audit_band_drift.py` measures
+how much of the same error the un-reviewed half is still hiding.
+
 **A rejection is not a deletion in the small band -- unless it is definitional.**
 Boxed review confirms only ~2/3 of sub-patch positives even when the box is drawn
 for the reviewer, and the same objects defeat the model, so "not confirmed" there
@@ -67,6 +78,23 @@ def _cell_band(cell: str) -> str:
     return cell.rsplit("@", 1)[1] if "@" in cell else ""
 
 
+def _box_band(box: list[float]) -> str:
+    """The band a NORMALISED correction box falls in, or ``""`` outside them all.
+
+    A band is a fraction of the frame and a normalised box's area already *is*
+    that fraction, so this needs no image dimensions -- which is the whole reason
+    the drift can be reported here rather than only at build time. The builder's
+    banding (``pilebuild.loaders.vg_scale.band_for``) additionally rejects a
+    scattered *union* of several boxes; a correction carries exactly one box, so
+    there is no scatter to reject and the two agree by construction.
+    """
+    area = max(0.0, box[2] - box[0]) * max(0.0, box[3] - box[1])
+    for band, (lo, hi) in pc.BOX_BANDS.items():
+        if lo <= area < hi:
+            return band
+    return ""
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     base = pc.PILE.parent / "vgscale-3156"
@@ -93,6 +121,8 @@ def main() -> int:
 
     out: dict[tuple[int, str], dict] = {}
     stats: Counter = Counter()
+    # (class, image_id, band sampled, band the redrawn box implies) -- #3616.
+    moves: list[tuple[str, int, str, str]] = []
 
     # --- adjudications first, so a later source cannot silently overrule them
     adj = {}
@@ -145,6 +175,19 @@ def main() -> int:
                         "source": "human_rebox",
                     }
                     stats["positive_reboxed"] += 1
+                    # The redrawn box decides the band, so a rebox can move the
+                    # image out of the cell it was sampled to fill. The move is
+                    # kept -- see the module docstring -- but it is named here,
+                    # because a cell that quietly rebalances is how the small
+                    # band erodes without anyone deciding that it should.
+                    new_band = _box_band(box)
+                    if not band:
+                        stats["positive_reboxed_UNSAMPLED"] += 1
+                    elif new_band == band:
+                        stats["positive_reboxed_band_kept"] += 1
+                    else:
+                        stats["positive_reboxed_band_moved"] += 1
+                        moves.append((key[1], key[0], band, new_band or "oversize"))
                 else:
                     stats["positive_confirmed"] += 1
                 continue
@@ -223,7 +266,28 @@ def main() -> int:
     boxed = sum(1 for r in rows if r["boxes"])
     print(f"\n   {'of which carry a box':<32}{boxed:>6}  (can move an image between bands)")
     print(f"   {'excluded, no box':<32}{len(rows) - boxed:>6}  (dropped from every cell of that class)")
+    _report_moves(moves, stats)
     return 0
+
+
+def _report_moves(moves: list[tuple[str, int, str, str]], stats: Counter) -> None:
+    """Name every rebox that left the cell it was sampled into (#3616)."""
+    if not moves:
+        return
+    reboxed = stats["positive_reboxed_band_moved"] + stats["positive_reboxed_band_kept"]
+    print(f"\n=== {len(moves)} of {reboxed} redrawn boxes LEAVE the cell they were sampled into ===")
+    print("   Kept, not refused: VG is not exhaustive, so an image holding an unannotated")
+    print("   larger instance was mis-banded before the reviewer ever saw it. Printed")
+    print("   because it rebalances the cells, and the small band is the binding")
+    print("   constraint on supply (#3603). `audit_band_drift.py` measures the same")
+    print("   error on the images nobody has reviewed.\n")
+    print("   %-14s %-10s %-8s    %s" % ("class", "image_id", "sampled", "redrawn"))
+    for cls, iid, was, now in sorted(moves):
+        print("   %-14s %-10d %-8s -> %s" % (cls, iid, was, now))
+    per_class: Counter = Counter(m[0] for m in moves)
+    vacated: Counter = Counter(m[2] for m in moves)
+    print("\n   by class:      " + ", ".join(f"{c}={n}" for c, n in sorted(per_class.items())))
+    print("   band vacated:  " + ", ".join(f"{b}={n}" for b, n in sorted(vacated.items())))
 
 
 if __name__ == "__main__":

--- a/tests_lib/meta/test_pile_band_drift.py
+++ b/tests_lib/meta/test_pile_band_drift.py
@@ -1,0 +1,213 @@
+"""Band drift: a rebox that leaves its cell, and the audit that measures the rest (#3616).
+
+A ``vg_scale`` image sits in ``class@band`` because of the box it arrived with.
+A reviewer who redraws that box onto a *different, larger* instance of the same
+class therefore moves the image to another cell and vacates the one it was
+sampled to fill -- 6 of the first 13 redrawn boxes did.
+
+The move is kept, because VG's annotation is not exhaustive and the sampled band
+was the error. Two things had to change around that:
+
+* ``verdicts_to_corrections.py`` now names every band-changing rebox instead of
+  applying it silently, which needs a band derived from the *normalised* box the
+  reviewer drew -- the coordinate space that has already cost this pile one
+  published defect (#3281). :func:`_box_band` is tested here against the
+  builder's own ``band_for`` rather than against hand-written edges.
+* ``audit_band_drift.py`` measures how often VG's boxes alone would have made
+  the same mistake, using the COCO-anchored half as a control. Its verdict
+  vocabulary is what the report tabulates, so a verdict outside that vocabulary
+  is a row that silently vanishes from the totals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+
+@pytest.fixture(scope="module")
+def drift():
+    """``audit_band_drift``, imported without ``pile_config.setup_env()``.
+
+    The audit keeps its ``coco_anchor`` import inside ``main`` precisely so that
+    importing the module does not edit ``sys.meta_path`` and ``os.environ`` for
+    the whole test process; if that import ever moves back to module scope this
+    fixture is what fails.
+    """
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import audit_band_drift
+
+    return audit_band_drift
+
+
+@pytest.fixture(scope="module")
+def pc():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pile_config
+
+    return pile_config
+
+
+class TestAuditState:
+    """What one source's reading of an ``(image, class)`` pair comes out as."""
+
+    def test_a_class_the_source_does_not_annotate_is_absent(self, drift):
+        assert drift._state({"dog": [[0.0, 0.0, 5.0, 5.0]]}, "bus", (100, 100)) == drift.ABSENT
+
+    def test_an_empty_box_list_is_absent_rather_than_an_error(self, drift):
+        """COCO records "annotated and absent" as an empty entry, not a missing one."""
+        assert drift._state({"bus": []}, "bus", (100, 100)) == drift.ABSENT
+
+    def test_boxes_are_read_through_the_builders_own_banding(self, drift, pc):
+        band, (lo, hi) = next(iter(pc.BOX_BANDS.items()))
+        side = (((lo + hi) / 2) * 10000) ** 0.5
+        assert drift._state({"bus": [[0.0, 0.0, side, side]]}, "bus", (100, 100)) == band
+
+
+class TestAuditVerdict:
+    """Which disagreements between VG and COCO count as the #3616 defect."""
+
+    @pytest.fixture
+    def order(self, pc):
+        return list(pc.BOX_BANDS)
+
+    def test_a_larger_coco_band_is_the_defect(self, drift, order):
+        assert drift._verdict("small", "medium", order) == "up"
+        assert drift._verdict("small", "large", order) == "up"
+
+    def test_a_smaller_coco_band_is_reported_apart_from_it(self, drift, order):
+        """An extent error in VG's box, not an instance VG failed to annotate."""
+        assert drift._verdict("large", "small", order) == "down"
+
+    def test_the_same_band_agrees(self, drift, order):
+        assert drift._verdict("medium", "medium", order) == "agrees"
+
+    def test_the_non_band_readings_pass_through_as_themselves(self, drift, order):
+        for state in (drift.ABSENT, drift.SCATTERED, drift.OVERSIZE):
+            assert drift._verdict("small", state, order) == state
+
+    def test_every_verdict_it_can_return_is_one_the_report_prints(self, drift, order):
+        """The table is built from ``VERDICTS``; anything outside it is a lost row."""
+        states = [*order, drift.ABSENT, drift.SCATTERED, drift.OVERSIZE]
+        produced = {drift._verdict(vg, coco, order) for vg in order for coco in states}
+        assert produced <= set(drift.VERDICTS)
+
+    def test_the_report_prints_nothing_it_cannot_produce(self, drift, order):
+        """The other direction: a stale verdict name would print a column of zeros."""
+        states = [*order, drift.ABSENT, drift.SCATTERED, drift.OVERSIZE]
+        produced = {drift._verdict(vg, coco, order) for vg in order for coco in states}
+        assert set(drift.VERDICTS) == produced
+
+
+class TestAuditReport:
+    """The two numbers a reader acts on: the measured rate, and its projection."""
+
+    def _tally(self, pc, audited: list[str]) -> dict[str, dict[str, Counter]]:
+        tally = {c: {b: Counter() for b in audited} for c in pc.SCALE_CLASSES}
+        first, second = pc.SCALE_CLASSES[0], pc.SCALE_CLASSES[1]
+        tally[first]["small"].update({"up": 3, "scattered": 1, "agrees": 16})
+        tally[second]["small"].update({"up": 0, "agrees": 20})
+        return tally
+
+    def test_the_defect_rate_counts_up_and_scattered_together(self, drift, pc, capsys):
+        """Both mean the image does not belong in the band VG put it in."""
+        drift._report(self._tally(pc, ["small"]), ["small"], Counter())
+        totals = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("ALL")]
+        assert len(totals) == 1
+        # 4 of 40 over both classes; the per-class rows are 4/20 and 0/20.
+        assert totals[0].split()[2] == "40"
+        assert totals[0].endswith("10.0%")
+
+    def test_the_projection_applies_the_rate_to_unanchored_seats_only(self, drift, pc, tmp_path, monkeypatch, capsys):
+        """An anchored seat already carries COCO's band, so it is not exposed."""
+        roster = tmp_path / "roster.json"
+        roster.write_text(json.dumps({"cells": {pc.scale_cell(pc.SCALE_CLASSES[0], "small"): list(range(100))}}))
+        monkeypatch.setattr(pc, "ROSTER", roster)
+
+        drift._project(["small"], set(range(40)), self._tally(pc, ["small"]))
+        row = next(ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("small"))
+        # 100 seats, 40 anchored, so 60 exposed; 10% of 60 is 6.
+        assert row.split()[1:4] == ["100", "40", "60"]
+        assert row.endswith("10.0% of 60 = 6 images")
+
+    def test_a_missing_roster_is_said_rather_than_guessed_at(self, drift, pc, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(pc, "ROSTER", tmp_path / "absent.json")
+        drift._project(["small"], {1}, self._tally(pc, ["small"]))
+        out = capsys.readouterr().out
+        assert "no roster" in out and "projected onto the designated cells" not in out
+
+
+def _run(code: str, tmp_path: Path) -> subprocess.CompletedProcess:
+    """Run *code* inside the pile directory, with the pile pointed at *tmp_path*.
+
+    A subprocess because ``verdicts_to_corrections`` calls
+    ``pile_config.setup_env()`` at import, which rewrites ``os.environ`` and
+    ``sys.meta_path`` process-wide.
+    """
+    env = {
+        **os.environ,
+        "VTS_PILE": str(tmp_path),
+        "VTSEARCH_DATA_DIR": str(tmp_path / "datadir"),
+        "VTSEARCH_MODELS_DIR": str(tmp_path / "models"),
+        "HF_HOME": str(tmp_path / "models"),
+    }
+    return subprocess.run(  # noqa: S603  # interpreter + test-controlled source
+        [sys.executable, "-c", code],
+        cwd=str(_PILE_DIR),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+class TestCorrectionBoxBand:
+    """The band a *normalised* correction box implies, as the rebox report reads it."""
+
+    def test_it_agrees_with_the_builder_at_every_band(self, tmp_path):
+        """The report and the rebuild must name the same band, or the report lies.
+
+        The two derive it from the same box in different coordinate spaces --
+        normalised here, pixels there -- which is the exact confusion that put
+        130 boxes on the frame origin in #3281. So this compares the two
+        implementations rather than either one against a written-down edge.
+        """
+        code = """
+import json
+import verdicts_to_corrections as vtc
+import pile_config as pc
+from pilebuild.loaders.vg_scale import band_for
+
+W = H = 640
+out = {}
+for band, (lo, hi) in pc.BOX_BANDS.items():
+    side = ((lo + hi) / 2) ** 0.5
+    out[band] = [vtc._box_band([0.0, 0.0, side, side]), band_for([[0.0, 0.0, side * W, side * H]], W, H)]
+print(json.dumps(out))
+"""
+        proc = _run(code, tmp_path)
+        assert proc.returncode == 0, proc.stderr
+        got = json.loads(proc.stdout.strip().splitlines()[-1])
+        assert got, "no bands were compared"
+        for band, (from_normalised, from_pixels) in got.items():
+            assert from_normalised == band == from_pixels
+
+    def test_a_box_bigger_than_a_region_falls_in_no_band(self, tmp_path):
+        """Above ``MAX_VOTED_AREA`` there is no band to move to, and none is invented."""
+        code = """
+import verdicts_to_corrections as vtc
+print(repr(vtc._box_band([0.0, 0.0, 1.0, 1.0])))
+"""
+        proc = _run(code, tmp_path)
+        assert proc.returncode == 0, proc.stderr
+        assert proc.stdout.strip().splitlines()[-1] == "''"

--- a/tests_lib/meta/test_pile_band_drift.py
+++ b/tests_lib/meta/test_pile_band_drift.py
@@ -38,7 +38,7 @@ def drift():
     """``audit_band_drift``, imported without ``pile_config.setup_env()``.
 
     The audit keeps its ``coco_anchor`` import inside ``main`` precisely so that
-    importing the module does not edit ``sys.meta_path`` and ``os.environ`` for
+    importing the module does not rewrite the import machinery and ``os.environ`` for
     the whole test process; if that import ever moves back to module scope this
     fixture is what fails.
     """

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -179,6 +179,38 @@ class TestAnchorToCoco:
         assert box_dims == {7: (500, 375), 8: (600, 400)} and n_anchored == 0
 
 
+class TestBandFor:
+    """The banding rule itself, split out of :func:`band_candidates` for #3616.
+
+    ``audit_band_drift.py`` re-bands the same images off COCO's annotation to
+    measure how often VG's own boxes put one in too small a band. A second copy
+    of the rule would answer that drift question with a drift of its own, so
+    both callers go through this one.
+    """
+
+    def _square(self, frac: float) -> list[float]:
+        """A box covering *frac* of a 100x100 frame."""
+        side = (frac * 10000) ** 0.5
+        return [0.0, 0.0, side, side]
+
+    def test_each_band_claims_the_range_it_declares(self, vgs, pc):
+        for band, (lo, hi) in pc.BOX_BANDS.items():
+            assert vgs.band_for([self._square((lo + hi) / 2)], 100, 100) == band
+
+    def test_scattered_instances_say_so_rather_than_banding(self, vgs):
+        """The union describes the scatter, not an object anyone would drag."""
+        assert vgs.band_for([[0.0, 0.0, 1.0, 1.0], [99.0, 99.0, 100.0, 100.0]], 100, 100) == vgs.SCATTERED
+
+    def test_a_box_bigger_than_a_region_says_so_rather_than_banding(self, vgs, pc):
+        """Above ``MAX_VOTED_AREA`` a box is not a region, it is the image."""
+        assert vgs.band_for([self._square(pc.MAX_VOTED_AREA + 0.05)], 100, 100) == vgs.OVERSIZE
+
+    def test_neither_refusal_can_be_mistaken_for_a_band(self, vgs, pc):
+        """`band_candidates` filters on exactly this, and so does the audit."""
+        assert vgs.SCATTERED not in pc.BOX_BANDS
+        assert vgs.OVERSIZE not in pc.BOX_BANDS
+
+
 class TestBandCandidates:
     def _labels_with_area_fraction(self, pc, frac: float):
         """One image whose single ``bus`` box covers *frac* of a 100x100 frame."""


### PR DESCRIPTION
A `vg_scale` image sits in `class@band` because of the box it arrived with, so a reviewer who redraws that box onto a different, more prominent instance of the same class moves it to another cell and vacates the one it was sampled to fill. Six of the first thirteen redrawn boxes did, two of them leaving `small` — already the binding constraint on supply (#3603).

**The move is kept.** VG's recall over *C* is 0.61, so an image holding a small annotated bowl and a large unannotated one was banded by the only box anyone had written down: the sampled band was the error, and the reviewer is the first person to have seen the other instance. What was wrong is that it happened silently.

## What changed

- **`verdicts_to_corrections.py` names every band-changing rebox** — class, image id, band vacated, band landed in, plus per-class and per-band summaries. The band comes from the normalised box's own area, so it needs no image dimensions. Run against a synthetic slate it reproduces the `bowl` rows from the issue exactly.

- **`audit_band_drift.py` (new) measures how much of the same error the un-reviewed half still hides**, with no human pass and no model pass. 48% of VG is COCO-sourced and `anchor_to_coco` already replaces VG's labels with COCO's exhaustive ones there, so the anchored images are a control group carrying *both* readings: band each one from VG's boxes alone, band it again from COCO's, and every disagreement is one instance of the defect a reviewer catches by hand. The roster then says how many un-anchored seats that rate applies to — the number that decides whether a re-slate is worth a human's time. `--out` writes the affected pairs for a targeted re-slate.

- **The banding rule moves out of `band_candidates` into `band_for`**, so the builder and the audit answer a drift question through one implementation rather than two. It now names *why* boxes fall in no band (`scattered` vs `oversize`), which is the distinction the audit reports on.

## Scope of the audit

`small,medium` by default. The mechanism can only push an image *up* — a band can hide a larger instance — and `large` has nowhere to go. A disagreement in the other direction is an extent error in VG's box, a different problem, and it is counted in a separate `down` column rather than folded into the headline rate. `scattered` sits *with* `up` in that rate because it means the same thing operationally: the image belongs in no cell of that class.

One subtlety worth a reviewer's eye: the VG-only side runs `lift_ambiguous` with an **empty** exhaustive set. Anchored images are exhaustive, so letting COCO's presence resolve `bike`/`bicycle` there would have made the control flatter itself — the un-anchored half it stands in for gets no such answer.

## Tests

`tests_lib/meta/test_pile_band_drift.py` (new) covers the audit's verdict vocabulary in both directions — every verdict it can produce is one the report prints, and every column the report prints is one it can produce, so neither a lost row nor a stale column of zeros survives. `_box_band` is checked against the builder's own `band_for` rather than against written-down edges, since the two read the same box in different coordinate spaces and that confusion is exactly #3281. `TestBandFor` in `test_pile_vg_scale.py` covers the extracted rule.

Full `./run-tests.sh` green.

## Not done here

The guide amendment the issue mentions — "on a pre-boxed positive, redraw only to correct the extent of the *same* object" — stops the drift by asking the reviewer to leave an annotation error in place once they have seen it. Per the discussion on the issue that is the wrong trade if the mis-banding is common, and the audit is what says whether it is. Recorded as open work in `docs/plans/vg-scale-bands-and-corrections.md`; the guide is not in this repo.

The audit has not been *run* (it needs the VG source and COCO's instances), and no action is taken on the 6 existing moves.

Refs #3616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RwDr4QWoWraetxuNdz5Gf

---
_Generated by [Claude Code](https://claude.ai/code/session_018RwDr4QWoWraetxuNdz5Gf)_