### PR TITLE
CLI: calibrate the threshold on the snapshot that gets scored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A CLI Auto-Find run that converts or re-clips its dataset now calibrates the
+  threshold on what it actually scores.** The cut was fitted on the loaded
+  medias while scoring read the converted frames, pages or clips those medias
+  fan out into - and those are systematically different populations, because a
+  media's score is the *max* over its sub-items and is therefore never below its
+  own whole-item score. A cut chosen as a quantile of the first distribution
+  lands far lower in the second, so the run reported more hits than the
+  algorithm ever chose, with nothing in the output looking wrong. On a dataset
+  the detector needs no conversion or re-clip for - the common case, and the
+  only one anyone had noticed - the two populations are the same set and
+  thresholds are unchanged. Everywhere else the threshold moves, generally up.
+  A pure converter route was the sharper edge of the same bug: none of the
+  loaded medias carried a vector in the detector's space yet, so the population
+  estimator saw an empty haystack and silently did not run at all, shipping the
+  plain cross-calibration cut. Both now read the routed snapshot, which is
+  prepared once and shared between calibration and scoring rather than built
+  twice.
+
 - **The Dashboard's `⋯` › Export labels now exports the detector whose row you
   clicked.** It exported the *active* pair's live labels instead - whatever the
   top-bar pulldown was on, which the row's checkbox does not change - so the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -180,6 +180,19 @@ media by the same **max** rule as converter fan-out. A dataset already loaded
 with the matching clipper is scored as-is (no redundant re-clip), and a detector
 with no `input_spec.clipper` scores whole media.
 
+**The threshold is calibrated on whatever the run ends up scoring.** Converting
+and re-clipping change the population, not just the item count: the max over a
+media's clips is never below the media's own whole-item score, so a cut fitted
+on the loaded medias and applied to the routed ones sits systematically lower in
+the distribution it decides — more hits than the algorithm chose, in a run whose
+numbers all look reasonable. So the routing pass happens **before** calibration,
+and each detector's cut is realized on the converted, re-clipped, re-embedded
+snapshot its own scoring pass will read (issue #3647). On a natively-typed
+dataset needing no re-clip the two are the same set and nothing changes; on a
+converter-routed or re-clipped one the threshold moves, and moving it is the
+fix. The first chunk is prepared once and handed to both passes, so the
+correction costs no extra conversion or embedding work.
+
 **How to get the files:**
 
 - **Dataset file**: Export from the web UI via the dataset menu ("Export dataset"), or use a cached `.pkl` file from the `data/embeddings/` directory after loading a demo dataset.

--- a/scripts/eval-app-sync.pins.json
+++ b/scripts/eval-app-sync.pins.json
@@ -57,7 +57,7 @@
     "harness": "33e0ad5486369bf6646ccacd13b8ba076a12a55f4a92849c4bac36360b5b79ca"
   },
   "training.train_and_threshold": {
-    "app": "33e8c9e139c82d4b0e145bc79e10b30a1ea43265bf8aa8713e55014e1141f710",
+    "app": "54023ddec7758a6169876cb4efa43ded52e2ec2178a55b56eabb896ab3e3c110",
     "harness": "0802e5b7860de2c827b6dfa1c83c6242b686f1894d834e95a03fb6f6e8b20305"
   }
 }

--- a/tests/cli/test_chunked_id_renumber.py
+++ b/tests/cli/test_chunked_id_renumber.py
@@ -139,7 +139,7 @@ def _stub_detector_training(monkeypatch):
 
     import vtscore.cli as cli_mod
 
-    def _fake_load_and_train(detector_names, media_type, first_chunk_medias):
+    def _fake_load_and_train(detector_names, media_type, first_chunk_medias, routed=None):
         # Tiny linear "MLP" that always returns 0.5 logit → 0.62 sigmoid.
         linear = nn.Linear(2, 1)
         with torch.no_grad():

--- a/tests/cli/test_cli_calibration_population.py
+++ b/tests/cli/test_cli_calibration_population.py
@@ -1,0 +1,253 @@
+"""The CLI calibrates each detector on the snapshot it is about to score.
+
+``_load_and_train_detectors`` used to hand ``train_from_labelset`` the loaded
+medias while ``_score_medias_with_detectors`` scored the converted, re-clipped
+and re-embedded ones.  On a natively-typed dataset the detector needs no
+re-clip for, those are the same set - which is why it went unnoticed.
+Everywhere else the cut was fitted on one population and applied to another
+(issue #3647).  These tests pin the two halves that keep them the same
+snapshot: the routed memo the training pass calibrates against, and the
+scoring pass reusing that same object rather than preparing a second one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+
+import vtscore.cli as cli
+import vtscore.detectors.converter_routing as cr
+from vtscore.cli import _RoutedSnapshots, _detector_group_key, _score_medias_with_detectors
+
+DIM = 4
+
+
+def _constant_mlp() -> torch.nn.Module:
+    mlp = torch.nn.Linear(DIM, 1)
+    with torch.no_grad():
+        mlp.weight.fill_(1.0)
+        mlp.bias.fill_(0.0)
+    return mlp
+
+
+def _stub_embed(monkeypatch) -> None:
+    def _fake_embed(medias, name="", on_progress=None):
+        vec = np.ones(DIM, dtype=np.float32)
+        for m in medias.values():
+            m["embeddings"] = {name: vec}
+            m["embedder"] = name
+
+    monkeypatch.setattr("vtscore.datasets.stages.embedding.embed_missing", _fake_embed)
+
+
+class TestRoutedSnapshotsMemo:
+    def test_one_route_pass_per_group(self, client, monkeypatch):
+        calls: list[tuple] = []
+
+        def _fake_route(medias, target_type, embedder_name, clipper="", clipper_params=None):
+            calls.append((target_type, embedder_name, clipper))
+            out = {i + 1: dict(m) for i, m in enumerate(medias.values())}
+            return out, {i + 1: cid for i, cid in enumerate(medias)}
+
+        monkeypatch.setattr(cr, "route_and_embed", _fake_route)
+
+        medias = {1: {"id": 1, "media_type": "image"}, 2: {"id": 2, "media_type": "image"}}
+        routed = _RoutedSnapshots(medias)
+        key = _detector_group_key("image", "fake", "", {})
+
+        first = routed.get(key)
+        second = routed.get(key)
+
+        assert len(calls) == 1, "a repeated group must not re-route"
+        assert second is first, "both passes must see the same objects, not equal copies"
+
+    def test_distinct_groups_route_separately(self, client, monkeypatch):
+        calls: list[tuple] = []
+
+        def _fake_route(medias, target_type, embedder_name, clipper="", clipper_params=None):
+            calls.append((target_type, embedder_name, clipper))
+            return {1: {"id": 1, "media_type": target_type}}, {1: 1}
+
+        monkeypatch.setattr(cr, "route_and_embed", _fake_route)
+
+        routed = _RoutedSnapshots({1: {"id": 1, "media_type": "image"}})
+        routed.get(_detector_group_key("image", "fake", "", {}))
+        routed.get(_detector_group_key("image", "fake", "tiling", {"duration": "2.0"}))
+
+        assert [c[2] for c in calls] == ["", "tiling"]
+
+    def test_clipper_params_key_is_order_insensitive(self):
+        """Two detectors that declare the same params in a different dict order
+        are one group, not two - otherwise they'd re-clip the dataset twice."""
+        a = _detector_group_key("image", "e", "tiling", {"duration": "2.0", "overlap": "0.5"})
+        b = _detector_group_key("image", "e", "tiling", {"overlap": "0.5", "duration": "2.0"})
+        assert a == b
+
+
+class TestScoringReusesTheCalibrationSnapshot:
+    def test_scoring_pass_takes_the_memo(self, client, monkeypatch):
+        """The first chunk is both trained on and scored; preparing it twice
+        would re-decode every video and re-slice every clip."""
+        calls: list[str] = []
+
+        def _fake_route(medias, target_type, embedder_name, clipper="", clipper_params=None):
+            calls.append(target_type)
+            out = {
+                i + 1: {**m, "embeddings": {embedder_name: np.ones(DIM, dtype=np.float32)}}
+                for i, m in enumerate(medias.values())
+            }
+            return out, {i + 1: cid for i, cid in enumerate(medias)}
+
+        monkeypatch.setattr(cr, "route_and_embed", _fake_route)
+        _stub_embed(monkeypatch)
+
+        medias = {1: {"id": 1, "media_type": "image", "filename": "a.png"}}
+        detector_mlps = {
+            "det": {"mlp": _constant_mlp(), "threshold": 0.5, "media_type": "image", "embedder": "fake"},
+        }
+
+        routed = _RoutedSnapshots(medias)
+        routed.get(_detector_group_key("image", "fake", "", {}))
+        assert len(calls) == 1
+
+        results = _score_medias_with_detectors(medias, detector_mlps, routed)
+
+        assert len(calls) == 1, "scoring must reuse the prepared snapshot, not re-route"
+        assert "det" in results
+
+    def test_without_a_memo_scoring_routes_for_itself(self, client, monkeypatch):
+        """Every chunk after the first has no prepared snapshot to inherit."""
+        calls: list[str] = []
+
+        def _fake_route(medias, target_type, embedder_name, clipper="", clipper_params=None):
+            calls.append(target_type)
+            out = {
+                i + 1: {**m, "embeddings": {embedder_name: np.ones(DIM, dtype=np.float32)}}
+                for i, m in enumerate(medias.values())
+            }
+            return out, {i + 1: cid for i, cid in enumerate(medias)}
+
+        monkeypatch.setattr(cr, "route_and_embed", _fake_route)
+        _stub_embed(monkeypatch)
+
+        medias = {1: {"id": 1, "media_type": "image", "filename": "a.png"}}
+        detector_mlps = {
+            "det": {"mlp": _constant_mlp(), "threshold": 0.5, "media_type": "image", "embedder": "fake"},
+        }
+
+        _score_medias_with_detectors(medias, detector_mlps, None)
+        assert calls == ["image"]
+
+
+class TestGroupKeysCannotDrift:
+    def test_scoring_groups_on_the_same_key_the_haystack_was_built_from(self, client, monkeypatch):
+        """The whole fix rests on the two passes agreeing on what a group is,
+        so both read it off ``_detector_group_key`` rather than spelling it
+        out twice."""
+        info: dict[str, Any] = {
+            "media_type": "image",
+            "embedder": "fake",
+            "clipper": "tiling",
+            "clipper_params": {"duration": "2.0"},
+        }
+        seen: list[tuple] = []
+
+        def _fake_route(medias, target_type, embedder_name, clipper="", clipper_params=None):
+            seen.append(_detector_group_key(target_type, embedder_name, clipper, clipper_params or {}))
+            return {}, {}
+
+        monkeypatch.setattr(cr, "route_and_embed", _fake_route)
+        _stub_embed(monkeypatch)
+
+        _score_medias_with_detectors(
+            {1: {"id": 1, "media_type": "image"}},
+            {"det": {**info, "mlp": _constant_mlp(), "threshold": 0.5}},
+            None,
+        )
+
+        assert seen == [
+            _detector_group_key(info["media_type"], info["embedder"], info["clipper"], info["clipper_params"])
+        ]
+
+
+class TestTrainingIsHandedTheRoutedSnapshot:
+    def _detector(self, input_spec: dict | None = None) -> dict:
+        det = {
+            "name": "det",
+            "media_type": "image",
+            "labelset": {"labels": [{"md5": "a", "label": "good"}, {"md5": "b", "label": "bad"}]},
+        }
+        if input_spec is not None:
+            det["input_spec"] = input_spec
+        return det
+
+    def _run(self, monkeypatch, det: dict, medias: dict, routed_out: dict, to_source: dict):
+        """Train through ``_load_and_train_detectors``, capturing the haystack."""
+        import vtscore.detectors.labelset_training as lt
+        import vtscore.detectors.store as store_mod
+
+        monkeypatch.setattr(store_mod, "_read_detector", lambda _p: det)
+        monkeypatch.setattr(cr, "route_and_embed", lambda *a, **k: (routed_out, to_source))
+        monkeypatch.setattr("vtscore.detectors.input_spec.extract_input_spec_from_medias", lambda _m: None)
+
+        captured: dict[str, Any] = {}
+
+        def _fake_train(det_ctx, labelset, *, media_type, snap, haystack_for=None, on_progress=None):
+            det_ctx.embedder = "fake"
+            det_ctx.model = _constant_mlp()
+            det_ctx.threshold = 0.5
+            captured["snap"] = snap
+            captured["haystack"] = haystack_for("fake") if haystack_for is not None else None
+            return True
+
+        monkeypatch.setattr(lt, "train_from_labelset", _fake_train)
+        routed = _RoutedSnapshots(medias)
+        cli._load_and_train_detectors(["det"], "image", medias, routed)
+        return captured
+
+    def test_haystack_is_the_routed_snapshot_not_the_loaded_medias(self, client, monkeypatch):
+        medias = {1: {"id": 1, "media_type": "image"}}
+        clips = {1: {"id": 1, "media_type": "image"}, 2: {"id": 2, "media_type": "image"}}
+        captured = self._run(
+            monkeypatch,
+            self._detector({"clipper": "tiling", "clipper_params": {"duration": "2.0"}}),
+            medias,
+            clips,
+            {1: 1, 2: 1},
+        )
+
+        # ``snap`` keeps its other job - resolving the labelset's origins - and
+        # is still the loaded medias.  The haystack is what scoring will read.
+        assert captured["snap"] is medias
+        assert captured["haystack"] is not None
+        assert captured["haystack"].medias is clips
+        assert captured["haystack"].to_source == {1: 1, 2: 1}
+
+    def test_empty_routed_snapshot_falls_back_to_the_snap(self, client, monkeypatch):
+        """Nothing converted or embedded: keep the loaded medias rather than
+        fitting the population estimator on an empty distribution."""
+        medias = {1: {"id": 1, "media_type": "image"}}
+        captured = self._run(monkeypatch, self._detector(), medias, {}, {})
+        assert captured["haystack"] is None
+
+    def test_no_memo_leaves_the_snap_as_the_haystack(self, client, monkeypatch):
+        """A caller with no scoring pass to agree with keeps the old behaviour."""
+        import vtscore.detectors.labelset_training as lt
+        import vtscore.detectors.store as store_mod
+
+        monkeypatch.setattr(store_mod, "_read_detector", lambda _p: self._detector())
+        monkeypatch.setattr("vtscore.detectors.input_spec.extract_input_spec_from_medias", lambda _m: None)
+        captured: dict[str, Any] = {}
+
+        def _fake_train(det_ctx, labelset, *, media_type, snap, haystack_for=None, on_progress=None):
+            det_ctx.embedder = "fake"
+            det_ctx.model = _constant_mlp()
+            det_ctx.threshold = 0.5
+            captured["haystack"] = haystack_for("fake") if haystack_for is not None else None
+            return True
+
+        monkeypatch.setattr(lt, "train_from_labelset", _fake_train)
+        cli._load_and_train_detectors(["det"], "image", {1: {"id": 1, "media_type": "image"}})
+        assert captured["haystack"] is None

--- a/tests/cli/test_cli_streaming.py
+++ b/tests/cli/test_cli_streaming.py
@@ -130,7 +130,7 @@ def _stub_split_training(monkeypatch):
 
     import vtscore.cli as cli_mod
 
-    def _fake_load_and_train(detector_names, media_type, first_chunk_medias):
+    def _fake_load_and_train(detector_names, media_type, first_chunk_medias, routed=None):
         linear = nn.Linear(2, 1)
         with torch.no_grad():
             linear.weight.data = torch.tensor([[100.0, 0.0]])

--- a/tests_lib/detectors/test_calibration_haystack.py
+++ b/tests_lib/detectors/test_calibration_haystack.py
@@ -1,0 +1,249 @@
+"""The threshold is realized on the population that will be *scored*.
+
+The fold-anchored estimator carries its per-fold cuts to the final model in
+quantile space and realizes them against one distribution.  Which distribution
+that is has to be the one inference reads.  For every caller that scores the
+snapshot it loaded - the GUI - the two are the same set, and ``snap`` serves as
+both the label-resolution snapshot and the haystack.  The CLI converts,
+re-clips and re-embeds before scoring, so it names its haystack separately
+(issue #3647); these tests pin that seam.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+import vtscore.detectors.labelset_training as lt
+import vtscore.training.thresholds as thresholds_mod
+from vtscore.datasets.labelset import LabeledElement, LabelSet
+from vtscore.detectors.labelset_training import Haystack, train_from_labelset
+from vtscore.state.core import DetectorContext
+
+DIM = 8
+N = 40
+ID_BASE = 9000
+EMBEDDER = "test_embedder"
+
+
+def _unit(vec: np.ndarray) -> np.ndarray:
+    return (vec / (np.linalg.norm(vec) + 1e-8)).astype(np.float32)
+
+
+def _media(cid: int, vec: np.ndarray) -> dict:
+    return {"id": cid, "media_type": "image", "embedder": EMBEDDER, "embeddings": {EMBEDDER: vec}}
+
+
+@pytest.fixture
+def captured_final_scores(monkeypatch):
+    """The score distribution the cut is finally realized on."""
+    seen: list[list[float]] = []
+    real = thresholds_mod.fit_fold_anchored_cut
+
+    def _spy(fold_haystacks, fold_orderings, final_scores, **kwargs):
+        seen.append([float(s) for s in final_scores])
+        return real(fold_haystacks, fold_orderings, final_scores, **kwargs)
+
+    monkeypatch.setattr(thresholds_mod, "fit_fold_anchored_cut", _spy)
+    return seen
+
+
+@pytest.fixture
+def stub_labels(monkeypatch):
+    """Ten labels around two prototypes, cached as if their origins resolved.
+
+    Stands in for ``populate_label_embeddings``, whose real job (fetching each
+    origin's file and embedding it) is not what these tests are about; what
+    matters is that it stamps ``det_ctx.embedder`` before the haystack hook is
+    consulted, which the stub reproduces.
+    """
+    rng = np.random.default_rng(3)
+    good_proto = _unit(rng.standard_normal(DIM))
+    bad_proto = _unit(rng.standard_normal(DIM))
+
+    elements = []
+    vecs: dict[str, np.ndarray] = {}
+    from vtscore.detectors.labelset_elements import stable_element_id
+
+    for i in range(5):
+        for label, proto in (("good", good_proto), ("bad", bad_proto)):
+            elem = LabeledElement(md5=f"{label}-{i}", label=label, origin_name=f"{label}-{i}.png")
+            elements.append(elem)
+            vecs[stable_element_id(elem)] = _unit(proto + 0.1 * rng.standard_normal(DIM))
+
+    def _fake_populate(det_ctx, labelset, *, media_type, snap, on_progress=None):
+        det_ctx.embedder = EMBEDDER
+        det_ctx.label_embeddings.update(vecs)
+
+    monkeypatch.setattr(lt, "populate_label_embeddings", _fake_populate)
+    return LabelSet(elements=elements), good_proto, rng
+
+
+def _snapshots(rng, good_proto):
+    """The loaded medias, and the re-clipped snapshot scoring would read.
+
+    Every media fans out into four clips: three copies of the parent and one
+    "hot" crop that looks more good-like.  Scoring maxes over a media's clips,
+    so the routed distribution is by construction >= the native one - the same
+    one-sided bias #3180 fixed on the region-pooling side.
+    """
+    native: dict[int, dict] = {}
+    clips: dict[int, dict] = {}
+    to_source: dict[int, int] = {}
+    next_clip = 1
+    for cid in range(ID_BASE, ID_BASE + N):
+        img = _unit(rng.standard_normal(DIM))
+        native[cid] = _media(cid, img)
+        for k in range(4):
+            vec = img if k < 3 else _unit(0.5 * img + 0.5 * good_proto + 0.2 * rng.standard_normal(DIM))
+            clips[next_clip] = _media(next_clip, vec)
+            to_source[next_clip] = cid
+            next_clip += 1
+    return native, clips, to_source
+
+
+def _scores(model, snap) -> np.ndarray:
+    from vtscore.detectors.training import score_rows_with_model, scoring_rows_for_snap
+
+    rows = scoring_rows_for_snap(snap, EMBEDDER)
+    return np.asarray(score_rows_with_model(model, rows)[0], dtype=np.float64)
+
+
+class TestHaystackOverride:
+    def test_cut_is_realized_on_the_haystack_not_the_snap(self, stub_labels, captured_final_scores):
+        labelset, good_proto, rng = stub_labels
+        native, clips, to_source = _snapshots(rng, good_proto)
+
+        det_ctx = DetectorContext("d", media_type="image")
+        assert train_from_labelset(
+            det_ctx,
+            labelset,
+            media_type="image",
+            snap=native,
+            haystack_for=lambda _emb: Haystack(clips, to_source),
+        )
+
+        assert len(captured_final_scores) == 1
+        fitted = np.asarray(captured_final_scores[0], dtype=np.float64)
+        np.testing.assert_allclose(fitted, _scores(det_ctx.model, clips), rtol=0, atol=0)
+
+        # ...and the two populations really are different, or this proves nothing.
+        assert fitted.mean() > _scores(det_ctx.model, native).mean() + 1e-3
+
+    def test_hook_sees_the_space_the_labels_landed_in(self, stub_labels):
+        """The routing decision needs the embedder, which only exists once the
+        labels are embedded - so the hook is called after, not before."""
+        labelset, good_proto, rng = stub_labels
+        native, clips, to_source = _snapshots(rng, good_proto)
+        seen: list[str] = []
+
+        def _hook(embedder_name: str):
+            seen.append(embedder_name)
+            return Haystack(clips, to_source)
+
+        train_from_labelset(
+            DetectorContext("d", media_type="image"),
+            labelset,
+            media_type="image",
+            snap=native,
+            haystack_for=_hook,
+        )
+        assert seen == [EMBEDDER]
+
+    def test_no_hook_keeps_the_snap_as_the_haystack(self, stub_labels, captured_final_scores):
+        """Every caller that scores what it loaded is byte-for-byte unchanged."""
+        labelset, good_proto, rng = stub_labels
+        native, _clips, _to_source = _snapshots(rng, good_proto)
+
+        det_ctx = DetectorContext("d", media_type="image")
+        assert train_from_labelset(det_ctx, labelset, media_type="image", snap=native)
+
+        fitted = np.asarray(captured_final_scores[0], dtype=np.float64)
+        np.testing.assert_allclose(fitted, _scores(det_ctx.model, native), rtol=0, atol=0)
+
+    def test_hook_returning_none_keeps_the_snap(self, stub_labels, captured_final_scores):
+        """An empty routed snapshot must not fit the estimator on nothing."""
+        labelset, good_proto, rng = stub_labels
+        native, _clips, _to_source = _snapshots(rng, good_proto)
+
+        det_ctx = DetectorContext("d", media_type="image")
+        assert train_from_labelset(
+            det_ctx,
+            labelset,
+            media_type="image",
+            snap=native,
+            haystack_for=lambda _emb: None,
+        )
+        fitted = np.asarray(captured_final_scores[0], dtype=np.float64)
+        np.testing.assert_allclose(fitted, _scores(det_ctx.model, native), rtol=0, atol=0)
+
+    def test_threshold_moves_with_the_population(self, stub_labels):
+        """The whole point: the same head cuts the scored population at the
+        quantile the algorithm chose, instead of one fitted on a lower one."""
+        labelset, good_proto, rng = stub_labels
+        native, clips, to_source = _snapshots(rng, good_proto)
+
+        ctx_a = DetectorContext("a", media_type="image")
+        train_from_labelset(ctx_a, labelset, media_type="image", snap=native)
+        ctx_b = DetectorContext("b", media_type="image")
+        train_from_labelset(
+            ctx_b,
+            labelset,
+            media_type="image",
+            snap=native,
+            haystack_for=lambda _emb: Haystack(clips, to_source),
+        )
+
+        # Same labels, same head - only the haystack differs.
+        assert torch.allclose(ctx_a.model.state_dict()["0.weight"], ctx_b.model.state_dict()["0.weight"], atol=1e-5)
+
+        clip_scores = _scores(ctx_b.model, clips)
+        per_source: dict[int, float] = {}
+        for cid, score in zip(sorted(clips), clip_scores):
+            src = to_source[cid]
+            per_source[src] = max(per_source.get(src, -np.inf), float(score))
+        scored = np.array(sorted(per_source.values()))
+
+        assert ctx_b.threshold > ctx_a.threshold
+        # The old cut sits lower in the population it is applied to than the
+        # new one - which is over-inclusion, measured as hits.
+        assert int((scored >= ctx_a.threshold).sum()) > int((scored >= ctx_b.threshold).sum())
+
+
+class TestVoteExclusionFollowsTheHaystack:
+    def test_voted_ids_are_mapped_through_to_source(self, stub_labels, monkeypatch):
+        """The #3308 exclusion names media ids; routing throws those ids away,
+        so the mapping is what keeps it meaning anything."""
+        labelset, good_proto, rng = stub_labels
+        native, clips, to_source = _snapshots(rng, good_proto)
+
+        # Two loaded medias carry labels.
+        voted_sources = {ID_BASE, ID_BASE + 1}
+        monkeypatch.setattr(lt, "labeled_media_ids", lambda _ls, _snap: set(voted_sources))
+
+        seen: dict = {}
+        import vtscore.detectors.training as training_mod
+
+        real = training_mod.train_and_threshold
+
+        def _spy(*args, **kwargs):
+            seen.update(kwargs)
+            return real(*args, **kwargs)
+
+        # ``train_from_labelset`` imports the symbol inside its own body, so
+        # the module attribute is what the call resolves against.
+        monkeypatch.setattr(training_mod, "train_and_threshold", _spy)
+
+        train_from_labelset(
+            DetectorContext("d", media_type="image"),
+            labelset,
+            media_type="image",
+            snap=native,
+            haystack_for=lambda _emb: Haystack(clips, to_source),
+        )
+
+        expected = {cid for cid, src in to_source.items() if src in voted_sources}
+        assert seen["voted_ids"] == expected
+        # Every clip of both voted media, and nothing else.
+        assert len(expected) == 8

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -129,10 +129,73 @@ def _list_exporter_names() -> list[str]:
     return [exp.name for exp in list_exporters()]
 
 
+def _detector_group_key(
+    target_type: str,
+    embedder_name: str,
+    clipper: str,
+    clipper_params: dict[str, Any],
+) -> tuple[str, str, str, tuple]:
+    """The identity of a scoring snapshot: what it is routed, clipped and embedded to.
+
+    Detectors sharing a key share one prepared snapshot, so a dataset scored by
+    two image/siglip detectors at the same granularity is converted, re-clipped
+    and embedded once.  Calibration and scoring both key on this, from the one
+    definition, so the population the threshold is fitted on cannot drift from
+    the population it is applied to (issue #3647).
+    """
+    return (
+        target_type,
+        embedder_name,
+        clipper,
+        tuple(sorted((str(k), str(v)) for k, v in (clipper_params or {}).items())),
+    )
+
+
+class _RoutedSnapshots:
+    """One :func:`~vtscore.detectors.converter_routing.route_and_embed` pass per
+    detector group, over one chunk of medias.
+
+    Threshold calibration and scoring want the **same** routed snapshot: the
+    fold-anchored cut is realized as a quantile of the population it is about
+    to cut, so fitting it on the loaded medias while inference reads the
+    converted/re-clipped ones lands the quantile on the wrong distribution
+    (issue #3647).  Routing twice would also pay twice - a converter re-decodes
+    the video, a re-clip re-slices and re-embeds every clip - so the first
+    chunk, which is both the chunk detectors are trained on and a chunk that
+    gets scored, memoises its snapshots here and hands the same objects to both
+    passes.
+
+    Scoped to one chunk deliberately: later chunks route themselves and are
+    scored at the threshold the first chunk fixed, which is what keeps every
+    chunk of a streaming run judged by one cut.
+    """
+
+    def __init__(self, medias: dict[int, dict[str, Any]]) -> None:
+        self._medias = medias
+        self._cache: dict[tuple[str, str, str, tuple], tuple[dict[int, dict[str, Any]], dict[int, int]]] = {}
+
+    def get(self, key: tuple[str, str, str, tuple]) -> tuple[dict[int, dict[str, Any]], dict[int, int]]:
+        cached = self._cache.get(key)
+        if cached is None:
+            from vtscore.detectors.converter_routing import route_and_embed  # noqa: PLC0415
+
+            target_type, embedder_name, clipper, clipper_params_items = key
+            cached = route_and_embed(
+                self._medias,
+                target_type,
+                embedder_name,
+                clipper=clipper,
+                clipper_params=dict(clipper_params_items),
+            )
+            self._cache[key] = cached
+        return cached
+
+
 def _load_and_train_detectors(
     detector_names: list[str],
     media_type: str,
     snap: dict[int, dict[str, Any]],
+    routed: "_RoutedSnapshots | None" = None,
 ) -> dict[str, dict[str, Any]]:
     """Resolve, re-embed, and train an MLP for each named detector.
 
@@ -146,6 +209,15 @@ def _load_and_train_detectors(
     embeddings would be from a different granularity and the scores would
     be meaningless.
 
+    When *routed* is given, each detector's threshold is calibrated on the
+    snapshot **scoring will read** - the converted, re-clipped, re-embedded one
+    that :class:`_RoutedSnapshots` prepares - rather than on the loaded medias.
+    The two are the same set on a natively-typed dataset the detector needs no
+    re-clip for, which is why this went unnoticed; they are systematically
+    different everywhere else, and the cut is realized as a quantile of
+    whichever it is handed (issue #3647).  ``None`` keeps the loaded medias as
+    the haystack, for callers with no scoring pass to agree with.
+
     Returns a ``{name: {"mlp": nn.Sequential, "threshold": float}}`` map.
     Raises :class:`ValueError` if a detector cannot be trained - for example
     when none of its labels' origin files are resolvable from the CLI
@@ -158,7 +230,7 @@ def _load_and_train_detectors(
         extract_input_spec_from_medias,
     )
     from vtscore.detectors.store import _detector_path, _read_detector
-    from vtscore.detectors.labelset_training import train_from_labelset
+    from vtscore.detectors.labelset_training import Haystack, train_from_labelset
     from vtscore.state.core import DetectorContext
 
     dataset_spec = extract_input_spec_from_medias(snap)
@@ -223,11 +295,35 @@ def _load_and_train_detectors(
             raise ValueError(f"Detector '{det_name}' has no labels.")
 
         det_ctx = DetectorContext(det_name, media_type=det_media_type or media_type)
+
+        target_type = det_media_type or media_type
+
+        def _haystack_for(
+            embedder_name: str,
+            _target: str = target_type,
+            _clipper: str = reclip_clipper,
+            _params: dict[str, Any] = reclip_params,
+        ) -> "Haystack | None":
+            """The population this detector's threshold is realized on.
+
+            Called once the labels are embedded, so ``embedder_name`` is the
+            space they landed in - which is exactly what the routing key needs
+            and what does not exist before training starts.  An empty routed
+            snapshot (nothing converts, nothing embeds) yields ``None``, which
+            leaves the loaded medias as the haystack rather than fitting the
+            estimator on nothing.
+            """
+            if routed is None or not _target:
+                return None
+            hay_medias, to_source = routed.get(_detector_group_key(_target, embedder_name, _clipper, _params))
+            return Haystack(hay_medias, to_source) if hay_medias else None
+
         trained = train_from_labelset(
             det_ctx,
             labelset,
-            media_type=det_media_type or media_type,
+            media_type=target_type,
             snap=snap,
+            haystack_for=_haystack_for,
         )
         if not trained:
             cached = len(det_ctx.label_embeddings)
@@ -263,6 +359,7 @@ def _load_and_train_detectors(
 def _score_medias_with_detectors(
     medias: dict[int, dict[str, Any]],
     detector_mlps: dict[str, dict[str, Any]],
+    routed: "_RoutedSnapshots | None" = None,
 ) -> dict[str, dict[str, Any]]:
     """Score *medias* against pre-trained detector MLPs, routing across types.
 
@@ -279,6 +376,11 @@ def _score_medias_with_detectors(
     sub-items clears the threshold ("find the needle").  Homogeneous single-type
     datasets with no re-clip take the identity route (one hit per media),
     byte-for-byte the pre-routing behaviour.
+
+    *routed* is the first chunk's memo of those prepared snapshots, shared with
+    the calibration pass that fitted these thresholds on them (issue #3647), so
+    that chunk is routed once rather than once per pass.  ``None`` - every
+    later chunk - prepares its own.
     """
     if not medias or not detector_mlps:
         return {}
@@ -293,17 +395,17 @@ def _score_medias_with_detectors(
     # detectors with the same granularity is prepared once, not per detector.
     groups: dict[tuple[str, str, str, tuple], list[str]] = defaultdict(list)
     for det_name, info in detector_mlps.items():
-        clipper_params = info.get("clipper_params") or {}
-        key = (
+        key = _detector_group_key(
             info.get("media_type") or "",
             info.get("embedder") or "",
             info.get("clipper") or "",
-            tuple(sorted((str(k), str(v)) for k, v in clipper_params.items())),
+            info.get("clipper_params") or {},
         )
         groups[key].append(det_name)
 
     results: dict[str, dict[str, Any]] = {}
-    for (target_type, embedder_name, clipper, clipper_params_items), det_names in groups.items():
+    for key, det_names in groups.items():
+        target_type, embedder_name, clipper, clipper_params_items = key
         if not target_type:
             # Legacy detector with no declared media_type: score every media
             # directly, one hit per media (media with no usable vector are
@@ -313,13 +415,16 @@ def _score_medias_with_detectors(
             # dataset those differ. Typed detectors take the routing path below.
             results.update(_score_direct_all(det_names, detector_mlps, medias, embedder_name))
             continue
-        scoring_medias, scoring_to_source = route_and_embed(
-            medias,
-            target_type,
-            embedder_name,
-            clipper=clipper,
-            clipper_params=dict(clipper_params_items),
-        )
+        if routed is not None:
+            scoring_medias, scoring_to_source = routed.get(key)
+        else:
+            scoring_medias, scoring_to_source = route_and_embed(
+                medias,
+                target_type,
+                embedder_name,
+                clipper=clipper,
+                clipper_params=dict(clipper_params_items),
+            )
         if not scoring_medias:
             continue
         # One row build per group; every head in the group forwards the same
@@ -1011,23 +1116,29 @@ def _train_detectors_for_first_chunk(
     media_type: str,
     override_detectors: list[str] | None,
     autofind_detectors: list[str],
-) -> dict[str, dict[str, Any]]:
+) -> tuple[dict[str, dict[str, Any]], _RoutedSnapshots]:
     """Train each Auto-Find (or override) detector once against the first chunk.
+
+    Returns the trained detectors alongside the routed snapshots their
+    thresholds were calibrated on, so the caller can score this same chunk
+    against the identical population instead of preparing it a second time
+    (issue #3647).
 
     Raises :class:`ValueError` when no detector applies to *media_type* -
     that's almost always a settings-file misconfiguration the caller wants
     surfaced immediately.
     """
     detector_names = list(override_detectors) if override_detectors is not None else list(autofind_detectors)
+    routed = _RoutedSnapshots(chunk_medias)
     detector_mlps: dict[str, dict[str, Any]] = (
-        _load_and_train_detectors(detector_names, media_type, chunk_medias) if detector_names else {}
+        _load_and_train_detectors(detector_names, media_type, chunk_medias, routed) if detector_names else {}
     )
     if not detector_mlps:
         raise ValueError(
             f"No Auto-Find detectors found for media type: {media_type}. "
             "Add detectors to the settings file's autofind_detectors list."
         )
-    return detector_mlps
+    return detector_mlps, routed
 
 
 def _score_chunk(
@@ -1036,6 +1147,7 @@ def _score_chunk(
     total_medias: int,
     detector_mlps: dict[str, dict[str, Any]],
     merged_results: dict[str, dict[str, Any]],
+    routed: "_RoutedSnapshots | None" = None,
 ) -> None:
     """Emit chunk-start progress when relevant, score this chunk, and merge in place."""
     if chunk_num > 1 or total_medias != len(chunk_medias):
@@ -1045,7 +1157,7 @@ def _score_chunk(
             chunk_num=chunk_num,
             chunk_size=len(chunk_medias),
         )
-    chunk_results = _score_medias_with_detectors(chunk_medias, detector_mlps)
+    chunk_results = _score_medias_with_detectors(chunk_medias, detector_mlps, routed)
     _merge_detector_results(merged_results, chunk_results)
 
 
@@ -1062,6 +1174,9 @@ def _run_live_pipeline(
     merged_results: dict[str, dict[str, Any]] = {}
     media_type: str | None = None
     detector_mlps: dict[str, dict[str, Any]] | None = None
+    # The first chunk's prepared snapshots, held only until that chunk is
+    # scored against them; every later chunk routes itself.
+    routed: _RoutedSnapshots | None = None
     total_medias = 0
     chunk_num = 0
 
@@ -1074,12 +1189,13 @@ def _run_live_pipeline(
 
         if media_type is None:
             media_type = _detect_media_type(chunk_medias)
-            detector_mlps = _train_detectors_for_first_chunk(
+            detector_mlps, routed = _train_detectors_for_first_chunk(
                 chunk_medias, media_type, override_detectors, autofind_detectors
             )
 
         if detector_mlps:
-            _score_chunk(chunk_medias, chunk_num, total_medias, detector_mlps, merged_results)
+            _score_chunk(chunk_medias, chunk_num, total_medias, detector_mlps, merged_results, routed)
+        routed = None
 
     if not merged_results:
         raise ValueError(empty_error)
@@ -1110,13 +1226,16 @@ def _stream_hit_records(
     rest: Iterator[dict[int, dict[str, Any]]],
     detector_mlps: dict[str, dict[str, Any]],
     keep_negatives: bool,
+    routed: "_RoutedSnapshots | None" = None,
 ) -> Iterator[tuple[str, dict[str, Any]]]:
     """Score each chunk and yield ``(detector_name, hit)`` pairs in chunk order.
 
     No global accumulation and no global sort: each chunk is scored, its hits
     are yielded, and the chunk is dropped before the next one is pulled, so
     peak memory stays bounded by the chunk size regardless of how many hits
-    the whole run produces.  Above-threshold hits carry ``label="good"``;
+    the whole run produces.  *routed* is the first chunk's already-prepared
+    scoring snapshots, handed over from training (issue #3647) and released as
+    soon as that chunk is scored.  Above-threshold hits carry ``label="good"``;
     below-threshold hits are emitted (with ``label="bad"``) only when
     *keep_negatives* is set.
     """
@@ -1135,7 +1254,11 @@ def _stream_hit_records(
                 chunk_num=chunk_num,
                 chunk_size=len(chunk),
             )
-        chunk_results = _score_medias_with_detectors(chunk, detector_mlps)
+        chunk_results = _score_medias_with_detectors(chunk, detector_mlps, routed)
+        # Only the first chunk has prepared snapshots to reuse, and holding
+        # them past its scoring pass would keep every clip alive for the whole
+        # run - the one thing this pipeline exists to avoid.
+        routed = None
         for det_name, det_result in chunk_results.items():
             for hit in det_result.get("hits", []):
                 yield det_name, {**hit, "label": "good"}
@@ -1187,7 +1310,9 @@ def _run_streaming_pipeline(
 
     apply_custom_metadata_md5(first_chunk)
     media_type = _detect_media_type(first_chunk)
-    detector_mlps = _train_detectors_for_first_chunk(first_chunk, media_type, override_detectors, autofind_detectors)
+    detector_mlps, routed = _train_detectors_for_first_chunk(
+        first_chunk, media_type, override_detectors, autofind_detectors
+    )
 
     header = {
         "media_type": media_type,
@@ -1197,7 +1322,7 @@ def _run_streaming_pipeline(
         "keep_negatives": bool(keep_negatives),
     }
 
-    records = _stream_hit_records(first_chunk, iterator, detector_mlps, keep_negatives)
+    records = _stream_hit_records(first_chunk, iterator, detector_mlps, keep_negatives, routed)
     result = exporter.export_cli_streaming(header, records, exporter_field_values or {})
     message = result.get("message", "Export complete.")
     cli_progress.emit("export_complete", text=message, message=message)

--- a/vtscore/detectors/labelset_training.py
+++ b/vtscore/detectors/labelset_training.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, NamedTuple
 
 import numpy as np
 
@@ -851,18 +851,46 @@ def maybe_labelset_structural_rerank(
     )
 
 
+class Haystack(NamedTuple):
+    """A calibration population that is not the label-resolution snapshot.
+
+    ``medias`` is the snapshot the fold-anchored cut is realized on, and
+    ``to_source`` maps each of its ids back to the id in *snap* it descends
+    from - the identity for a snapshot that is just *snap* renumbered, the
+    parent media for every converter output or re-clip sub-item.  The mapping
+    is what lets the vote exclusion (#3308) still name the labelled items after
+    routing has thrown their ids away.
+    """
+
+    medias: dict[int, dict[str, Any]]
+    to_source: dict[int, int]
+
+
 def train_from_labelset(
     det_ctx,
     labelset: LabelSet,
     *,
     media_type: str,
     snap: dict[int, dict[str, Any]] | None,
+    haystack_for: "Callable[[str], Haystack | None] | None" = None,
     on_progress: ProgressCallback | None = None,
 ) -> bool:
     """Populate the embedding cache, build (X, y), train, and store on *det_ctx*.
 
     Returns ``True`` when an MLP was trained (need ≥1 good and ≥1 bad cached
     vector); otherwise leaves ``det_ctx.model`` untouched.
+
+    *snap* does two jobs, and a caller that scores something other than what it
+    loaded needs them separated.  It is the snapshot the labelset's elements
+    are resolved against, and it is the haystack the threshold is calibrated
+    on.  For the GUI those are the same set - it scores the dataset it loaded -
+    but the CLI converts, re-clips and re-embeds before scoring, so calibrating
+    on *snap* would realize the cut's quantile on a population inference never
+    sees (issue #3647).  Such a caller passes *haystack_for*, which is invoked
+    **after** the labels are embedded - so it is handed ``det_ctx.embedder``,
+    the space they turned out to land in, which is the very thing a routing
+    decision needs and which does not exist before this call.  Returning
+    ``None`` from it keeps *snap* as the haystack.
     """
     populate_label_embeddings(
         det_ctx,
@@ -883,6 +911,12 @@ def train_from_labelset(
     # labels were embedded in; score the safe-threshold pass in that same space.
     # Pass det_ctx so the fold orderings are cached for a no-retrain Inclusion
     # slide (otherwise the slide can't move the cutoff — see train_and_threshold).
+    haystack = haystack_for(det_ctx.embedder or "") if haystack_for is not None else None
+    voted_ids = labeled_media_ids(labelset, snap)
+    if haystack is not None:
+        # The haystack's ids are its own; name the labelled items in them.
+        voted_ids = {hid for hid, src in haystack.to_source.items() if src in voted_ids}
+
     mlp, threshold = train_and_threshold(
         X_list,
         y_list,
@@ -891,7 +925,8 @@ def train_from_labelset(
         det_ctx=det_ctx,
         groups=groups,
         score_rows=score_rows,
-        voted_ids=labeled_media_ids(labelset, snap),
+        voted_ids=voted_ids,
+        haystack=haystack.medias if haystack is not None else None,
     )
     det_ctx.model = mlp
     det_ctx.threshold = threshold

--- a/vtscore/detectors/training.py
+++ b/vtscore/detectors/training.py
@@ -401,6 +401,7 @@ def train_and_threshold(
     groups: list | None = None,
     score_rows: dict | None = None,
     voted_ids: "set[int] | None" = None,
+    haystack: dict | None = None,
     haystack_rows: "ScoringRows | None" = None,
 ) -> tuple[Any, float]:
     """Train the detector head and compute a calibrated threshold.
@@ -427,7 +428,8 @@ def train_and_threshold(
         X_list: Embedding vectors (list of numpy arrays).
         y_list: Binary labels (1.0 = good, 0.0 = bad).
         snap: Optional media snapshot - the haystack the population
-            estimator is fitted on.  Without it the threshold is the plain
+            estimator is fitted on, unless *haystack* overrides it.  Without
+            either there is nothing to fit on and the threshold is the plain
             cross-calibration cut.
         embedder_name: The detector's primary embedder, used so the
             haystack scoring pass reads vectors from the same space the
@@ -446,16 +448,35 @@ def train_and_threshold(
         score_rows: Per-bag inference row stacks; see
             :func:`_calibration_score_rows`.  Only consulted when *groups*
             reveals flooding.
-        voted_ids: Media ids in *snap* whose labels the training set carries.
+        haystack: The population the cut is *realized* on, when that is not
+            *snap*.  The two are the same set for every caller that scores the
+            snapshot it calibrated against - the GUI, which scores the loaded
+            dataset it was handed - and differ for the CLI, whose scoring pass
+            converts, re-clips and re-embeds the loaded medias into the
+            detector's own granularity before scoring them
+            (:func:`~vtscore.detectors.converter_routing.route_and_embed`).
+            The fold-anchored estimator carries its per-fold cuts to the final
+            model *in quantile space* and realizes them against this
+            distribution, so handing it the loaded medias while inference reads
+            the routed ones lands the quantile on the wrong ruler: a cut fitted
+            on whole images and applied to the max over their clips sits far
+            lower in the scored population than the algorithm intended (issue
+            #3647).  *snap* keeps its other job either way - it is the snapshot
+            a caller's labels are resolved against, which the routed items,
+            with their throwaway ids and recomputed hashes, cannot serve as.
+            The blend schedule follows *haystack* too, since it is chosen off
+            the scoring geometry.
+        voted_ids: Media ids in the haystack whose labels the training set
+            carries.
             Excluded from every haystack the fold-anchored estimator fits on -
             their scores under the models trained on them are optimistically
             shifted (issue #3308; see :func:`_fused_threshold`).  ``None`` (the
             callers with no way to name their labels' media) keeps the full
             haystack.
-        haystack_rows: *snap*'s already-built
+        haystack_rows: the haystack's already-built
             :func:`scoring_rows_for_snap` matrix, when the caller has one in
             hand.  Purely an optimisation - it must be the rows this call would
-            have built itself, i.e. ``scoring_rows_for_snap(snap,
+            have built itself, i.e. ``scoring_rows_for_snap(haystack or snap,
             embedder_name)``.  A caller that scores the same snapshot for its
             own purposes (cross-dataset Find, which scores every media it just
             loaded) passes its copy so the corpus is stacked once for the whole
@@ -561,11 +582,9 @@ def train_and_threshold(
     # Mirrors `_train_and_score_xy` and
     # `eval.voting_iterations._safe_threshold_for_step`.
     #
-    # The row builder skips media it cannot score, so an empty score list
-    # means the haystack contributed nothing to fit on - either there was no
-    # snap at all, or none of its media carry a usable vector in this space
-    # (a chunk of media reachable only through a converter route, which
-    # `route_and_embed` embeds later in the detector's own target space).  Both
+    # The row builder skips media it cannot score, so an empty score list means
+    # the haystack contributed nothing to fit on - either there was no haystack
+    # at all, or none of its media carry a usable vector in this space.  Both
     # take the no-haystack branch rather than fitting the estimator on an empty
     # distribution.
     #
@@ -574,11 +593,16 @@ def train_and_threshold(
     # vector is silent, plausible, and wrong - a lower threshold over fewer
     # items (issue #3556).  `vtscore.cli._embed_loaded_medias` is what keeps the
     # CLI's snap embedded before this call, mirroring the GUI's load pipeline.
+    #
+    # The population the quantile is realized on is almost always *snap* - the
+    # caller scores what it calibrated against - but the CLI converts and
+    # re-clips before scoring, so it names the routed snapshot instead (#3647).
+    hay = haystack if haystack is not None else snap
     rows: ScoringRows | None = None
     all_ids: list[int] = []
     all_scores: list[float] = []
-    if snap:
-        rows = haystack_rows if haystack_rows is not None else scoring_rows_for_snap(snap, embedder_name)
+    if hay:
+        rows = haystack_rows if haystack_rows is not None else scoring_rows_for_snap(hay, embedder_name)
         all_ids = rows.ids
         all_scores, _best_region = score_rows_with_model(model, rows)
     if rows is not None and all_scores:
@@ -589,7 +613,7 @@ def train_and_threshold(
             all_scores,
             inclusion,
             blend_ctx,
-            _blend_schedule_for_snap(snap),
+            _blend_schedule_for_snap(hay),
             det_ctx=det_ctx,
             final_ids=all_ids,
             voted_ids=voted_ids,


### PR DESCRIPTION
Closes #3647

## The bug

The CLI's autodetect flow fitted each detector's cut on one population and applied it to another. `_load_and_train_detectors` passed the loaded medias as `snap`, so `train_from_labelset` calibrated over those; `_score_medias_with_detectors` then scored the snapshot `route_and_embed` produces — a video's frames, a document's pages, or the sub-items a detector's `input_spec` clipper fans each media into.

Those are systematically different distributions, not just different item counts: a source media's score is the **max** over its sub-items and is therefore never below its own whole-item score. The fold-anchored estimator carries its per-fold cuts to the final model *in quantile space* and realizes them against the haystack it was handed, so realizing on the loaded medias and cutting the routed ones lands the quantile on the wrong ruler.

Measured on a 60-media fixture with a 4-way re-clip and a byte-identical head:

| | median score | θ | hits |
|---|---|---|---|
| calibration haystack (loaded medias) | 0.485 | **0.485** | — |
| scored population (clips, max-pooled) | 0.616 | 0.533 | 47 |
| …cut by today's θ | | | **54** |

The cut sat at quantile **0.10** of the population it decides, where the algorithm chose 0.22.

A pure converter route was the sharper edge of the same bug. None of the loaded medias carry a vector in the detector's target space yet — `route_and_embed` fills those in later — so `scoring_rows_for_snap` yielded **zero rows** and the population estimator took the no-haystack branch. The shipped threshold was byte-identical to `snap=None`, the plain cross-calibration cut, with the whole safe-threshold machinery silently inert.

**The GUI is consistent by construction and is unchanged.** It hands `snapshot_medias()` to training and scores that same set, and it never routes or re-clips at Find time — it only captures the active dataset's clipper into `input_spec`. This was a CLI-only divergence, of the same family as #3556.

## The fix

Separate the two jobs `snap` was doing. It stays the snapshot the labelset's origins are resolved against — the routed items, with throwaway ids and recomputed hashes, cannot serve as that — and the haystack becomes explicit.

- **`train_and_threshold` gains `haystack`**, the population the cut is realized on, defaulting to `snap`. The blend schedule follows it too, since that is chosen off the scoring geometry.
- **`train_from_labelset` gains `haystack_for`**, called *after* the labels are embedded so it is handed `det_ctx.embedder`. Routing needs that name and it does not exist before training starts, which is why the hook is a callable rather than a value. The #3308 vote exclusion is mapped through the returned `to_source`, so it still names the labelled items after routing discards their ids.
- **The CLI memoises one `route_and_embed` pass per detector group** in `_RoutedSnapshots` and hands the same object to calibration and to the first chunk's scoring pass. The correction therefore costs no extra conversion, re-clip or embedding work — it *removes* a duplicate corpus stack. Both passes key on one `_detector_group_key`, so the two populations cannot drift apart again. Later chunks route themselves and are scored at the threshold the first chunk fixed, which keeps a streaming run judged by a single cut.

An empty routed snapshot falls back to `snap` rather than fitting the estimator on nothing, and a caller that passes no hook is byte-for-byte unchanged — which is every caller but this one.

## Behaviour change

Thresholds move for CLI runs that convert or re-clip, generally **up** (fewer, better hits). A natively-typed dataset the detector needs no re-clip for — the common case, and the only one anyone had noticed — is unaffected: the two populations are the same set.

Nothing is persisted. Both populations exist in the same process seconds apart; this is an ordering fix, not a stored calibration. In particular it does **not** introduce a hard-coded cardinal θ, which is the thing quantile transfer exists to avoid.

## Tests

- `tests_lib/detectors/test_calibration_haystack.py` — the library seam: the cut is realized on the haystack and not on `snap`; the hook sees the space the labels landed in; no hook (and a hook returning `None`) keeps `snap`; the threshold moves with the population and the old cut over-includes on it; voted ids are mapped through `to_source`.
- `tests/cli/test_cli_calibration_population.py` — the CLI wiring: one route pass per group, distinct groups route separately, the params key is order-insensitive, scoring reuses the memo (and routes for itself without one), the group keys the two passes use cannot drift, and `_load_and_train_detectors` hands training the routed snapshot while `snap` keeps its own job.

Two existing `_load_and_train_detectors` stubs gained the new argument.

## Gates

Full `./run-tests.sh`: **RUN PASSED** — 10772 passed, 6 skipped; pyright, pip-audit, vulture whitelist, npm audit and the Vitest suite all green.

The eval/app sync mirror for `train_and_threshold` is re-pinned. The harness's default arm scores the snapshot it calibrated against and has no routing to model, so the new parameter's default reproduces its behaviour exactly — `--update` alone was the right answer here, per the gate's own guidance.

## Found on the way

#3650 — `_collapse_to_primary` decides the whole matrix path by looking at one media, so a mixed-type snapshot can stack one space's vectors into another space's matrix. Filed separately; this PR makes the CLI's own instance moot but does not fix the matrix layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v6pQdx6RhADuBmybko4tn

---
_Generated by [Claude Code](https://claude.ai/code/session_014v6pQdx6RhADuBmybko4tn)_