### PR TITLE
suite.sbatch refuses a stale ref, and the lesson says prevented (#3677)

### DIFF
--- a/scripts/experiments/lessons/2026-09-06-a-force-push-left-the-suite-testing-the-old-commit.md
+++ b/scripts/experiments/lessons/2026-09-06-a-force-push-left-the-suite-testing-the-old-commit.md
@@ -15,7 +15,33 @@ Force-fetching the ref by hand was not enough either: the local branch is
 whatever the *working* worktree's HEAD is, so the fix was
 `git reset --hard origin/<branch>` in the worktree that owns the branch.
 
-**Prevented?** *Advice only.* Two things follow from it:
+**Prevented?** **Yes**, by a guard in `suite.sbatch` (#3677). After its
+`checkout --detach "$REF"` the script compares `HEAD` against `origin/$REF` and
+refuses the run when they differ, naming which way:
+
+```
+FATAL: checked out 22fe41c12… for 'claude/tmp-3677-guard', but origin/… is f206d7048…
+  The local branch is BEHIND origin -- a force-push, or a fetch that could
+  not fast-forward it. …
+    git -C <that worktree> fetch -f origin && git reset --hard origin/<branch>
+```
+
+It **refuses rather than auto-corrects**, and that is the whole design decision.
+Checking out `origin/$REF` would fix this incident and cause the opposite one:
+whenever the grid clone is legitimately *ahead* of origin, it would silently
+test older code and discard the commit somebody made here — which is
+[the #3292 failure](2026-09-05-a-commit-made-during-the-suite-job-was-orphaned.md),
+already in this log. Both directions are mistakes and only a human knows which,
+so the script names the direction and stops. A ref with no `origin/` counterpart
+(a bare SHA, a local-only branch) is not compared, and every run now prints a
+`=== ref` line beside `=== HEAD` saying which of the three it was.
+
+Both refusal paths were verified against the real script before this was
+written — a branch deliberately left behind, then one deliberately left ahead —
+each exiting 2 with SLURM reporting `FAILED`.
+
+Two things still follow from it, because the guard covers one script and not the
+habit:
 
 - **Read the job's `=== HEAD` line before reading its verdict.** A suite result
   is about a commit, not about a branch name, and this is the same failure
@@ -26,6 +52,7 @@ whatever the *working* worktree's HEAD is, so the fix was
   fetched the branch. A squash before the first suite run costs nothing; a
   squash after it costs a job and can be read as a test failure.
 
-The mechanical version — `suite.sbatch` refusing to run when the checked-out SHA
-is not `origin/<ref>` — belongs in that script, which lives outside this repo at
-`/exp/sgreenberg/suite.sbatch`; filed as **#3677**.
+The guard lives in `/exp/sgreenberg/suite.sbatch`, **outside this repository**, so
+nothing here reviews it, tests it, or notices if it is edited away — the previous
+version is kept beside it as `suite.sbatch.bak.20260906`. That gap is filed as
+**#3694**.

--- a/scripts/experiments/lessons/2026-09-06-a-force-push-left-the-suite-testing-the-old-commit.md
+++ b/scripts/experiments/lessons/2026-09-06-a-force-push-left-the-suite-testing-the-old-commit.md
@@ -32,13 +32,23 @@ whenever the grid clone is legitimately *ahead* of origin, it would silently
 test older code and discard the commit somebody made here — which is
 [the #3292 failure](2026-09-05-a-commit-made-during-the-suite-job-was-orphaned.md),
 already in this log. Both directions are mistakes and only a human knows which,
-so the script names the direction and stops. A ref with no `origin/` counterpart
-(a bare SHA, a local-only branch) is not compared, and every run now prints a
-`=== ref` line beside `=== HEAD` saying which of the three it was.
+so the script names the direction and stops. Every run now prints a `=== ref`
+line beside `=== HEAD` saying which state it was in.
 
-Both refusal paths were verified against the real script before this was
-written — a branch deliberately left behind, then one deliberately left ahead —
-each exiting 2 with SLURM reporting `FAILED`.
+**Testing the guard found a second defect in the same line.** `git checkout
+--detach <name>` *refuses* a name that exists only on the remote: git's DWIM
+wants to create a tracking branch, `--detach` forbids it, and the job dies on
+`'--detach' cannot be used with '-b/-B/--orphan'` — a message about nothing to
+do with the situation. That is every branch pushed from the laptop and not yet
+checked out on the grid, and it had been hidden by the habit of running
+`git worktree add <path> <branch>` first, which creates the local branch as a
+side effect. The script now falls back to `origin/$REF` when **no** local ref
+exists — safe there and nowhere else, because with no local ref there is no
+local commit to discard.
+
+All four states were exercised against the live script before this was written:
+behind and ahead each exit 2 with SLURM reporting `FAILED`; in-sync and
+remote-only run the suite and say which they were.
 
 Two things still follow from it, because the guard covers one script and not the
 habit:


### PR DESCRIPTION
Closes #3677.

`suite.sbatch` takes a *ref* and runs `git checkout --detach "$REF"` on a **local** branch name, while its `git fetch origin` is not forced. So a branch that was squashed, amended or rebased and force-pushed leaves the grid's copy where it was, and the job tests the **previous commit** while reporting under the branch's name. Both steps exit 0. On 2026-09-06 that ran twice and the stale commit failed a docs gate for a row the *new* commit adds — which reads exactly like a real finding about the branch under test.

The script lives at `/exp/sgreenberg/suite.sbatch`, outside this repo, so what lands here is the lesson flipped from *advice only* to **prevented**. The previous version is kept beside it as `suite.sbatch.bak.20260906`.

## The guard

After the checkout, compare `HEAD` against `origin/$REF` and refuse on a mismatch, naming the direction:

```
FATAL: checked out 22fe41c12… for 'claude/tmp-3677-guard', but origin/… is f206d7048…
  The local branch is BEHIND origin -- a force-push, or a fetch that could
  not fast-forward it. Fetching harder is not enough: the branch is wherever
  the worktree that owns it has its HEAD. Fix it there:
    git -C <that worktree> fetch -f origin && git reset --hard origin/<branch>
```

**It refuses rather than auto-corrects, and that is the design decision.** Checking out `origin/$REF` would fix this incident and cause its opposite: whenever the grid clone is legitimately *ahead* of origin it would silently test older code and discard the commit somebody made there — the #3292 failure already in this log. Both directions are mistakes and only a human knows which.

## A second defect, found by testing the first

`git checkout --detach <name>` **refuses** a name that exists only on the remote — DWIM wants to create a tracking branch, `--detach` forbids it, and the job dies on `'--detach' cannot be used with '-b/-B/--orphan'`, a message about nothing to do with the situation. That is every branch pushed from the laptop and not yet checked out on the grid; the habit of running `git worktree add <path> <branch>` first had been hiding it. The script now falls back to `origin/$REF` when **no** local ref exists — safe there and nowhere else, since with no local ref there is no local commit to discard.

## Verified against the live script

| state | result |
|---|---|
| local **behind** origin | `FATAL … BEHIND`, exit 2, SLURM `FAILED` |
| local **ahead** of origin | `FATAL … AHEAD. Push it first` |
| in sync | runs; `=== ref '…' matches origin/…` |
| **no local ref** | runs; `=== ref '…' resolved through origin/… -- no local ref here` |

Every run now prints that `=== ref` line beside `=== HEAD` — the line that was the only thing disclosing the original incident.

## Follow-up

**#3694** — `suite.sbatch` is not in this repository, so nothing reviews or tests the only gate a branch passes before it is pushed, including the guard added here. The issue names the bootstrapping wrinkle a fix has to solve: the script checks out the worktree it would live in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv
