### PR TITLE
Say what vg_scale may be asked, not just what it is

### DIFF
--- a/docs/experiments/2026-08-25-vg-scale/DATASHEET.md
+++ b/docs/experiments/2026-08-25-vg-scale/DATASHEET.md
@@ -18,7 +18,7 @@ remain valid for what they measured and are **not** comparable to this one.
 | cells | 36 = 12 classes × {small, medium, large} |
 | positives | exactly **100 per cell**, each carrying its ground-truth box |
 | negatives | one shared pool of **3,900**, identical for every cell |
-| prevalence | **0.0250 in all 36 cells**, by construction |
+| prevalence | **designed 0.0250** in all 36 cells; **realised 0.0172** since #3667 admitted other classes' positives as negatives (evaluable 4,000 → 5,806 per cell). `SCALE_PREVALENCE` is the designed number and every k\* is computed from it (#3681). |
 | embedders | `siglip`, `siglip2_l`, `clip`, `clip_l`, `dinov3_patch` — five columns, all built from the same medias (`clip_l` is eval-only, not offered in the app) |
 | region arm | the **pair** `siglip+dinov3_patch`: DINOv3 carries the patch grids that make region voting real, SigLIP carries the text tower the run opens on. Bare `dinov3_patch` is a *column of the pile*, never an arm of a study — with no text tower it cannot open the way the app does (#3276). |
 
@@ -114,6 +114,59 @@ large, and drawing the box cut that to 18% vs 3%. Both a human and a
 vision-language model confirm only ~2/3 of them even with the box. So a
 small-band "not confirmed" is recorded as *unconfirmed* and the label stands —
 **any small-band result should be read beside that fact.**
+
+## What this dataset can and cannot be asked
+
+The sections above say what the data *is*. This one says what a study may
+**conclude** from it, because the two are not the same and the difference has
+cost real GPU hours. Every verdict below points at the measurement that licenses
+or blocks it; a question shape that is not listed has not been thought about, and
+that is itself the finding.
+
+The organising fact: **label error here is not uniform, and the design cancels it
+in exactly one direction.** Cells within a class share their negatives, their
+prevalence and their positives' provenance, so a contrast *across bands of one
+class* is paired and the noise is common. Nothing about the construction makes
+the noise comparable *across classes*, and nothing makes it harmless in a
+*sequential* run, where a wrong label does not average out but steers every
+acquisition after it.
+
+| question shape | verdict | what decides it |
+|---|---|---|
+| Does target size change cost, **within one class**? | **supported** — the construction exists for it | Same 3,900 negatives and the same prevalence in every band of a class, and only the positives' *size* differs. But the published #3156 effect is a **lower bound**: the pre-#3667 pool let a head learn scene context, 2.50 ± 0.42× at `@small` against 1.25 ± 0.20× at `@large` (#3679). |
+| **Method A vs method B**, one class, one band | **supported, with a stated floor** | Contamination is common to both arms, but its *cost* is not: a hidden positive among the negatives is expensive only for the method that ranks it highly. Do not call a difference smaller than that class's contamination rate (table below). |
+| Method A vs B where the two are **confused by different things** | **unmeasured** | Since #3667 a class's negatives include images holding *other* classes, so the pool's co-occurrence structure is set by COCO's scene statistics rather than by design. Nobody has priced it. `cooccur.py` / `cooccur25.py` measure co-occurrence but were written to group review passes, not to price this confound. |
+| Is class **X** harder than class **Y**? | **not currently supported** | Per-class label quality varies more than most task effects: pool contamination spans ~10× (`backpack` 2.8% → `kite`/`dog` ~0.3%, `pool_contamination.py`), definition risk ~5× (`book` 43.1% of VG boxes on no COCO class → `bus` 8.6%, #3673), and eleven of twelve classes had no written definition when they were reviewed — `SCALE_CLASS_RULES` now covers eleven, but it postdates the review (#3612, #3673). A class ranking reads that spread as difficulty. |
+| Absolute cost / AP **for one class** | **supported, with a stated floor** | Quote the class's own contamination rate beside the number, not the pooled 1.4%. |
+| Anything about `@small` **in absolute terms** | **read beside the verification limit** | A sub-patch object is under 1/196 of the frame; both a human and a VLM confirm only **~2/3** of small-band positives *with the box drawn*. Small-band "not confirmed" is recorded as unconfirmed and the label stands. |
+| Does more labelling monotonically help? Any claim about a **run's trajectory** | **unmeasured, and structurally hazardous** | A mislabelled image in a sequential loop is not additive error: it enters the training set and steers later acquisition. Worse, the loop samples contamination *adversarially* — hidden positives are by construction the most class-looking negatives available, so they are served early, when the head has fewest positives to outvote them. Unquantified; see the flip probe (#3686). |
+| Compare a result here against `vg_box_small/medium/large` | **not supported** | Disjoint vocabularies; the gap confounds box size with class identity. Stated at the top of this datasheet. |
+| Any **per-class** reading of `bicycle` (or, in smaller measure, the other eleven) in the published cells | **carries a known defect** | All twelve are built from one VG spelling and the published pickle still is. `bike` carries 638 of COCO's 3,683 `bicycle` boxes against the `bicycle` spelling's 775, and on the non-COCO half those became `bicycle` **negatives** (#3605, #3618). |
+| Compare a number against one published **before 2026-09-06** | **not comparable** | #3667 changed both the evaluable set (4,000 → 5,806 per cell) and the realised prevalence (2.50% → 1.72%), which moves every k\* quoted from it. |
+
+**Per-class floors** (`pool_contamination.py`, #3635 — the estimated share of the
+shared pool that actually holds the class, on VG's evidence alone):
+
+| class | rate | | class | rate |
+|---|---|---|---|---|
+| `backpack` | **2.8%** | | `clock` | 1.1% |
+| `book` | 1.7% | | `bus`, `umbrella` | 0.7% |
+| `knife` | 1.6% | | `bicycle` | 0.6% |
+| `stop sign` | 1.2% | | `bird`, `boat`, `dog`, `kite` | 0.3–0.5% |
+
+`backpack` is the one to watch: ~110 expected hidden positives in a 3,900-image
+pool against the 100 labelled ones per cell — more real backpacks among the
+negatives than among the positives, which is the worst case `coco_anchor.py`
+names.
+
+**Two of these are removable rather than permanent**, and cheaply: the negative
+pool can be made *provable* instead of audited (#3668, #3670 — 18,986 images
+outside the pile where COCO confirms none of the classes is present, no human
+labelling involved), which retires the per-class spread and with it the
+cross-class row. What cannot be made provable that way is the **off-COCO
+positives** and their bands, because sourcing those from COCO would make this a
+subset of COCO with extra steps — the thing the construction was corrected to
+avoid.
 
 ## Reproducing and extending it
 


### PR DESCRIPTION
The `vg_scale` datasheet said what the data **is** and left every consumer to
infer what it may be used to **conclude**. Those differ, and the answers were
spread across eight study reports and about twenty issue threads — which is the
same as not existing at the moment somebody is deciding what to launch.

## What this adds

A **use register**: ten question shapes, each with a verdict
(`supported` / `supported with a stated floor` / `not currently supported` /
`unmeasured`) and the measurement that licenses or blocks it, plus the per-class
contamination floors a study should quote beside any absolute number.

Most rows restate something already measured. **Two are new:**

- **A cross-class difficulty ranking is not supported.** Per-class label quality
  spans ~10× (pool contamination `backpack` 2.8% → `kite`/`dog` ~0.3%) and
  definition risk ~5× (`book` 43.1% → `bus` 8.6%). A ranking reads that spread as
  task difficulty. The paired design cancels noise across *bands of one class*
  and does nothing across classes.
- **Any claim about a run's trajectory is unmeasured, and structurally
  hazardous.** A wrong label in a sequential loop is not additive error — it
  enters the training set and steers later acquisition, and the loop samples
  contamination *adversarially*, because a hidden positive is by construction one
  of the most class-looking negatives available. Filed as **#3686**.

It also names the confound #3667 introduced and nobody has priced: a class's
negatives now include images holding *other* classes, so the pool's co-occurrence
structure is COCO's scene statistics rather than a design choice. That is exactly
the term that decides a comparison between two methods confused by different
things.

## Also

Corrects the prevalence row, stale since #3667 changed the evaluable set from
4,000 to 5,806 per cell: **designed 0.0250, realised 0.0172**. A consumer reading
2.50% off this table sets k\* half a bit wrong (#3681).

## Verification

Docs only, no code paths touched. `scripts/check-docs.py` passes (321 markdown
files, 7 invariants, no drift).

**Full suite not yet run** — the GRID is unreachable from the laptop right now
(the JHU VPN is down; `login2.hltcoe.jhu.edu` does not resolve). To be submitted
before merge.

Closes nothing; opens #3686.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYrDwiQ8zejoDdm8DKm5fR
