### PR TITLE
Pace the text-sort bar for the branch the sort will actually take

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **The text-sort progress bar no longer reserves most of itself for a model
+  load that has already happened.** `text_sort` paces three steps -- load the
+  embedder, embed the query, score every media -- and the first one is either
+  seconds (the first sort a server process runs) or *exactly zero* (every sort
+  after it, since the encoder stays resident). One static weight vector cannot
+  serve both, and every vector the app has ever shipped or measured was the
+  cold one: [#3521](docs/experiments/2026-09-03-drive-cold-3521/REPORT.md)
+  scored both fitted timing profiles and the shipped defaults at 0.80-0.85
+  *bar error* on this task -- the fraction of the bar budgeted to the wrong
+  step -- while their per-step predictions were off by only ~20 %. So the most
+  frequently run bar in the app spent three quarters of itself parked on a step
+  that was already over. The sort route now asks whether the encoder is
+  resident (it is a lookup, not a guess) and drops the load step out of the
+  pacing when it is, which is the overwhelmingly common case.
+
 - **CLI autodetect no longer drops media the GUI keeps, and its detector
   threshold no longer moves as a result.** The CLI forced *thin* loading on
   every import -- storing a path reference in place of each media's bytes --

--- a/docs/EXTENDING-media.md
+++ b/docs/EXTENDING-media.md
@@ -586,6 +586,7 @@ loaded via `spec_from_file_location` so discovery still works.
 | `_embed_text_impl(text)`              | `(str) -> Optional[np.ndarray]`                    | Embed a text query (default: `None`). Override this, not `embed_text` — the public wrapper handles locking and L2-normalisation. |
 | `embed_text_enriched(text)`           | `(str) -> Optional[np.ndarray]`                    | Average over `description_wrappers`  |
 | `_embed_media_bulk_impl(medias)`      | `(list[dict]) -> list[Optional[np.ndarray]]`       | Embed a list of medias. Default loops over `embed_media` with per-item progress. Override for a native bulk path (e.g. a remote API that accepts many items per request); overrides that batch internally must emit their own progress through `self._on_progress`. |
+| `models_loaded()`                     | `() -> bool`                                       | Whether the model is already resident in this process, without loading it. Default reads the same private model attribute `load_models()` sets; override it alongside `loaded_backbone()` if the backbone lives elsewhere. Read by code that plans around the load rather than performing it — the text-sort bar budgets nothing for its model-load step when this is `True`. |
 
 **Convenience wrappers (don't override these):**
 

--- a/tests/sorting/test_sort_pacing.py
+++ b/tests/sorting/test_sort_pacing.py
@@ -1,0 +1,88 @@
+"""The text-sort bar is paced for the branch this sort will actually take (#3596).
+
+`text_sort`'s three steps are `load_model`, `embed_query`, `score`, and the
+first one is bimodal in a way no coefficient can express: seconds on a process's
+first sort, and *exactly zero* on every later one, because the encoder is
+already resident and `_load_embedder_with_progress` returns before it even
+reports step 1. #3521 measured the consequence — two fitted profiles and the
+shipped defaults alike put 0.80-0.85 of this task's bar in the wrong step.
+
+The route does not have to guess: residency is a lookup. These tests hold the
+weight vector to that lookup in both directions.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from vtsearch.routes import sorting
+from vtscore.concurrency.progress import sort_progress
+
+
+class _StubEmbedder:
+    """Just enough embedder for `_load_embedder_with_progress` to run."""
+
+    def __init__(self, loaded: bool):
+        self._loaded = loaded
+        self._on_progress = None
+
+    def models_loaded(self) -> bool:
+        return self._loaded
+
+    def load_models(self) -> None:
+        self._loaded = True
+
+
+@pytest.fixture
+def captured_weights(monkeypatch):
+    """Record what the route hands `set_step_weights`, then apply it as usual."""
+    seen: list[list[float] | None] = []
+    original = sort_progress.set_step_weights
+
+    def _record(weights):
+        seen.append(weights)
+        original(weights)
+
+    monkeypatch.setattr(sort_progress, "set_step_weights", _record)
+    yield seen
+    original(None)
+
+
+def _sort(client, loaded: bool):
+    with patch.object(sorting, "_get_embedder_for_loaded_data", return_value=_StubEmbedder(loaded)):
+        return client.post("/api/sort", json={"text": "a high pitched beep"})
+
+
+class TestTextSortPacing:
+    def test_a_warm_sort_budgets_nothing_for_the_model_load(self, client, captured_weights):
+        assert _sort(client, loaded=True).status_code == 200
+        weights = captured_weights[-1]
+        assert weights is not None
+        # Step 1 is never reported on this branch, so its slice must be zero
+        # rather than the 0.75 the shipped defaults carry for a cold load.
+        assert weights[0] == 0.0
+        assert sum(weights) == pytest.approx(1.0)
+        assert weights[2] > weights[1]  # scoring is the step the user waits on
+
+    def test_a_cold_sort_still_budgets_for_it(self, client, captured_weights):
+        assert _sort(client, loaded=False).status_code == 200
+        weights = captured_weights[-1]
+        assert weights is not None
+        # The branch somebody waits seconds for keeps the shipped pacing.
+        assert weights == pytest.approx([0.75, 0.05, 0.20])
+
+    def test_the_two_branches_disagree(self, client, captured_weights):
+        # The point of the change: one static vector cannot serve both, so the
+        # route must produce different ones. A regression that dropped the
+        # residency lookup would make these identical and pass every other test.
+        _sort(client, loaded=True)
+        _sort(client, loaded=False)
+        assert captured_weights[-2] != captured_weights[-1]
+
+    def test_no_embedder_at_all_is_the_warm_shape(self, client, captured_weights):
+        # `_load_embedder_with_progress` returns on `emb is None` just as it does
+        # on a resident model, without reporting step 1 either way.
+        with patch.object(sorting, "_get_embedder_for_loaded_data", return_value=None):
+            assert client.post("/api/sort", json={"text": "beep"}).status_code == 200
+        assert captured_weights[-1] is not None
+        assert captured_weights[-1][0] == 0.0

--- a/tests/sorting/test_sorting.py
+++ b/tests/sorting/test_sorting.py
@@ -947,6 +947,9 @@ class TestLoadEmbedderConcurrentCallback:
         mock_mt = MagicMock()
         mock_mt._model = None  # force "needs loading"
         mock_mt._on_progress = original_cb
+        # Residency is read through the public accessor (#3596), so a mock has
+        # to answer it rather than only carry the private attribute.
+        mock_mt.models_loaded.side_effect = lambda: mock_mt._model is not None
 
         def slow_load_models():
             """Simulate a slow load; first call loads, second sees it loaded."""
@@ -955,7 +958,7 @@ class TestLoadEmbedderConcurrentCallback:
 
         mock_mt.load_models = slow_load_models
 
-        with unittest.mock.patch("vtscore.media.get", return_value=mock_mt):
+        with unittest.mock.patch("vtsearch.routes.sorting._get_embedder_for_loaded_data", return_value=mock_mt):
             t1 = threading.Thread(target=_load_embedder_with_progress)
             t2 = threading.Thread(target=_load_embedder_with_progress)
             t1.start()
@@ -979,6 +982,7 @@ class TestLoadEmbedderConcurrentCallback:
         original_cb = MagicMock(name="original_cb")
         mock_emb = MagicMock()
         mock_emb._model = None
+        mock_emb.models_loaded.return_value = False  # cold: the load is attempted
         mock_emb._on_progress = original_cb
         mock_emb.load_models.side_effect = RuntimeError("boom")
 

--- a/tests_lib/core/test_timing_profile.py
+++ b/tests_lib/core/test_timing_profile.py
@@ -210,6 +210,70 @@ class TestAffineScaling:
         assert weights[0] == pytest.approx(0.4)  # download + extract share step 1
 
 
+class TestSkippedSteps:
+    """A step this run will not enter is priced at zero, not merely cheap.
+
+    #3596: `text_sort`'s `load_model` is seconds on a process's first sort and
+    exactly zero on the next 47, so no single coefficient paces both branches —
+    every profile #3521 fitted, and the shipped defaults, sat at 0.80-0.85 bar
+    error on the task. The caller can tell the branches apart before it starts;
+    `skip_steps` is how it says so.
+    """
+
+    def test_a_skipped_step_gives_its_whole_slice_to_the_others(self):
+        # Shipped defaults: (0.75, 0.05, 0.20). Warm, the load never happens.
+        warm = _weights("text_sort", device="cpu", skip_steps=("load_model",))
+        assert warm[0] == 0.0
+        assert warm[1] == pytest.approx(0.2)
+        assert warm[2] == pytest.approx(0.8)
+        assert sum(warm) == pytest.approx(1.0)
+
+    def test_a_measured_cell_is_skipped_the_same_way(self, tmp_path):
+        path = _write(
+            tmp_path,
+            _profile(
+                {
+                    "text_sort": {
+                        "cells": {
+                            "cpu||": {
+                                "steps": {
+                                    # What a sweep of 47 warm sorts and one cold
+                                    # one actually fits: a floored model load
+                                    # that is most of the predicted total.
+                                    "load_model": {"a": 0.5},
+                                    "embed_query": {"a": 0.05},
+                                    "score": {"a": 0.85},
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+        )
+        timing.reload_profile(path)
+        cold = _terms("text_sort", device="cpu")
+        warm = _terms("text_sort", device="cpu", skip_steps=("load_model",))
+        assert cold["load_model"] == pytest.approx(0.5)
+        assert warm["load_model"] == 0.0
+        assert warm["score"] == cold["score"]  # the others are untouched
+        # The floor was 36% of the predicted bar and 0% of the measured one.
+        assert _weights("text_sort", device="cpu")[0] == pytest.approx(0.5 / 1.4)
+        assert _weights("text_sort", device="cpu", skip_steps=("load_model",))[0] == 0.0
+
+    def test_skipping_everything_falls_back_rather_than_dividing_by_zero(self):
+        assert timing.step_weights("text_sort", device="cpu", skip_steps=TASKS["text_sort"].steps) is None
+        assert timing.step_weights(
+            "text_sort", device="cpu", skip_steps=TASKS["text_sort"].steps, fallback=[1.0, 0.0, 0.0]
+        ) == [1.0, 0.0, 0.0]
+
+    def test_an_unknown_step_name_is_inert(self):
+        # Skipping is a claim about this run, not about the registry, so a name
+        # that no longer exists must not blank a task's pacing.
+        assert _weights("text_sort", device="cpu", skip_steps=("no_such_step",)) == pytest.approx(
+            _weights("text_sort", device="cpu")
+        )
+
+
 class TestSlotShares:
     def test_slot_shares_resolve_through_the_same_cell_chain(self, tmp_path):
         path = _write(

--- a/tests_lib/core/test_timing_recorder_and_fit.py
+++ b/tests_lib/core/test_timing_recorder_and_fit.py
@@ -604,6 +604,88 @@ class TestRoundTrip:
         lines = "\n".join(coverage_report(rows, fit_profile(rows, min_samples=2)))
         assert "below 0.90" in lines
 
+    def test_coverage_report_says_when_a_task_is_too_short_to_pace(self):
+        # #3596: text_sort's 288 step-samples were the largest count in #3521's
+        # report and described a 0.9 s job that every arm of that study paced
+        # 0.80-0.85 wrong. A sample count reads that as excellent coverage, so
+        # the report has to say the other thing out loud.
+        rows = [
+            {
+                "task": "text_sort",
+                "device": "cpu",
+                "media_type": "image",
+                "embedder": "siglip",
+                "n": n,
+                "size_mb": 0,
+                "step": step,
+                "seconds": secs,
+                "ok": True,
+                "complete": True,
+                "cold_model": False,
+            }
+            for n in (1000, 2000, 3000)
+            for step, secs in (("load_model", 0.0), ("embed_query", 0.05), ("score", 0.0003 * n))
+        ]
+        lines = "\n".join(coverage_report(rows, fit_profile(rows, min_samples=2)))
+        assert "TOO SHORT TO PACE" in lines
+        assert "load_model 0.00" in lines and "embed_query 0.05" in lines
+
+    def test_coverage_report_names_the_deferred_floor_beside_the_measurement(self):
+        # The floor is right (a cold run really does pay it) and invisible: on a
+        # sub-second task it is most of the predicted total, so it redistributes
+        # the bar for every warm run while the rows say the step was free.
+        rows = [
+            {
+                "task": "text_sort",
+                "device": "cpu",
+                "media_type": "image",
+                "embedder": "siglip",
+                "n": n,
+                "size_mb": 0,
+                "step": step,
+                "seconds": secs,
+                "ok": True,
+                "complete": True,
+                "cold_model": cold,
+            }
+            for cold, n in ((True, 1000), (False, 2000), (False, 3000))
+            for step, secs in (
+                ("load_model", 15.4 if cold else 0.0),
+                ("embed_query", 0.05),
+                ("score", 0.0003 * n),
+            )
+        ]
+        fitted = fit_profile(rows, min_samples=2)
+        # The fit really does store the floor, which is what the line reports.
+        assert fitted["tasks"]["text_sort"]["cells"]["cpu|image|siglip"]["steps"]["load_model"]["a"] == 0.5
+        lines = "\n".join(coverage_report(rows, fitted))
+        assert "load_model: measured 0.00 s on 2 of 3 runs and real on 1" in lines
+        assert "0.50 s floor" in lines
+
+    def test_coverage_report_leaves_a_paceable_task_alone(self):
+        # The counterpart the two tests above need: a task whose steps are long
+        # enough to pace gets no pacing complaint, so the line means something.
+        rows = [
+            {
+                "task": "text_sort",
+                "device": "cpu",
+                "media_type": "image",
+                "embedder": "siglip",
+                "n": n,
+                "size_mb": 0,
+                "step": step,
+                "seconds": secs,
+                "ok": True,
+                "complete": True,
+                "cold_model": False,
+            }
+            for n in (1000, 2000, 3000)
+            for step, secs in (("load_model", 8.0), ("embed_query", 0.05), ("score", 0.003 * n))
+        ]
+        lines = "\n".join(coverage_report(rows, fit_profile(rows, min_samples=2)))
+        assert "TOO SHORT TO PACE" not in lines
+        assert "floor" not in lines
+
     def test_coverage_report_does_not_score_a_step_it_did_not_fit_as_a_line(self):
         # A byte-scaled step and a median fallback carry no r2 at all. Counting
         # either as a bad fit would be the exact confusion #3345 set out to

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -10,6 +10,23 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`skip_steps` on `vtscore.timing.step_weights()` / `step_terms()`, and
+  `MediaEmbedder.models_loaded()`** (issue #3596). A timing profile prices how
+  long a step takes; it has no way to say a step will not run at all. That gap
+  is what left `text_sort` unpaced by anything: its `load_model` step is
+  seconds on a process's first sort and exactly zero on the next 47, so every
+  profile fitted for it - and the shipped defaults - put 0.80-0.85 of the bar
+  in the wrong step. `skip_steps` names the steps this particular run will
+  skip and prices them at zero, which needs no measurement; the remaining
+  steps share the whole bar. Purely additive - an omitted `skip_steps` paces
+  exactly as before.
+
+  `models_loaded()` is the accompanying public read on `MediaEmbedder`: "would
+  `load_models()` do any work?", answered without doing it. The default reads
+  the same private model attribute `load_models()` and `loaded_backbone()`
+  already rely on, so an embedder built the usual way needs no change; one
+  that holds its backbone elsewhere should override both together.
+
 - **`slot_embedders_for_snap(snap)` and `keying_embedder_for_type(type, snap)`
   on `vtscore.embedding.binding`** (issue #3386). Purely additive companions to
   the two existing snapshot resolvers, added so the near-synonymous private

--- a/vtscore/docs/extending/embedders.md
+++ b/vtscore/docs/extending/embedders.md
@@ -48,6 +48,7 @@ Optional but commonly overridden:
 | `description_wrappers` | `[]` | Templates with `{text}` for enriched text embedding (e.g. `["the sound of {text}"]`). Keep the default unless you have measured that the ensemble beats the typed query on your checkpoint - it is a loss on most (#3127/#3341) |
 | `_embed_media_bulk_impl(medias)` | per-item loop | Native bulk hook for service embedders or batched GPU forward passes |
 | `_patch_forward_impl(media)` | `None` | For patch-capable image encoders; required when `supports_patch_regions = True` |
+| `models_loaded()` | `self._model is not None` | Whether the weights are already resident. Callers that must *plan around* the load read this - the text-sort progress bar drops its model-load step entirely when it is `True`. Override it only if you hold the backbone somewhere other than `self._model` (override `loaded_backbone()` in the same breath); the default's permanent `False` is safe but wrong |
 
 Don't override the public methods `embed_media`, `embed_text`,
 `embed_media_bulk`, `load_models`, or `patch_forward` - they wrap the

--- a/vtscore/docs/packages/timing.md
+++ b/vtscore/docs/packages/timing.md
@@ -130,10 +130,40 @@ The vector has one entry per tracker step and sums to 1, ready for
 `set_step_weights`. Pass a `fallback` - `step_weights` returns it when
 the task is unknown or nothing resolves.
 
+### Steps this run will skip
+
+A cost model answers "how long does this step take". It cannot answer
+"does this step happen at all", and where a step forks on process state
+the second question is the one that decides the bar. A text sort's
+`load_model` is seconds on a process's first sort and **exactly zero**
+on every later one, so no single coefficient paces both branches: fitted
+from the warm runs the step is free (and gets floored back up, below),
+fitted from the cold one it eats a bar that will not move. #3596
+measured every arm of #3521's study - two fitted profiles and the
+shipped defaults alike - at 0.80-0.85 bar error on `text_sort` for
+exactly this reason, while their *step* error stayed near 0.2.
+
+The caller usually knows which branch it is on before it starts. Name
+the steps that will not run and they are priced at zero for this run:
+
+```python
+weights = step_weights(
+    "text_sort",
+    media_type="image", embedder="siglip", n=len(medias),
+    skip_steps=() if encoder_is_cold else ("load_model",),
+)
+```
+
+This needs no measurement and no branch axis in the profile format - a
+step that does not run costs nothing, and that is knowable in advance
+where a step's *cost* is not. Steps whose cost merely varies by branch
+(a coverage atlas restored versus rebuilt) are a different problem and
+are not what this parameter is for.
+
 | Function | Description |
 |----------|-------------|
-| `step_weights(task, *, device, media_type, embedder, n, size_mb, fallback)` | Normalised per-tracker-step weights, or *fallback* |
-| `step_terms(...)` | The same prediction before normalisation - raw predicted seconds per phase |
+| `step_weights(task, *, device, media_type, embedder, n, size_mb, skip_steps, fallback)` | Normalised per-tracker-step weights, or *fallback* |
+| `step_terms(...)` | The same prediction before normalisation - raw predicted seconds per phase (takes `skip_steps` too) |
 | `slot_shares(task, step, ...)` | Measured sub-stage shares *within* one step, for steps that pace several ordered sub-stages behind one number (today only the dataset load's `finalize`). Raw weights; the consumer normalises |
 | `profile_covers(task)` | Whether the active profile has any measured cell for *task*. Public API with no in-repo caller - for out-of-tree callers that want to branch on coverage before asking for weights |
 | `active_profile()` / `reload_profile(path=None)` | The parsed profile; re-read it |
@@ -251,7 +281,11 @@ The fit is deliberately plain. Per `(task, cell, step)`:
   sweep's first run is always the cold one. When the warm runs then
   measure a step as *exactly* free while a cold one measured it as real,
   the step is not free here but deferred, and it keeps a small floor
-  rather than 0 so the bar still shows a slice for it.
+  rather than 0 so the bar still shows a slice for it. The floor is a
+  guard against a confident zero, not a cost model, and on a short task
+  it is most of the predicted total - which is why a caller that can
+  tell the branches apart should pass the step as
+  [skipped](#steps-this-run-will-skip) rather than lean on it.
 - A fit with no spread in `n`, or one that comes back with a **negative**
   slope (noise beating signal on a short step), collapses to the median
   seconds with no slope. A confidently wrong slope extrapolates badly at
@@ -325,3 +359,22 @@ and is kept; a rollup with one group behind it is a rename of the cell it
 backs up and is never suppressed. The withheld count is printed in the
 coverage report, because a step the profile does *not* contain is invisible
 to anything that reads the profile.
+
+### When the task is too short to pace at all
+
+A sample count is also silent about whether there is anything to pace. The
+coverage report says it directly:
+
+```
+  text_sort        3 cells, 288 step-samples
+                   TOO SHORT TO PACE: a typical run totals 0.90 s at the swept sizes (load_model 0.00, embed_query 0.05, score 0.85) — the bar is decided by which of these is largest, which is below the error any fit of them carries
+                   load_model: measured 0.00 s on 47 of 48 runs and real on 1 — deferred, so it is priced at the 0.50 s floor, 36% of the predicted total; a caller that knows the step will be skipped should say so
+```
+
+Those 288 step-samples were the largest count in #3521's report and describe
+a job whose bar every arm of that study got 0.80-0.85 wrong. The first line
+is why coefficients cannot fix it: when the whole run is under a second, the
+ranking of three tiny numbers decides the bar and an absolute error far too
+small to fit reorders them. The second names the mechanism behind most of it
+and the remedy - the deferred floor, and the
+[skip](#steps-this-run-will-skip) that makes it moot on the warm branch.

--- a/vtscore/media/embedder.py
+++ b/vtscore/media/embedder.py
@@ -462,6 +462,26 @@ class MediaEmbedder(ABC):
         Override this instead of :meth:`load_models`.
         """
 
+    def models_loaded(self) -> bool:
+        """Whether this embedder's model is already resident in this process.
+
+        The supported way to ask "would :meth:`load_models` do any work?"
+        without doing it. Callers that merely need vectors should not care;
+        this is for code that has to *plan around* the load — pacing a progress
+        bar (the text-sort route budgets its ``load_model`` step out of the bar
+        entirely when the encoder is already resident, see
+        :func:`vtscore.timing.step_weights`) or skipping a speculative warm-up.
+
+        Reads the same ``_model`` attribute convention :meth:`load_models` and
+        :meth:`loaded_backbone` rely on, so it works for any embedder built the
+        usual way. An embedder that holds its backbone elsewhere should
+        **override this** alongside :meth:`loaded_backbone`; the default's
+        answer would otherwise be a permanent ``False``, which is the safe
+        direction (a caller re-plans for a load that turns out to be free)
+        but wrong.
+        """
+        return getattr(self, "_model", None) is not None
+
     def loaded_backbone(self) -> tuple[Any, Any]:
         """Return ``(model, processor)`` for this embedder's underlying backbone.
 

--- a/vtscore/timing/fit.py
+++ b/vtscore/timing/fit.py
@@ -697,6 +697,89 @@ def _withheld_by_specificity(spec, cells: _CellSamples) -> dict[str, int]:
     return dict(out)
 
 
+#: A task whose whole run is shorter than this, at the sizes the sweep visited,
+#: cannot be usefully paced. The bar is then decided by the ranking of a handful
+#: of tiny numbers, and an absolute error far too small to fit reorders them —
+#: which is the state #3596 measured on ``text_sort``: three steps totalling
+#: 0.9 s, all three profiles ranking them differently, and every arm sitting at
+#: 0.80-0.85 bar error while its *step* error stayed near 0.2.
+#:
+#: One second is where a bar stops being a bar: below it the job is a flash, and
+#: whatever slice each step drew never rendered at a size anybody read. It is a
+#: reporting threshold only — nothing branches on it — so it is deliberately a
+#: round number rather than a measured one.
+_UNPACEABLE_TOTAL_SECONDS = 1.0
+
+
+def _typical_seconds(samples: list[dict]) -> float:
+    """Median seconds this step took, over the population a fit would price.
+
+    Warm runs when there are any, mirroring :func:`fit_step`'s holdout, because
+    the warm population is what a served process spends nearly all of its runs
+    in. Raw: the deferred floor is reported separately, since conflating "this
+    step measured zero" with "the profile stores 0.5 for it" is the confusion
+    these lines exist to undo.
+    """
+    warm = [s["seconds"] for s in samples if not s.get("cold")]
+    seconds = warm or [s["seconds"] for s in samples]
+    return statistics.median(seconds) if seconds else 0.0
+
+
+def _pace_lines(spec, samples_by_step: dict[str, list[dict]]) -> list[str]:
+    """Say when a task's own measurements cannot pace its bar.
+
+    Two things a sample count actively misreports, both measured on
+    ``text_sort`` in #3521's sweep, where 288 step-samples read as the
+    best-covered task in the report:
+
+    **The whole task is too short.** Its three steps total 0.9 s warm, so the
+    bar is settled by which of three sub-second numbers comes out largest, and
+    the fitted profiles disagreed with each other about that ordering while
+    predicting each step to within ~20 %. Coefficients cannot fix an ordering
+    that noise decides; the line says so rather than letting a full sample count
+    imply the opposite.
+
+    **A step measured free is not priced free.** When the warm runs measure a
+    step at exactly zero and a cold run measured it as real,
+    :func:`_deferred_cost_floor` keeps a floor for it — right for a step that
+    might yet be paid, and on a short task it is most of the predicted total,
+    so it redistributes the bar for every warm run. Naming the floor beside the
+    measurement is what makes that visible; a task whose caller can tell the
+    two branches apart should pass the step to
+    :func:`vtscore.timing.step_weights` as skipped instead (``text_sort`` now
+    does).
+    """
+    steps = {step: samples for step, samples in samples_by_step.items() if step in spec.steps}
+    if not steps:
+        return []
+    lines: list[str] = []
+    typical = {step: _typical_seconds(samples) for step, samples in steps.items()}
+    total = sum(typical.values())
+    if 0 < total < _UNPACEABLE_TOTAL_SECONDS:
+        breakdown = ", ".join(f"{step} {typical[step]:.2f}" for step in spec.steps if step in typical)
+        lines.append(
+            f"  {'':<16} TOO SHORT TO PACE: a typical run totals {total:.2f} s at the swept "
+            f"sizes ({breakdown}) — the bar is decided by which of these is largest, which "
+            f"is below the error any fit of them carries"
+        )
+    for step in spec.steps:
+        samples = steps.get(step)
+        if not samples or step in spec.byte_scaled:
+            continue
+        cold = [s for s in samples if s.get("cold")]
+        floor = _deferred_cost_floor(typical[step], cold)
+        if floor <= typical[step]:
+            continue
+        warm_zero = sum(1 for s in samples if not s.get("cold") and s["seconds"] <= 0)
+        share = floor / (total - typical[step] + floor) if total - typical[step] + floor > 0 else 1.0
+        lines.append(
+            f"  {'':<16} {step}: measured 0.00 s on {warm_zero} of {len(samples)} runs and real on "
+            f"{len(cold)} — deferred, so it is priced at the {floor:.2f} s floor, {share:.0%} of "
+            f"the predicted total; a caller that knows the step will be skipped should say so"
+        )
+    return lines
+
+
 def _branch_lines(spec, samples_by_step: dict[str, list[dict]]) -> list[str]:
     """Name every step whose runs only ever took a cached path.
 
@@ -757,6 +840,12 @@ def coverage_report(rows: Iterable[dict], profile: dict[str, Any]) -> list[str]:
     one wearing a full sample count, and it is the state that made #3345's sweep
     price a minutes-long atlas rebuild at 2 % of the bar. :func:`_branch_lines`
     names those explicitly (#3521).
+
+    A fourth is whether the task is long enough for *any* coefficients to pace.
+    ``text_sort``'s 288 step-samples are the largest count in #3521's report and
+    describe a 0.9 s job whose bar every arm of that study got 0.80-0.85 wrong;
+    :func:`_pace_lines` says that outright, along with the deferred floor that
+    causes most of it (#3596).
     """
     rows = list(rows)
     normalized = [n for n in (normalize_row(r) for r in rows) if n is not None]
@@ -774,6 +863,7 @@ def coverage_report(rows: Iterable[dict], profile: dict[str, Any]) -> list[str]:
             lines.append(f"  {task:<16} {len(cells)} cells, {samples} step-samples")
             lines.extend(_specificity_lines(TASKS[task], cells, by_cell.get(task, {})))
             lines.extend(_branch_lines(TASKS[task], by_step.get(task, {})))
+            lines.extend(_pace_lines(TASKS[task], by_step.get(task, {})))
         elif task in seen_tasks:
             branch_lines = _branch_lines(TASKS[task], by_step.get(task, {}))
             if branch_lines:

--- a/vtscore/timing/profile.py
+++ b/vtscore/timing/profile.py
@@ -55,6 +55,7 @@ import logging
 import math
 import os
 import threading
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -478,6 +479,7 @@ def step_terms(
     embedder: str = "",
     n: float = 0.0,
     size_mb: float = 0.0,
+    skip_steps: Iterable[str] = (),
 ) -> Optional[dict[str, float]]:
     """Predicted seconds per step for *task*, keyed by step name.
 
@@ -490,6 +492,12 @@ def step_terms(
     ``n`` is the task's scale variable (see :attr:`TaskSpec.scale`); ``size_mb``
     is the archive size for byte-scaled phases. Both may be zero, which simply
     collapses their terms.
+
+    *skip_steps* names steps **this invocation will not enter at all**, and
+    prices them at zero regardless of what the profile or the defaults say. It
+    is not a cost model and needs no measurement: a step that does not run
+    costs nothing, and that is knowable in advance where a step's cost is not.
+    See :func:`step_weights` for why a task reaches for it.
     """
     spec = task_spec(task)
     if spec is None:
@@ -498,8 +506,12 @@ def step_terms(
     defaults = dict(zip(spec.steps, spec.default_terms)) if spec.default_terms else {}
     if not measured and not defaults:
         return None
+    skipped = frozenset(skip_steps)
     terms: dict[str, float] = {}
     for step in spec.steps:
+        if step in skipped:
+            terms[step] = 0.0
+            continue
         coeffs = measured.get(step)
         terms[step] = coeffs.seconds(n, size_mb) if coeffs is not None else max(0.0, defaults.get(step, 0.0))
     if sum(terms.values()) <= 0:
@@ -517,6 +529,7 @@ def step_weights(
     embedder: str = "",
     n: float = 0.0,
     size_mb: float = 0.0,
+    skip_steps: Iterable[str] = (),
     fallback: Optional[list[float]] = None,
 ) -> Optional[list[float]]:
     """Normalized per-tracker-step weights for *task*, or *fallback*.
@@ -526,9 +539,35 @@ def step_weights(
     :meth:`~vtscore.concurrency.progress.ProgressTracker.set_step_weights`.
     Phases that share a tracker step have their predicted seconds summed into
     that step's slot.
+
+    **Steps this run will skip.** A cost model answers "how long does this step
+    take"; it cannot answer "does this step happen at all", and for a step that
+    forks on process state the second question decides the bar. A text sort's
+    ``load_model`` is seconds on the first sort of a process and *exactly zero*
+    on every later one, so no single coefficient paces both: fitted from the
+    warm runs it is free (and gets floored back up, see
+    :data:`vtscore.timing.fit._ONCE_PER_PROCESS_FLOOR_S`), fitted from the cold
+    one it eats a bar that will not move. #3596 measured every arm of #3521's
+    study — two fitted profiles and the shipped defaults alike — at 0.80–0.85
+    bar error on ``text_sort`` for exactly this reason.
+
+    The caller usually *knows*: the sort route can ask whether the encoder is
+    already resident before it starts. Naming the step in *skip_steps* prices it
+    at zero for this run, which needs no measurement and no branch axis in the
+    profile format — a step that does not run costs nothing. Steps whose cost
+    merely *varies* by branch are a different problem and are not this
+    parameter's job (#3594).
     """
     spec = task_spec(task)
-    terms = step_terms(task, device=device, media_type=media_type, embedder=embedder, n=n, size_mb=size_mb)
+    terms = step_terms(
+        task,
+        device=device,
+        media_type=media_type,
+        embedder=embedder,
+        n=n,
+        size_mb=size_mb,
+        skip_steps=skip_steps,
+    )
     if spec is None or terms is None:
         return fallback
     weights = [0.0] * spec.tracker_steps

--- a/vtsearch/routes/sorting.py
+++ b/vtsearch/routes/sorting.py
@@ -110,6 +110,22 @@ def _get_embedder_for_loaded_data(snap=None):
     return embedder_for_medias(snap)
 
 
+def _sort_will_load_model(snap=None) -> bool:
+    """Whether this sort will actually pay its ``load_model`` step.
+
+    ``True`` only on the branch a user waits seconds for: an encoder exists and
+    is not yet resident. Mirrors the two early returns in
+    :func:`_load_embedder_with_progress` exactly — both of them leave step 1
+    *unreported*, so its slice of the bar should be zero rather than merely
+    small. See the call site for why the bar needs the distinction and why
+    reading it here is safe.
+
+    *snap* threads in an already-taken medias snapshot, like its neighbours.
+    """
+    emb = _get_embedder_for_loaded_data(snap)
+    return emb is not None and not emb.models_loaded()
+
+
 def _load_embedder_with_progress(snap=None):
     """Load the embedding model, forwarding its load progress to step 1 of the bar.
 
@@ -129,7 +145,7 @@ def _load_embedder_with_progress(snap=None):
         return
 
     with _embedder_load_lock:
-        if getattr(emb, "_model", None) is not None:
+        if emb.models_loaded():
             return
 
         update_sort_progress("sorting", "Loading embedder…", 0, 0, step=1, total_steps=_SORT_STEPS)
@@ -184,8 +200,24 @@ def sort_clips(body: dict):
 
     from vtscore import timing  # noqa: PLC0415
 
+    # A warm sort never enters step 1: ``_load_embedder_with_progress`` returns
+    # before reporting it when the encoder is already resident, which is 47 of
+    # every 48 sorts in a served process. Budgeting the bar for a load that will
+    # not happen is what put 0.80-0.85 of this task's bar in the wrong step under
+    # every profile #3521 fitted and under the shipped defaults alike (#3596), so
+    # the residency the route can simply *look up* is passed to the pacing.
+    #
+    # Racy in one harmless direction only: models are never unloaded, so a warm
+    # answer stays true, and a cold answer that another request warms first
+    # merely paces this run as it was paced before this call existed.
     sort_progress.set_step_weights(
-        timing.step_weights(_SORT_TASK, media_type=media_type, embedder=embedder_name, n=len(snap))
+        timing.step_weights(
+            _SORT_TASK,
+            media_type=media_type,
+            embedder=embedder_name,
+            n=len(snap),
+            skip_steps=() if _sort_will_load_model(snap) else ("load_model",),
+        )
     )
     # Every exit below — success and abort alike — parks the tracker at "idle"
     # via ``sort_idle()``, which is what closes the recorder.


### PR DESCRIPTION
Closes #3596.

## The diagnosis

The issue asked first whether `text_sort` can be paced at all. It can — but not by any one weight vector, and the reason is not that its steps are short.

`load_model` is **bimodal**: seconds on a server process's first sort, and *exactly zero* on every later one, because the encoder stays resident and `_load_embedder_with_progress` returns before it even reports step 1. That is 47 of every 48 sorts in #3521's sweep. So the bar's largest slice is budgeted for work that, almost always, has already happened — and no coefficient can be right about both branches at once. It also explains the shape #3596 flagged: the *step* error stayed near 0.2 (each prediction was roughly right) while the *bar* error sat at 0.80–0.85 (their ranking was not).

The issue's suspect — `_ONCE_PER_PROCESS_FLOOR_S = 0.5` — is the mechanism for the fitted arms specifically. Warm runs fit the step to exactly zero, the floor lifts it back to 0.5 s, and on a 0.9 s task that floor is most of the predicted total. The floor is not wrong (a cold run really does pay it); it is answering a question the profile cannot ask.

## The fix

A cost model answers "how long does this step take". It cannot answer "does this step happen at all" — and the caller already knows: residency is a lookup, not a guess.

- **`skip_steps` on `step_weights()` / `step_terms()`** prices named steps at zero for one run. It needs no measurement and no branch axis in the profile format: a step that does not run costs nothing. Steps whose cost merely *varies* by branch are #3594's problem and are explicitly not this parameter's job.
- **The sort route passes `load_model`** when the encoder is already resident, mirroring the two early returns in `_load_embedder_with_progress` exactly (both leave step 1 unreported). Racy in one harmless direction only: models are never unloaded, so a warm answer stays true, and a cold answer another request warms first paces as it did before this existed.
- **`MediaEmbedder.models_loaded()`** makes that lookup a supported read instead of a fourth private `_model` probe. Additive; the default reads the same attribute convention `load_models()` and `loaded_backbone()` already rely on.

On synthetic rows shaped like the study's (47 warm sorts + 1 cold, 2954 images), warm bar error goes **0.75 → 0.14** on the shipped defaults and **0.36 → 0.00** on a profile fitted from those rows. The cold branch is untouched.

## Point 3: the report can now say so

`coverage_report` prints, for `text_sort`:

```
  text_sort        3 cells, 288 step-samples
                   TOO SHORT TO PACE: a typical run totals 0.90 s at the swept sizes (load_model 0.00, embed_query 0.05, score 0.85) — the bar is decided by which of these is largest, which is below the error any fit of them carries
                   load_model: measured 0.00 s on 47 of 48 runs and real on 1 — deferred, so it is priced at the 0.50 s floor, 36% of the predicted total; a caller that knows the step will be skipped should say so
```

Those 288 step-samples were the largest count in #3521's report and described a job whose bar every arm of that study got 0.80–0.85 wrong. The second line is what makes the floor visible rather than silent.

## What this does *not* fix

A **cold** run under a fitted profile is still mispaced, because the coefficient it reads is the 0.5 s floor and the real load is ~15 s. Pricing it properly means storing a per-branch cost, which is the profile-format change filed as #3594 — commented there rather than folded in here.

## Docs / tests

- `vtscore/docs/packages/timing.md` gains "Steps this run will skip" and "When the task is too short to pace at all"; the extending guides and both CHANGELOGs record the two new public members.
- Library tier: `skip_steps` semantics (including that skipping everything falls back rather than dividing by zero, and that an unknown step name is inert) and the two new report lines, with a paceable-task counterpart so the lines mean something.
- App tier: `tests/sorting/test_sort_pacing.py` holds the route's weight vector to the residency lookup in both directions, including that the two branches actually disagree — a regression that dropped the lookup would pass every other test.

`./run-tests.sh` is green here except for the four `tests_lib/meta/test_pile_class_rules.py` failures already filed as #3625 — `dev` is red on them with this branch stashed, and they are untouched by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkmirGPyAeK6LTw9LwXYDE