### PR TITLE
Scope the Dashboard's Export Labels to the detector row it was clicked on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **The Dashboard's `⋯` › Export labels now exports the detector whose row you
+  clicked.** It exported the *active* pair's live labels instead - whatever the
+  top-bar pulldown was on, which the row's checkbox does not change - so the
+  same row gave three different answers depending only on where the app had
+  been: the right labels when the pulldown happened to agree, nothing at all
+  after a refresh left no detector active, and the entire dataset after a Find
+  run, because Find fills that pair's votes with the detector's own call for
+  every item (they are presumptions, deliberately kept out of the labelset, and
+  the export was reading them as labels). The row action now names its detector
+  and reads that detector's persisted labelset - the exact artefact that
+  re-imports as the detector - so it is right whatever else the app is pointed
+  at. The Find and Train windows' exports are unchanged: there the live session
+  *is* what you are exporting.
+
 - **The text-sort progress bar no longer reserves most of itself for a model
   load that has already happened.** `text_sort` paces three steps -- load the
   embedder, embed the query, score every media -- and the first one is either

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1278,7 +1278,15 @@ vote state on load — without that, the next vote's labelset resync would erase
 every recorded vote's provenance, the bug `region_box` shipped with.
 
 The `GET /api/labels/export` endpoint returns a `LabelSet` serialised
-as JSON.  The format is backward-compatible: old consumers that only
+as JSON.  It answers two different questions, and the caller picks which:
+without `detector_name` it composes the **active pair's live labels** (votes
+∩ the active dataset, topped up from the labelset for elements the dataset
+can't see); with `detector_name` it reads **that detector's persisted
+labelset** off disk, independent of the active pair and of any live Find
+session.  A caller naming a detector in a list — the Dashboard's row action —
+wants the second: the first would follow the top-bar pulldown, and during a
+Find run those votes are the detector's call for every item in the dataset,
+not labels.  The format is backward-compatible: old consumers that only
 read `md5` + `label` continue to work.  With `enrich=true`, each entry
 gains `custom_metadata` (merged from media type display metadata, the
 media's `custom_metadata`, and the flattened `origin.params`) and the

--- a/docs/api/medias.md
+++ b/docs/api/medias.md
@@ -770,6 +770,14 @@ GET /api/labels/export
   include `origin_only` fallback entries.
 - `?enrich=1` (optional): add per-entry `custom_metadata` and a top-level
   `available_columns` list (see the flattened `origin.params` note above).
+- `?detector_name=<name>` (optional): export **that** detector's persisted
+  labelset, read from its JSON file, instead of the active pair's live
+  labels. Independent of `X-Dataset-Id` / `X-Detector-Id` and of any live
+  Find session, so a caller naming a detector in a list (the Dashboard's row
+  action) gets that detector's labels whatever the app is pointed at. The
+  session-scoped `label_filter` modes are refused with 400 here — they
+  partition a session this export has no part in — and an unknown name is a
+  404.
 - `?format=ndjson` (optional): stream the response as newline-delimited JSON
   (`application/x-ndjson`), one label entry per line, instead of the buffered
   `{"labels": [...]}` object. Use for large exports that shouldn't be
@@ -797,7 +805,8 @@ region) appear when the underlying element has them. The export is a faithful
 rendering of the **detector's** labelset, not just the session's votes: elements
 that don't resolve into the active dataset are appended and marked
 `"origin_only": true`. Entries where the user changed the detector's original
-label carry `"is_correction": true`.
+label carry `"is_correction": true` (never under `detector_name`, whose rows
+belong to a detector the live session says nothing about).
 
 ### Import labels
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -12226,7 +12226,7 @@
     },
     "/api/labels/export": {
       "get": {
-        "description": "Each label entry includes the element's ``origin`` and ``origin_name``\nso consumers know exactly where each labeled element came from. The\nformat is a superset of the legacy export format; old consumers\nthat only read ``md5`` and ``label`` keys continue to work unchanged.\n\nThe payload is composed from the session's votes intersected with the\nactive dataset, then topped up with persisted labelset elements that\ndon't resolve into the active dataset (marked ``origin_only: true``) so\nthe export is always a faithful rendering of the detector's labelset -\nsee :func:`_origin_only_fallback_entries`.",
+        "description": "Each label entry includes the element's ``origin`` and ``origin_name``\nso consumers know exactly where each labeled element came from. The\nformat is a superset of the legacy export format; old consumers\nthat only read ``md5`` and ``label`` keys continue to work unchanged.\n\nWithout ``detector_name`` the payload is composed from the session's\nvotes intersected with the active dataset, then topped up with persisted\nlabelset elements that don't resolve into the active dataset (marked\n``origin_only: true``) so the export is always a faithful rendering of\nthe detector's labelset - see :func:`_origin_only_fallback_entries`.\n\nWith ``detector_name`` it is that detector's persisted labelset instead,\nread from disk and independent of the request's active pair - see\n:func:`_export_persisted_labelset`.",
         "operationId": "export_labels",
         "parameters": [
           {
@@ -12269,6 +12269,16 @@
             }
           },
           {
+            "description": "Name of the detector whose *persisted* labelset to export. When given, the export is read from that detector's JSON file and is independent of the request's active dataset/detector pair and of any live Find session; the vote-scoped filters (``corrections`` / ``unverified`` / ``verified``) are rejected with 400 because they partition that session. Omit it to export the active pair's live labels.",
+            "in": "query",
+            "name": "detector_name",
+            "required": false,
+            "schema": {
+              "default": "",
+              "type": "string"
+            }
+          },
+          {
             "description": "Response encoding. ``json`` (default) returns the buffered ``{labels: [...]}`` object. ``ndjson`` streams one label entry per line (newline-delimited JSON, ``application/x-ndjson``) so large exports are never materialised in memory; the top-level ``available_columns`` list is omitted in this mode since it's a whole-set aggregate a streamed response can't compute.",
             "in": "query",
             "name": "format",
@@ -12293,6 +12303,12 @@
               }
             },
             "description": "OK"
+          },
+          "400": {
+            "description": "A vote-scoped label_filter was combined with detector_name."
+          },
+          "404": {
+            "description": "detector_name names a detector that does not exist."
           },
           "422": {
             "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"

--- a/frontend/src/app/components/dashboard/dashboard.component.html
+++ b/frontend/src/app/components/dashboard/dashboard.component.html
@@ -349,6 +349,7 @@
 @if (modals.export.open) {
   <vt-export-modal
     [detectorName]="modals.export.detectorName"
+    [labelsetDetectorName]="modals.export.detectorName"
     (closed)="modals.closeExport()"
     (exported)="modals.closeExport()"
   />

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.spec.ts
@@ -230,6 +230,39 @@ describe('ExportModalComponent', () => {
     });
   });
 
+  // The Dashboard row action names a detector in a list, so its read must be
+  // that detector's persisted labelset rather than whatever pair the top-bar
+  // pulldown is on — and must survive a live Find session, which fills that
+  // pair's votes with the detector's call for every item (issue #3639).
+  describe('labelset-scoped read', () => {
+    it('asks for the named detector when one is given', async () => {
+      fixture.componentRef.setInput('labelsetDetectorName', 'Sirens');
+      TestBed.tick();
+      await settleResource();
+      httpMock
+        .expectOne('/api/dataset/status')
+        .flush({ display_name: 'My Dataset' });
+      httpMock.expectOne('/api/exporters').flush(mockExporters);
+      const req = httpMock.expectOne((r) => r.url === '/api/labels/export');
+      expect(req.request.params.get('detector_name')).toBe('Sirens');
+      req.flush(mockLabels);
+      await settleResource();
+    });
+
+    it('reads the live session when no detector is named', async () => {
+      TestBed.tick();
+      await settleResource();
+      httpMock
+        .expectOne('/api/dataset/status')
+        .flush({ display_name: 'My Dataset' });
+      httpMock.expectOne('/api/exporters').flush(mockExporters);
+      const req = httpMock.expectOne((r) => r.url === '/api/labels/export');
+      expect(req.request.params.has('detector_name')).toBe(false);
+      req.flush(mockLabels);
+      await settleResource();
+    });
+  });
+
   it('reports correction availability', async () => {
     await flushInit();
     expect(component.hasCorrections).toBe(true);

--- a/frontend/src/app/components/modals/export-modal/export-modal.component.ts
+++ b/frontend/src/app/components/modals/export-modal/export-modal.component.ts
@@ -63,6 +63,17 @@ export interface ColumnDef {
 export class ExportModalComponent implements OnInit {
   readonly detectorName = input('');
   /**
+   * Name of the detector whose *persisted* labelset to export, when the
+   * caller is naming one rather than exporting the pair it is working in.
+   *
+   * The Dashboard's row action is the case: it points at a detector in a
+   * list, so the answer must not depend on which pair the top-bar pulldown
+   * happens to be on — and must not be the whole collection when a Find run
+   * has filled that pair's votes with the detector's per-item calls (issue
+   * #3639). Empty (the Find and Train callers) keeps the live read.
+   */
+  readonly labelsetDetectorName = input('');
+  /**
    * What the caller is exporting, which decides both the default category and
    * how a one-sided selection is framed.
    *
@@ -116,7 +127,11 @@ export class ExportModalComponent implements OnInit {
     stream: () => {
       const labelFilter =
         this.serverFilter === 'both' ? undefined : this.serverFilter;
-      return this.sortingApi.exportLabels(false, { enrich: true, labelFilter });
+      return this.sortingApi.exportLabels(false, {
+        enrich: true,
+        labelFilter,
+        detectorName: this.labelsetDetectorName(),
+      });
     },
   });
 

--- a/frontend/src/app/services/sorting-api.service.spec.ts
+++ b/frontend/src/app/services/sorting-api.service.spec.ts
@@ -100,6 +100,20 @@ describe('SortingApiService', () => {
     req.flush({ labels: [] });
   });
 
+  it('exportLabels with detectorName should scope to that detector', () => {
+    service.exportLabels(false, { detectorName: 'My Detector' }).subscribe();
+    const req = httpMock.expectOne(r => r.url === '/api/labels/export');
+    expect(req.request.params.get('detector_name')).toBe('My Detector');
+    req.flush({ labels: [] });
+  });
+
+  it('exportLabels omits detector_name when no detector is named', () => {
+    service.exportLabels(false, { enrich: true }).subscribe();
+    const req = httpMock.expectOne(r => r.url === '/api/labels/export');
+    expect(req.request.params.has('detector_name')).toBe(false);
+    req.flush({ labels: [] });
+  });
+
   it('importLabels should POST', () => {
     service.importLabels({ labels: [{ md5: 'abc', label: 'good' }] }).subscribe(data => {
       expect(data.applied).toBe(1);

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -134,14 +134,21 @@ export class SortingApiService {
     );
   }
 
+  /** Fetch labels for export.
+   *
+   *  ``detectorName`` switches the read from the active pair's live labels to
+   *  that detector's *persisted* labelset, which is what a caller naming a
+   *  detector in a list (the Dashboard row action) means — see the route's
+   *  ``detector_name`` param. */
   exportLabels(
     goodsOnly?: boolean,
-    options?: { enrich?: boolean; labelFilter?: ServerLabelFilter },
+    options?: { enrich?: boolean; labelFilter?: ServerLabelFilter; detectorName?: string },
   ): Observable<LabelsExportResponse> {
     return exportLabels(this.http, this.config.rootUrl, {
       goods_only: goodsOnly || undefined,
       enrich: options?.enrich || undefined,
       label_filter: options?.labelFilter || undefined,
+      detector_name: options?.detectorName || undefined,
     }).pipe(map((r) => r.body));
   }
 

--- a/tests/io/test_labels.py
+++ b/tests/io/test_labels.py
@@ -420,3 +420,155 @@ class TestExportOriginOnlyFallback:
         assert ghost["custom_metadata"]["shard"] == "elsewhere"
         assert "contentID" in data["available_columns"]
         assert "shard" in data["available_columns"]
+
+
+class TestExportNamedDetectorLabelset:
+    """``?detector_name=`` exports a *named* detector's persisted labelset.
+
+    The Dashboard's row action points at a detector in a list, so its export
+    must answer "what is detector X's labelset" rather than "what is labelled
+    in whatever pair the top-bar pulldown is on" — the mismatch behind issue
+    #3639, where the same row exported the right labels, then nothing, then
+    the entire dataset depending only on where the ambient context had been.
+    """
+
+    GHOST = {
+        "md5": "d" * 32,
+        "label": "good",
+        "origin": {"importer": "test", "params": {"shard": "elsewhere"}},
+        "origin_name": "ghost_named.wav",
+        "filename": "ghost_named.wav",
+        "metadata": {"contentID": "c-999"},
+    }
+
+    def _detector_with_labels(self, client, name="NamedExport"):
+        """Create + load a detector, vote one good and one bad, return its name."""
+        if len(medias) < 2:
+            pytest.skip("Need at least 2 medias")
+        ids = list(medias.keys())
+        good_cid, bad_cid = ids[0], ids[1]
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": name, "media_type": "audio", "text_query": "test"},
+        )
+        detector_id = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, detector_id)
+        client.post(f"/api/medias/{good_cid}/vote", json={"target": "good"})
+        client.post(f"/api/medias/{bad_cid}/vote", json={"target": "bad"})
+        return name, detector_id, good_cid, bad_cid
+
+    def test_exports_the_named_detector_with_no_active_detector(self, client):
+        """The headline: the row action names the detector, and the ambient
+        pair is irrelevant. Symptom 2 of #3639 exported nothing here."""
+        name, _, good_cid, bad_cid = self._detector_with_labels(client)
+
+        # Fresh request with no X-Detector-Id at all, as a Dashboard visit
+        # after a page refresh sends.
+        from vtscore.state.core import get_active_detector_context
+
+        det_ctx = get_active_detector_context()
+        det_ctx.good_votes.clear()
+        det_ctx.bad_votes.clear()
+
+        data = client.get(f"/api/labels/export?detector_name={name}").get_json()
+        assert {e["label"] for e in data["labels"]} == {"good", "bad"}
+        assert {e["md5"] for e in data["labels"]} == {
+            medias[good_cid]["md5"],
+            medias[bad_cid]["md5"],
+        }
+
+    def test_live_find_session_does_not_leak_into_the_export(self, client):
+        """Symptom 3: Find fills the detector's votes with its own call for
+        every item in the dataset, flagged ``find_mode`` so they stay out of
+        the labelset. A labelset export must not resurrect them as labels."""
+        name, _, good_cid, _ = self._detector_with_labels(client)
+
+        from vtscore.state.core import get_active_detector_context
+
+        det_ctx = get_active_detector_context()
+        det_ctx.find_mode = True
+        # Find's presumptions: a call for *every* media in the dataset.
+        det_ctx.good_votes.clear()
+        det_ctx.bad_votes.clear()
+        det_ctx.good_votes.update({cid: None for cid in medias})
+        det_ctx.find_scores.update({cid: 0.9 for cid in medias})
+
+        # The session-scoped export sees the whole collection...
+        live = client.get("/api/labels/export").get_json()["labels"]
+        assert len(live) == len(medias)
+
+        # ...while the detector-scoped one stays the two real labels.
+        scoped = client.get(f"/api/labels/export?detector_name={name}").get_json()["labels"]
+        assert len(scoped) == 2
+        assert {e["label"] for e in scoped} == {"good", "bad"}
+        assert medias[good_cid]["md5"] in {e["md5"] for e in scoped}
+
+    def test_other_detectors_labelset_is_not_exported(self, client):
+        """Two detectors, one active: naming the other one exports the other
+        one's labels, not the active pair's."""
+        ids = list(medias.keys())
+        first, first_id, first_good, _ = self._detector_with_labels(client, "FirstDetector")
+        res = client.post(
+            "/api/detectors/registry",
+            json={"name": "SecondDetector", "media_type": "audio", "text_query": "test"},
+        )
+        second_id = res.get_json()["detector"]["id"]
+        _load_detector_and_wait(client, second_id)
+        second_good = ids[2] if len(ids) > 2 else ids[0]
+        client.post(f"/api/medias/{second_good}/vote", json={"target": "good"})
+
+        # SecondDetector is the active one now; ask for FirstDetector's.
+        data = client.get(f"/api/labels/export?detector_name={first}").get_json()
+        assert {e["md5"] for e in data["labels"]} == {
+            medias[first_good]["md5"],
+            medias[list(medias.keys())[1]]["md5"],
+        }
+        assert first_id != second_id
+
+    def test_good_and_bad_filters_apply(self, client):
+        name, _, good_cid, bad_cid = self._detector_with_labels(client)
+
+        goods = client.get(f"/api/labels/export?detector_name={name}&goods_only=true").get_json()
+        assert {e["md5"] for e in goods["labels"]} == {medias[good_cid]["md5"]}
+
+        bads = client.get(f"/api/labels/export?detector_name={name}&label_filter=bad").get_json()
+        assert {e["md5"] for e in bads["labels"]} == {medias[bad_cid]["md5"]}
+
+    def test_unresolvable_element_is_marked_origin_only(self, client):
+        from vtscore.detectors.dataset_sync import reset_mtime_cache_for_tests
+        from vtscore.detectors.store import _detector_path, _read_detector, _write_detector
+
+        name, _, _, _ = self._detector_with_labels(client)
+        path = _detector_path(name)
+        data = _read_detector(path)
+        assert data is not None
+        data.setdefault("labelset", {}).setdefault("labels", []).append(dict(self.GHOST))
+        _write_detector(path, data)
+        reset_mtime_cache_for_tests()
+
+        exported = client.get(f"/api/labels/export?detector_name={name}&enrich=true").get_json()
+        by_name = {e.get("origin_name"): e for e in exported["labels"]}
+        ghost = by_name["ghost_named.wav"]
+        assert ghost["origin_only"] is True
+        assert ghost["custom_metadata"]["contentID"] == "c-999"
+        # Elements the active dataset *can* see are ordinary labels.
+        resolved = [e for e in exported["labels"] if e.get("origin_name") != "ghost_named.wav"]
+        assert resolved and all("origin_only" not in e for e in resolved)
+
+    def test_ndjson_matches_the_buffered_export(self, client):
+        name, _, _, _ = self._detector_with_labels(client)
+        buffered = client.get(f"/api/labels/export?detector_name={name}").get_json()["labels"]
+        streamed = _read_ndjson(client.get(f"/api/labels/export?detector_name={name}&format=ndjson"))
+        assert streamed == buffered
+
+    def test_unknown_detector_is_404(self, client):
+        resp = client.get("/api/labels/export?detector_name=NoSuchDetector")
+        assert resp.status_code == 404
+
+    def test_vote_scoped_filters_are_refused(self, client):
+        """They partition the live session, which a persisted labelset has no
+        part in; refusing beats silently exporting something else."""
+        name, _, _, _ = self._detector_with_labels(client)
+        for label_filter in ("corrections", "unverified", "verified"):
+            resp = client.get(f"/api/labels/export?detector_name={name}&label_filter={label_filter}")
+            assert resp.status_code == 400, label_filter

--- a/vtsearch/routes/labels/vote.py
+++ b/vtsearch/routes/labels/vote.py
@@ -247,27 +247,65 @@ def _origin_only_fallback_entries(
 
     from vtscore.datasets.labelset import element_key
 
+    seen = {element_key(el) for el in labelset.elements}
+    seen.discard(None)
+
+    return _serialise_persisted_elements(
+        persisted.elements,
+        all_medias,
+        label_filter,
+        goods_only,
+        seen=seen,
+        skip_resolved=True,
+    )
+
+
+def _serialise_persisted_elements(
+    elements,
+    all_medias: dict,
+    label_filter: str,
+    goods_only: bool,
+    *,
+    seen: set | None = None,
+    skip_resolved: bool = False,
+) -> list[dict]:
+    """Serialise on-disk labelset elements into export entries.
+
+    Shared by the two paths that read straight from a detector's persisted
+    labelset, which differ only in what they skip:
+
+    * :func:`_origin_only_fallback_entries` tops up a *vote-derived* export,
+      so it passes the vote-derived keys as *seen* and sets *skip_resolved*:
+      an element the active dataset can see is the session's to represent.
+    * :func:`_export_persisted_labelset` renders the labelset on its own, so
+      it skips nothing and every element is emitted.
+
+    ``origin_only`` marks an entry whose media does not resolve into the
+    active dataset, in both paths - a resolved entry from the second path is
+    a normal label, not a provenance-only rendering.
+    """
+    from vtscore.datasets.labelset import element_key
+
     if all_medias:
         origin_lookup, md5_lookup, name_lookup = cached_media_lookups()
     else:
         origin_lookup, md5_lookup, name_lookup = {}, {}, {}
 
-    seen = {element_key(el) for el in labelset.elements}
-    seen.discard(None)
-
     entries: list[dict] = []
-    for el in persisted.elements:
+    for el in elements:
         if el.label not in ("good", "bad"):
             continue
         if not _fallback_passes_filter(el.label, label_filter, goods_only):
             continue
-        key = element_key(el)
-        if key is not None and key in seen:
-            continue
+        if seen:
+            key = element_key(el)
+            if key is not None and key in seen:
+                continue
         entry = el.to_dict()
-        if resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup):
+        if not resolve_media_ids(entry, origin_lookup, md5_lookup, name_lookup):
+            entry["origin_only"] = True
+        elif skip_resolved:
             continue
-        entry["origin_only"] = True
         entries.append(entry)
     return entries
 
@@ -308,7 +346,9 @@ def _make_enricher(all_medias: dict):
     importer's own ``custom_metadata``.  Entries with no media in the active
     dataset degrade to :func:`_build_unresolved_entry_metadata`.
     """
-    md5_lookup = cached_md5_lookup()
+    # No medias means no resolution to do, and the lookup itself reads the
+    # active dataset context - which the detector-scoped export may not have.
+    md5_lookup = cached_md5_lookup() if all_medias else {}
 
     def enrich(entry: dict) -> set[str]:
         cids = md5_lookup.get(entry.get("md5") or "")
@@ -334,9 +374,73 @@ def _enrich_with_metadata(result: dict, all_medias: dict) -> None:
     result["available_columns"] = _BASE_EXPORT_COLUMNS + extra_keys
 
 
+def _export_persisted_labelset(name: str, query: dict):
+    """Export a *named* detector's on-disk labelset, ignoring the live session.
+
+    The session-composed path below answers "what has the human labelled in
+    the active (dataset, detector) pair right now"; this one answers "what is
+    detector X's labelset", which is a different question and the one the
+    Dashboard's row action asks - it names a detector in a list, and the
+    answer must not depend on which pair the top-bar pulldown happens to be
+    pointing at (issue #3639).  Reading the detector JSON is what makes that
+    true: the labelset on disk is kept in step with every vote by
+    :func:`~vtscore.detectors.label_sync.sync_labels_to_loaded_detector`, so
+    it is current, and it is the exact artefact that re-imports as the
+    detector.
+
+    It is also the only reading that survives a live Find session.  Find
+    replaces the detector's in-memory votes with its own call for *every*
+    item in the dataset, flagged ``find_mode`` so the sync above keeps those
+    presumptions out of the labelset (see ``end_find_session``); composing
+    from votes would export the whole collection as labels.
+
+    The vote-scoped filters partition that live session, so they have no
+    meaning here and are refused rather than silently ignored.
+    """
+    from vtscore.datasets.labelset import LabelSet
+    from vtscore.detectors.store import _detector_path, _read_detector
+    from vtscore.state.core import DatasetNotLoadedError
+    from vtsearch.state import medias
+
+    label_filter = query["label_filter"]
+    if label_filter in _VOTE_SCOPED_FILTERS:
+        abort(
+            400,
+            message=(
+                f"label_filter='{label_filter}' partitions the live vote session and "
+                "cannot be combined with detector_name, which exports a persisted labelset."
+            ),
+        )
+
+    data = _read_detector(_detector_path(name))
+    if data is None:
+        abort(404, message=f"Detector '{name}' not found")
+
+    labelset = LabelSet.from_dict(data.get("labelset") or {})
+    # The active dataset is only ever *enrichment* here, so an absent or
+    # unloaded one degrades to an unenriched export rather than failing it:
+    # the whole point of this path is that the labels do not depend on which
+    # pair the app happens to be pointed at.
+    try:
+        all_medias = dict(medias)
+    except DatasetNotLoadedError:
+        all_medias = {}
+    entries = _serialise_persisted_elements(labelset.elements, all_medias, label_filter, query["goods_only"])
+
+    if query["format"] == "ndjson":
+        return _stream_labels_ndjson(LabelSet(), all_medias, label_filter, query["enrich"], entries, annotate=False)
+
+    result: dict = {"labels": entries}
+    if query["enrich"]:
+        _enrich_with_metadata(result, all_medias)
+    return result
+
+
 @labels_bp.route("/api/labels/export")
 @labels_bp.arguments(LabelsExportQuerySchema, location="query")
 @labels_bp.response(200, LabelsExportResponseSchema)
+@labels_bp.alt_response(400, description="A vote-scoped label_filter was combined with detector_name.")
+@labels_bp.alt_response(404, description="detector_name names a detector that does not exist.")
 def export_labels(query: dict):
     """Export labels as a :class:`~vtscore.datasets.labelset.LabelSet`.
 
@@ -345,13 +449,20 @@ def export_labels(query: dict):
     format is a superset of the legacy export format; old consumers
     that only read ``md5`` and ``label`` keys continue to work unchanged.
 
-    The payload is composed from the session's votes intersected with the
-    active dataset, then topped up with persisted labelset elements that
-    don't resolve into the active dataset (marked ``origin_only: true``) so
-    the export is always a faithful rendering of the detector's labelset -
-    see :func:`_origin_only_fallback_entries`.
+    Without ``detector_name`` the payload is composed from the session's
+    votes intersected with the active dataset, then topped up with persisted
+    labelset elements that don't resolve into the active dataset (marked
+    ``origin_only: true``) so the export is always a faithful rendering of
+    the detector's labelset - see :func:`_origin_only_fallback_entries`.
+
+    With ``detector_name`` it is that detector's persisted labelset instead,
+    read from disk and independent of the request's active pair - see
+    :func:`_export_persisted_labelset`.
     """
     from vtscore.datasets.labelset import LabelSet
+
+    if query["detector_name"]:
+        return _export_persisted_labelset(query["detector_name"], query)
 
     label_filter = query["label_filter"]
     # Atomic (medias, good_votes, bad_votes, vote_region_boxes) snapshot so
@@ -391,7 +502,13 @@ def export_labels(query: dict):
 
 
 def _stream_labels_ndjson(
-    labelset, all_medias: dict, label_filter: str, enrich: bool, fallback_entries: list[dict] | None = None
+    labelset,
+    all_medias: dict,
+    label_filter: str,
+    enrich: bool,
+    fallback_entries: list[dict] | None = None,
+    *,
+    annotate: bool = True,
 ):
     """Stream the labelset as newline-delimited JSON, one label entry per line (S13).
 
@@ -404,6 +521,8 @@ def _stream_labels_ndjson(
     non-corrections under ``label_filter=corrections``, then enrich).
     *fallback_entries* (origin-only labelset elements, already serialised)
     stream after the vote-derived rows through the same annotation pipeline.
+    *annotate* is off for the detector-scoped export, whose rows belong to a
+    detector the request's live Find session says nothing about.
 
     The top-level ``available_columns`` list has no place in NDJSON: it's a
     whole-set aggregate that can't be emitted before the last row is seen, and
@@ -414,14 +533,14 @@ def _stream_labels_ndjson(
 
     from flask import Response, stream_with_context
 
-    annotate = _make_correction_annotator(all_medias)
+    annotator = _make_correction_annotator(all_medias) if annotate else None
     enricher = _make_enricher(all_medias) if enrich else None
     corrections_only = label_filter == "corrections"
 
     def generate():
         for entry in chain(labelset.iter_dicts(), fallback_entries or ()):
-            if annotate is not None:
-                annotate(entry)
+            if annotator is not None:
+                annotator(entry)
             if corrections_only and not entry.get("is_correction"):
                 continue
             if enricher is not None:

--- a/vtsearch/schemas/labels.py
+++ b/vtsearch/schemas/labels.py
@@ -98,6 +98,20 @@ class LabelsExportQuerySchema(Schema):
             ),
         },
     )
+    detector_name = fields.String(
+        load_default="",
+        metadata={
+            "description": (
+                "Name of the detector whose *persisted* labelset to export. When "
+                "given, the export is read from that detector's JSON file and is "
+                "independent of the request's active dataset/detector pair and of "
+                "any live Find session; the vote-scoped filters "
+                "(``corrections`` / ``unverified`` / ``verified``) are rejected "
+                "with 400 because they partition that session. Omit it to export "
+                "the active pair's live labels."
+            ),
+        },
+    )
     format = fields.String(
         load_default="json",
         validate=validate.OneOf(["json", "ndjson"]),


### PR DESCRIPTION
Closes #3639

## The bug

The `⋯` › **Export labels** action on a Dashboard detector row never said *which* detector it meant. It fetched `GET /api/labels/export`, which composes the **active pair's live labels** from the `X-Dataset-Id` / `X-Detector-Id` the interceptor attaches — and the row's checkbox does not touch that pair (only the top-bar pulldown and the Train/Find navigations do). So the same row gave a different answer depending only on where the app had been, which is exactly the three-step reproduction in the issue:

1. **Right count** — the pulldown happened to be on that detector.
2. **"No labels to export"** after a refresh — nothing was active, so there was no labelset to compose from.
3. **200 labels (the whole dataset)** after a Find run — `/api/find-label` leaves the detector's in-memory votes holding its own call for *every* item in the dataset, flagged `find_mode` so `sync_labels_to_loaded_detector` keeps those presumptions out of the labelset. The export was reading them straight back as labels. (Same class as #3212, where the Train window read the same votes.)

## The fix

`GET /api/labels/export` gains an optional `?detector_name=`, which reads **that detector's persisted labelset** off disk instead of composing the active pair's votes. It is independent of both context headers and of any live Find session, and it is the exact artefact that re-imports as the detector — which is what a caller naming a detector in a list means. The Dashboard row action passes it; the Find and Train windows do not, because there the live session *is* what is being exported.

Details:

- The vote-scoped filters (`corrections` / `unverified` / `verified`) partition a session this path has no part in, so they are refused with **400** rather than silently answering something else. An unknown name is a **404**.
- `is_correction` annotation is off for this path: those rows belong to a detector the request's live session says nothing about.
- The active dataset is only ever *enrichment* here, so an absent or unloaded one degrades to an unenriched export rather than failing it.
- Serialising persisted labelset elements is now shared with the origin-only fallback, which differs only in what it skips (`skip_resolved` / `seen`). `origin_only` still marks entries whose media don't resolve into the active dataset, in both paths.

## Tests

`tests/io/test_labels.py::TestExportNamedDetectorLabelset` reproduces all three symptoms at the HTTP level — export with no active detector, export with a *different* detector active, and export during a live `find_mode` session where the session-scoped read returns the whole collection and the scoped one returns the two real labels — plus the good/bad filters, `origin_only` marking, enrichment, NDJSON parity, the 404 and the 400. Frontend specs cover the new query param and the modal's scoped vs. live read. Full `./run-tests.sh` is green (10620 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9Ay1XAUVGKkH2d5LWNDJB

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9Ay1XAUVGKkH2d5LWNDJB)_