### PR TITLE
Correct the "minutes-long" coverage-atlas rebuild claim to the measured rate

### DIFF
--- a/scripts/experiments/drive_cold/figures_drive_3521.py
+++ b/scripts/experiments/drive_cold/figures_drive_3521.py
@@ -6,8 +6,8 @@ Three, because the study makes three claims.
 1. **branch_cost.png** — what the fork is actually worth: the coverage step's
    seconds against ``n``, restored versus rebuilt, on a log axis. This is the
    mechanism figure. Everything else in the study is a consequence of the gap it
-   shows, and it is also where the shipped comment's "minutes-long" claim gets
-   checked against a measurement.
+   shows, and it is also where the shipped comment's then-"minutes-long" claim
+   got checked against a measurement, and corrected (#3595).
 2. **bar_error_by_branch.png** — the fraction of the progress bar each arm
    budgets to the wrong step, from the **within-leg holdout**, which is the only
    split in which all three arms meet all the branches. Combinations an arm was

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -794,6 +794,7 @@ SCALE_CANDIDATE_VG_NAMES: dict[str, tuple[str, ...]] = {
     "cell phone": ("cell phone", "phone", "cellphone"),
 }
 
+
 def scale_class_dataset_name(category: str) -> str:
     """The dataset/detector name *category* is reviewed under.
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -383,7 +383,12 @@ class ClassRule(NamedTuple):
     #: The full wording the name abbreviates: what counts as Good, what counts
     #: as Bad, and the near-miss the short name does not settle. Read by whoever
     #: builds the slate and whoever adjudicates it, so both apply one definition.
-    test: str
+    #:
+    #: Empty means *not written down yet*, not *no boundary case*: the rule was
+    #: measured as a name before :class:`ClassRule` existed and its wording has
+    #: never been recorded. Fill one in when a slate of that class is issued --
+    #: an unwritten test is the state #3612 exists to end.
+    test: str = ""
 
 
 #: Per-class review definitions, for the classes whose plain English name is not
@@ -432,6 +437,28 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
             "or cradle is still Good."
         ),
     ),
+    # The remaining rules were measured as names before ``test`` existed
+    # (#3588): `coco_folds.py` asks which VG names land on a COCO class's boxes
+    # over the ~51k-image overlap, which enumerates a class's boundary cases
+    # before a human meets one -- run against `book` it prints `magazine` (79)
+    # and `magazines` (30). Each name below states the boundary case that
+    # measurement found; the long form is in the annotation guide, and belongs
+    # in ``test`` the next time one of these is slated.
+    #
+    # Deliberately literals rather than a formatting of the class name: the
+    # whole point is that they say something the class name does not.
+    "truck": ClassRule(name="truck incl vans not SUVs"),
+    "car": ClassRule(name="car incl SUVs and minivans"),
+    "fork": ClassRule(name="fork incl plastic"),
+    "spoon": ClassRule(name="spoon incl plastic not spatulas"),
+    "cup": ClassRule(name="cup incl mugs and glasses not stemware"),
+    "bowl": ClassRule(name="bowl incl plates and dishes"),
+    "bottle": ClassRule(name="bottle incl jars"),
+    "vase": ClassRule(name="vase incl pots and planters"),
+    "bench": ClassRule(name="bench not chairs"),
+    "chair": ClassRule(name="chair incl stools not couches"),
+    "sink": ClassRule(name="sink basin not counter"),
+    "fire hydrant": ClassRule(name="fire hydrant not standpipes"),
 }
 
 
@@ -767,48 +794,17 @@ SCALE_CANDIDATE_VG_NAMES: dict[str, tuple[str, ...]] = {
     "cell phone": ("cell phone", "phone", "cellphone"),
 }
 
-#: The definition each class is reviewed under, and the name that definition
-#: travels on.
-#:
-#: **This is the `book` failure made structural.** COCO has no magazine class,
-#: so COCO's annotators put magazines in `book`; the human pass applied the
-#: narrower English reading; and the class became two definitions wearing one
-#: name -- 21 verdicts on one, 49 on the other, with every structural check
-#: passing (`make_definition_reslate.py`). A reviewer cannot see a manifest
-#: while voting, so the rule has to travel on the one string the app shows:
-#: the dataset and detector name.
-#:
-#: The rules are **measured, not drafted**. `coco_folds.py` asks which VG names
-#: land on a COCO class's boxes over the ~51k-image overlap, which enumerates
-#: the boundary cases before a human meets one -- run against `book` it prints
-#: `magazine` (79) and `magazines` (30). Each entry below names the boundary
-#: case that measurement found, and the long form is in the annotation guide.
-#:
-#: Keyed by class; the value is the dataset/detector name. Deliberately a
-#: literal rather than a formatting of the class name: the whole point is that
-#: it says something the class name does not.
-SCALE_CLASS_RULES: dict[str, str] = {
-    "truck": "truck incl vans not SUVs",
-    "car": "car incl SUVs and minivans",
-    "fork": "fork incl plastic",
-    "spoon": "spoon incl plastic not spatulas",
-    "cup": "cup incl mugs and glasses not stemware",
-    "bowl": "bowl incl plates and dishes",
-    "bottle": "bottle incl jars",
-    "vase": "vase incl pots and planters",
-    "bench": "bench not chairs",
-    "chair": "chair incl stools not couches",
-    "sink": "sink basin not counter",
-    "cell phone": "cell phone not landlines",
-    "fire hydrant": "fire hydrant not standpipes",
-}
-
-
 def scale_class_dataset_name(category: str) -> str:
     """The dataset/detector name *category* is reviewed under.
 
-    Falls back to the bare class name, which is correct for a class with no
-    boundary case worth stating -- and wrong to invent one for, since a rule
-    nobody needs is a rule a reviewer will misread.
+    A thin spelling of :func:`review_name` with no pass suffix, kept because
+    ``make_class_slate.py`` bands a *candidate* rather than issuing a voted
+    slate and so has no pass to name.
+
+    This used to read a second ``SCALE_CLASS_RULES`` of its own, declared later
+    in this module and therefore shadowing the first: #3588 and #3612 each gave
+    the same table the same name from opposite ends of one branch, and the
+    survivor -- the string one -- left :func:`review_name` reading ``.name`` off
+    a ``str``. Both rule sets now live in the one table above.
     """
-    return SCALE_CLASS_RULES.get(category, category)
+    return review_name(category)

--- a/scripts/profiling/tune_timing_profile.py
+++ b/scripts/profiling/tune_timing_profile.py
@@ -288,8 +288,9 @@ def drive_dataset_open(client, datasets: list[dict], reps: int, *, cold_atlas: b
     through ``POST /api/datasets/registry/<id>/coverage-atlas``. Every ordinary
     open restores the atlas cached in the pickle at import time, so without this
     a sweep measures the coverage step's millisecond branch however many times
-    it repeats and never once the minutes-long one the shipped weights are
-    paced for. The endpoint rebuilds in memory and leaves the pickle alone,
+    it repeats and never once the rebuild the shipped weights are paced for --
+    seconds rather than milliseconds, ~700x the restore at n = 2954 (#3595).
+    The endpoint rebuilds in memory and leaves the pickle alone,
     which is what keeps ``dataset_open`` a read-only family.
     """
     from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415

--- a/tests_lib/core/test_timing_branches.py
+++ b/tests_lib/core/test_timing_branches.py
@@ -7,8 +7,8 @@ the same sweep's ``dataset_stage`` leg read the embeddings pkl the
 ``dataset_load`` leg had just written and recorded 0.000-0.002 s of embedding
 across all four image tiers, in a separate interpreter. Every one of those
 numbers is correct. None of them is a cost model, because the branch a user
-waits on — the minutes-long hierarchical-k-means rebuild, the real embed — was
-never run (#3521, measured in
+waits on — the hierarchical-k-means rebuild (0.0026 s/item, ~700× the restore
+at n = 2954), the real embed — was never run (#3521, measured in
 ``docs/experiments/2026-09-02-timing-r2-3345/REPORT.md``).
 
 These tests pin the three halves of the answer: the recorder carries the branch

--- a/tests_lib/meta/test_pile_class_rules.py
+++ b/tests_lib/meta/test_pile_class_rules.py
@@ -68,7 +68,11 @@ def test_rule_names_are_usable_as_a_detector_and_a_folder(pc):
     for cls, rule in pc.SCALE_CLASS_RULES.items():
         assert rule.name == rule.name.strip() and rule.name
         assert not set(rule.name) & set("/\\"), f"{cls}: path separator in {rule.name!r}"
-        assert re.fullmatch(r"[a-z0-9 ]+", rule.name), f"{cls}: {rule.name!r} is not plain lowercase"
+        # Letters, digits and spaces only -- no punctuation to mangle a folder
+        # name or an API path. Case is *not* constrained: `truck incl vans not
+        # SUVs` and `car incl SUVs and minivans` carry an acronym that reads
+        # wrong lowercased, and neither a directory nor a path minds it.
+        assert re.fullmatch(r"[A-Za-z0-9 ]+", rule.name), f"{cls}: {rule.name!r} is not plain alphanumeric"
         # `ingest_slate.py` attributes an export by matching the slate folder in
         # the origin path, and a human has to recognise the class at a glance.
         assert rule.name.startswith(cls), f"{cls}: {rule.name!r} does not name its class"

--- a/vtscore/timing/fit.py
+++ b/vtscore/timing/fit.py
@@ -282,7 +282,8 @@ def cheap_branch_only(samples: list[dict]) -> bool:
     reading of 0.008-0.016 s is not "the atlas costs 10 ms here", it is "this
     sweep never saw one built". Both are correct measurements; only one of them
     is a cost model, and ``tasks.py`` weights that step at 0.85 of the bar
-    precisely because the branch nobody measured is the minutes-long one.
+    precisely because the branch nobody measured is the one that does the work:
+    a rebuild costs 0.0026 s/item, ~700x the restore at n = 2954 (#3595).
     """
     dear, cheap, unmarked = branch_split(samples)
     return bool(cheap) and not dear and not unmarked
@@ -755,7 +756,7 @@ def coverage_report(rows: Iterable[dict], profile: dict[str, Any]) -> list[str]:
     A third thing a count cannot say is *which branch* the runs took. A step
     whose every run read a cache is not a well-covered step; it is an unmeasured
     one wearing a full sample count, and it is the state that made #3345's sweep
-    price a minutes-long atlas rebuild at 2 % of the bar. :func:`_branch_lines`
+    price a 7.7 s atlas rebuild at 2 % of the bar. :func:`_branch_lines`
     names those explicitly (#3521).
     """
     rows = list(rows)

--- a/vtscore/timing/tasks.py
+++ b/vtscore/timing/tasks.py
@@ -128,8 +128,24 @@ TASKS: dict[str, TaskSpec] = {
     ),
     # Re-opening an already-imported dataset from its pkl. Step 1 (pickle read +
     # convert + the near-instant exact-dedup) is seconds at most; step 2 is the
-    # coverage atlas, instant when the cached atlas restores but a minutes-long
-    # hierarchical-k-means rebuild when it does not.
+    # coverage atlas, ~10 ms when the cached atlas restores and a hierarchical
+    # k-means rebuild when it does not.
+    #
+    # That rebuild is *seconds*, not minutes, at every size anybody has swept.
+    # Driven cold on a V100 with cuML active it fits 0.0026 s/item (r^2 0.95)
+    # over n = 412..2954 -- 0.98 s to 7.7 s. The same fit reaches ~26 s at
+    # n = 10 000 and ~131 s (2.2 min) only near COVERAGE_ATLAS_AUTO_THRESHOLD
+    # (50 000), so "minutes" is true near the threshold and off by two orders
+    # of magnitude below ~3000 items. Both of those figures extrapolate a fit
+    # whose largest point is 2954, across a 17x gap nothing has measured, and
+    # hierarchical k-means need not be linear there
+    # (docs/experiments/2026-09-03-drive-cold-3521/REPORT.md section 2, #3595).
+    #
+    # The 0.85 below is a direction, not a measurement: the rebuild does
+    # dominate step 1 whenever it runs, but the weight was never fitted and is
+    # roughly 100x too generous at the small end. Re-deriving it waits on a
+    # sweep past 2954 (#3595) -- and no single weight can pace both branches
+    # anyway, since the restore is ~700x cheaper at n = 2954 (#3594).
     "dataset_open": _linear(
         "dataset_open",
         ("items", "coverage"),

--- a/vtsearch/routes/datasets/registry.py
+++ b/vtsearch/routes/datasets/registry.py
@@ -206,10 +206,13 @@ def load_registered_dataset(dataset_id: str):  # noqa: C901
     )
     # Pace the unified bar against the real phase split. Step 1 (pickle read +
     # convert + the near-instant exact-dedup) is seconds at most; step 2 is the
-    # coverage atlas, which is instant when the cached atlas restores but a
-    # minutes-long hierarchical-k-means rebuild when it doesn't. Weighting step 2
-    # as the dominant slice keeps a rebuild advancing the bar across its whole
-    # span instead of the old equal split, where the instant dedup drove step 2
+    # coverage atlas, ~10 ms when the cached atlas restores and a hierarchical
+    # k-means rebuild when it doesn't. That rebuild measures 0.0026 s/item
+    # (r^2 0.95) over n = 412..2954, so it is 1-8 s at the sizes swept and only
+    # approaches minutes near COVERAGE_ATLAS_AUTO_THRESHOLD, where the same fit
+    # extrapolates to ~131 s at n = 50 000 (#3595). Weighting step 2 as the
+    # dominant slice keeps a rebuild advancing the bar across its whole span
+    # instead of the old equal split, where the instant dedup drove step 2
     # to ~100% and the bar then sat frozen there through the entire rebuild.
     # That reasoning is the *fallback*; an admin ``VTSEARCH_TIMING_PROFILE``
     # replaces it with the split this host's disk and clustering backend


### PR DESCRIPTION
The coverage-atlas rebuild is **seconds, not minutes**, at every size anybody has swept. #3521 drove it cold on a V100 with cuML active and fitted `0.0026 s/item` (r² 0.95) over n = 412…2954 — 0.98 s to 7.7 s. "Minutes" becomes true only near `COVERAGE_ATLAS_AUTO_THRESHOLD`, where the same fit extrapolates to ~131 s at n = 50 000.

Six sites in the tree repeated the "minutes-long hierarchical-k-means" phrasing, and a reader took it as licence to believe `dataset_open`'s 0.85 coverage weight was conservative at any size — when below ~3000 items it is roughly 100× too generous. Each now carries the measured rate and the size at which minutes become real.

Comments and docstrings only; no behaviour change, and the 0.85 is unchanged.

## What changed

| File | What it now says |
|---|---|
| `vtscore/timing/tasks.py` | The load-bearing one. Carries the fit, the extrapolation *and* its 17× caveat, and records that the 0.85 is a direction rather than a measurement — plus the #3594 note that no single weight can pace both branches. |
| `vtsearch/routes/datasets/registry.py` | Same correction, short form; the step-weighting rationale around it is untouched. |
| `vtscore/timing/fit.py` (×2) | `cheap_branch_only` now says the unmeasured branch is the one that *does the work* (~700× the restore at n = 2954) rather than "the minutes-long one"; the coverage-report docstring prices #3345's mispriced rebuild at its measured 7.7 s. |
| `scripts/profiling/tune_timing_profile.py` | `drive_dataset_open`'s `--cold-atlas` rationale. |
| `tests_lib/core/test_timing_branches.py` | Module docstring. |
| `scripts/experiments/drive_cold/figures_drive_3521.py` | Reads as history now (`then-"minutes-long"`, and corrected), since the shipped comment no longer makes the claim the figure checks. |

The dated `docs/experiments/*/REPORT.md` files are left alone — they are the record of what was measured and when.

## Still owed on #3595 (hence `Refs`, not `Closes`)

Two of the issue's three bullets need machine time this container does not have (`sbatch` absent, `/exp` unmounted), and the issue has been labelled `experiment` to say so:

- Extend the measurement past n = 2954 (`urbansound8k_a` at 8732, `places365_s` at 5110). Every figure above 2954 in this PR is an extrapolation across a 17× gap, and hierarchical k-means is not obviously linear there.
- Re-derive the 0.85 default once that is known.

## Unrelated fix: `dev` was red

The full suite surfaced four pre-existing failures in `tests_lib/meta/test_pile_class_rules.py`, fixed here in their own commit per the repo's fix-all-errors rule.

#3588 and #3612 each added a `SCALE_CLASS_RULES` to `scripts/experiments/pile/pile_config.py` from opposite ends of one branch, and both landed in #3606. The later declaration (#3588's `dict[str, str]`) shadowed #3612's `dict[str, ClassRule]`, so `review_name` read `.name` off a `str`. #3612's own title asks for one home; this is that:

- The `ClassRule` table survives as the richer shape, and #3588's thirteen name-only rules fold into it.
- `ClassRule.test` defaults to `""`, documented as *not written down yet* rather than *no boundary case* — those rules were measured as names before `test` existed, and inventing wording for them would be inventing review definitions nobody measured.
- `scale_class_dataset_name` stays as a thin `review_name` delegation; `make_class_slate.py` bands a candidate rather than issuing a voted slate, so it has no pass suffix to name.
- The rule-name check relaxes from `[a-z0-9 ]+` to `[A-Za-z0-9 ]+`: it was written when both rules were all-lowercase, and two folded-in names carry the `SUVs` acronym, which neither a folder nor an API path minds.

## Testing

Full `./run-tests.sh`: **10575 passed, 6 skipped, 2 xpassed**, every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

Refs #3595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKQ83NMQRcdbGFEDraA2Sz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKQ83NMQRcdbGFEDraA2Sz)_