### PR TITLE
coco_folds: fold-out reads the whole COCO vocabulary, not just --classes

### DIFF
--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -462,6 +462,13 @@ mechanical floor is ~7-15%; `book`, the class that actually broke, scores 43%.
 Anything near that is a class whose rule has to be settled before review, not
 during it.
 
+`--classes` scopes the *question*, never the COCO vocabulary the answer is read
+against: fold-out always tests a VG box against every COCO class, so the score
+for a name does not move when you ask about it alongside different company. It
+did once — a class nobody named carried no boxes, so `bike` read 100% "means
+nothing" against a recorded 40.1% (#3640) — and 100% is the reading that sends a
+good spelling to `SCALE_VG_AMBIGUOUS` and costs the class half its positives.
+
 That rule then travels in `pile_config.SCALE_CLASS_RULES`, whose value is the
 **dataset and detector name** — the only string the app shows while voting. A
 rule in a manifest is a rule the reviewer never reads.

--- a/scripts/experiments/pile/coco_folds.py
+++ b/scripts/experiments/pile/coco_folds.py
@@ -138,7 +138,9 @@ def main() -> int:
     anchor = Path(args.anchor_dir)
 
     cboxes, cdims, _ = coco_boxes(anchor)
-    log(f"  {len(cdims)} COCO images; {sum(len(v) for v in cboxes.values())} class-groups over the full COCO vocabulary")
+    log(
+        f"  {len(cdims)} COCO images; {sum(len(v) for v in cboxes.values())} class-groups over the full COCO vocabulary"
+    )
 
     log("loading VG image_data.json")
     with (anchor / "image_data.json").open() as fh:

--- a/scripts/experiments/pile/coco_folds.py
+++ b/scripts/experiments/pile/coco_folds.py
@@ -69,12 +69,22 @@ def iou(a: list[float], b: list[float]) -> float:
     return inter / ua if ua > 0 else 0.0
 
 
-def coco_boxes(anchor: Path, classes: set[str]) -> tuple[dict, dict, dict]:
+def coco_boxes(anchor: Path) -> tuple[dict, dict, dict]:
     """``({coco_id: {class: [norm boxes]}}, {coco_id: (W, H)}, {coco_id: set(all classes)})``.
 
-    The third return is every COCO class present on the image, not just the
-    wanted ones: fold-out needs to say "this VG box sits on a COCO *bench*",
-    which is only possible if the whole vocabulary was read.
+    **Every COCO class is loaded**, not just the ones the caller asked about.
+    Fold-out needs to say "this VG box sits on a COCO *bench*", and it can only
+    say that if `bench`'s boxes are here to be tested against.
+
+    This used to take a `classes` filter and keep only those boxes, which made
+    fold-out answer with the caller's own question: a class nobody named had no
+    boxes, so every VG box over it fell through to `(no COCO class)`. `bike`
+    read 100% "means nothing" against a recorded 40.1%, because `bicycle` was
+    not in the set -- and 100% is exactly the reading that banishes a good
+    spelling to :data:`pile_config.SCALE_VG_AMBIGUOUS` and costs the class half
+    its positives (#3640, the #3605 failure again). The filter saved nothing
+    worth having: the boxes are small beside `objects.json`, which every caller
+    of this function also loads.
     """
     zip_path = anchor / "annotations_trainval2017.zip"
     files = [anchor / "instances_val2017.json", anchor / "instances_train2017.json"]
@@ -106,8 +116,6 @@ def coco_boxes(anchor: Path, classes: set[str]) -> tuple[dict, dict, dict]:
                 continue
             iid = int(ann["image_id"])
             present[iid].add(name)
-            if name not in classes:
-                continue
             x, y, w, h = (float(v) for v in ann["bbox"])
             if w <= 0 or h <= 0:
                 continue
@@ -129,8 +137,8 @@ def main() -> int:
     classes = set(c.strip() for c in args.classes.split(",") if c.strip()) or set(pc.SCALE_CLASSES)
     anchor = Path(args.anchor_dir)
 
-    cboxes, cdims, cpresent = coco_boxes(anchor, classes)
-    log(f"  {len(cdims)} COCO images; {sum(len(v) for v in cboxes.values())} class-groups over {len(classes)} classes")
+    cboxes, cdims, _ = coco_boxes(anchor)
+    log(f"  {len(cdims)} COCO images; {sum(len(v) for v in cboxes.values())} class-groups over the full COCO vocabulary")
 
     log("loading VG image_data.json")
     with (anchor / "image_data.json").open() as fh:
@@ -181,8 +189,11 @@ def main() -> int:
                 continue
             vg_named.append((name, [x / W, y / H, (x + w) / W, (y + h) / H]))
 
-        for c, boxes in cboxes.get(cid, {}).items():
-            for cb in boxes:
+        # fold-in is asked only of the classes the caller named; fold-out below
+        # is asked of the whole vocabulary, which is why `cboxes` carries it.
+        on_image = cboxes.get(cid, {})
+        for c in classes:
+            for cb in on_image.get(c, []):
                 n_coco_boxes[c] += 1
                 hits = {n for n, vb in vg_named if iou(cb, vb) >= args.iou}
                 if hits:
@@ -197,10 +208,9 @@ def main() -> int:
                 continue
             n_vg_boxes[n] += 1
             under = set()
-            for c2 in cpresent.get(cid, set()):
-                for cb in cboxes.get(cid, {}).get(c2, []):
-                    if iou(cb, vb) >= args.iou:
-                        under.add(c2)
+            for c2, cbs in on_image.items():
+                if any(iou(cb, vb) >= args.iou for cb in cbs):
+                    under.add(c2)
             if not under:
                 fold_out[n]["(no COCO class)"] += 1
             for c2 in under:

--- a/scripts/experiments/pile/name_coverage.py
+++ b/scripts/experiments/pile/name_coverage.py
@@ -98,7 +98,7 @@ def main() -> int:
             wanted.update(ns)
     log(f"{len(classes)} classes; {len(wanted)} VG names to match")
 
-    cboxes, cdims, _ = cf.coco_boxes(Path(args.anchor_dir), set(classes))
+    cboxes, cdims, _ = cf.coco_boxes(Path(args.anchor_dir))
 
     log("loading VG image_data.json")
     with (Path(args.anchor_dir) / "image_data.json").open() as fh:
@@ -195,7 +195,13 @@ def main() -> int:
         if abs((vd[0] / vd[1]) - (cd[0] / cd[1])) > pc.MAX_ASPECT_DRIFT:
             skipped_aspect += 1
             continue
-        for c, boxes in cboxes.get(cid, {}).items():
+        # `coco_boxes` carries the whole COCO vocabulary (#3640); only the
+        # classes under proposal are scored, and the counters are keyed on them.
+        on_image = cboxes.get(cid, {})
+        for c in classes:
+            boxes = on_image.get(c, [])
+            if not boxes:
+                continue
             own = by_name.get(c, [])
             folded = [b for n in alias.get(c, ()) for b in by_name.get(n, [])]
             amb = [b for n in ambig.get(c, ()) for b in by_name.get(n, [])]

--- a/scripts/experiments/pile/name_evidence.py
+++ b/scripts/experiments/pile/name_evidence.py
@@ -149,7 +149,7 @@ def main() -> int:
     wanted = set(classes) | {n for ns in cands.values() for n in ns}
     log(f"{len(classes)} classes; {len(wanted)} VG names")
 
-    cboxes, cdims, cpresent = cf.coco_boxes(Path(args.anchor_dir), set(classes))
+    cboxes, cdims, cpresent = cf.coco_boxes(Path(args.anchor_dir))
 
     log("loading VG image_data.json")
     with (Path(args.anchor_dir) / "image_data.json").open() as fh:

--- a/tests_lib/meta/test_pile_coco_folds.py
+++ b/tests_lib/meta/test_pile_coco_folds.py
@@ -87,12 +87,7 @@ def _stage(root: Path) -> tuple[Path, dict[str, str]]:
     (anchor / "instances_val2017.json").write_text(json.dumps(_coco_annotations()))
     # An absent train split is a supported state: the loader logs and skips it.
     (anchor / "image_data.json").write_text(
-        json.dumps(
-            [
-                {"image_id": 2000 + i, "coco_id": 1000 + i, "width": _W, "height": _H}
-                for i in range(_N_IMAGES)
-            ]
-        )
+        json.dumps([{"image_id": 2000 + i, "coco_id": 1000 + i, "width": _W, "height": _H} for i in range(_N_IMAGES)])
     )
 
     demo = root / "demos"

--- a/tests_lib/meta/test_pile_coco_folds.py
+++ b/tests_lib/meta/test_pile_coco_folds.py
@@ -1,0 +1,187 @@
+"""Fold-out must answer with COCO's vocabulary, not with the caller's (#3640).
+
+``coco_folds.py``'s **fold-out** column claims to say what COCO class sits under
+a VG box of a given name, and that reading is what decides whether a VG spelling
+is folded in as an alias or banished to
+:data:`pile_config.SCALE_VG_AMBIGUOUS`. It used to load only the boxes of the
+classes passed to ``--classes``, so a class nobody had happened to name carried
+no boxes and every VG box over it fell through to ``(no COCO class)``.
+
+The failure direction is the dangerous one: `bike` read **100%** "means nothing"
+against a recorded 40.1%, and a 100% reading sends a perfectly good spelling to
+the ambiguous table, costing the class half its positives -- the #3605 defect,
+re-created by the tool built to detect it.
+
+What the fix pins is an *invariance*: fold-out for a name must not depend on
+which other classes the caller asked about. These tests run the real script in a
+subprocess (``pile_config.setup_env()`` rewrites ``os.environ`` and
+``sys.meta_path`` at import, which is not something to do to the test process)
+over a synthetic COCO/VG overlap built so the two answers differ.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+#: One VG image per COCO image, same pixel dimensions, so a box transfers
+#: exactly and IoU is 1.0 for a co-located pair.
+_W, _H = 640, 480
+
+#: Enough images that the default ``--min-count`` floor is irrelevant either way.
+_N_IMAGES = 20
+
+
+def _coco_annotations() -> dict:
+    """Every image carries one `bicycle` box and one `bench` box.
+
+    `bicycle` is the class VG's `bike` really denotes; `bench` is there so a
+    second unasked-for class is present, which is what makes an "all classes"
+    load distinguishable from "the one class that happens to matter".
+    """
+    images, annotations = [], []
+    for i in range(_N_IMAGES):
+        images.append({"id": 1000 + i, "width": _W, "height": _H})
+        annotations.append(
+            {"id": 10 * i + 1, "image_id": 1000 + i, "category_id": 2, "bbox": [100.0, 100.0, 200.0, 200.0]}
+        )
+        annotations.append(
+            {"id": 10 * i + 2, "image_id": 1000 + i, "category_id": 15, "bbox": [400.0, 300.0, 100.0, 100.0]}
+        )
+    return {
+        "categories": [
+            {"id": 2, "name": "bicycle"},
+            {"id": 15, "name": "bench"},
+            {"id": 47, "name": "cup"},
+        ],
+        "images": images,
+        "annotations": annotations,
+    }
+
+
+def _vg_objects() -> list[dict]:
+    """VG names the same pixels `bike` (on the bicycle) and `bench` (on the bench)."""
+    return [
+        {
+            "image_id": 2000 + i,
+            "objects": [
+                {"names": ["bike"], "x": 100, "y": 100, "w": 200, "h": 200},
+                {"names": ["bench"], "x": 400, "y": 300, "w": 100, "h": 100},
+            ],
+        }
+        for i in range(_N_IMAGES)
+    ]
+
+
+def _stage(root: Path) -> tuple[Path, dict[str, str]]:
+    """Write a synthetic anchor + VG cache; return the anchor dir and its env."""
+    anchor = root / "coco_anchor"
+    anchor.mkdir(parents=True)
+    (anchor / "instances_val2017.json").write_text(json.dumps(_coco_annotations()))
+    # An absent train split is a supported state: the loader logs and skips it.
+    (anchor / "image_data.json").write_text(
+        json.dumps(
+            [
+                {"image_id": 2000 + i, "coco_id": 1000 + i, "width": _W, "height": _H}
+                for i in range(_N_IMAGES)
+            ]
+        )
+    )
+
+    demo = root / "demos"
+    (demo / "visual_genome").mkdir(parents=True)
+    (demo / "visual_genome" / "objects.json").write_text(json.dumps(_vg_objects()))
+
+    env = {
+        **os.environ,
+        "VTS_PILE": str(root / "pile"),
+        "VTS_DEMO_CACHE": str(demo),
+        "VTSEARCH_DATA_DIR": str(root / "pile" / "datadir"),
+        "VTSEARCH_MODELS_DIR": str(root / "pile" / "models"),
+        "HF_HOME": str(root / "pile" / "models"),
+    }
+    return anchor, env
+
+
+def _folds(root: Path, classes: str) -> dict:
+    """Run the real script for ``--classes`` and return its JSON output."""
+    anchor, env = _stage(root)
+    out = root / "folds.json"
+    result = subprocess.run(  # noqa: S603  # interpreter + test-controlled args
+        [
+            sys.executable,
+            "coco_folds.py",
+            "--classes",
+            classes,
+            "--anchor-dir",
+            str(anchor),
+            "--min-count",
+            "1",
+            "--out",
+            str(out),
+        ],
+        cwd=str(_PILE_DIR),
+        capture_output=True,
+        text=True,
+        timeout=180,
+        env=env,
+    )
+    assert result.returncode == 0, f"coco_folds failed:\n{result.stdout}\n{result.stderr}"
+    return json.loads(out.read_text())
+
+
+@pytest.fixture(scope="module")
+def narrow(tmp_path_factory) -> dict:
+    """`bike` alone: the caller never names the class its boxes actually sit on."""
+    return _folds(tmp_path_factory.mktemp("narrow"), "bike")
+
+
+@pytest.fixture(scope="module")
+def wide(tmp_path_factory) -> dict:
+    """`bike` with its target loaded, which is what used to be required."""
+    return _folds(tmp_path_factory.mktemp("wide"), "bike,bicycle,bench")
+
+
+class TestFoldOutSeesTheWholeVocabulary:
+    def test_unnamed_target_class_is_found(self, narrow: dict) -> None:
+        """The regression: `bicycle` under `bike` without `bicycle` in --classes."""
+        assert narrow["fold_out"]["bike"].get("bicycle") == _N_IMAGES
+
+    def test_no_coco_class_is_not_reported_for_a_box_that_has_one(self, narrow: dict) -> None:
+        """A 100% `(no COCO class)` is the reading that costs a class its positives."""
+        assert narrow["fold_out"]["bike"].get("(no COCO class)", 0) == 0
+
+    def test_fold_out_does_not_depend_on_what_else_was_asked(self, narrow: dict, wide: dict) -> None:
+        """The invariance. What a VG name denotes is a fact about VG and COCO."""
+        assert narrow["fold_out"]["bike"] == wide["fold_out"]["bike"]
+        assert narrow["vg_boxes"]["bike"] == wide["vg_boxes"]["bike"] == _N_IMAGES
+
+
+class TestFoldInStaysScopedToTheRequestedClasses:
+    """Loading the whole vocabulary must not widen the *other* two tables.
+
+    Fold-in and the self-match canary answer a question about the classes the
+    caller named; every counter behind them is keyed on that set, so a stray
+    `bench` row would be a crash in ``name_coverage.py`` and a bogus row here.
+    """
+
+    def test_non_coco_name_has_no_coco_boxes(self, narrow: dict) -> None:
+        assert narrow["coco_boxes"].get("bike", 0) == 0
+        assert narrow["fold_in"]["bike"] == {}
+
+    def test_only_requested_classes_are_counted(self, narrow: dict) -> None:
+        assert set(narrow["fold_in"]) == {"bike"}
+        assert set(narrow["coco_boxes"]) <= {"bike"}
+
+    def test_a_requested_coco_class_still_folds_in(self, wide: dict) -> None:
+        """`bench` is spelled the same in both vocabularies, so it self-matches."""
+        assert wide["coco_boxes"]["bench"] == _N_IMAGES
+        assert wide["fold_in"]["bench"].get("bench") == _N_IMAGES
+        assert wide["fold_in"]["bicycle"].get("bike") == _N_IMAGES


### PR DESCRIPTION
`coco_boxes()` filled `want_boxes` under `if name not in classes: continue`, so a COCO class the caller had not named carried no boxes at all. Fold-out then tested each VG box against those boxes and, finding none, recorded `(no COCO class)` — answering the caller's own question back to them instead of COCO's.

The failure direction is the costly one. Fold-out is the test that decides whether a VG spelling is folded in as an alias or banished to `SCALE_VG_AMBIGUOUS`; a silent 100% "means nothing" is exactly what sends a good spelling to the ambiguous table and costs a class half its positives — the #3605 defect, re-created by the tool built to detect it. `bike` read 100% against the 40.1% `pile_config.SCALE_VG_AMBIGUOUS` records, purely because `bicycle` was absent from `--classes`.

## What changed

**`coco_folds.py`** — `coco_boxes()` loses its `classes` parameter and loads every COCO class. This is fix option 1 from the issue: what the docstring already claimed, and what the `present` map already did. The filter saved nothing worth having — the boxes are small beside `objects.json`, which every caller of this function also loads.

`--classes` now scopes the *question* only. Fold-in and the self-match canary are asked of the named classes alone, so their loops iterate `classes` rather than whatever is on the image.

**`name_coverage.py` / `name_evidence.py`** — the two sibling callers drop the argument. In `name_coverage.py` the loop scoping is load-bearing rather than cosmetic: its overlap counters are plain `dict.fromkeys(classes, 0)`, so a `bench` row arriving from the widened load would have been a `KeyError` rather than a wrong number. `name_evidence.py` only ever indexes `cboxes[cid][c]` for `c` in its class set and uses `present` (already the full vocabulary) for its base rate, so its figures are unchanged.

**`README.md`** — one paragraph stating the invariant where the definition-risk score is defined, since that is the number the bug corrupted.

## Verification

`tests_lib/meta/test_pile_coco_folds.py` runs the real script in a subprocess over a synthetic VG/COCO overlap where VG names `bike` on a COCO `bicycle` box, and pins the invariance: what a VG name denotes must not depend on which other classes the caller asked about.

Checked against the pre-fix script (`git show HEAD~1:…` restored in place) — the three fold-out tests fail, reproducing the issue's exact symptom:

```
FAILED test_unnamed_target_class_is_found
FAILED test_no_coco_class_is_not_reported_for_a_box_that_has_one
FAILED test_fold_out_does_not_depend_on_what_else_was_asked
3 failed, 3 passed
```

The three fold-in scoping tests pass there, because that half was already correct — they are guarding the widened load, not the bug.

Full `./run-tests.sh`: `RUN PASSED`, 10752 passed / 6 skipped, all heavy gates OK.

Closes #3640

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYGiULM6btwa6CMunCYxR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYGiULM6btwa6CMunCYxR4)_