### PR TITLE
Suppress `glass` as ambiguous, and rule the Chair boundaries

### DIFF
--- a/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
+++ b/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
@@ -627,10 +627,18 @@ harder call and much rarer.
 
 ### Someone is clearly sitting, and the Chair is invisible
 
-Vote **Good, and draw no box.**
+Vote **Good, and draw no box** — on an image that arrived **without** one.
 
-This is the one place the three-valued design is reachable from the voting UI,
-and it is exactly right here. A Good *with* a box says "present, and this is its
+**The stratum decides what "no box drawn" means, and the two meanings are
+opposite.** On a `positive_boxed` image a box already arrived, so a Good that
+draws nothing *confirms that box* (`positive_confirmed`) — which is the normal
+action, and what happened for 27 of every 30 positives confirmed so far.
+Drawing on a pre-boxed image is the exceptional case (`positive_reboxed`), and
+it is the one that moves bands. Everything below is about a **bare** image, from
+the `boundary` or `random` stratum, where no box arrived at all.
+
+There, it is the one place the three-valued design is reachable from the voting
+UI, and it is exactly right. A Good *with* a box says "present, and this is its
 size". A Good *without* one says **"present, but no size was measured"** — and
 `verdicts_to_corrections` files it as `negative_excluded`: `present: True`,
 `boxes: []`. The image is taken **out of the shared negative pool**, because a

--- a/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
+++ b/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
@@ -613,9 +613,41 @@ poisons the shared negative pool everywhere a car appears. Three things agree:
 - **The pool.** Cars are everywhere in VG, so this is the one exclusion here
   whose absence would be catastrophic rather than merely wrong.
 
+**The same goes for a motorcycle's seat, and for a saddle.** A motorcycle
+almost always shows a little single-person seat, so admitting them would do to
+motorcycles what car seats would do to cars; and a saddle is tack, part of the
+horse's kit rather than free-standing furniture. Free, as with the toilet: the
+whole family — `saddle`, `motorcycle seat`, `bike seat`, `motorcycle` — appears
+**zero** times in 15,868 chair boxes, with a single stray `scooter`.
+
 The corollary, as with the jerry can: **a car seat removed from the car** —
 sitting in a garage, a scrapyard, a skip — is free-standing, nothing owns it,
-and it is a Chair.
+and it is a Chair. The same for a saddle on a rack in a tack room, which is a
+harder call and much rarer.
+
+### Someone is clearly sitting, and the Chair is invisible
+
+Vote **Good, and draw no box.**
+
+This is the one place the three-valued design is reachable from the voting UI,
+and it is exactly right here. A Good *with* a box says "present, and this is its
+size". A Good *without* one says **"present, but no size was measured"** — and
+`verdicts_to_corrections` files it as `negative_excluded`: `present: True`,
+`boxes: []`. The image is taken **out of the shared negative pool**, because a
+Chair really is there and scoring a detector wrong for finding it would be
+absurd, and it is **not made a positive**, because a band is a claim about size
+and you did not measure one. Neither, precisely.
+
+Do **not** box where you think the Chair is. An invented box is an invented
+size, in a study whose entire subject is size.
+
+**One caveat, and it is a real one.** A boxless Good cannot distinguish *"I
+could not see it"* from *"I forgot to draw"*. Both land in the same state. On
+2026-09-03 eight boxless Goods in `cell phone` were the second kind and had to
+be re-issued to recover them (#3616 neighbourhood); here they are the first kind
+and want no recovery at all. The pipeline cannot tell, so the reviewer has to —
+which is the argument in #3643 for making the third state something you can say
+out loud.
 
 **A headrest is not a Chair either — and the reason is not that it is small.**
 Seeing part of a thing is normally good evidence of the thing: a chair back over

--- a/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
+++ b/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
@@ -33,6 +33,15 @@ Every ruling in this guide is one of those three, and each carries its cost in
 the text. That is the discipline the goal requires: not "does COCO agree" but
 "if it does not, do we know what that costs us".
 
+## A note on names
+
+**A capitalised name means the class; a lowercase one means the English word.**
+A Chair is whatever this guide says it is; a chair is what you would call a
+chair. The two come apart constantly — a judge's bench is not a Bench, a toilet
+bowl is not a Bowl, a jar of flowers is a Bottle — and most of the rulings here
+exist precisely at that gap. Code keeps the lowercase form, because `"chair"` is
+the COCO key and a string is not prose.
+
 ## The protocol, once
 
 - **Good = the object is present.** Drag a box on it. **Bad = not present.**
@@ -539,10 +548,52 @@ even though it is part of a boat.
 
 Dining chairs, office chairs, folding and deck chairs, armchairs, high chairs,
 and **stools and bar stools** all count — 98 VG `stool` and 42 `armchair` boxes
-land on COCO chair boxes. Couches and sofas do **not**: COCO has a separate
-`couch` class, and the 37 `couch` boxes sitting on COCO chairs are its errors,
-not its rule. Benches do not count either. A single seat within a row of
-stadium, theatre or waiting-room seating counts as a chair. Like `car`, this
+land on COCO chair boxes, with 8 more under `arm chair` and 7 under `recliner`.
+Benches do not count. A single seat within a row of stadium, theatre or
+waiting-room seating counts, and `seat` (206) plus `seats` (63) is the third
+largest fold-in here, so that case is common.
+
+**One seat, one Chair; two or more, a couch.** COCO has a separate `couch`
+class, and the 37 `couch` and 16 `sofa` boxes on COCO chairs are its errors, not
+its rule. But *upholstered* is not the test — a single-seat upholstered piece,
+club chair or recliner, is a Chair, which is what `armchair` (50 across both
+spellings) and `recliner` (7) already say. A true two-seat loveseat is a couch by
+the same head-count that separates Chair from Bench. `love seat` appears once in
+15,868 boxes, so this is a rule for the reviewer's benefit rather than a
+measured boundary.
+
+**A lifeguard station is a Chair** — built as seating for one, which is the test
+`bench` already uses. Measured at exactly 1 box, so it is decided by the
+principle, not the data.
+
+**A toilet is not a Chair.** COCO has a separate `toilet` class and the two are
+never confused: `toilet`, `commode` and `urinal` appear **zero** times in 15,868
+chair boxes. Free.
+
+**A car seat is not a Chair, and that is the important one.** Sam's argument is
+the reductio: *every* car almost certainly has seats inside, so counting them
+makes Chair a class that fires on every street scene, stops discriminating, and
+poisons the shared negative pool everywhere a car appears. Three things agree:
+
+- **COCO never does it** — `car seat` 2, `child seat` 1, `car` 1, out of 15,868.
+- **A component is not an instance.** A car seat is part of the car, the same
+  test that keeps a concrete bed cast into the pavement out of `vase` and a fuel
+  tank out of `bottle`.
+- **The pool.** Cars are everywhere in VG, so this is the one exclusion here
+  whose absence would be catastrophic rather than merely wrong.
+
+The corollary, as with the jerry can: **a car seat removed from the car** —
+sitting in a garage, a scrapyard, a skip — is free-standing, nothing owns it,
+and it is a Chair.
+
+**A headrest is not a Chair either — and the reason is not that it is small.**
+Seeing part of a thing is normally good evidence of the thing: a chair back over
+a table, a leg under it, and you box the Chair. VG names COCO chair boxes by a
+part often enough to matter — `back` 57, `cushion` 34, `legs` 13, `backrest` 7.
+So the rule is **a part inherits the ruling of its whole**: a headrest on a
+dining chair is evidence of a Chair and you box the Chair; a headrest in a car is
+part of a car seat, which is part of a car, and neither of those is a Chair, so
+neither is the headrest. (`headrest` itself: 2 boxes in 15,868.) Like `car`, this
 class is prevalent — 6.3% of VG — so its negative pool is thin and the boundary
 stratum will hold many genuine chairs rather than near-misses.
 

--- a/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
+++ b/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
@@ -33,6 +33,37 @@ Every ruling in this guide is one of those three, and each carries its cost in
 the text. That is the discipline the goal requires: not "does COCO agree" but
 "if it does not, do we know what that costs us".
 
+### And when two definitions are both defensible, take the one that labels clean
+
+The table above prices a change against the *reference*. It says nothing about
+the other cost, which is usually the larger one: **a definition that is hard to
+apply produces noisy labels, and noisy labels are worse than an odd boundary.**
+So where the taxonomy leaves a choice — and it usually does — the tie-break is
+*which definition can a reviewer apply quickly and repeatably at three in the
+afternoon on the two-hundredth image*.
+
+That is the thread through most of what is here, and it is worth seeing as one
+idea rather than nine separate rulings:
+
+- **A car seat is not a Chair** partly because otherwise every street scene
+  becomes an agonised judgement call.
+- **A part inherits the ruling of its whole** replaces "is this fragment enough?"
+  with a lookup.
+- **The vessel ladder** turns an unanswerable semantic question — empty Vase or
+  ornamental Bowl? — into a glance at proportions.
+- **Judge the object in the box** removes the standing invitation to hunt for a
+  better example.
+- **"Neither", for a handle with no evidence either way**, is cleaner than a
+  coin-flip carrying a 4:1 prior.
+
+**The scored subset is the measurement of this.** Agreement against COCO on the
+fifth of each slate that has an answer is not only a check on the reviewer; it is
+a check on the *definition*, because a rule that is hard to apply shows up as
+disagreement. A class that scores 98% is telling you its rule is mechanical. One
+that scores 89% is telling you something is still being decided image by image —
+which is exactly what `bottle` was doing while its boundaries were being widened.
+Read that column as a labelability score and it earns its keep twice.
+
 ## A note on names
 
 **A capitalised name means the class; a lowercase one means the English word.**

--- a/scripts/experiments/pile/make_class_slate.py
+++ b/scripts/experiments/pile/make_class_slate.py
@@ -57,6 +57,7 @@ from make_positive_slate import draw_with_inset  # noqa: E402
 from pilebuild.loaders.vg_scale import (  # noqa: E402
     anchor_to_coco,
     band_candidates,
+    lift_ambiguous,
     canonicalise,
     read_vg_labels,
 )
@@ -95,7 +96,14 @@ def main() -> int:
 
     # ---- positives, from the VG source through the loader's own passes -----
     vg_names = {c: pc.SCALE_CANDIDATE_VG_NAMES.get(c, (c,)) for c in classes}
+    # Ambiguous spellings must be READ even though they are never folded: their
+    # whole job is to bar an image from the shared negative pool, and a name that
+    # was not read is invisible to `lift_ambiguous` -- it suppresses nothing and
+    # the contaminated negative stays. `pile_config.scale_vg_wanted` reads both
+    # tables for the built classes; this is the candidate-side equivalent.
+    ambiguous_names = {c: pc.SCALE_CANDIDATE_VG_AMBIGUOUS.get(c, ()) for c in classes}
     wanted_vg = {n for names in vg_names.values() for n in names}
+    wanted_vg |= {n for names in ambiguous_names.values() for n in names}
     log(f"reading VG source for {len(wanted_vg)} names")
     paths, records, dims = vg_source()
     labels = read_vg_labels(records, paths, dims, wanted_vg)
@@ -136,7 +144,17 @@ def main() -> int:
     )
     log(f"anchored {n_anchored} images to COCO ({n_reframed} skipped as re-framed copies)")
 
-    supply, boxes_for, _clean = band_candidates(labels, box_dims, set(), classes=classes)
+    # An ambiguous spelling is evidence in neither direction, so it is dropped
+    # from the bands and its image barred from the shared negative pool -- the
+    # same `lift_ambiguous` pass the built classes get, which is why this runs
+    # AFTER `anchor_to_coco`: on the COCO-annotated half the answer is already
+    # known and suppressing there would discard good negatives to fix nothing.
+    ambiguous = {c: names for c, names in ambiguous_names.items() if names}
+    unbanded = lift_ambiguous(labels, ambiguous, exhaustive) if ambiguous else set()
+    if ambiguous:
+        log(f"suppressed {len(unbanded)} (image, class) pairs on {sorted(ambiguous)}")
+
+    supply, boxes_for, _clean = band_candidates(labels, box_dims, unbanded, classes=classes)
 
     print(f"\n{'class':<16}{'small':>8}{'medium':>8}{'large':>8}   name the reviewer sees")
     print("-" * 78)

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -654,7 +654,11 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
             "one). Bad: couches and sofas (`couch`), benches, a TOILET (separate COCO "
             "class, zero confusions), and a CAR SEAT -- a component is not an instance, "
             "and counting them would fire on every street scene. A car seat REMOVED from "
-            "the car is free-standing, so it counts. A PART INHERITS THE RULING OF ITS "
+            "the car is free-standing, so it counts; so do a motorcycle's seat and a "
+            "saddle NOT (both are part of the vehicle or the tack, and both are zero "
+            "boxes in COCO). Someone clearly sitting on an INVISIBLE chair: vote Good and "
+            "draw NO box -- present, no size measured, which excludes the image from the "
+            "negative pool without making it a positive. A PART INHERITS THE RULING OF ITS "
             "WHOLE: a chair back or leg is evidence of a Chair and you box the Chair, but "
             "a headrest in a car is part of a car seat, so it is not one."
         ),

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -648,7 +648,15 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
         test=(
             "Good: dining, office, folding and deck chairs, armchairs, high chairs, "
             "stools and bar stools, and one seat within a row of stadium or theatre "
-            "seating. Bad: couches and sofas, which are `couch`, and benches."
+            "seating; `seat`/`seats` (269) is the third largest fold-in here. One seat "
+            "is a Chair, two or more a couch -- upholstered is NOT the test, so a club "
+            "chair or recliner counts. A lifeguard station counts (built as seating for "
+            "one). Bad: couches and sofas (`couch`), benches, a TOILET (separate COCO "
+            "class, zero confusions), and a CAR SEAT -- a component is not an instance, "
+            "and counting them would fire on every street scene. A car seat REMOVED from "
+            "the car is free-standing, so it counts. A PART INHERITS THE RULING OF ITS "
+            "WHOLE: a chair back or leg is evidence of a Chair and you box the Chair, but "
+            "a headrest in a car is part of a car seat, so it is not one."
         ),
     ),
     "sink": ClassRule(
@@ -1041,23 +1049,21 @@ SCALE_CANDIDATE_VG_NAMES: dict[str, tuple[str, ...]] = {
     # `goblet` 8, `champagne glass` 5, `champagne flute` 5; `mug` 238 is the
     # cup half's own missing spelling.
     #
-    # `glass` IS here. It was briefly left out because it also means a windowpane
-    # and eyeglasses -- an English argument where a measurement was available,
-    # and the wrong test. The right one is fold-out, which put `bike` in
-    # SCALE_VG_AMBIGUOUS at 40.1%: of 3,224 VG `glass` boxes, 1,146 land on COCO
-    # `cup` and 861 on `wine glass`, so 62.2% land on the merged class -- against
-    # self-match rates of 72.1% (cup), 71.2% (bowl), 72.8% (bottle) and 74.2%
-    # (vase) for the class names themselves. Ten points under the names, twenty
-    # above `bike`.
+    # `glass` is NOT here, and the reasoning that briefly put it here is worth
+    # keeping because it was subtly wrong. Its fold-out is 62.2% onto the merged
+    # class (1,146 of 3,224 VG boxes on COCO `cup`, 861 on `wine glass`), well
+    # clear of `bike`'s 40.1%, which reads as a usable alias.
     #
-    # The merge is what makes it usable, which is an argument for the merge that
-    # was not made when the merge was decided: unmerged, `glass` split 35.5% cup
-    # and 26.7% wine glass with neither dominant -- ambiguity between two classes
-    # rather than about the world. `mug` self-matches at 81.7%, the highest of
-    # any name measured here.
+    # But a fold-out rate is NOT a positive-precision rate. Fold-out is measured
+    # only on the COCO-annotated half, where a reference exists; POSITIVES are
+    # drawn from all of VG, including the half with no check, and there the 35%
+    # of `glass` boxes that land on no COCO class -- windowpanes, eyeglasses --
+    # arrive as positives unexamined. The review measured the damage: the merged
+    # `cup` slate rejected 9 of 30 boxed positives, 30%, against 0-17% for every
+    # other class, and worst in the LARGE band at 40%, which is where a
+    # windowpane lands. `glass` is in SCALE_CANDIDATE_VG_AMBIGUOUS instead.
     "cup": (
         "cup",
-        "glass",
         "mug",
         "wine glass",
         "wine glasses",
@@ -1067,6 +1073,24 @@ SCALE_CANDIDATE_VG_NAMES: dict[str, tuple[str, ...]] = {
         "champagne flute",
     ),
 }
+
+#: Candidate-class spellings that MAY denote the class but also denote something
+#: else -- :data:`SCALE_VG_AMBIGUOUS` for classes not yet in *C*.
+#:
+#: Same three-valued treatment, for the same reason: a box under one of these is
+#: evidence in neither direction, so it is dropped from the bands *and* bars its
+#: image from the shared negative pool. :func:`pilebuild.loaders.vg_scale.lift_ambiguous`
+#: does both, and exempts any image COCO annotates exhaustively or a reviewer has
+#: ruled on -- there the question is already answered and the spelling is ignored.
+#:
+#: `glass` is the entry that named this table. It is 62.2% good by fold-out, which
+#: is why it was first tried as a plain alias, and the 35% that is windowpanes and
+#: eyeglasses still cost `cup` 30% of its boxed positives -- the measurement is in
+#: the comment on that table above.
+SCALE_CANDIDATE_VG_AMBIGUOUS: dict[str, tuple[str, ...]] = {
+    "cup": ("glass",),
+}
+
 
 #: Classes this project defines as the UNION of several COCO classes.
 #:


### PR DESCRIPTION
Two pieces of #3588. Together because they land in one file; the commit message covers both.

## `glass` was the wrong kind of evidence

It went into `cup`'s aliases on a fold-out of **62.2%** onto the merged class, well clear of
`bike`'s 40.1%. That reasoning was subtly wrong, and the comment now records why:

**A fold-out rate is not a positive-precision rate.** Fold-out is measured only on the
COCO-annotated half, where a reference exists. *Positives are drawn from all of VG*, and there
the 35% of `glass` boxes that are windowpanes and eyeglasses arrive unexamined.

The review measured the damage. The merged `cup` slate rejected **9 of 30 boxed positives —
30%**, against 0–17% for every other class, and worst in the **large** band at 40%, which is
exactly where a windowpane lands.

So `glass` moves to a new **`SCALE_CANDIDATE_VG_AMBIGUOUS`** — the `SCALE_VG_AMBIGUOUS`
treatment for a class not yet in *C*. Evidence in neither direction: no positive, and barred
from the shared negative pool.

### Two gaps in the candidate path

`make_class_slate` passed an **empty `unbanded`** to `band_candidates`, so `lift_ambiguous`
never ran at all.

Wiring it exposed a second one. The first attempt **suppressed zero pairs** — dropping `glass`
from the alias tuple also dropped it from what gets *read*, and a name that was never read is
invisible to the suppressor: it suppresses nothing and the contaminated negative stays. The
built classes avoid this through `scale_vg_wanted()`, which reads both tables. This adds the
candidate-side equivalent.

**Result: 1,909 `(image, class)` pairs suppressed.** Supply is unchanged at 1036/1990/629 —
the whole effect is on the negative side, which is the point.

**Cost worth stating:** this also drops the ~62% of `glass` boxes that were genuine cups.
Supply says that is affordable (`cup`, `mug` at 81.7% self-match, and the stemware spellings
carry it), but if `cup`'s redo returns noticeably fewer boundary discoveries than the 13 found
last time, that is this trade showing up.

## Chair, and a naming convention

**A capitalised name means the class; a lowercase one means the English word.** A Chair is
whatever the guide says it is; a chair is what you would call a chair. The two come apart
constantly — a judge's bench is not a Bench, a toilet bowl is not a Bowl — and most rulings in
this guide live precisely at that gap. Code keeps lowercase, since `"chair"` is the COCO key.

Measured and free: a **toilet** is not a Chair (its own COCO class, **zero** confusions in
15,868 boxes). A **lifeguard station** is one, built as seating for one. **Upholstered is not
the test** — a club chair or recliner counts, a two-seat loveseat is a couch.

**A car seat is not a Chair**, and it is the one that matters. Every car almost certainly has
seats inside, so counting them makes Chair fire on every street scene, stop discriminating,
and poison the negative pool wherever a car appears. COCO agrees emphatically — `car seat` 2,
`child seat` 1, `car` 1, out of 15,868 — and so does the component rule that keeps a fuel tank
out of Bottle. A car seat **removed** from the car is free-standing and counts, as the jerry
can does.

**A part inherits the ruling of its whole.** Asked whether a visible headrest is a Chair: not
because it is small. Seeing part of a thing is normally good evidence of the thing, and VG
names COCO chair boxes by a part often enough to matter (`back` 57, `cushion` 34, `legs` 13).
A chair back over a table is evidence of a Chair; a headrest in a car is part of a car seat,
so it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv