### PR TITLE
Re-read the detector registry when disk has moved on

### DIFF
--- a/tests/detectors/test_detector_registry_reread.py
+++ b/tests/detectors/test_detector_registry_reread.py
@@ -1,0 +1,91 @@
+"""The detector registry must re-read when another process writes it (#3627).
+
+`vtscore.datasets.registry` was fixed for this in #3167; its twin here was not.
+The cache was filled once and refreshed only by *this* process's mutations, so
+every read stayed blind to a sibling writer — a CLI run against the same data
+dir, a second server, a hand-edited registry.
+
+It surfaced while clearing six finished slates from a running VTSearch: the file
+on disk held nine detectors, ``GET /api/detectors/registry`` went on listing
+fifteen, and ``GET /api/detectors`` — which reads the detector files rather than
+the registry — said nine. Two views of one dashboard, disagreeing, with the
+stale one being the view a person was looking at.
+
+Mutations were never at risk: :func:`_read_modify_write` re-reads under the lock
+before mutating, so a stale cache could not clobber a sibling's write. This is
+read-path staleness only, which is why nothing failed loudly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+
+import pytest
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    """A detector registry module bound to an empty registry file in tmp_path."""
+    monkeypatch.setenv("VTSEARCH_DATA_DIR", str(tmp_path))
+    from vtscore.detectors import registry as reg
+
+    importlib.reload(reg)
+    reg.REGISTRY_PATH = tmp_path / "detector_registry.json"
+    reg._entries = None
+    reg._entries_stamp = None
+    return reg
+
+
+def _write(reg, names):
+    """Write the registry the way another process would: straight to the file."""
+    reg.REGISTRY_PATH.write_text(json.dumps([{"id": f"id{i}", "name": n} for i, n in enumerate(names)]))
+
+
+def test_a_read_sees_a_write_by_another_process(registry):
+    """The bug: the second read returned the first read's cache."""
+    _write(registry, ["alpha", "beta"])
+    assert {d["name"] for d in registry.list_detectors()} == {"alpha", "beta"}
+
+    _write(registry, ["alpha"])  # a sibling process unregisters `beta`
+    assert {d["name"] for d in registry.list_detectors()} == {"alpha"}, (
+        "list_detectors served a stale cache after the registry file changed"
+    )
+
+
+def test_a_removal_by_another_process_is_visible(registry):
+    """Clearing a finished slate from a CLI must not leave the app listing it."""
+    _write(registry, ["done", "todo"])
+    registry.list_detectors()
+    _write(registry, ["todo"])
+    assert registry.find_by_name("done") is None
+    assert registry.find_by_name("todo") is not None
+
+
+def test_an_unchanged_file_is_not_re_parsed(registry):
+    """The stamp is what keeps a stat-per-read from becoming a parse-per-read."""
+    _write(registry, ["alpha"])
+    registry.list_detectors()
+    first = registry._entries
+    registry.list_detectors()
+    assert registry._entries is first, "re-parsed a file that had not changed"
+
+
+def test_a_missing_registry_reads_as_empty(registry):
+    """No file is a legitimate state, not an error, and must not poison the stamp."""
+    assert registry.list_detectors() == []
+    _write(registry, ["alpha"])
+    assert {d["name"] for d in registry.list_detectors()} == {"alpha"}
+
+
+def test_this_process_own_mutation_stays_visible(registry):
+    """`_read_modify_write` swaps the cache; the stamp must match what it wrote."""
+    _write(registry, ["alpha"])
+    registry.list_detectors()
+
+    def mutate(entries):
+        entries.append({"id": "idX", "name": "gamma"})
+        return True
+
+    registry._read_modify_write(mutate)
+    assert {d["name"] for d in registry.list_detectors()} == {"alpha", "gamma"}

--- a/vtscore/detectors/registry.py
+++ b/vtscore/detectors/registry.py
@@ -40,6 +40,8 @@ _T = TypeVar("_T")
 _lock = threading.RLock()
 
 _entries: list[dict[str, Any]] | None = None
+#: ``(mtime_ns, size)`` of the registry file the cache was filled from.
+_entries_stamp: tuple[int, int] | None = None
 
 # Set of detector IDs currently loaded in memory (each has a DetectorContext).
 _loaded_ids: set[str] = set()
@@ -71,10 +73,39 @@ def _save(entries: list[dict[str, Any]]) -> None:
     atomic_write_json(REGISTRY_PATH, entries)
 
 
+def _manifest_stamp() -> tuple[int, int] | None:
+    """Return ``(mtime_ns, size)`` for the registry file, or ``None`` if absent."""
+    try:
+        stat = REGISTRY_PATH.stat()
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
 def _ensure_loaded() -> list[dict[str, Any]]:
-    global _entries
-    if _entries is None:
+    """Return the in-memory cache, re-reading it whenever disk has moved on.
+
+    The dataset registry was fixed for this in #3167 and its twin here was not,
+    so every *read* stayed blind to a write by anyone else. A detector could be
+    unregistered on disk while ``GET /api/detectors/registry`` went on listing
+    it until the process restarted -- which is what happened when six finished
+    slates were cleared from a running app: the file said nine, that endpoint
+    said fifteen, and ``GET /api/detectors`` (which reads the detector files
+    rather than the registry) said nine, so two views of one dashboard
+    disagreed.
+
+    Mutations were never at risk -- :func:`_read_modify_write` re-reads under
+    the lock before mutating -- so this is a read-path staleness, but a
+    convincing one: the stale view is the one a person is looking at.
+
+    A stat per read is cheap next to the JSON parse it usually skips, and the
+    stamp makes the re-read happen exactly when the file has actually changed.
+    """
+    global _entries, _entries_stamp
+    stamp = _manifest_stamp()
+    if _entries is None or stamp != _entries_stamp:
         _entries = _load()
+        _entries_stamp = stamp
     return _entries
 
 
@@ -95,6 +126,9 @@ def _read_modify_write(mutator: Callable[[list[dict[str, Any]]], _T]) -> _T:
         _save(entries)
         with _lock:
             _entries = entries
+            # Stamp what we just wrote, so the next read does not re-parse it.
+            global _entries_stamp
+            _entries_stamp = _manifest_stamp()
     return result
 
 


### PR DESCRIPTION
Closes #3627.

`vtscore/datasets/registry._ensure_loaded` re-reads whenever the file's `(mtime_ns, size)`
changes — that was #3167, with a docstring explaining exactly why. Its twin,
`vtscore/detectors/registry._ensure_loaded`, never got the same treatment: filled once,
refreshed only by this process's own mutations, so every read stayed blind to a sibling
writer.

## How it surfaced

Six finished #3588 slates were cleared from a running VTSearch by a CLI process. Afterwards
the same dashboard reported two different things:

| source | detectors |
|---|---:|
| `detector_registry.json` on disk | 9 |
| `GET /api/detectors` (reads the detector *files*) | 9 |
| `GET /api/detectors/registry` (reads this cache) | **15** |

The stale one is the view a person is looking at. Sam noticed it as *"you cleaned up the
DATASET half of the dashboard, but the DETECTOR side is still cluttered"* — the dataset half
looked right precisely because it already has this fix.

## Severity: reads only

`_read_modify_write` re-reads from disk under the cross-process lock before mutating, so a
stale cache could never clobber a sibling's write and no data was at risk. That is also why
nothing failed loudly, and why the only workarounds were restarting the app or provoking an
incidental mutation — I refreshed the live instance by renaming a detector to a temporary
name and back, which is not something a user would think to do.

## The change

- `_manifest_stamp()` and a `(mtime_ns, size)` check in `_ensure_loaded`, matching the
  dataset registry.
- `_read_modify_write` stamps the cache it just wrote, so a write does not cost the next
  read a re-parse.

## Tests

Five, in `tests/detectors/test_detector_registry_reread.py`. **Three fail without the
change**:

- a read sees a write by another process
- a removal by another process is visible through `find_by_name`
- a missing registry reads as empty, then picks up a later write

The other two pass either way on purpose, pinning that the fix is not over-applied: an
unchanged file is *not* re-parsed, and this process's own mutation stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv