### PR TITLE
CLAUDE.md: merge PRs with a merge commit, and say why it is load-bearing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,46 @@ When you're done with your changes, open a PR targeting `dev`. Do not ask; just 
 
 This standing instruction **is** the explicit request that the remote-environment harness rule ("do not create a pull request unless the user explicitly asks for one") defers to. The harness rule only suppresses *unsolicited* PRs; a durable, repo-committed instruction to auto-open one satisfies its "unless the user explicitly asks" carve-out. So the two do not conflict: in this repo, finishing your changes is your cue to open the PR (base `dev`) without further prompting.
 
+## Merging a PR
+
+**Use a normal merge commit: `gh pr merge <n> --merge`.** Never `--squash`, never
+`--rebase`.
+
+This is not a style preference — [`docs/RELEASE.md`](docs/RELEASE.md) finds what
+shipped by walking **merge commits**. Steps 4 and 6 both say to *inspect the
+merge commits in that range to get the PR numbers*, and a squashed PR is not a
+merge commit: it lands as an ordinary commit whose subject ends `(#N)`, so
+`git log --merges origin/main..origin/dev` never lists it. Measured on a live
+window (197 commits, 52 of them merges): a PR squashed by mistake was **absent**
+from that walk while one merged normally an hour later was present. The issue
+sweep has a second net — step 6's orphan backstop reads `Addressed in #M`
+comments, which is PR data rather than git — but the release summary and the
+punch-card data (`scripts/punchcard/pr_merges.txt`) have none, so a squashed PR
+can drop out of both without anything saying so.
+
+Two smaller costs, both paid at merge time:
+
+- **Ancestry.** A squash-merged branch is no longer an ancestor of `dev`, so a
+  follow-up PR from it re-shows its *entire* diff rather than the new commits.
+  Sessions here routinely keep working on a branch after its PR lands, which is
+  exactly when that bites.
+- **Structure.** Every commit collapses into one. The messages survive in the
+  squash body, but `cherry picked from` provenance and the shape of the work do
+  not.
+
+None of it is repairable afterwards: fixing the history means rewriting a shared,
+protected branch. So the check belongs **before** the merge. If you are ever
+unsure what this repo does, ask the repo rather than the last commit you happened
+to read — a two-commit sample is not a convention:
+
+```
+git log --pretty=%s -100 origin/dev | grep -c "^Merge pull request"   # 21
+git log --pretty=%s -100 origin/dev | grep -cE "\(#[0-9]+\) \(#[0-9]+\)$"  # 3
+```
+
+**Merging is not part of Auto-PR.** Open the PR without being asked; merge it
+only when the user says so.
+
 ## Linking a fix PR to its GitHub issue
 
 When your change resolves a GitHub issue, **link the PR back to that issue** so the two are connected on GitHub:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -69,7 +69,7 @@ Now that the release PR is open, close the GitHub issues whose fixes are include
 
 **Find the candidate issues** from this release's PRs:
 
-- List the pull requests merged into `dev` within this release range — the same `origin/main..origin/dev` window used for the summary in step 3 (inspect the merge commits in that range to get the PR numbers).
+- List the pull requests merged into `dev` within this release range — the same `origin/main..origin/dev` window used for the summary in step 3 (inspect the merge commits in that range to get the PR numbers). **This walk is why PRs here are merged and not squashed** (CLAUDE.md, "Merging a PR"): a squashed PR lands as an ordinary commit, so `git log --merges` does not list it and only the orphan backstop below can still find it.
 - For each such PR, read its body and collect **every** issue it references, keeping track of which keyword introduced each reference. Sort them into two buckets:
   - **Closing** — `Closes #N`, `Fixes #N`, `Resolves #N` (case-insensitive).
   - **Non-closing** — `Refs #N`, `Part of #N`, or a bare `#N` mention.


### PR DESCRIPTION
Adds a **`## Merging a PR`** section to CLAUDE.md, between `Auto-PR` (which covers opening one) and the issue-linking rules.

CLAUDE.md said nothing about merge method, so the only available check was the repo's own history — and I read the two commits at the top of `dev`, both of which happened to be squashes, and squashed #3685 to match. The actual split over the last 100 commits on `dev` is **21 merge commits to 3 squashes**.

## Why the rule is load-bearing rather than stylistic

`docs/RELEASE.md` steps 4 and 6 find what shipped by walking **merge commits** — *"inspect the merge commits in that range to get the PR numbers"*. A squashed PR is not a merge commit: it lands as an ordinary commit whose subject ends `(#N)`, so `git log --merges origin/main..origin/dev` never lists it.

Checked on the live window (197 commits, 52 of them merges):

| PR | merged as | found by `git log --merges origin/main..origin/dev` |
|---|---|---|
| #3685 | squash (mistake) | **no** |
| #3689 | merge commit | yes |

The issue sweep has a second net — step 6's orphan backstop reads `Addressed in #M` comments, which is PR data rather than git — but the **release summary** and the **punch-card data** (`scripts/punchcard/pr_merges.txt`) have none. That is the same shape as the `Refs #N` incident the runbook already records, where three issues shipped to `main` and stayed open forever.

## Also recorded

- **Ancestry**: a squash-merged branch stops being an ancestor of `dev`, so a follow-up PR from it re-shows its entire diff. Sessions here routinely keep working on a branch after its PR lands, which is exactly when that bites — it happened twice in one afternoon.
- **Structure**: commits collapse into one; the messages survive in the squash body, `cherry picked from` provenance does not.
- None of it is repairable afterwards without rewriting a shared protected branch, so the check belongs *before* the merge — with the one-liner that asks the repo instead of the last commit you happened to read.
- **Merging is not part of Auto-PR**: open the PR unasked, merge only when the user says so.

`docs/RELEASE.md` gains one sentence pointing back, so the constraint is visible from the side that depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv
