### PR TITLE
Embed the CLI's haystack at load, not incidentally at scoring

### DIFF
--- a/tests/cli/test_failed_embed_skips.py
+++ b/tests/cli/test_failed_embed_skips.py
@@ -15,6 +15,7 @@ and ``route_and_embed`` already used: drop the item, say so, score the rest.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -157,67 +158,110 @@ class TestTrainAndThresholdOverAPartlyEmbeddedHaystack:
         assert with_empty_snap == pytest.approx(with_no_snap)
 
 
+def _stage_folder_run(tmp_path, monkeypatch) -> tuple[str, str, str]:
+    """Stage a four-file audio folder, a detector over two of them, and settings.
+
+    Returns ``(folder, settings_path, out_path)`` ready for
+    ``autodetect_importer_main("server_folder", ...)``.
+    """
+    from contextlib import contextmanager
+
+    import vtscore.detectors.resolver as resolver_mod
+    from vtscore.detectors.store import _detector_path, _write_detector
+
+    folder = tmp_path / "sounds"
+    folder.mkdir()
+    files = {}
+    for i, name in enumerate(["alpha.wav", "beta.wav", "gamma.wav", "delta.wav"]):
+        path = folder / name
+        path.write_bytes(generate_wav(220 + 110 * i, 0.1))
+        files[name] = path
+
+    @contextmanager
+    def _fake_ctx(origin, origin_name="", filename=""):
+        yield files.get(origin_name) or files.get(filename)
+
+    monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
+
+    labelset = {
+        "labels": [
+            {
+                "md5": "a" * 32,
+                "label": "good",
+                "origin": {"importer": "ds_a", "params": {}},
+                "origin_name": "alpha.wav",
+            },
+            {
+                "md5": "c" * 32,
+                "label": "bad",
+                "origin": {"importer": "ds_a", "params": {}},
+                "origin_name": "gamma.wav",
+            },
+        ]
+    }
+    _write_detector(
+        _detector_path("folder-det"),
+        {"name": "folder-det", "media_type": "audio", "labelset": labelset},
+    )
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps({"autofind_detectors": ["folder-det"], "detectors_dir": str(get_detectors_dir())})
+    )
+    return str(folder), str(settings_path), str(tmp_path / "hits.json")
+
+
 class TestCliImporterRunCompletes:
     """End-to-end regression: ``--autodetect --importer server_folder`` used to
     exit(1) on every run, since the importer leaves each media unembedded and
     the training pass scored that raw chunk."""
 
     def test_folder_importer_autodetect_exports_hits(self, client, tmp_path, monkeypatch):
-        from contextlib import contextmanager
-
-        import vtscore.detectors.resolver as resolver_mod
         from vtscore.cli import autodetect_importer_main
-        from vtscore.detectors.store import _detector_path, _write_detector
 
-        folder = tmp_path / "sounds"
-        folder.mkdir()
-        files = {}
-        for i, name in enumerate(["alpha.wav", "beta.wav", "gamma.wav", "delta.wav"]):
-            path = folder / name
-            path.write_bytes(generate_wav(220 + 110 * i, 0.1))
-            files[name] = path
-
-        @contextmanager
-        def _fake_ctx(origin, origin_name="", filename=""):
-            yield files.get(origin_name) or files.get(filename)
-
-        monkeypatch.setattr(resolver_mod, "resolve_file_context", _fake_ctx)
-
-        labelset = {
-            "labels": [
-                {
-                    "md5": "a" * 32,
-                    "label": "good",
-                    "origin": {"importer": "ds_a", "params": {}},
-                    "origin_name": "alpha.wav",
-                },
-                {
-                    "md5": "c" * 32,
-                    "label": "bad",
-                    "origin": {"importer": "ds_a", "params": {}},
-                    "origin_name": "gamma.wav",
-                },
-            ]
-        }
-        _write_detector(
-            _detector_path("folder-det"),
-            {"name": "folder-det", "media_type": "audio", "labelset": labelset},
-        )
-
-        settings_path = tmp_path / "settings.json"
-        settings_path.write_text(
-            json.dumps({"autofind_detectors": ["folder-det"], "detectors_dir": str(get_detectors_dir())})
-        )
-        out_path = tmp_path / "hits.json"
+        folder, settings_path, out_path = _stage_folder_run(tmp_path, monkeypatch)
 
         autodetect_importer_main(
             "server_folder",
-            {"path": str(folder), "media_type": "audio"},
-            settings_path=str(settings_path),
+            {"path": folder, "media_type": "audio"},
+            settings_path=settings_path,
             exporter_name="server_json_file",
-            exporter_field_values={"filepath": str(out_path)},
+            exporter_field_values={"filepath": out_path},
         )
 
-        det = json.loads(out_path.read_text())["results"]["folder-det"]
+        det = json.loads(Path(out_path).read_text())["results"]["folder-det"]
         # All four files scored: none was dropped, and the run did not exit(1).
         assert len(det["hits"]) + len(det["negative_hits"]) == 4
+
+    def test_the_haystack_reaches_calibration_fully_embedded(self, client, tmp_path, monkeypatch):
+        """Issue #3556's second half.  ``train_from_labelset`` fits the detector's
+        threshold on the snap it is handed, and ``scoring_rows_for_snap`` drops
+        every media in it with no vector - so a snap that arrives part-embedded
+        calibrates the cut on a strict subset of the dataset, silently and
+        plausibly.  The CLI used to hand it the raw importer output and let
+        ``route_and_embed`` fill the vectors in afterwards.
+        """
+        import vtscore.detectors.labelset_training as labelset_training
+        from vtscore.cli import autodetect_importer_main
+        from vtscore.embedding.media_vectors import media_embedding
+
+        folder, settings_path, out_path = _stage_folder_run(tmp_path, monkeypatch)
+
+        snaps: list[list[bool]] = []
+        real = labelset_training.train_from_labelset
+
+        def _spy(ctx, labelset, media_type="", snap=None, **kw):
+            snaps.append([media_embedding(m) is not None for m in (snap or {}).values()])
+            return real(ctx, labelset, media_type=media_type, snap=snap, **kw)
+
+        monkeypatch.setattr(labelset_training, "train_from_labelset", _spy)
+
+        autodetect_importer_main(
+            "server_folder",
+            {"path": folder, "media_type": "audio"},
+            settings_path=settings_path,
+            exporter_name="server_json_file",
+            exporter_field_values={"filepath": out_path},
+        )
+
+        assert snaps == [[True] * 4]

--- a/tests/cli/test_failed_embed_skips.py
+++ b/tests/cli/test_failed_embed_skips.py
@@ -145,8 +145,9 @@ class TestTrainAndThresholdOverAPartlyEmbeddedHaystack:
         assert calls == []
 
     def test_wholly_unembedded_haystack_falls_back_to_the_no_snap_threshold(self, client):
-        """The CLI importer path: the chunk is embedded later, per detector
-        group, so at train time nothing in it is scoreable."""
+        """A haystack in which nothing is scoreable - every media reachable
+        only through a converter route, embedded later by ``route_and_embed``
+        in the detector's target space - fits on no distribution at all."""
         from vtscore.detectors.training import train_and_threshold
 
         snap = {1: _media(1, None), 2: _media(2, None)}

--- a/tests_lib/cli/test_load_embed_stage.py
+++ b/tests_lib/cli/test_load_embed_stage.py
@@ -1,0 +1,209 @@
+"""The CLI runs the framework's embed stage over a fresh import.
+
+Importers never call an embedder: they emit media dicts with ``embedding=None``
+and the framework's ``embed_missing`` stage fills the vectors in once the
+importer returns.  The GUI's ``load_pipeline`` runs that stage; the CLI ran none
+of the post-import stages and left the vectors to appear incidentally at scoring
+time, inside ``route_and_embed``'s per-detector-group embed pass.
+
+That is the second half of issue #3556.  The first thing to read the haystack is
+not scoring but *threshold calibration* - ``train_from_labelset`` fits the cut on
+``scoring_rows_for_snap(snap)``, which drops every media with no vector - so an
+import that arrived unembedded calibrated the detector against a strict subset of
+the dataset: a lower cut over fewer items, and only afterwards were the vectors
+filled in.  Same dataset, same detector, a different threshold in the CLI than in
+the GUI.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any
+
+import numpy as np
+import pytest
+
+from vtscore import cli_progress
+from vtscore.cli import _load_importer_chunked, _load_importer_whole
+from vtscore.embedding.media_vectors import media_embedding, set_media_embedding
+
+
+DIM = 8
+
+
+class _FakeEmbedder:
+    """A registered-looking embedder that stamps a recognisable vector."""
+
+    supports_patch_regions = False
+    supports_geometric_verification = False
+
+    def __init__(self, name: str, fill: float = 1.0, *, refuses: set[str] | None = None) -> None:
+        self.name = name
+        self.fill = fill
+        self.refuses = refuses or set()
+        self.seen: list[str] = []
+        # Non-None so ``_ensure_model_loaded`` treats the model as warm.
+        self._model = object()
+
+    @contextmanager
+    def progress_scope(self, _on_progress):
+        yield
+
+    def embed_media_bulk(self, medias: list[dict[str, Any]]):
+        out = []
+        for m in medias:
+            self.seen.append(m.get("origin_name", ""))
+            if m.get("origin_name") in self.refuses:
+                out.append(None)
+            else:
+                out.append(np.full(DIM, self.fill, dtype=np.float32))
+        return out
+
+
+class _StubImporter:
+    """Emits the media dicts it was constructed with, unembedded."""
+
+    name = "stub"
+
+    def __init__(self, medias: list[dict[str, Any]], chunk_size: int = 0) -> None:
+        self._medias = medias
+        self._chunk_size = chunk_size
+
+    def validate_cli_field_values(self, field_values: dict[str, Any]) -> None:
+        return None
+
+    def run_cli(self, field_values: dict[str, Any], medias: dict, thin: bool = False) -> None:
+        for i, media in enumerate(self._medias, 1):
+            medias[i] = dict(media, id=i)
+
+    def run_chunked_cli(self, field_values: dict[str, Any], chunk_size: int, thin: bool = False):
+        batch: dict[int, dict[str, Any]] = {}
+        for media in self._medias:
+            batch[len(batch) + 1] = dict(media)
+            if len(batch) == chunk_size:
+                yield batch
+                batch = {}
+        if batch:
+            yield batch
+
+
+def _media(name: str, media_type: str = "audio") -> dict[str, Any]:
+    return {"media_type": media_type, "origin_name": name, "embedding": None}
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    """Register one fake embedder per media type and hand them back by type."""
+    by_type = {"audio": _FakeEmbedder("fake_audio", 1.0), "image": _FakeEmbedder("fake_image", 2.0)}
+    by_name = {e.name: e for e in by_type.values()}
+    monkeypatch.setattr("vtscore.media.embedders_for_type", lambda mt: [by_type[mt]] if mt in by_type else [])
+    monkeypatch.setattr("vtscore.media.get_embedder", lambda name: by_name[name])
+    return by_type
+
+
+def _install(monkeypatch, importer) -> None:
+    monkeypatch.setattr("vtscore.datasets.importers.get_importer", lambda _n: importer)
+
+
+class TestImportArrivesEmbedded:
+    def test_every_media_carries_a_vector_before_the_chunk_is_yielded(self, monkeypatch, registry):
+        """The #3556 regression: these used to reach calibration unembedded."""
+        _install(monkeypatch, _StubImporter([_media("a"), _media("b"), _media("c")]))
+
+        (chunk,) = list(_load_importer_whole("stub", {}))
+
+        assert len(chunk) == 3
+        assert all(media_embedding(m) is not None for m in chunk.values())
+
+    def test_the_whole_import_is_embedded_not_just_the_first_item(self, monkeypatch, registry):
+        _install(monkeypatch, _StubImporter([_media(n) for n in "abcdefgh"]))
+
+        (chunk,) = list(_load_importer_whole("stub", {}))
+
+        assert sorted(registry["audio"].seen) == list("abcdefgh")
+
+    def test_each_chunk_is_embedded_as_it_is_yielded(self, monkeypatch, registry):
+        """Chunking exists so a big dataset is scored a chunk at a time; each
+        chunk is calibrated and scored before the next is loaded, so each must
+        be embedded on the way out rather than once at the end."""
+        _install(monkeypatch, _StubImporter([_media(n) for n in "abcd"]))
+
+        chunks = list(_load_importer_chunked("stub", {}, 2))
+
+        assert [len(c) for c in chunks] == [2, 2]
+        for chunk in chunks:
+            assert all(media_embedding(m) is not None for m in chunk.values())
+
+    def test_already_embedded_media_are_left_alone(self, monkeypatch, registry):
+        """A content-vector importer ships its own vectors; the stage is a no-op."""
+        pre = _media("a")
+        set_media_embedding(pre, "fake_audio", np.full(DIM, 9.0, dtype=np.float32))
+        _install(monkeypatch, _StubImporter([pre]))
+
+        (chunk,) = list(_load_importer_whole("stub", {}))
+
+        assert registry["audio"].seen == []
+        assert media_embedding(chunk[1]) == pytest.approx(np.full(DIM, 9.0))
+
+
+class TestMixedTypeImports:
+    def test_each_media_type_resolves_its_own_embedder(self, monkeypatch, registry):
+        """A single whole-dict ``embed_missing`` call resolves one embedder from
+        the first media type it finds, which would push every video in a mixed
+        import through the image model.  Group by type instead."""
+        _install(monkeypatch, _StubImporter([_media("a", "audio"), _media("i", "image"), _media("b", "audio")]))
+
+        (chunk,) = list(_load_importer_whole("stub", {}))
+
+        assert registry["audio"].seen == ["a", "b"]
+        assert registry["image"].seen == ["i"]
+        assert media_embedding(chunk[2]) == pytest.approx(np.full(DIM, 2.0))
+
+
+class TestNothingIsDropped:
+    def test_a_media_the_embedder_refused_is_kept(self, monkeypatch, registry):
+        """The GUI drops these; the CLI must not.  Its dataset is not scored in
+        the space it was loaded in - an item with no native vector may still be
+        scoreable through the one-hop converter route ``route_and_embed``
+        applies later, so dropping it here would lose hits the CLI finds today.
+        """
+        registry["audio"].refuses = {"b"}
+        _install(monkeypatch, _StubImporter([_media("a"), _media("b"), _media("c")]))
+
+        (chunk,) = list(_load_importer_whole("stub", {}))
+
+        assert sorted(chunk) == [1, 2, 3]
+        assert media_embedding(chunk[2]) is None
+
+    def test_a_type_with_no_registered_embedder_is_kept(self, monkeypatch, registry):
+        _install(monkeypatch, _StubImporter([_media("a"), _media("d", "document")]))
+
+        (chunk,) = list(_load_importer_whole("stub", {}))
+
+        assert sorted(chunk) == [1, 2]
+        assert media_embedding(chunk[2]) is None
+
+    def test_what_stayed_unembedded_is_announced(self, monkeypatch, registry, capsys):
+        """Silence here is what made #3556 hard to see from the outside: the
+        export was simply short.  Report it on the same event stream as the
+        scoring-time skips, so ``--progress-format json`` shows the count."""
+        registry["audio"].refuses = {"b"}
+        _install(monkeypatch, _StubImporter([_media("a"), _media("b")]))
+        monkeypatch.setattr(cli_progress, "_format", "json")
+
+        list(_load_importer_whole("stub", {}))
+
+        events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+        (announced,) = [e for e in events if e["event"] == "medias_unembedded"]
+        assert announced["unembedded"] == 1
+        assert announced["unembedded_ids"] == [2]
+
+    def test_a_fully_embedded_import_announces_nothing(self, monkeypatch, registry, capsys):
+        _install(monkeypatch, _StubImporter([_media("a"), _media("b")]))
+        monkeypatch.setattr(cli_progress, "_format", "json")
+
+        list(_load_importer_whole("stub", {}))
+
+        events = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+        assert [e for e in events if e["event"] == "medias_unembedded"] == []

--- a/tests_lib/meta/test_pile_config_single_definition.py
+++ b/tests_lib/meta/test_pile_config_single_definition.py
@@ -68,7 +68,7 @@ def _duplicate_dict_keys() -> dict[str, list[str]]:
             target, value = node.target.id, node.value
         elif isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
             target, value = node.targets[0].id, node.value
-        if not isinstance(value, ast.Dict):
+        if target is None or not isinstance(value, ast.Dict):
             continue
         seen: set = set()
         dupes: list[str] = []

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -783,6 +783,71 @@ def _reference_files_choice(field_values: dict[str, Any]) -> bool:
     return parse_checkbox(field_values.pop("reference_files", False))
 
 
+def _embed_loaded_medias(medias: dict[int, dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    """Run the framework's embed stage over freshly-imported *medias*.
+
+    Importers never call an embedder - that is the contract on
+    :class:`~vtscore.datasets.importers.base.core.DataSourceImporter`.  They emit
+    media dicts with ``embedding=None`` and the framework's
+    :func:`~vtscore.datasets.stages.embedding.embed_missing` stage embeds
+    everything still at ``None`` once the importer returns.  The GUI's
+    ``load_pipeline`` runs that stage; the CLI ran *none* of the post-import
+    stages and let the vectors appear incidentally at scoring time, inside
+    ``route_and_embed``'s per-detector-group embed pass.
+
+    That ordering is what issue #3556 cost, because the first thing to read the
+    haystack is not scoring but **threshold calibration**: ``train_from_labelset``
+    fits the cut on ``scoring_rows_for_snap(snap)``, which drops every media with
+    no vector.  An import whose items were still unembedded therefore calibrated
+    the detector against a strict subset of the dataset - a lower cut over fewer
+    items - and only afterwards did ``route_and_embed`` fill the vectors in.
+    Same dataset, same detector, a different threshold and different hits in the
+    CLI than in the GUI.
+
+    Media are embedded in groups sharing a ``media_type`` so each group resolves
+    its own embedder: a mixed-type import (a folder of videos and PDFs) must not
+    have every item pushed through the first item's model, which a single
+    whole-dict call would do - ``embed_missing`` resolves one embedder from the
+    first media type it finds.
+
+    Nothing is dropped.  The GUI's ``_drop_none_embeddings_stage`` can drop what
+    stays at ``None`` because its dataset is scored in the space it was loaded
+    in; the CLI's is not.  An item with no native vector - no embedder
+    registered for its type, an unreadable file - may still be scoreable through
+    the one-hop converter route ``route_and_embed`` applies later, so dropping it
+    here would lose hits the CLI finds today.  The count is announced instead, on
+    the same event stream as the scoring-time skips.
+    """
+    from collections import defaultdict  # noqa: PLC0415
+
+    from vtscore.datasets.stages.embedding import embed_missing  # noqa: PLC0415
+    from vtscore.embedding.media_vectors import media_embedding  # noqa: PLC0415
+
+    by_type: dict[str, dict[int, dict[str, Any]]] = defaultdict(dict)
+    for mid, media in medias.items():
+        by_type[media.get("media_type") or ""][mid] = media
+    for group in by_type.values():
+        # Empty name = the framework's own resolution order (the embedder the
+        # media already carry, else the media-type default).  The CLI has no
+        # embedder pick to forward; ``--solo-embedder`` narrows the registry
+        # that resolution reads rather than naming a pick here.
+        embed_missing(group, "", on_progress=cli_progress.progress_callback)
+
+    unembedded = [mid for mid in sorted(medias) if media_embedding(medias[mid]) is None]
+    if unembedded:
+        cli_progress.emit(
+            "medias_unembedded",
+            text=(
+                f"{len(unembedded)} media carry no embedding after the load embed pass "
+                f"and will only score through a converter route: "
+                f"{unembedded[:10]}{'…' if len(unembedded) > 10 else ''}"
+            ),
+            unembedded=len(unembedded),
+            unembedded_ids=unembedded[:100],
+        )
+    return medias
+
+
 def _load_importer_whole(importer_name: str, field_values: dict[str, Any]) -> Iterator[dict[int, dict[str, Any]]]:
     """Yield a single medias dict loaded via a named importer."""
     from vtscore.datasets.importers import get_importer
@@ -799,7 +864,7 @@ def _load_importer_whole(importer_name: str, field_values: dict[str, Any]) -> It
     importer.run_cli(field_values, medias, thin=thin)
     if not medias:
         raise ValueError(f"No medias loaded by importer '{importer_name}'")
-    yield medias
+    yield _embed_loaded_medias(medias)
 
 
 def _load_importer_chunked(
@@ -815,7 +880,11 @@ def _load_importer_chunked(
 
     importer.validate_cli_field_values(field_values)
     thin = _reference_files_choice(field_values)
-    yield from _renumber_chunks(importer.run_chunked_cli(field_values, chunk_size, thin=thin))
+    for chunk in _renumber_chunks(importer.run_chunked_cli(field_values, chunk_size, thin=thin)):
+        # Per chunk, not once at the end: the chunked path exists so a dataset
+        # too big to hold at once is scored a chunk at a time, and each chunk is
+        # calibrated and scored on its own before the next is loaded.
+        yield _embed_loaded_medias(chunk)
 
 
 @dataclass(frozen=True)

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -564,9 +564,16 @@ def train_and_threshold(
     # The row builder skips media it cannot score, so an empty score list
     # means the haystack contributed nothing to fit on - either there was no
     # snap at all, or none of its media carry a usable vector in this space
-    # (the CLI importer path, where the chunk is embedded later, per detector
-    # group, by `route_and_embed`).  Both take the no-haystack branch rather
-    # than fitting the estimator on an empty distribution.
+    # (a chunk of media reachable only through a converter route, which
+    # `route_and_embed` embeds later in the detector's own target space).  Both
+    # take the no-haystack branch rather than fitting the estimator on an empty
+    # distribution.
+    #
+    # A *partly* embedded haystack has no such branch, and that is why the CLI
+    # must embed at load: fitting the cut on the subset that happens to carry a
+    # vector is silent, plausible, and wrong - a lower threshold over fewer
+    # items (issue #3556).  `vtscore.cli._embed_loaded_medias` is what keeps the
+    # CLI's snap embedded before this call, mirroring the GUI's load pipeline.
     rows: ScoringRows | None = None
     all_ids: list[int] = []
     all_scores: list[float] = []


### PR DESCRIPTION
## The bug

Importers never call an embedder. That is the contract on `DataSourceImporter`: they emit media dicts with `embedding=None`, and the framework's `embed_missing` stage embeds everything still at `None` once the importer returns.

The GUI honours it — `load_pipeline.py` runs `_embed_missing_stage`. **The CLI ran none of the post-import stages.** `_load_importer_whole` called `importer.run_cli(...)` and handed the raw medias straight to training; grepping `vtscore/cli.py` for `embed_missing|drop_none|clipper_stage` returned nothing at all. The vectors appeared incidentally, later, inside `route_and_embed`'s per-detector-group embed pass.

That ordering is what #3556 cost, because the first thing to read the haystack is not scoring but **threshold calibration**. `train_from_labelset` fits the cut on `scoring_rows_for_snap(snap)`, which drops every media with no vector. So an import that arrived unembedded calibrated the detector against a strict subset of the dataset — a lower cut over fewer items — and only afterwards were the vectors filled in. Same dataset, same detector, a different threshold and different hits in the CLI than in the GUI.

The comment at `training.py:566` named the path (*"the CLI importer path, where the chunk is embedded later, per detector group, by `route_and_embed`"*) and treated it as tolerable. It is not: a *wholly* unembedded haystack takes an explicit no-haystack branch, but a *partly* embedded one has no such branch — it just fits on the subset, silently and plausibly.

This is the second half of #3556. The first half — the CLI forcing thin mode on every import — was fixed in #3609; the reporter's follow-up showed media still being dropped, with `route_and_embed` embedding them *after* the skip warning had already fired.

## The fix

`vtscore/cli.py` grows `_embed_loaded_medias`, called by both importer loaders (per chunk on the chunked path, since each chunk is calibrated and scored before the next is loaded).

Two things it does deliberately differently from the GUI:

- **Embeds in groups sharing a `media_type`.** `embed_missing` resolves one embedder from the first media type it finds, so a single whole-dict call would push every video in a mixed import through the image model. The CLI supports mixed-type datasets via converter routing, so it must group.
- **Drops nothing.** The GUI's `_drop_none_embeddings_stage` can drop what stays at `None` because its dataset is scored in the space it was loaded in; the CLI's is not. An item with no native vector — no embedder registered for its type, an unreadable file — may still be scoreable through the one-hop converter route `route_and_embed` applies later, so dropping it here would lose hits the CLI finds today. The count is announced instead, as a `medias_unembedded` event on the same stream as the scoring-time skips.

The pickle path is untouched: those media arrive pre-embedded, and the contract this restores is specifically the importer's.

## Tests

- `tests_lib/cli/test_load_embed_stage.py` — nine unit tests over the new stage: every media carries a vector before the chunk is yielded, each chunk is embedded as it goes out, already-embedded media are left alone, each media type resolves its own embedder, refused and embedder-less media are kept rather than dropped, and the leftover count is announced (and only when non-zero).
- `tests/cli/test_failed_embed_skips.py` — an end-to-end regression over `server_folder`: spy on the snap `train_from_labelset` is handed and assert every media in it carries a vector. Reverting the fix makes it fail with the reporter's own log line, `Scoring skipped 4 media with no usable vector`.

Also fixes a pyright error on `dev` (`tests_lib/meta/test_pile_config_single_definition.py`) that was blocking the gate.

Full `./run-tests.sh`: 10745 passed, all gates green.

## Still owed

Filed as #3647, not fixed here: on a **converter-routed or re-clipped** dataset the calibration population is still the native snap while the scoring population is `route_and_embed`'s converted snapshot. Those legitimately differ, so the threshold is cut on one distribution and applied to another. The reporter's case is homogeneous images with no conversion, where the two are the same set.

Closes #3556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ExSDXxzE5p6LazA7832e5