### PR TITLE
Collapse to the primary matrix path only when every media agrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A mixed-media dataset is no longer scored against another embedding space's
+  vectors.** Asking the matrix layer for a specific embedder checked only the
+  *first* media to decide whether that name was the dataset's primary - and if
+  it was, every media then contributed whatever vector it happened to carry.
+  On a dataset holding, say, native images in one space and videos in another,
+  that stacked the videos' vectors into the images' matrix and scored them
+  through the images' detector head: no error, plausible-looking numbers, and a
+  different answer if the same items were loaded in a different order. It was
+  reachable whenever the two spaces share a dimension, which is common. The
+  check now requires every media to agree, so a request for one space reads
+  only that space and reports the media it had to leave out.
+
 - **A CLI Auto-Find run that converts or re-clips its dataset now calibrates the
   threshold on what it actually scores.** The cut was fitted on the loaded
   medias while scoring read the converted frames, pages or clips those medias

--- a/tests_lib/core/test_embedding_matrix.py
+++ b/tests_lib/core/test_embedding_matrix.py
@@ -729,3 +729,204 @@ class TestScoreableSnapshot:
         from vtscore.embedding.matrix import scoreable_snapshot
 
         assert scoreable_snapshot({}) == ({}, [])
+
+
+class TestMixedSpaceSnapshotDoesNotCollapse:
+    """Issue #3650: the primary-collapse quantifier is "every", not "the first".
+
+    ``_collapse_to_primary`` used to decide whether a routed embedder name *is*
+    the primary by looking at one media.  On a mixed-type snapshot that is a
+    sampling error: media #1's primary picked the path for all N, so asking for
+    space ``A`` on a snapshot led by an ``A`` media stacked the *other* media's
+    ``B``-space vectors into an ``A``-space matrix - silently, whenever the two
+    spaces share a width.  Reordering the same dict flipped the answer.
+    """
+
+    def _mixed(self) -> dict[int, dict]:
+        """Two ``test``-space media and two ``vid``-space ones, same width."""
+        return {
+            1: {"id": 1, "embedder": "test", "embeddings": {"test": np.full(4, 1.0, dtype=np.float32)}},
+            2: {"id": 2, "embedder": "test", "embeddings": {"test": np.full(4, 2.0, dtype=np.float32)}},
+            3: {"id": 3, "embedder": "vid", "embeddings": {"vid": np.full(4, 30.0, dtype=np.float32)}},
+            4: {"id": 4, "embedder": "vid", "embeddings": {"vid": np.full(4, 40.0, dtype=np.float32)}},
+        }
+
+    def test_collapse_requires_every_media_to_agree(self):
+        from vtscore.embedding.matrix import _collapse_to_primary
+
+        mixed = self._mixed()
+        # Mixed: the name survives, so the named path (which reads only "test"
+        # vectors) is taken instead of the primary path (which reads whatever
+        # each media happens to carry).
+        assert _collapse_to_primary(mixed, "test") == "test"
+        assert _collapse_to_primary(mixed, "vid") == "vid"
+        # Homogeneous: unchanged - this is the single-embedder hot path.
+        homogeneous = {cid: m for cid, m in mixed.items() if m["embedder"] == "test"}
+        assert _collapse_to_primary(homogeneous, "test") is None
+
+    def test_collapse_is_independent_of_dict_order(self):
+        from vtscore.embedding.matrix import _collapse_to_primary
+
+        mixed = self._mixed()
+        reversed_order = {cid: mixed[cid] for cid in sorted(mixed, reverse=True)}
+        assert _collapse_to_primary(mixed, "test") == _collapse_to_primary(reversed_order, "test")
+
+    def test_scoreable_snapshot_drops_the_foreign_space(self):
+        """The `calibration haystack size: 60 of 60` of #3650, now 30 of 60."""
+        from vtscore.embedding.matrix import scoreable_snapshot
+
+        scoreable, dropped = scoreable_snapshot(self._mixed(), "test")
+        assert sorted(scoreable) == [1, 2]
+        assert dropped == [3, 4]
+
+    def test_scoreable_snapshot_answer_is_order_independent(self):
+        from vtscore.embedding.matrix import scoreable_snapshot
+
+        mixed = self._mixed()
+        reversed_order = {cid: mixed[cid] for cid in sorted(mixed, reverse=True)}
+        assert scoreable_snapshot(mixed, "test") == scoreable_snapshot(reversed_order, "test")
+
+    def test_snap_matrix_never_stacks_the_other_space(self):
+        """Pre-fix this built a 4-row matrix holding two ``vid`` rows."""
+        ctx = DatasetContext("test_mixed_space_snap")
+        set_thread_dataset_context(ctx)
+        mixed = self._mixed()
+
+        with pytest.raises(ValueError, match=r"media 3.*has no embedding for embedder 'test'"):
+            get_embedding_matrix_for_snap(mixed, "test")
+
+        # The pre-filtered snapshot builds cleanly, in the requested space only.
+        from vtscore.embedding.matrix import scoreable_snapshot
+
+        scoreable, _dropped = scoreable_snapshot(mixed, "test")
+        ids, mat = get_embedding_matrix_for_snap(scoreable, "test")
+        assert ids == [1, 2]
+        assert mat[:, 0].tolist() == [1.0, 2.0]
+
+    def test_ctx_matrix_never_stacks_the_other_space(self):
+        ctx = DatasetContext("test_mixed_space_ctx")
+        ctx.medias.update(self._mixed())
+        with pytest.raises(ValueError, match=r"media 3.*has no embedding for embedder 'test'"):
+            get_embedding_matrix(ctx, "test")
+        # ...and the named path left the primary cache alone.
+        assert ctx._emb_matrix is None
+
+    def test_unnamed_request_still_reads_each_medias_primary(self):
+        """Only the *named* request changes: an unnamed one is by definition a
+        request for whatever each media carries, and keeps doing that."""
+        ctx = DatasetContext("test_mixed_space_unnamed")
+        ctx.medias.update(self._mixed())
+        ids, mat = get_embedding_matrix(ctx)
+        assert ids == [1, 2, 3, 4]
+        assert mat[:, 0].tolist() == [1.0, 2.0, 30.0, 40.0]
+
+
+class TestUniformPrimaryMemo:
+    """``_collapse_to_primary_for_ctx`` memoises the O(N) scan per revision.
+
+    The scan runs under ``_state_lock`` *before* the matrix-cache check, so the
+    hot path must not pay it per call - but the memo must not outlive the
+    medias it answered for.
+    """
+
+    def _ctx(self) -> DatasetContext:
+        ctx = DatasetContext("test_uniform_primary_memo")
+        for cid in (1, 2):
+            ctx.medias[cid] = {
+                "id": cid,
+                "embedder": "siglip",
+                "embeddings": {"siglip": np.full(4, float(cid), dtype=np.float32)},
+            }
+        return ctx
+
+    def test_memo_is_computed_once_per_revision(self, monkeypatch):
+        from vtscore.embedding.matrix import _collapse_to_primary_for_ctx
+
+        ctx = self._ctx()
+        calls: list[int] = []
+        real = matrix_mod._uniform_primary_embedder
+        monkeypatch.setattr(
+            matrix_mod,
+            "_uniform_primary_embedder",
+            lambda medias: (calls.append(len(medias)), real(medias))[1],
+        )
+        assert _collapse_to_primary_for_ctx(ctx, "siglip") is None
+        assert _collapse_to_primary_for_ctx(ctx, "siglip") is None
+        assert len(calls) == 1
+
+    def test_a_structural_mutation_reopens_the_question(self):
+        from vtscore.embedding.matrix import _collapse_to_primary_for_ctx
+
+        ctx = self._ctx()
+        assert _collapse_to_primary_for_ctx(ctx, "siglip") is None
+        # Adding a media from another space bumps media_revision via MediasDict.
+        ctx.medias[3] = {"id": 3, "embedder": "vid", "embeddings": {"vid": np.zeros(4, dtype=np.float32)}}
+        assert _collapse_to_primary_for_ctx(ctx, "siglip") == "siglip"
+
+    def test_matrix_cache_is_not_served_across_a_mixing_mutation(self):
+        """The end-to-end shape of the memo going stale: the cached primary
+        matrix must not be handed back for a *named* request once the dataset
+        stops being homogeneous."""
+        ctx = self._ctx()
+        _ids, mat = get_embedding_matrix(ctx, "siglip")
+        assert mat[:, 0].tolist() == [1.0, 2.0]
+        assert ctx._emb_matrix is not None  # collapsed to the cached path
+
+        ctx.medias[3] = {"id": 3, "embedder": "vid", "embeddings": {"vid": np.zeros(4, dtype=np.float32)}}
+        with pytest.raises(ValueError, match=r"media 3.*has no embedding for embedder 'siglip'"):
+            get_embedding_matrix(ctx, "siglip")
+
+    def test_reset_derived_caches_drops_the_memo(self):
+        from vtscore.embedding.matrix import _collapse_to_primary_for_ctx
+
+        ctx = self._ctx()
+        _collapse_to_primary_for_ctx(ctx, "siglip")
+        assert ctx._uniform_primary == "siglip"
+        ctx.reset_derived_caches()
+        assert ctx._uniform_primary is None
+        assert ctx._uniform_primary_revision is None
+
+
+class TestMixedSpaceDropIsLogged:
+    """A short haystack caused by space-mixing says so, once per call."""
+
+    def _snap(self) -> dict[int, dict]:
+        return {
+            1: {"id": 1, "embedder": "test", "embeddings": {"test": np.ones(4, dtype=np.float32)}},
+            2: {"id": 2, "embedder": "vid", "embeddings": {"vid": np.ones(4, dtype=np.float32)}},
+            3: {"id": 3, "embedder": "vid", "embeddings": {"vid": np.ones(4, dtype=np.float32)}},
+        }
+
+    def test_warns_once_naming_the_other_space(self, caplog):
+        from vtscore.embedding.matrix import scoreable_snapshot
+
+        with caplog.at_level("WARNING", logger="vtscore.embedding.matrix"):
+            scoreable_snapshot(self._snap(), "test")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "Dropped 2 of 3 media" in message
+        assert "'vid'" in message and "'test'" in message
+
+    def test_a_plain_failed_embed_is_not_reported_as_mixing(self, caplog):
+        """A dropped media whose own primary *is* the requested embedder simply
+        failed to embed - the pre-existing per-item failure the callers already
+        report, not a space mismatch."""
+        from vtscore.embedding.matrix import scoreable_snapshot
+
+        snap = {
+            1: {"id": 1, "embedder": "test", "embeddings": {"test": np.ones(4, dtype=np.float32)}},
+            2: {"id": 2, "embedder": "test", "embeddings": {}},
+        }
+        with caplog.at_level("WARNING", logger="vtscore.embedding.matrix"):
+            _scoreable, dropped = scoreable_snapshot(snap, "test")
+        assert dropped == [2]
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+    def test_a_homogeneous_snapshot_is_silent(self, caplog):
+        from vtscore.embedding.matrix import scoreable_snapshot
+
+        snap = {cid: m for cid, m in self._snap().items() if m["embedder"] == "vid"}
+        with caplog.at_level("WARNING", logger="vtscore.embedding.matrix"):
+            scoreable_snapshot(snap, "vid")
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -335,6 +335,40 @@ instead, since every commit on `dev` is effectively a new app release.)
   for you, since the callbacks the load pipeline binds check cancellation
   before recording each tick.
 
+### Fixed
+
+- **A matrix built for one embedding space can no longer be filled with
+  another space's vectors** (issue #3650). `scoreable_snapshot()`,
+  `get_embedding_matrix()` and `get_embedding_matrix_for_snap()` decide whether
+  an explicitly named embedder *is* the snapshot's primary - and so may reuse
+  the cached primary path, which reads whatever vector each media happens to
+  carry. That test sampled **one** media. On a homogeneous snapshot that is
+  right and is the single-embedder optimisation it was written for; on a
+  mixed-type snapshot it was a sampling error, because media #1's primary
+  picked the path for all N.
+
+  Ask for space `A` on a snapshot whose first media is an `A` media and whose
+  rest are `B` media, and every media contributed its own vector: `B`-space
+  rows stacked into an `A`-space matrix and scored through an `A`-space head.
+  Nothing raised - the only guard was the width check, so this was reachable
+  whenever the two spaces share a dimension, which 512-d and 768-d encoders
+  routinely do. Reordering the same snapshot flipped the answer between "all N
+  rows, some of them wrong" and "only the `A` rows".
+
+  The collapse now requires **every** media to share that primary (a
+  short-circuiting scan, memoised per `media_revision` on `DatasetContext` so
+  the cached hot path stays O(1)). A snapshot whose medias disagree keeps the
+  name and takes the named path, which reads each media's vector *in the
+  requested space* - so `scoreable_snapshot()` drops the media that have none
+  and `get_embedding_matrix*()` raises on them, per their existing contracts.
+  Homogeneous snapshots are byte-for-byte unchanged.
+
+  `scoreable_snapshot()` additionally logs one `WARNING` per call naming the
+  requested embedder, the spaces the dropped media live in, and how many were
+  dropped. Dropping stays the policy - a mixed dataset scored for one space
+  *should* leave out the media that live in another - but a silently short
+  haystack is what hid this.
+
 ### Added
 
 - **`ProgressCallback`, `noop_progress()` and `resolve_progress_callback()` are

--- a/vtscore/embedding/matrix.py
+++ b/vtscore/embedding/matrix.py
@@ -57,27 +57,86 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _uniform_primary_embedder(medias: dict[int, dict[str, Any]]) -> str | None:
+    """The primary embedder *every* media in *medias* shares, else ``None``.
+
+    ``None`` means "no single answer": the medias disagree (a mixed-type
+    snapshot binding more than one embedding space), some media has no
+    recorded primary at all, or the mapping is empty.  Short-circuits on the
+    first disagreement, so the mixed case is cheap and only the homogeneous
+    case pays the full scan.
+
+    Callers use this to decide whether an explicitly-named embedder can be
+    treated as the primary for the whole snapshot - see
+    :func:`_collapse_to_primary`.
+    """
+    shared: str | None = None
+    for media in medias.values():
+        name = primary_embedder_name(media)
+        if name is None:
+            return None
+        if shared is None:
+            shared = name
+        elif name != shared:
+            return None
+    return shared
+
+
 def _collapse_to_primary(medias: dict[int, dict[str, Any]], embedder_name: str | None) -> str | None:
-    """Map a routed embedder name to ``None`` when it is the dataset's primary.
+    """Map a routed embedder name to ``None`` when it is *every* media's primary.
 
     The routing layer (``DatasetContext.routed_embedder``) hands callers an
     explicit embedder name even for the common single-embedder dataset, where
-    that name *is* the primary mirror.  The named matrix path builds fresh on
-    every call; the primary path is cached on the context.  Since a name equal
-    to the primary yields byte-for-byte the same vectors as the primary path
-    (the singular ``embedding`` mirrors the recorded embedder's vector), we
-    collapse it to ``None`` here so the cache is reused - keeping the
+    that name *is* the primary.  The named matrix path builds fresh on every
+    call; the primary path is cached on the context.  When every media's
+    primary is that name the two paths read byte-for-byte the same vectors, so
+    we collapse to ``None`` here and the cache is reused - keeping the
     single-embedder hot path unchanged after routing threads names through.
 
     A name that differs from the primary (a genuine second bound embedder)
     passes through unchanged and takes the uncached named path.
+
+    **The quantifier is "every", not "the first" (issue #3650).**  Sampling one
+    media is right on a homogeneous snapshot and a sampling error on a mixed
+    one: media #1's primary would decide the path for all N.  Ask for space
+    ``A`` on a snapshot whose first media is an ``A`` media and whose rest are
+    ``B`` media, and the name collapses, every media contributes *its own*
+    vector, and ``B``-space rows get stacked into an ``A``-space matrix and
+    scored through an ``A``-space head - silently, whenever the two spaces
+    share a width (512-d and 768-d encoders are common).  Reordering the same
+    dict flipped the answer.  Requiring agreement costs one short-circuiting
+    O(N) scan on a path that is about to stack N rows anyway (and the hot
+    ``DatasetContext`` path memoises it - see
+    :func:`_collapse_to_primary_for_ctx`), and it preserves the single-embedder
+    optimisation exactly, which is the only case it was written for.
     """
     if embedder_name is None or not medias:
         return embedder_name
-    first = next(iter(medias.values()))
-    if embedder_name == primary_embedder_name(first):
+    if embedder_name == _uniform_primary_embedder(medias):
         return None
     return embedder_name
+
+
+def _collapse_to_primary_for_ctx(ctx: "DatasetContext", embedder_name: str | None) -> str | None:
+    """:func:`_collapse_to_primary` over *ctx*'s medias, memoised per revision.
+
+    The scan is O(N) in Python, and :func:`get_embedding_matrix` runs it under
+    ``_state_lock`` *before* the cache check - i.e. on the hot path that would
+    otherwise do no per-media work at all.  Memoising the uniform-primary
+    answer on the context keeps that path O(1) after the first call.
+
+    Keyed on ``ctx.media_revision``, exactly like the matrix cache beside it:
+    a structural mutation of ``ctx.medias`` bumps the counter automatically,
+    and an in-place rewrite of a media's ``embedder`` field travels with the
+    vector rewrite that ``invalidate_embedding_matrix`` already signals.  Call
+    with ``_state_lock`` held (the callers do).
+    """
+    if embedder_name is None or not ctx.medias:
+        return embedder_name
+    if ctx._uniform_primary_revision != ctx.media_revision:
+        ctx._uniform_primary = _uniform_primary_embedder(ctx.medias)
+        ctx._uniform_primary_revision = ctx.media_revision
+    return None if embedder_name == ctx._uniform_primary else embedder_name
 
 
 def _require_embedding(cid: int, media: dict[str, Any], embedder_name: str | None = None) -> Any:
@@ -140,6 +199,10 @@ def scoreable_snapshot(
     With *region_rows* set the check is run against the snapshot's **patch-slot**
     embedder instead, matching what :func:`_build_region_arrays` reads for the
     image-level row of every media in a region-row matrix.
+
+    Drops caused by *snap* mixing embedding spaces are logged once per call by
+    :func:`_log_mixed_space_drops`; the drop itself is the policy, but a
+    silently short haystack is what made issue #3650 invisible.
     """
     key = _patch_embedder_for_region_snap(snap) if region_rows else _collapse_to_primary(snap, embedder_name)
     scoreable: dict[int, dict[str, Any]] = {}
@@ -157,7 +220,48 @@ def scoreable_snapshot(
             dropped.append(cid)
             continue
         scoreable[cid] = media
+    if not region_rows:
+        _log_mixed_space_drops(snap, embedder_name, dropped)
     return scoreable, dropped
+
+
+def _log_mixed_space_drops(
+    snap: dict[int, dict[str, Any]],
+    embedder_name: str | None,
+    dropped: list[int],
+) -> None:
+    """Warn once when *dropped* media were left out because *snap* mixes spaces.
+
+    Dropping is the right policy - a mixed-type dataset scored for one space
+    *should* leave out the media that live in another, rather than abort a long
+    run or (worse, pre-#3650) stack their vectors into the wrong matrix.  But a
+    quietly short haystack is exactly what hid that bug: the callers that
+    report skips (``vtscore.cli._emit_skipped_medias``) see a count, not a
+    reason, and library-tier callers see nothing at all.  So the layer that
+    knows *why* says so, once per call rather than once per media.
+
+    Only space-mixing is worth a warning.  A dropped media whose own primary
+    **is** *embedder_name* failed to embed (or carries an unusable vector) -
+    that is the pre-existing per-item failure the drop policy was written for,
+    already surfaced by the callers, and not this function's business.  A
+    dropped media with no primary at all is vector-less for the same reason.
+    """
+    if not dropped or embedder_name is None:
+        return
+    others = {primary_embedder_name(snap[cid]) for cid in dropped}
+    others -= {embedder_name, None}
+    if not others:
+        return
+    logger.warning(
+        "Dropped %d of %d media from the %r embedding matrix: this snapshot mixes embedding "
+        "spaces, and those media are embedded in %s instead. They carry no %r vector, so they "
+        "are excluded from scoring rather than scored against another space's head.",
+        len(dropped),
+        len(snap),
+        embedder_name,
+        ", ".join(sorted(repr(name) for name in others)),
+        embedder_name,
+    )
 
 
 def _vector_label(cid: int, media: dict[str, Any], embedder_name: str | None) -> str:
@@ -365,8 +469,10 @@ def get_embedding_matrix(ctx: "DatasetContext", embedder_name: str | None = None
         # rather than an id-list compare also catches an in-place vector
         # rewrite that leaves the id set unchanged (root-cause Pattern #4).
         revision = ctx.media_revision
-        # A routed name equal to the primary collapses to the cached path.
-        embedder_name = _collapse_to_primary(ctx.medias, embedder_name)
+        # A routed name equal to *every* media's primary collapses to the
+        # cached path (memoised per media_revision: this runs before the cache
+        # check, so the hot path must not pay an O(N) scan per call).
+        embedder_name = _collapse_to_primary_for_ctx(ctx, embedder_name)
         if embedder_name is None:
             cached_matrix = ctx._emb_matrix
             # A revision match guarantees the id set is unchanged, so the live
@@ -828,9 +934,13 @@ def get_embedding_matrix_for_snap(
     if not sorted_ids:
         return [], np.empty((0, 0), dtype=np.float32)
 
-    # A routed name equal to the snapshot's primary collapses to the cached
+    # A routed name equal to *every* media's primary collapses to the cached
     # primary path (matching get_embedding_matrix), so single-embedder
     # snapshots keep reusing the context cache after routing names through.
+    # A snapshot whose medias disagree keeps the name and takes the named
+    # path, which raises on a media lacking that vector rather than stacking
+    # another space's vector into this matrix (issue #3650); callers that
+    # would rather drop than raise pre-filter with scoreable_snapshot.
     embedder_name = _collapse_to_primary(snap, embedder_name)
 
     ctx = get_active_context()

--- a/vtscore/state/core.py
+++ b/vtscore/state/core.py
@@ -406,6 +406,16 @@ class DatasetContext:
         "_emb_matrix_ids",
         "_emb_matrix",
         "_emb_matrix_revision",
+        # Memoised answer to "do *all* these medias share one primary
+        # embedder, and which?" (``None`` = they disagree, or some media has
+        # no primary), plus the ``media_revision`` it was computed at.
+        # ``vtscore.embedding.matrix._collapse_to_primary_for_ctx`` asks this
+        # before the matrix-cache check to decide whether an explicitly routed
+        # embedder name is the whole dataset's primary and so may reuse the
+        # cached primary matrix (issue #3650).  Memoised because that question
+        # is an O(N) Python scan on a path that otherwise touches no media.
+        "_uniform_primary",
+        "_uniform_primary_revision",
         # One-way latch: set the first time ``invalidate_embedding_matrix``
         # fires for this context (an in-place vector rewrite - re-embed /
         # clip). Once set, ``get_embedding_matrix`` never again considers the
@@ -528,6 +538,8 @@ class DatasetContext:
                 "_emb_matrix_ids",
                 "_emb_matrix",
                 "_emb_matrix_revision",
+                "_uniform_primary",
+                "_uniform_primary_revision",
                 "_region_matrix_ids",
                 "_region_matrix",
                 "_region_matrix_revision",
@@ -610,6 +622,8 @@ class DatasetContext:
         self._emb_matrix_ids: list[int] | None = None
         self._emb_matrix: Any = None  # np.ndarray | None
         self._emb_matrix_revision: int | None = None  # media_revision the matrix was built at
+        self._uniform_primary: str | None = None  # primary embedder shared by every media, else None
+        self._uniform_primary_revision: int | None = None  # media_revision that answer was computed at
         self._emb_sidecar_disabled: bool = False  # latched True by invalidate_embedding_matrix
         self._region_matrix_ids: list[int] | None = None
         self._region_matrix: Any = None  # np.ndarray | None, shape (R, D)
@@ -728,6 +742,8 @@ class DatasetContext:
                 self._emb_matrix_ids = None
                 self._emb_matrix = None
                 self._emb_matrix_revision = None
+                self._uniform_primary = None
+                self._uniform_primary_revision = None
                 self._region_matrix_ids = None
                 self._region_matrix = None
                 self._region_matrix_revision = None


### PR DESCRIPTION
Closes #3650.

## The bug

`_collapse_to_primary` (`vtscore/embedding/matrix.py`) decides whether an explicitly routed embedder name *is* the snapshot's primary — and so may take the cached **primary** path, which reads whatever vector each media happens to carry — by looking at **one** media:

```python
first = next(iter(medias.values()))
if embedder_name == primary_embedder_name(first):
    return None
```

On a homogeneous snapshot that is correct, and is the single-embedder cache-reuse optimisation it was written for. On a mixed-type snapshot it is a sampling error: media #1's primary picks the path for all N.

Ask for space `A` on a snapshot whose first media is an `A` media and whose remaining media live in `B`, and the name collapsed to `None`, every media contributed *its own* vector, and `B`-space rows were stacked into an `A`-space matrix and scored through an `A`-space head. Nothing raised — the width check in `scoreable_snapshot` was the only guard, so this was reachable exactly when the two spaces share a dimension, which 512-d and 768-d encoders routinely do. Reordering the same snapshot flipped the answer between "all N rows, some of them wrong" and "only the `A` rows": same data, different result, decided by dict iteration order.

## The fix

**The quantifier is now "every", not "the first".** `_uniform_primary_embedder()` answers "do all these medias share one primary, and which?", short-circuiting on the first disagreement, and the collapse only fires when that answer equals the requested name.

- Homogeneous snapshots are byte-for-byte unchanged — the cached hot path still collapses.
- A snapshot whose medias disagree keeps the name and takes the **named** path, which reads each media's vector *in the requested space*. So `scoreable_snapshot()` drops the media that have none and `get_embedding_matrix*()` raises on them, per their existing contracts — the same policy those functions already apply to a media one bound embedder failed on.
- An **unnamed** request is unchanged in every case: by definition it asks for whatever each media carries.

### Keeping the hot path O(1)

The scan runs under `_state_lock` *before* `get_embedding_matrix`'s cache check — a path that otherwise touches no media at all. Measured at 13 ms for 100k medias, ~8× the `sorted(ctx.medias.keys())` already there, which would have undone this module's deliberate lock-scoping work. So `_collapse_to_primary_for_ctx()` memoises the uniform-primary answer on `DatasetContext` (`_uniform_primary` / `_uniform_primary_revision`), keyed on `media_revision` — the same key, the same automatic bump from `MediasDict`, and the same `invalidate_embedding_matrix` discipline as the matrix cache it sits beside. Both slots are filed in the `matrices` derived-cache family, so `reset_derived_caches` drops them and the slot-partition test accounts for them.

The snapshot paths (`scoreable_snapshot`, `get_embedding_matrix_for_snap`) take the plain scan: both already iterate or sort the snapshot, so it is proportionate there.

### Making a short haystack say why

`scoreable_snapshot()` now logs one `WARNING` per call when it drops media *because* the snapshot mixes spaces, naming the requested embedder, the spaces the dropped media actually live in, and the count.

Dropping stays the policy — a mixed dataset scored for one space *should* leave out the media that live in another, rather than abort a long run — but a quietly short haystack is precisely what hid this: the callers that report skips (`vtscore.cli._emit_skipped_medias`) see a count, not a reason, and library-tier callers see nothing. Only space-mixing warns; a dropped media whose own primary *is* the requested embedder simply failed to embed, which is the pre-existing per-item failure the drop policy was written for.

## Tests

New in `tests_lib/core/test_embedding_matrix.py`:

- `TestMixedSpaceSnapshotDoesNotCollapse` — the collapse requires agreement; the answer is independent of dict order; the mixed snapshot's foreign space is dropped rather than stacked (the `60 of 60` of #3650, now `2 of 4`); both matrix builders raise instead of mixing; the unnamed request still reads each media's primary.
- `TestUniformPrimaryMemo` — the scan happens once per revision, a structural mutation reopens the question, the cached primary matrix is not served for a named request once the dataset stops being homogeneous, and `reset_derived_caches` drops the memo.
- `TestMixedSpaceDropIsLogged` — warns once naming the other space; silent for a plain failed embed and for a homogeneous snapshot.

Full `./run-tests.sh` green (10786 passed, 6 skipped; all gates OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013g3PX3iNLjJ6aeBHWahSyg

---
_Generated by [Claude Code](https://claude.ai/code/session_013g3PX3iNLjJ6aeBHWahSyg)_