### PR TITLE
Stop masking a still-loading pair as a labeling-status 500

### DIFF
--- a/frontend/src/app/services/sorting-api.service.spec.ts
+++ b/frontend/src/app/services/sorting-api.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 
 import { SortingApiService } from './sorting-api.service';
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 import { provideHttpTesting } from '../testing/test-providers';
 
 describe('SortingApiService', () => {
@@ -149,6 +150,18 @@ describe('SortingApiService', () => {
     service.getLabelingStatus().subscribe();
     const req = httpMock.expectOne('/api/labeling-status');
     expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  // Issue #3644: this is a 2s poll for the whole labeling session, and
+  // adaptivePoll already absorbs a failed tick. A tick that lands while
+  // ContextSwitchService is still loading the pair 409s `detector_not_loaded`,
+  // which resolves itself moments later; without the opt-out the global
+  // interceptor puts a red toast over the panel a reviewer just opened.
+  it('getLabelingStatus should opt out of the global error toast', () => {
+    service.getLabelingStatus().subscribe({ error: () => undefined });
+    const req = httpMock.expectOne('/api/labeling-status');
+    expect(req.request.context.get(SKIP_ERROR_TOAST)).toBe(true);
     req.flush({});
   });
 

--- a/frontend/src/app/services/sorting-api.service.ts
+++ b/frontend/src/app/services/sorting-api.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
+import { SKIP_ERROR_TOAST } from '../interceptors/error.interceptor';
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
 import type { CoverageAtlasNextResponse } from '../generated/api-client/models/coverage-atlas-next-response';
 import type { EvalTrainAndScoreCancelResponse } from '../generated/api-client/models/eval-train-and-score-cancel-response';
@@ -266,8 +267,22 @@ export class SortingApiService {
     return this.http.post('/api/labeling-progress', {});
   }
 
+  /** The left panel polls this every 2 s for the whole labeling session, and
+   *  `adaptivePoll` already absorbs a failed tick (it skips that tick and keeps
+   *  polling), so the caller handles the failure itself. Pass
+   *  {@link SKIP_ERROR_TOAST} so a tick that lands mid-load does not raise a
+   *  global toast: while `ContextSwitchService` is still loading the pair the
+   *  poll's `X-Detector-Id` names a detector the backend has not registered
+   *  yet, which is a 409 `detector_not_loaded` that resolves itself a moment
+   *  later. Issue #3644 is what that toast looked like to a reviewer opening a
+   *  new class. */
   getLabelingStatus(): Observable<LabelingStatusResponse> {
-    return labelingStatusIndicator(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+    return labelingStatusIndicator(
+      this.http,
+      this.config.rootUrl,
+      undefined,
+      new HttpContext().set(SKIP_ERROR_TOAST, true),
+    ).pipe(map((r) => r.body));
   }
 
   getIndicatorScoreHistory(

--- a/tests/api/test_eval_routes_failures.py
+++ b/tests/api/test_eval_routes_failures.py
@@ -4,9 +4,10 @@ The happy paths for these routes live in ``tests/sorting/test_sorting.py``
 (``TestEvalTrainAndScoreAsync``), ``tests/api/test_api_contracts.py``, and
 ``tests/core/test_votes.py``.  This module covers the error branches those
 suites skip: precondition rejects (missing votes / history), internal
-computation failures surfacing as 500, schema rejects (422), and the
-job-lifecycle branches of the poll/cancel endpoints (missing job → 404,
-errored job → 500, cancelled job → ``"cancelled"``).
+computation failures surfacing as 500, schema rejects (422), context-
+resolution rejects (409), and the job-lifecycle branches of the poll/cancel
+endpoints (missing job → 404, errored job → 500, cancelled job →
+``"cancelled"``).
 """
 
 from __future__ import annotations
@@ -90,6 +91,64 @@ class TestIndicatorScoreHistoryFailures:
             resp = client.get("/api/indicator-score-history?metric=smart")
         assert resp.status_code == 500
         assert "score history" in resp.get_json()["message"].lower()
+
+
+class TestContextErrorsAreNot500:
+    """A not-yet-loaded pair must keep its 409, not be masked as a 500.
+
+    Regression for issue #3644.  Every route in this blueprint reads the
+    request-scoped proxies, which raise ``DetectorNotLoadedError`` /
+    ``DatasetNotLoadedError`` when the client names a pair the backend has not
+    finished loading - the app-wide 409 contract that ``vtsearch/hooks.py``
+    hands off to the global error handlers.  These handlers each wrap their
+    body in ``except Exception`` and abort 500, which used to swallow that
+    contract and report a poll landing inside a detector's load window as an
+    opaque "computation failed" 500.  The reviewer in #3644 saw it as a red
+    toast over an empty panel that cleared on its own once the load landed;
+    because the 500 carried no detail, it read as a bug in the empty-labelset
+    branch (the failing detectors were the ones just opened, so also the ones
+    with no labels yet) rather than as a detector still loading.
+    """
+
+    UNLOADED = {"X-Detector-Id": "no-such-detector"}
+
+    def _assert_detector_409(self, resp):
+        assert resp.status_code == 409, resp.get_json()
+        body = resp.get_json()
+        assert body["error_code"] == "detector_not_loaded"
+
+    def test_labeling_status_returns_409(self, client):
+        self._assert_detector_409(client.get("/api/labeling-status", headers=self.UNLOADED))
+
+    def test_labeling_progress_returns_409(self, client):
+        self._assert_detector_409(client.post("/api/labeling-progress", headers=self.UNLOADED))
+
+    def test_indicator_score_history_returns_409(self, client):
+        self._assert_detector_409(
+            client.get("/api/indicator-score-history?metric=smart", headers=self.UNLOADED)
+        )
+
+    def test_unloaded_dataset_returns_409(self, client):
+        resp = client.get("/api/labeling-status", headers={"X-Dataset-Id": "no-such-dataset"})
+        assert resp.status_code == 409, resp.get_json()
+        assert resp.get_json()["error_code"] == "dataset_not_loaded"
+
+    def test_loaded_detector_with_no_labels_still_returns_200(self, client):
+        """The other half of #3644: an empty labelset is *not* the fault.
+
+        Once the pair is loaded, zero votes and zero label history take the
+        inline branch and answer 200 with an honest red/red - which is why the
+        issue's proposed "treat no labels as the placeholder case" fix would
+        have masked the load-window 409 while replacing a true status with a
+        transient "Computing indicators..." placeholder.
+        """
+        resp = client.get("/api/labeling-status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total_count"] == 0
+        assert data["stale"] is False
+        assert data["smart"]["status"] == "red"
+        assert data["stable"]["status"] == "red"
 
 
 class TestIndicatorScoreHistoryIsReadOnly:

--- a/tests/api/test_eval_routes_failures.py
+++ b/tests/api/test_eval_routes_failures.py
@@ -124,9 +124,7 @@ class TestContextErrorsAreNot500:
         self._assert_detector_409(client.post("/api/labeling-progress", headers=self.UNLOADED))
 
     def test_indicator_score_history_returns_409(self, client):
-        self._assert_detector_409(
-            client.get("/api/indicator-score-history?metric=smart", headers=self.UNLOADED)
-        )
+        self._assert_detector_409(client.get("/api/indicator-score-history?metric=smart", headers=self.UNLOADED))
 
     def test_unloaded_dataset_returns_409(self, client):
         resp = client.get("/api/labeling-status", headers={"X-Dataset-Id": "no-such-dataset"})

--- a/vtsearch/routes/eval.py
+++ b/vtsearch/routes/eval.py
@@ -42,11 +42,33 @@ from vtscore.concurrency.progress import (
     CancelledError,
     update_eval_progress,
 )
+from vtscore.state.core import (
+    DatasetNotLoadedError,
+    DetectorNotLoadedError,
+    RequestMissingContextError,
+)
 
 eval_bp = Blueprint(
     "eval",
     __name__,
     description="Labeling-progress analysis and learned-sort eval indicators.",
+)
+
+
+# Failures of *context resolution* are not this blueprint's 500s.  Every route
+# below reads the request-scoped proxies (``label_history``, ``good_votes``,
+# ``snapshot_medias()``, ``get_inclusion()``), and each of those raises when
+# the client named a dataset / detector the backend has not finished loading -
+# which ``vtsearch/errors.py`` maps to the app-wide 409 ``dataset_not_loaded``
+# / ``detector_not_loaded`` (or a 400 for the request-missing sentinel).  A
+# blanket ``except Exception`` swallows that contract and reports a load-window
+# poll as an opaque "computation failed" 500, which is what made issue #3644
+# read as a bug in the empty-labelset branch rather than a detector that was
+# still loading.  Let these through; only genuine computation faults are 500s.
+_CONTEXT_ERRORS = (
+    DatasetNotLoadedError,
+    DetectorNotLoadedError,
+    RequestMissingContextError,
 )
 
 
@@ -64,6 +86,8 @@ def labeling_progress():
 
     try:
         return analyze_labeling_progress(snapshot_medias(), label_history, good_votes, bad_votes, get_inclusion())
+    except _CONTEXT_ERRORS:
+        raise
     except Exception:
         import logging
 
@@ -155,6 +179,8 @@ def labeling_status_indicator():
         status["stale"] = True
         _schedule_status_refresh(span)
         return status
+    except _CONTEXT_ERRORS:
+        raise
     except Exception:
         import logging
 
@@ -197,6 +223,8 @@ def indicator_score_history(query: dict):
     try:
         data, complete = cached_indicator_history(metric, clips, label_history, good_votes, bad_votes, inclusion)
         return {"metric": metric, "history": data, "complete": complete}
+    except _CONTEXT_ERRORS:
+        raise
     except Exception:
         import logging
 


### PR DESCRIPTION
## The issue's diagnosis doesn't hold

#3644 reports `GET /api/labeling-status` 500ing for detectors with no labels yet, and traces it to the empty-history case taking the inline `compute_labeling_status` branch instead of the `stale_labeling_status` placeholder.

The branching half is right — `is_status_cache_fresh([], 0)` is `True` and the empty case does go inline. The fault half isn't. With zero votes the inline branch does *strictly less* work than the 300-label case the issue reports as `200`:

- `_ensure_cache` returns immediately at `start >= len(label_history)` (`0 >= 0`) — `vtscore/detectors/labeling_progress.py:683`
- `_compute_smart_status` and `_compute_stable_status` both return early under `good < 5 or bad < 5` — `:922`, `:973`
- `_compute_span_status` is called identically by *both* branches (`:1012`, and via `_pending_labeling_status`), so it can't be what separates them

Three existing tests already pin the empty case at 200, including `TestLabelingStatusResetOnDetectorSwitch`, which registers a fresh detector with no votes and asserts the *inline* branch's red/red. Either suggested fix would have routed that to the placeholder's yellow `"Computing indicators..."` — replacing a true status with a transient one — and regressed it.

## What actually 500s

Context resolution, not the labelset. Every route in this blueprint reads the request-scoped proxies (`label_history`, `good_votes`, `snapshot_medias()`, `get_inclusion()`), and each raises `DetectorNotLoadedError` / `DatasetNotLoadedError` when the client names a pair the backend hasn't finished loading — the app-wide 409 that `vtsearch/hooks.py` explicitly hands off to the global error handlers ("the route handler will hit the same error when it touches the proxies; the global error handler turns it into a 409").

All three handlers wrap their body in `except Exception` and `abort(500, ...)`, swallowing that contract. Reproduced against `dev`, exactly matching the reported envelope:

```
BEFORE LOAD: 500 {'code': 500, 'message': 'Labeling status computation failed', ...}
              DetectorNotLoadedError: detector 'fa8c67cc…' is not loaded
AFTER LOAD:  200 {'total_count': 0, 'stale': False,
                  'smart': {'status': 'red', 'reason': 'Need at least 5 good and 5 bad. …'}, …}
```

`/api/detectors/registry/load` is asynchronous (`{"message": "Loading started", "task_id": …}`), so that window is real. It also fits the report better than the labelset does: the detectors showing 500 were the ones the reviewer had just opened — hence also the ones with no labels yet — and the error "went away on its own", which is the load landing, not the first vote.

## Changes

- **`vtsearch/routes/eval.py`** — re-raise `DatasetNotLoadedError` / `DetectorNotLoadedError` / `RequestMissingContextError` ahead of the blanket catch in all three handlers, so they reach their 409 / 400. Genuine computation faults still 500. No OpenAPI churn: the not-loaded 409 is cross-cutting and no route documents it via `alt_response` today.
- **`frontend/src/app/services/sorting-api.service.ts`** — mark the left panel's 2 s poll `SKIP_ERROR_TOAST`. `adaptivePoll` already absorbs a failed tick, so the caller handles the failure itself; without the opt-out the global interceptor toasts on *any* non-zero status, which is the red toast over an empty panel the issue actually complains about.
- **Tests** — `TestContextErrorsAreNot500` covers all three routes plus the dataset variant, and pins the loaded-with-no-labels case at 200/red/red so the rejected fix can't be reintroduced. A Vitest case asserts the poll carries the opt-out. Verified the two masked cases fail without the backend change.

## Testing

Full `./run-tests.sh`: `RUN PASSED`, 10741 passed / 6 skipped, every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

Closes #3644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TzVftkBhUeUVPLASLck1P

---
_Generated by [Claude Code](https://claude.ai/code/session_011TzVftkBhUeUVPLASLck1P)_