### PR TITLE
Refuse a `present` on an object the class cannot hold (#3676)

### DIFF
--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -332,6 +332,26 @@ the sampled band was the error, not the redraw. What was wrong is that it
 happened silently, so `verdicts_to_corrections.py` now prints every
 band-changing rebox with the band it left and the band it lands in.
 
+## A `present` the class cannot hold is refused, and named
+
+A boxless `present` on a negative excludes the image from every cell of its
+class; a boxed one turns it into a positive. Both are the wrong answer when the
+object the reviewer correctly saw is one the class's construction would never
+have admitted — a wristwatch for `clock`, a pop-up canopy for `umbrella`. #3666
+adjudicated nine such finds in the negative pass and **four** were exactly that,
+so applying them would have spent four good negatives on readings the build does
+not use.
+
+The gate is the adjudication file the positive side already reads, with the same
+two fields (`"claude": "absent"` plus `"reason": "definition"`), because it is
+the same sentence pointed the other way: *what the object is* settles it, and no
+amount of looking changes the answer. It is a **table of decided cases** and
+never a heuristic — a verdict carries no object identity, so nothing in the
+script can infer one — and `shipped_pool_error.py --adjudication-out` writes that
+table from the study's own adjudication. Every refusal is printed with its note,
+and a refused class with no entry in `SCALE_CLASS_RULES` is named as a ruling
+somebody owes (#3673).
+
 `audit_band_drift.py` asks how much of the same error the *un*-reviewed half is
 still hiding, without spending a human on it. The COCO-anchored half has both
 readings available — VG's boxes and COCO's exhaustive ones — so banding each

--- a/scripts/experiments/pile/shipped_pool_error.py
+++ b/scripts/experiments/pile/shipped_pool_error.py
@@ -379,6 +379,13 @@ def main() -> int:
     ap.add_argument("--verdicts", default=str(STUDY / "verdicts.csv"))
     ap.add_argument("--rebank", action="store_true", help="re-distil verdicts.csv from the passes on scratch")
     ap.add_argument("--figures", action="store_true", help="also emit the report's figures")
+    ap.add_argument(
+        "--adjudication-out",
+        default="",
+        help="write the `no` rows as a verdicts_to_corrections.py adjudication file (#3676): the "
+        "finds whose object the class provably cannot hold, so a `present` on them must not "
+        "spend a negative or manufacture a positive",
+    )
     ap.add_argument("--out", default="")
     args = ap.parse_args()
 
@@ -532,6 +539,28 @@ def main() -> int:
             )
     swing = 100 * (table["clock"]["random_hits"] - table["clock"]["random_admissible"]) / len(rand)
     print(f"  one ruling on `clock` (is a wristwatch a clock?) moves it {swing:.1f}pp, for one sentence")
+
+    if args.adjudication_out:
+        # Only the `no` rows. `unverifiable` is exactly the case an adjudication
+        # must NOT be written for -- it would assert from the pixels what the
+        # pixels do not say -- and a `yes` row is a correction to apply, not one
+        # to refuse.
+        rows = [
+            {
+                "image_id": iid,
+                "class": a["cls"],
+                "claude": "absent",
+                "reason": "definition",
+                "note": f"{a['what']} -- {a['why']}",
+                "source": "shipped_pool_error #3666",
+            }
+            for iid, a in sorted(ADJUDICATION.items())
+            if a["admits"] == "no" and a["cls"] and "+" not in a["cls"]
+        ]
+        Path(args.adjudication_out).write_text(json.dumps(rows, indent=1) + "\n")
+        print(f"\nwrote {len(rows)} definitional adjudications to {args.adjudication_out}")
+        for r in rows:
+            print(f"   {r['class']:<12}{r['image_id']:<10}{r['note'][:88]}")
 
     if args.out:
         Path(args.out).write_text(json.dumps({"classes": table, "candidates": cand}, indent=1) + "\n")

--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -24,6 +24,20 @@ builder therefore drops it from every cell of that class: not a positive, and no
 longer a negative either. That is the whole point of the three-valued design --
 the alternative is inventing a box to keep the arithmetic tidy.
 
+**A `present` the class cannot hold is refused, and refusing it is not the same
+as ignoring it.** A boxless `present` on a negative excludes the image; a boxed
+one turns it into a positive. Both are wrong when the object the reviewer
+correctly saw is one the class's own construction would never have admitted --
+a wristwatch for `clock`, a pop-up canopy for `umbrella` -- because the class
+then loses a good negative, or gains a positive it does not believe in, on the
+strength of a reading it does not use. #3666 adjudicated nine such finds and
+**four** were exactly this. The gate is the same adjudication file the positive
+side already reads, with the same two fields (``"claude": "absent"`` plus
+``"reason": "definition"``), because it is the same sentence pointed the other
+way: *what the object is* settles it, and no amount of looking changes the
+answer. It is a table of decided cases and never a heuristic -- a verdict
+carries no object identity, so nothing here can infer one.
+
 **A rebox can move an image between bands, and that is reported, not refused.**
 An image entered a `class@band` cell because of the box it arrived with, so a
 reviewer who retargets the box to a different instance of the same class moves
@@ -123,6 +137,8 @@ def main() -> int:
     stats: Counter = Counter()
     # (class, image_id, band sampled, band the redrawn box implies) -- #3616.
     moves: list[tuple[str, int, str, str]] = []
+    # (class, image_id, carried a box, the adjudicator's note) -- #3676.
+    kept: list[tuple[str, int, bool, str]] = []
 
     # --- adjudications first, so a later source cannot silently overrule them
     adj = {}
@@ -151,6 +167,15 @@ def main() -> int:
         # changed (`make_definition_reslate.py`).
         if v["stratum"] in ("boundary", "random", "flag", "audit", "redef", "redef_fresh"):
             if v["human"] == "present":
+                # Refused only where an adjudication names the object and says
+                # the class cannot hold it -- see the module docstring. The
+                # reviewer is not being overruled about the pixels; the class is
+                # being held to its own vocabulary.
+                a = adj.get(key)
+                if a and a.get("claude") == "absent" and a.get("reason") == "definition":
+                    stats["negative_kept_definitional"] += 1
+                    kept.append((key[1], key[0], bool(v.get("box")), a.get("note", "")))
+                    continue
                 box = v.get("box")
                 out[key] = {
                     "image_id": key[0],
@@ -267,7 +292,33 @@ def main() -> int:
     print(f"\n   {'of which carry a box':<32}{boxed:>6}  (can move an image between bands)")
     print(f"   {'excluded, no box':<32}{len(rows) - boxed:>6}  (dropped from every cell of that class)")
     _report_moves(moves, stats)
+    _report_kept(kept)
     return 0
+
+
+def _report_kept(kept: list[tuple[str, int, bool, str]]) -> None:
+    """Name every correction refused because the class cannot hold the object (#3676).
+
+    Printed rather than silent for the same reason the band moves are: a
+    correction that does not happen is invisible in the output file, and this
+    one is a *decision* about what the class means. The line also says whether
+    the class has a written rule at all -- an unruled class here is a ruling
+    somebody owes (#3673), not a defect in this script.
+    """
+    if not kept:
+        return
+    print(f"\n=== {len(kept)} `present` verdicts REFUSED: the class cannot hold the object ===")
+    print("   The reviewer saw what they say they saw. The class's own names do not")
+    print("   admit it, so applying the correction would spend a good negative (no box)")
+    print("   or manufacture a positive (box) on a reading the build does not use.\n")
+    print("   %-12s %-10s %-6s %s" % ("class", "image_id", "boxed", "why"))
+    for cls, iid, boxed, note in sorted(kept):
+        print("   %-12s %-10d %-6s %s" % (cls, iid, "yes" if boxed else "no", note or "(no note)"))
+    unruled = sorted({c for c, _, _, _ in kept if c not in pc.SCALE_CLASS_RULES})
+    if unruled:
+        print("\n   NO WRITTEN RULE for: " + ", ".join(unruled))
+        print("   Each of those is a sentence owed to `SCALE_CLASS_RULES` (#3673); until it")
+        print("   exists the next reviewer re-derives the same call from scratch.")
 
 
 def _report_moves(moves: list[tuple[str, int, str, str]], stats: Counter) -> None:

--- a/tests_lib/meta/test_pile_definitional_rejection.py
+++ b/tests_lib/meta/test_pile_definitional_rejection.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -109,6 +110,9 @@ def _run(tmp_path: Path, adjudication: list[dict]) -> dict:
         capture_output=True,
         text=True,
         check=False,
+        # `pile_config.setup_env()` creates the pile dir at import, so without
+        # this the test needs the scratch mount and fails everywhere else.
+        env={**os.environ, "VTS_PILE": str(tmp_path / "pile")},
     )
     assert proc.returncode == 0, proc.stderr
     return {(r["image_id"], r["class"]): r for r in json.loads(out.read_text())}

--- a/tests_lib/meta/test_pile_inadmissible_negative.py
+++ b/tests_lib/meta/test_pile_inadmissible_negative.py
@@ -1,0 +1,195 @@
+"""A `present` the class cannot hold must not spend a negative (#3676).
+
+``verdicts_to_corrections.py`` turns a reviewer's `present` on a negative into
+a correction: boxless it excludes the image from every cell of that class, boxed
+it makes the image a positive. Both are the wrong answer when the object the
+reviewer correctly saw is one the class's own construction would never have
+admitted — a wristwatch for `clock`, a pop-up canopy for `umbrella`. #3666
+adjudicated nine such finds and four were exactly that, so the class would have
+lost four good negatives on a reading the build does not use.
+
+The gate is the adjudication file the positive side already reads, with the same
+two fields, because it is the same sentence pointed the other way:
+``"claude": "absent"`` plus ``"reason": "definition"`` means *what the object is*
+settles it. These tests pin all three states — refused with a note, applied when
+no adjudication names it, and applied when an adjudication exists but is about
+confirmability rather than identity — plus the boxed case, which is the more
+damaging of the two and is not what the issue's title describes.
+
+The script runs in a subprocess because ``pile_config.setup_env()`` edits
+``os.environ`` and ``sys.meta_path`` at import; ``VTS_PILE`` is pointed at the
+tmp dir so the run needs no scratch mount and the test is runnable anywhere.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+_CLASS = "clock"
+_WATCH = 2408671  # a wristwatch on a bystander's wrist
+_REAL = 2327535  # an ordinary contaminated negative, nothing definitional about it
+
+
+def _slate(root: Path) -> Path:
+    """A negative-stratum manifest: no `cell`, because these are pool images."""
+    d = root / "slates" / _CLASS
+    d.mkdir(parents=True)
+    cols = ["image_id", "class", "stratum", "cell", "text_score", "reference", "exhaustive", "n_boxes", "detector"]
+    with (d / "manifest.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        for iid in (_WATCH, _REAL):
+            w.writerow(
+                {
+                    "image_id": iid,
+                    "class": _CLASS,
+                    "stratum": "random",
+                    "cell": "",
+                    "text_score": "0.0",
+                    "reference": "",
+                    "exhaustive": "no",
+                    "n_boxes": "0",
+                    "detector": _CLASS,
+                }
+            )
+    return root / "slates"
+
+
+def _run(tmp_path: Path, adjudication: list[dict], box: list[float] | None = None) -> tuple[dict, str]:
+    slates = _slate(tmp_path)
+    verdicts = [
+        {
+            "image_id": iid,
+            "class": _CLASS,
+            "stratum": "random",
+            "human": "present",
+            "reference": "",
+            "exhaustive": "no",
+            "box": box,
+            "text_score": 0.0,
+            "export": "test",
+        }
+        for iid in (_WATCH, _REAL)
+    ]
+    vpath = tmp_path / "verdicts.json"
+    vpath.write_text(json.dumps(verdicts))
+    apath = tmp_path / "adjudication.json"
+    apath.write_text(json.dumps(adjudication))
+    out = tmp_path / "corrections.json"
+
+    proc = subprocess.run(  # noqa: S603  # interpreter + test-controlled args
+        [
+            sys.executable,
+            "verdicts_to_corrections.py",
+            "--verdicts",
+            str(vpath),
+            "--adjudication",
+            str(apath),
+            "--slates",
+            str(slates),
+            "--triage",
+            str(tmp_path / "absent.json"),
+            "--sheets",
+            str(tmp_path / "no_sheets"),
+            "--out",
+            str(out),
+        ],
+        cwd=_PILE_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "VTS_PILE": str(tmp_path / "pile")},
+    )
+    assert proc.returncode == 0, proc.stderr
+    return {(r["image_id"], r["class"]): r for r in json.loads(out.read_text())}, proc.stdout
+
+
+def _adj(image_id: int, **extra) -> dict:
+    row = {
+        "image_id": image_id,
+        "class": _CLASS,
+        "claude": "absent",
+        "note": "a wristwatch, and `watch` is not a name this class reads",
+    }
+    row.update(extra)
+    return row
+
+
+def test_an_inadmissible_present_writes_no_correction(tmp_path):
+    """The class keeps the negative, and the refusal is named in the output."""
+    rows, stdout = _run(tmp_path, [_adj(_WATCH, reason="definition")])
+    assert (_WATCH, _CLASS) not in rows, "a `present` the class cannot hold must not exclude the image"
+    assert (_REAL, _CLASS) in rows, "the ordinary contaminated negative is still corrected"
+    assert "REFUSED" in stdout and str(_WATCH) in stdout, "a refused correction must not be silent"
+    assert "wristwatch" in stdout, "the adjudicator's note is what tells the next reader why"
+
+
+def test_a_boxed_present_is_refused_too(tmp_path):
+    """The boxed case manufactures a positive, which is the worse of the two.
+
+    A box on a wristwatch would make the image a `clock` positive in whatever
+    band the box implies — an object the class does not believe in, entering the
+    half of the benchmark it is scored against.
+    """
+    rows, stdout = _run(tmp_path, [_adj(_WATCH, reason="definition")], box=[0.4, 0.4, 0.5, 0.5])
+    assert (_WATCH, _CLASS) not in rows
+    assert rows[(_REAL, _CLASS)]["boxes"], "the ordinary find still carries its box"
+    assert "yes" in stdout.split("boxed")[-1], "the report says the refused verdict carried a box"
+
+
+def test_an_adjudication_about_confirmability_does_not_refuse(tmp_path):
+    """`absent` without `reason: definition` is not a statement about identity.
+
+    The positive side draws exactly this line — the small-band guard exists
+    because "I cannot tell at 26 px" and "it is not one" are different claims —
+    and the negative side must draw it in the same place, or an adjudicator's
+    hedge silently becomes a ruling.
+    """
+    rows, _ = _run(tmp_path, [_adj(_WATCH)])
+    assert (_WATCH, _CLASS) in rows, "only a DEFINITIONAL adjudication refuses the correction"
+
+
+def test_no_adjudication_leaves_the_old_behaviour_untouched(tmp_path):
+    """Nothing changes for the verdicts nobody has adjudicated."""
+    rows, stdout = _run(tmp_path, [])
+    assert (_WATCH, _CLASS) in rows and (_REAL, _CLASS) in rows
+    assert "REFUSED" not in stdout
+
+
+def test_the_emitter_and_the_gate_agree_on_their_two_fields(tmp_path):
+    """`shipped_pool_error.py --adjudication-out` writes what this gate reads.
+
+    The two live in different scripts and are joined only by a JSON shape, which
+    is the kind of seam that drifts. This asserts the shape rather than trusting
+    it: every row the emitter writes must be one the gate refuses.
+    """
+    out = tmp_path / "adj.json"
+    proc = subprocess.run(  # noqa: S603  # interpreter + test-controlled args
+        [
+            sys.executable,
+            "shipped_pool_error.py",
+            "--verdicts",
+            str(_PILE_DIR.parents[2] / "docs/experiments/2026-09-06-shipped-pool-3666/verdicts.csv"),
+            "--adjudication-out",
+            str(out),
+        ],
+        cwd=_PILE_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "VTS_PILE": str(tmp_path / "pile")},
+    )
+    assert proc.returncode == 0, proc.stderr
+    rows = json.loads(out.read_text())
+    assert rows, "the study adjudicated four finds as inadmissible; none reached the file"
+    for r in rows:
+        assert r["claude"] == "absent" and r["reason"] == "definition", r
+        assert r["note"].strip(), "a refusal with no note is a ruling nobody can check"
+        assert r["class"] and r["image_id"]


### PR DESCRIPTION
Closes #3676.

`verdicts_to_corrections.py` turns a reviewer's `present` on a negative into a correction: **boxless it excludes** the image from every cell of that class, **boxed it makes the image a positive**. Both are the wrong answer when the object the reviewer correctly saw is one the class's own construction would never have admitted — a wristwatch for `clock`, a pop-up canopy for `umbrella`.

#3666 adjudicated nine such finds and **four** were exactly that, so ingesting the negative pass as it stands (which #3660/#3604 are about to do) would spend four good negatives on readings the build does not use.

## The gate

The adjudication file the positive side already reads, with the same two fields:

```json
{"image_id": 2408671, "class": "clock", "claude": "absent", "reason": "definition",
 "note": "a wristwatch on a bystander's wrist -- `watch` is not in clock's names ..."}
```

It is the same sentence pointed the other way. The positive side's small-band guard exists because *"I cannot tell at 26 px"* and *"it is not one"* are different claims; this is the second of those, and no amount of looking changes the answer. **A table of decided cases, never a heuristic** — a verdict carries no object identity, so nothing in the script can infer one.

## Three things beyond the issue's text

- **The boxed case is refused too, and it is the more damaging of the two.** A box on a wristwatch manufactures a `clock` positive in whatever band the box implies — an object the class does not believe in, entering the half of the benchmark it is scored against. The issue's title describes only the boxless case.
- **`shipped_pool_error.py --adjudication-out` writes the table the gate reads**, so the study's own adjudication is the source rather than a hand-typed copy. A test asserts the two agree on their two fields, because a JSON shape shared across two scripts is exactly the seam that drifts.
- **Every refusal is printed with its note**, and a refused class with no entry in `SCALE_CLASS_RULES` is named as a ruling somebody owes (#3673). A correction that does not happen is invisible in the output file — the same reason the band moves are printed.

## Tests

Five new ones pinning all four states: refused with a note, refused when boxed, applied when no adjudication names it, and applied when an adjudication is about *confirmability* rather than identity (`absent` without `reason: definition` must not refuse — otherwise an adjudicator's hedge silently becomes a ruling).

Both subprocess test files now pass `VTS_PILE` into the child, so they no longer need the scratch mount. The three existing definitional-rejection tests failed on any machine without `/expscratch`, this laptop included; they run anywhere now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv
