### PR TITLE
Record a staging import's embedding under the embed step

### DIFF
--- a/scripts/profiling/tune_timing_profile.py
+++ b/scripts/profiling/tune_timing_profile.py
@@ -457,9 +457,16 @@ def drive_dataset_stage(demo_ids: list[str], reps: int, *, cold_embed: bool = Tr
     """Measure staging demo datasets (acquire, embed, serialize; no registry).
 
     Staging reads the same demo embeddings pkl a full import writes, so a
-    staging leg run after a load leg against a shared data dir measures nothing
-    at all — that is the 0.000-0.002 s #3345 recorded across all four image
-    tiers. *cold_embed* clears the cache before each rep.
+    staging leg run after a load leg against a shared data dir re-reads what the
+    load just cached rather than embedding; *cold_embed* clears the cache before
+    each rep so the ``fresh`` branch is the one measured.
+
+    That cache is *not* what made #3345's ``embed`` read 0.000-0.002 s across
+    all four image tiers: #3521 §5 cleared it and the step still read zero,
+    because a demo importer embeds inside ``run()`` and the staging flow was
+    recording that under ``acquire``. Fixed in #3593, so these rows now split
+    acquisition from embedding — and a profile fitted from rows recorded
+    *before* that fix prices ``embed`` at nothing.
     """
     from vtscore.concurrency.progress import loading_tasks  # noqa: PLC0415
     from vtscore.datasets.config import DEMO_DATASETS  # noqa: PLC0415

--- a/tests/datasets/test_dataset_load_timing_rows.py
+++ b/tests/datasets/test_dataset_load_timing_rows.py
@@ -282,3 +282,106 @@ class TestStagingImportRecordsTimingRows:
         _run_staging(tmp_path, monkeypatch)
 
         assert not sink.exists()
+
+
+class _FakeClock:
+    """Deterministic stand-in for the recorder's ``time`` module.
+
+    Patched into :mod:`vtscore.timing.recorder` alone, so the phase boundaries
+    under test are the only thing the fake clock decides.
+    """
+
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def monotonic(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class _EmbedsInsideRunImporter:
+    """An importer that embeds inside ``run()`` — what every demo source does.
+
+    ``load_demo_dataset`` embeds inside ``load_demo_source``, which the staging
+    flow calls from ``importer.run()``; it also signs off with a terminal
+    ``"idle"`` that is the importer finishing, not the staging job.
+    """
+
+    fields: list = []
+
+    def __init__(self, clock: _FakeClock, acquire: float, embed: float) -> None:
+        self._clock, self._acquire, self._embed = clock, acquire, embed
+
+    def run(self, field_values, target_medias, **kwargs):
+        from vtscore.concurrency.progress import update_progress
+
+        update_progress("loading", "Reading source…", 0, 1)
+        self._clock.advance(self._acquire)
+        update_progress("embedding", "Embedding…", 0, 1)
+        self._clock.advance(self._embed)
+        _fake_load(target_medias)
+        update_progress("idle", "Loaded demo dataset", 0, 0)
+
+    def resolve_display_name(self, field_values):
+        return "embeds inside run"
+
+
+class TestStagingRecordsTheImportersEmbeddingAsAnEmbed:
+    """#3593: ``dataset_stage``·``embed`` must measure embedding.
+
+    The staging flow bound the importer's progress sink straight to
+    ``tracker.update``, so its calls arrived stepless, the tracker kept step 1
+    through the whole of ``run()``, and a demo import's embedding was recorded
+    as ``acquire``. #3521 §5 cleared the embeddings cache before every rep,
+    moved 11-40 s of real embedding into the run, and watched ``embed`` not
+    move: the boundary put it there, not the cache.
+    """
+
+    def _rows_by_step(self, tmp_path, monkeypatch, *, acquire: float, embed: float) -> dict:
+        from vtscore.timing import recorder as recorder_mod
+
+        sink = tmp_path / "timings.jsonl"
+        monkeypatch.setenv(RECORD_ENV_VAR, str(sink))
+        clock = _FakeClock()
+        monkeypatch.setattr(recorder_mod, "time", clock)
+
+        from vtscore.datasets import load_pipeline
+        from vtscore.datasets.load_pipeline import _stage_importer_in_background
+
+        monkeypatch.setattr(load_pipeline, "STAGING_DIR", tmp_path / "staging")
+        with mock.patch(
+            "vtscore.datasets.load_pipeline.threading.Thread",
+            side_effect=_sync_thread_factory(),
+        ):
+            _stage_importer_in_background(
+                _EmbedsInsideRunImporter(clock, acquire, embed),
+                {"media_type": "audio", "embedder": "clap"},
+            )
+        return {r["step"]: r for r in load_rows([str(sink)])}
+
+    def test_the_embed_step_carries_the_importers_embedding(self, isolated_settings, tmp_path, monkeypatch):
+        rows = self._rows_by_step(tmp_path, monkeypatch, acquire=1.0, embed=9.0)
+
+        assert rows["embed"]["seconds"] >= 9.0, "the embedding inside run() belongs to the embed step"
+        assert rows["acquire"]["seconds"] == 1.0, "acquire must measure acquisition and nothing else"
+
+    def test_acquire_no_longer_carries_the_embed_curve(self, isolated_settings, tmp_path, monkeypatch):
+        """The shape of the defect, stated as the fit saw it: acquire scaling
+        with the work and embed pinned near zero."""
+        small = self._rows_by_step(tmp_path, monkeypatch, acquire=1.0, embed=2.0)
+        large = self._rows_by_step(tmp_path, monkeypatch, acquire=1.0, embed=20.0)
+
+        assert small["acquire"]["seconds"] == large["acquire"]["seconds"], "acquire must not scale with the embed"
+        assert large["embed"]["seconds"] - small["embed"]["seconds"] >= 18.0
+
+    def test_the_run_is_still_complete_and_fittable(self, isolated_settings, tmp_path, monkeypatch):
+        """The importer's terminal ``"idle"`` must not park the staging task
+        before it serializes, or the run stops reaching its last step and the
+        fitter drops every row."""
+        rows = self._rows_by_step(tmp_path, monkeypatch, acquire=1.0, embed=9.0)
+
+        assert set(rows) == {"acquire", "embed", "serialize"}
+        assert all(r["ok"] and r["complete"] for r in rows.values())
+        assert all(normalize_row(r) is not None for r in rows.values())

--- a/tests_lib/datasets/test_staging_progress_steps.py
+++ b/tests_lib/datasets/test_staging_progress_steps.py
@@ -19,6 +19,8 @@ makes mid-``run()``.
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from vtscore.concurrency.progress import ProgressTracker
 from vtscore.datasets.load_pipeline import _TOTAL_STAGE_STEPS, _make_staging_progress
 
@@ -41,7 +43,9 @@ def _make(held: str | None = "download"):
     tracker = ProgressTracker(extra_fields=dict(_STAGE_EXTRAS))
     tracker.update("loading", "Preparing dataset…", 0, 0, step=1, total_steps=_TOTAL_STAGE_STEPS)
     controller = _StubController(held)
-    return tracker, controller, _make_staging_progress(controller, tracker)
+    # ``_make_staging_progress`` is annotated for the real controller; the stub
+    # is the two members it touches.
+    return tracker, controller, _make_staging_progress(cast(Any, controller), tracker)
 
 
 def _step(tracker) -> int:

--- a/tests_lib/datasets/test_staging_progress_steps.py
+++ b/tests_lib/datasets/test_staging_progress_steps.py
@@ -1,0 +1,151 @@
+"""A staging import must report its importer's progress against the right step.
+
+``dataset_stage`` declares three steps — ``acquire``, ``embed``, ``serialize`` —
+and the timing recorder labels a measured duration with whichever step the
+tracker was on when it ran. The staging flow used to bind the importer's
+progress sink straight to ``tracker.update``, so the importer's calls arrived
+stepless and the tracker kept step 1 for the whole of ``run()``. Every demo
+source embeds *inside* ``run()``, so the entire embed landed under ``acquire``:
+#3521 §5 fitted that step at ``b = 0.0136 s/item, r² 0.9995`` — an embed curve
+wearing the wrong step's name — beside an ``embed`` at ``b = 7.2e-07``, on a
+sweep that had cleared the embeddings cache before every rep (#3593).
+
+``_make_staging_progress`` is the fix, mirroring the load pipeline's
+``_make_stepped_progress``. These tests pin the mapping, the two places it
+deliberately differs from the load pipeline's version (an unknown status leaves
+the step alone; the step never walks backwards), and the gate handoff it now
+makes mid-``run()``.
+"""
+
+from __future__ import annotations
+
+from vtscore.concurrency.progress import ProgressTracker
+from vtscore.datasets.load_pipeline import _TOTAL_STAGE_STEPS, _make_staging_progress
+
+_STAGE_EXTRAS = {"step": None, "total_steps": None, "overall": None, "eta_seconds": None, "error": None}
+
+
+class _StubController:
+    """The slice of ``_LoadGateController`` the progress callback touches."""
+
+    def __init__(self, held: str | None = "download") -> None:
+        self.held = held
+        self.swaps = 0
+
+    def swap_to_embed(self) -> None:
+        self.swaps += 1
+        self.held = "embed"
+
+
+def _make(held: str | None = "download"):
+    tracker = ProgressTracker(extra_fields=dict(_STAGE_EXTRAS))
+    tracker.update("loading", "Preparing dataset…", 0, 0, step=1, total_steps=_TOTAL_STAGE_STEPS)
+    controller = _StubController(held)
+    return tracker, controller, _make_staging_progress(controller, tracker)
+
+
+def _step(tracker) -> int:
+    return tracker.get()["step"]
+
+
+class TestTheImportersEmbeddingLandsOnTheEmbedStep:
+    def test_an_embedding_status_advances_to_step_two(self):
+        """The regression: an importer that embeds inside ``run()`` is on step 2."""
+        tracker, _, stepped = _make()
+
+        stepped("embedding", "Embedding…", 3, 10)
+
+        assert _step(tracker) == 2, "the importer's embedding must be recorded as the embed step"
+        assert tracker.get()["message"] == "Embedding…"
+        assert tracker.get()["total_steps"] == _TOTAL_STAGE_STEPS
+
+    def test_pre_embed_statuses_share_the_acquire_step(self):
+        """Staging folds the load's four steps into three, so download, unpack,
+        read and convert all report against acquire."""
+        for status in ("downloading", "extracting", "loading", "converting"):
+            tracker, _, stepped = _make()
+            stepped(status, "…", 0, 1)
+            assert _step(tracker) == 1, f"{status} belongs to acquire"
+
+    def test_an_unknown_status_leaves_the_step_alone(self):
+        """The load pipeline passes ``step=None`` here, which nulls the whole-job
+        fraction for that update. Staging has no pacer to absorb that, so an
+        unrecognised status keeps the step the tracker was last told."""
+        tracker, _, stepped = _make()
+        stepped("embedding", "Embedding…", 0, 1)
+
+        stepped("thinking", "Something new", 1, 2)
+
+        assert _step(tracker) == 2
+        assert tracker.get()["message"] == "Something new"
+
+    def test_the_step_never_walks_backwards(self):
+        """A demo's clipper reports its clip embedding under a plain ``loading``
+        status, which would otherwise send the bar back to acquire after the
+        embed slice had already started."""
+        tracker, _, stepped = _make()
+        stepped("embedding", "Embedding…", 0, 1)
+
+        stepped("loading", "Embedding clips…", 1, 4)
+
+        assert _step(tracker) == 2
+
+    def test_an_explicit_step_from_the_importer_wins(self):
+        """``update_progress(step=…)`` is part of the plugin contract; the map is
+        a default for the callers that do not use it."""
+        tracker, _, stepped = _make()
+
+        stepped("loading", "Writing…", 0, 0, step=3)
+
+        assert _step(tracker) == 3
+
+
+class TestTheImportersTerminalIdle:
+    def test_an_idle_does_not_park_the_staging_task(self):
+        """``load_demo_dataset`` ends with ``on_progress("idle", …)``. That is the
+        *importer* finishing, not the staging job: serialization still has to
+        run, and the terminal update is the one the staging body writes."""
+        tracker, _, stepped = _make()
+        stepped("embedding", "Embedding…", 0, 1)
+
+        stepped("idle", "Loaded demo dataset", 0, 0)
+
+        assert tracker.get()["status"] == "embedding"
+        assert _step(tracker) == 2
+
+    def test_an_idle_carrying_a_failure_is_forwarded(self):
+        """Dropping the status must not drop an error riding along with it."""
+        tracker, _, stepped = _make()
+
+        stepped("idle", "", 0, 0, error="importer gave up")
+
+        assert tracker.get()["error"] == "importer gave up"
+
+
+class TestTheGateHandoff:
+    def test_the_first_embedding_status_swaps_to_the_embed_gate(self):
+        """Staging used to swap only after ``run()`` returned, so a demo staging
+        did its embedding while holding the *download* gate — the one whose
+        limit exists to bound how many datasets fetch at once."""
+        tracker, controller, stepped = _make()
+
+        stepped("embedding", "Embedding…", 0, 1)
+
+        assert controller.swaps == 1
+        assert controller.held == "embed"
+
+    def test_later_embedding_statuses_do_not_swap_again(self):
+        tracker, controller, stepped = _make()
+
+        stepped("embedding", "Embedding…", 0, 1)
+        stepped("embedding", "Embedding…", 1, 1)
+
+        assert controller.swaps == 1
+
+    def test_a_pre_embed_status_holds_the_download_gate(self):
+        tracker, controller, stepped = _make()
+
+        stepped("downloading", "Fetching…", 0, 1)
+
+        assert controller.swaps == 0
+        assert controller.held == "download"

--- a/vtscore/datasets/load_pipeline.py
+++ b/vtscore/datasets/load_pipeline.py
@@ -988,6 +988,70 @@ STAGING_DIR = DATA_DIR / "staging"
 _STAGE_TASK = "dataset_stage"
 _TOTAL_STAGE_STEPS = 3  # acquire, embed, serialize
 
+#: Maps the status strings an importer emits onto ``dataset_stage``'s steps, the
+#: way :data:`_STATUS_TO_STEP` does for a load. Staging folds the load's four
+#: steps into three, so every pre-embed status shares the acquire slice.
+#:
+#: This map is what makes the ``embed`` step measure an embed. An importer that
+#: embeds *inside* ``run()`` — every demo source does, and the demo importer is
+#: what the combine flow stages — used to report stepless, so the tracker kept
+#: step 1 and the whole embedding leg was recorded as ``acquire``. #3521 §5
+#: fitted that step at ``b = 0.0136 s/item, r² 0.9995`` — an embed curve under
+#: the wrong name — beside an ``embed`` at ``b = 7.2e-07``, on a sweep that
+#: cleared the embeddings cache before every rep. Clearing the cache moved
+#: 11–40 s of real embedding into the run and ``embed`` did not move, because
+#: the boundary, not the cache, was what put it there (#3593).
+_STAGE_STATUS_TO_STEP = {
+    "downloading": 1,
+    "extracting": 1,
+    "loading": 1,
+    "converting": 1,
+    "embedding": 2,
+}
+
+
+def _make_staging_progress(controller: _LoadGateController, tracker):
+    """Build the importer-side progress callback for a staging run.
+
+    Mirrors :func:`_make_stepped_progress`: it stamps the step each status
+    belongs to — so the timing recorder labels a duration with the phase that
+    actually ran — and swaps the download gate for the embed gate on the first
+    ``"embedding"``, so a queued import can start fetching while this one holds
+    only the embed slot. Staging used to swap only after ``run()`` returned,
+    which meant a demo staging did its embedding under the *download* gate.
+
+    Two deliberate differences from the load pipeline's version, both because
+    staging has no :class:`AdaptiveLoadPacer` between the importer and the
+    tracker:
+
+    - a status the map does not know leaves ``step`` **unset** rather than
+      passing ``None``, so the tracker keeps the step it was last told instead
+      of nulling the whole-job fraction for that update;
+    - the step never moves backwards. A demo's clipper reports its clip
+      embedding under a plain ``"loading"`` status, which would otherwise walk
+      the bar back to acquire after the embed slice had already started.
+    """
+
+    def stepped(status: str, message: str = "", current: int = 0, total: int = 0, **kwargs) -> None:
+        # An importer signalling *its* completion is not the staging job's:
+        # serialization still has to run, and the terminal update is the one at
+        # the bottom of ``stage_task``. A failure riding along is another
+        # matter and is forwarded. (``load_demo_dataset`` ends with exactly such
+        # an ``"idle"``, which used to park the whole staging task at idle
+        # mid-run.)
+        if status == "idle" and "error" not in kwargs:
+            return
+        if status == "embedding" and controller.held != "embed":
+            controller.swap_to_embed()
+        if "step" not in kwargs:
+            step = _STAGE_STATUS_TO_STEP.get(status)
+            if step is not None and step >= (tracker.get().get("step") or 0):
+                kwargs["step"] = step
+        kwargs.setdefault("total_steps", _TOTAL_STAGE_STEPS)
+        tracker.update(status, message, current, total, **kwargs)
+
+    return stepped
+
 
 def _stage_importer_in_background(importer, field_values: dict, label: str = "") -> str:
     """Run *importer*.run() in a daemon thread, saving the result to a staging pkl.
@@ -1026,9 +1090,11 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     # Staging reports the same step structure every other long-running family
     # does, which is what earns it a whole-job bar and an ETA — and what lets the
     # timing recorder label each measured duration with the phase it belongs to.
-    # The importer's own progress calls come through stepless, and the tracker
-    # keeps the last step it was told, so stamping the boundaries below is
-    # enough.
+    # The boundaries stamped below mark the steps this function drives; the
+    # importer's own progress calls are mapped onto the same three steps by
+    # ``_make_staging_progress``, because an importer that embeds inside
+    # ``run()`` is embedding whatever step number the last stamp left behind
+    # (#3593).
     task = _start_import_task(
         prefix="_staging_",
         family=_STAGE_TASK,
@@ -1043,23 +1109,25 @@ def _stage_importer_in_background(importer, field_values: dict, label: str = "")
     tracker.update("loading", "Preparing dataset…", 0, 0, step=1, total_steps=_TOTAL_STAGE_STEPS)
 
     def stage_task():
+        controller = _LoadGateController(tracker, task.total_steps)
         # Route the importer's own progress calls (and embedding progress)
-        # into this task's tracker instead of the global singleton.
-        set_thread_progress(tracker.update)
+        # into this task's tracker instead of the global singleton, mapped onto
+        # this task's steps on the way.
+        set_thread_progress(_make_staging_progress(controller, tracker))
         # A staging import of a demo reads the same embeddings pkl a full import
         # writes, so it forks on the same cache and must record which branch it
-        # took. #3345 measured this leg at 0.000-0.002 s across all four image
-        # tiers for exactly that reason (#3521).
+        # took.
         timing_recorder.bind_thread()
-        controller = _LoadGateController(tracker, task.total_steps)
         try:
             controller.acquire_download()
             temp_medias: dict = {}
             importer.run(field_values, temp_medias)
             apply_custom_metadata_md5(temp_medias)
-            # Hand the download gate back before the embed so a queued import
-            # can start fetching while this one holds only the embed slot —
-            # the same download→embed handoff the load pipeline makes.
+            # Backstop for the handoff ``_make_staging_progress`` normally makes
+            # on the importer's first ``"embedding"`` status: an importer that
+            # embeds nothing itself (every non-demo source) never fires one, and
+            # would otherwise hold the download gate through the embed below.
+            # No-op when the swap already happened mid-run.
             controller.swap_to_embed()
             tracker.update("embedding", "Embedding…", 0, 0, step=2, total_steps=_TOTAL_STAGE_STEPS)
             embed_missing(temp_medias, field_values.get("embedder", "") or "", on_progress=tracker.update)

--- a/vtscore/timing/recorder.py
+++ b/vtscore/timing/recorder.py
@@ -36,9 +36,13 @@ The second exists because the first cannot see the caches that are not the
 encoder, and those are on **disk**, so they outlive the process a cold/warm
 ledger is scoped to. #3345 measured two: a ``dataset_open`` whose coverage step
 restored the atlas cached in its pickle on all 16 opens and never once rebuilt
-it, and a ``dataset_stage`` whose embed step read the embeddings pkl the
-``dataset_load`` leg before it had just written — 0.000–0.002 s across all four
-image tiers, in a different process (#3521).
+it, and a ``dataset_load``/``dataset_stage`` embed that read the demo
+embeddings pkl instead of embedding. (The ``dataset_stage`` half of that second
+one turned out to be a misdiagnosis: its embed step read 0.000–0.002 s across
+all four image tiers because the importer's embedding was being recorded under
+``acquire``, not because a cache was hit. #3521 §5 cleared the cache and the
+step still read zero; #3593 moved the boundary. The branch marker is what made
+that legible in one look.)
 
 **Cold vs warm.** Every row also carries ``cold_model``: whether this run was
 the first in the process to need its ``(media_type, embedder)`` encoder, and so

--- a/vtscore/timing/tasks.py
+++ b/vtscore/timing/tasks.py
@@ -27,7 +27,9 @@ that step's slot.
 before the profile existed, so an instance with no ``VTSEARCH_TIMING_PROFILE``
 paces exactly as it did. They are *pseudo-seconds*: only their ratios are
 meaningful, because nobody measured them. A profile replaces them with real
-seconds, which is what makes the ETA stop drifting.
+seconds, which is what makes the ETA stop drifting. One vector is no longer a
+transcription — ``dataset_stage``'s was re-derived from measured rows once its
+step boundary was corrected (#3593); its comment below says from which.
 """
 
 from __future__ import annotations
@@ -152,11 +154,24 @@ TASKS: dict[str, TaskSpec] = {
     # teach that finalize is free. No byte-scaled phases here — the staging path
     # is never told an archive size, so a per-MB rate would have nothing to
     # divide by.
+    #
+    # These are the one set of default terms not transcribed from a pre-profile
+    # hand-tuned vector. The shipped ``(0.30, 0.60, 0.10)`` budgeted 60 % of the
+    # bar to a step that measured 0.000–0.002 s on every run ever recorded,
+    # because the importer's embedding was landing under ``acquire``
+    # (``_STAGE_STATUS_TO_STEP`` in ``vtscore/datasets/load_pipeline.py`` is the
+    # fix). Re-derived from #3521 §5's image rows, reading the old ``acquire``
+    # slope as the embed it actually was: embed ``0.0136 s/item``, serialize
+    # ``~0.0042 s/item`` — 76:24, which is the 0.72:0.23 below. Acquire measured
+    # near zero there (a demo's acquisition is a cached local read, and its fresh
+    # rows leave no residual once the embed line is subtracted); it gets 0.05
+    # rather than 0.02 because the only importer these rows cover is the demo
+    # one, and a server-folder or upload import spends real I/O in that step.
     "dataset_stage": _linear(
         "dataset_stage",
         ("acquire", "embed", "serialize"),
         "media items staged",
-        (0.30, 0.60, 0.10),
+        (0.05, 0.72, 0.23),
         loads_encoder=True,
     ),
     # Loading a saved detector: read its labelset, pull the label examples back


### PR DESCRIPTION
Closes #3593

`dataset_stage` declares `acquire`, `embed`, `serialize`, and the timing recorder labels a measured duration with whichever step the tracker was on when it ran. The staging flow bound the importer's progress sink straight to `tracker.update`, so the importer's own calls arrived stepless, the tracker kept step 1 for the whole of `run()`, and every demo source — which embeds *inside* `run()` — had its embedding recorded as `acquire`.

[#3521 §5](https://github.com/samggreenberg/VTSearch/blob/dev/docs/experiments/2026-09-03-drive-cold-3521/REPORT.md) fitted that step at `b = 0.0136 s/item, r² 0.9995` — an embed curve wearing the wrong step's name — beside an `embed` at `b = 7.2e-07`, on a sweep that cleared the embeddings cache before every rep. Clearing the cache moved 11–40 s of real embedding into the run and `embed` did not move, because the boundary put it there, not the cache.

## Which option

The issue offered two: move the boundary, or rename the steps. **Moved the boundary**, because these names are already shared vocabulary rather than local labels — `dataset_load` maps importer statuses onto its own step numbers (`_STATUS_TO_STEP`) and gets a real embed out of it, and the fitter, the profile JSON and the `CHEAP_BRANCHES` / `DEAR_BRANCHES` table all key on `embed`. Renaming would have forked one vocabulary into two.

## What changed

**`_make_staging_progress`** (`vtscore/datasets/load_pipeline.py`) mirrors `_make_stepped_progress`, with two deliberate differences — both because staging has no `AdaptiveLoadPacer` between the importer and the tracker:

- a status the map does not know leaves `step` **unset** rather than passing `None`, so the tracker keeps the step it was last told instead of nulling the whole-job fraction;
- the step never walks backwards. A demo's clipper reports its clip embedding under a plain `"loading"` status, which would otherwise send the bar back to acquire after the embed slice had started.

It also drops the importer's terminal `"idle"` — `load_demo_dataset` ends with one, which used to park the staging task at idle mid-run — while forwarding an `error` riding along with it.

**The gate handoff the flow's own docstring already claimed.** Staging swapped the download gate for the embed gate only after `run()` returned, so a demo staging did its embedding while holding the *download* gate — the one whose limit exists to bound how many datasets fetch at once. The swap now fires on the first `"embedding"` status; the post-`run()` call stays as the backstop for importers that embed nothing themselves.

**Re-derived `default_terms`** from #3521 §5's image rows, reading the old `acquire` slope as the embed it actually was: embed `0.0136 s/item`, serialize `~0.0042 s/item` — 76:24, which is the `0.72 : 0.23` shipped here. Acquire measured near zero on those rows (a demo's acquisition is a cached local read, and the fresh rows leave no residual once the embed line is subtracted); it gets `0.05` rather than `0.02` because the only importer those rows cover is the demo one, and a server-folder or upload import spends real I/O there. This is the one default vector that is no longer a transcription of a pre-profile hand-tuned guess, so the module docstring says so.

**Three comments that repeated the misdiagnosis** — in `recorder.py`, the staging body, and `tune_timing_profile.py`'s `drive_dataset_stage` — now say the cache was innocent, and the tuning script's docstring warns that a profile fitted from rows recorded before this fix prices `embed` at nothing.

## Tests

- `tests_lib/datasets/test_staging_progress_steps.py` (new, 10 tests) pins the status→step map, both deliberate divergences from the load pipeline's version, the dropped-but-not-swallowed terminal `"idle"`, and the mid-`run()` gate handoff.
- `tests/datasets/test_dataset_load_timing_rows.py` grows an end-to-end class driving `_stage_importer_in_background` with an importer that embeds inside `run()`, against a fake clock patched into the recorder alone. Two of its three tests fail on `dev` (`acquire` reads 3.0 s and 21.0 s where the embed grew from 2 s to 20 s); the third guards that the run still reaches its last step, so the fitter keeps accepting it.

## Test run

Full `./run-tests.sh`: every gate green, 10584 passed. The 4 failures in `tests_lib/meta/test_pile_class_rules.py` are pre-existing on `dev` — reproduced on a clean `origin/dev` worktree at `af42d4b1`, unrelated to this diff, and already filed as #3625 (two merged PRs each added a module-level `SCALE_CLASS_RULES` to `pile_config.py` and the clean merge kept both) with a fix promised there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LCGR156EwwopMsd57B5yo

---
_Generated by [Claude Code](https://claude.ai/code/session_018LCGR156EwwopMsd57B5yo)_