### PR TITLE
Commit the simulation #3702's argument rests on, and two stale numbers in the probe

### DIFF
--- a/docs/experiments/2026-09-06-provable-negatives-3670/REPORT.md
+++ b/docs/experiments/2026-09-06-provable-negatives-3670/REPORT.md
@@ -64,7 +64,9 @@ the pool can be made of),
 [`provenance_shortcut.py`](../../../scripts/experiments/pile/provenance_shortcut.py)
 (would a head use it),
 [`negpool_coverage.py`](../../../scripts/experiments/pile/negpool_coverage.py)
-(what it costs the review, and the realised prevalence).
+(what it costs the review, and the realised prevalence),
+[`contamination_identity.py`](../../../scripts/experiments/pile/contamination_identity.py)
+(why the two probe arms are one route).
 Figures from
 [`figures_3670.py`](../../../scripts/experiments/pile/figures_3670.py) over
 [`measurements/`](measurements).
@@ -178,9 +180,13 @@ contamination the two arms must satisfy
 
 > forward + reverse = 2
 
-for any contamination rate and any TPR. Simulation confirms it: 2.00–2.02 for
-rates up to 2.5%, drifting to 2.1 only at an implausible 5%. So the **sum is a
-contamination-free diagnostic**, and the measured sums are **2.35** (`siglip`),
+for any contamination rate and any TPR.
+[`contamination_identity.py`](../../../scripts/experiments/pile/contamination_identity.py)
+confirms it with the answer planted — both negative strata drawn from the same
+distribution, so any departure from 2 is the first-order approximation's error
+and nothing else: 2.00–2.02 for rates up to 2.5%, drifting to 2.1 only at an
+implausible 5%. So the **sum is a contamination-free diagnostic**, and the
+measured sums are **2.35** (`siglip`),
 **2.36** (`clip`) and **2.42** (`siglip2_l`). Contamination alone is refuted: a
 real stratum asymmetry exists.
 

--- a/scripts/experiments/pile/contamination_identity.py
+++ b/scripts/experiments/pile/contamination_identity.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Why `forward + reverse = 2` under pure contamination, and what that buys.
+
+``provenance_shortcut.py`` runs two arms against #3667's FPR scale, and #3670's
+report first read their agreement as two independent routes converging on one
+number. **They are not independent**, and this is the demonstration.
+
+Both arms pin a threshold at the ``1 - FPR`` quantile of one stratum and score
+the other at it unchanged:
+
+* **forward** -- threshold on the clean (COCO-scored) negatives, score the silent
+  ones. A fraction *c* of those are really positives, found at the TPR rather
+  than at the false-positive rate, so the ratio rises to ``1 + c(TPR/FPR - 1)``.
+* **reverse** -- threshold on the *silent* negatives, score the clean ones. The
+  same hidden positives sit at the top of the distribution the quantile is taken
+  from, so they push the threshold **up**, and clean negatives then fire at under
+  ``FPR``. The ratio falls.
+
+One cause, two arms, opposite signs. To first order in *c* the two displacements
+are equal and opposite, so **the sum is 2 whatever the contamination rate and
+whatever the TPR** -- which makes ``forward + reverse - 2`` a *contamination-free
+diagnostic*, and ``1/reverse`` a lower bound on any real asymmetry rather than an
+estimate of one.
+
+This script is the check on that claim, over rates and separations spanning what
+this dataset plausibly has. It plants the answer -- there is no provenance effect
+in the simulation at all, the two strata are drawn from the same distribution --
+so any departure from 2 is the approximation's error and nothing else.
+
+Measured on the real cells the sums are **2.35 / 2.36 / 2.42**, far outside what
+this produces, which is what refutes contamination-alone. See
+``docs/experiments/2026-09-06-provable-negatives-3670/REPORT.md`` §3 and #3702.
+
+Usage::
+
+    python contamination_identity.py            # the table the report quotes
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+#: The operating point `provenance_shortcut.py` pins at.
+TARGET_FPR = 0.05
+#: Contamination rates worth checking: #3666 measured 1.40% [0.68, 2.86] pooled
+#: over the shipped twelve, and 5% is included only to show where the first-order
+#: approximation starts to visibly bend.
+RATES = (0.005, 0.014, 0.025, 0.05)
+#: Separation between the positive and negative score distributions, in SDs.
+#: These give a TPR of roughly 0.44 / 0.64 / 0.83 at the 5% threshold, bracketing
+#: the ~0.70 the report assumes.
+SEPARATIONS = (1.5, 2.0, 2.6)
+N = 2_000_000
+SEED = 0
+
+
+def arms(rng: np.random.Generator, c: float, sep: float) -> tuple[float, float, float]:
+    """``(forward, reverse, tpr)`` with NO provenance effect present.
+
+    The two negative strata are drawn from the same distribution on purpose: the
+    only thing that differs is that a fraction *c* of the silent one is really
+    positive. Anything the arms then show is contamination and nothing else.
+    """
+    positives = rng.normal(sep, 1.0, N)
+    provable = rng.normal(0.0, 1.0, N)
+    hidden = int(round(c * N))
+    silent = np.concatenate([rng.normal(0.0, 1.0, N - hidden), rng.normal(sep, 1.0, hidden)])
+
+    t_forward = float(np.quantile(provable, 1 - TARGET_FPR))
+    t_reverse = float(np.quantile(silent, 1 - TARGET_FPR))
+    return (
+        float((silent > t_forward).mean()) / TARGET_FPR,
+        float((provable > t_reverse).mean()) / TARGET_FPR,
+        float((positives > t_forward).mean()),
+    )
+
+
+def main() -> None:
+    rng = np.random.default_rng(SEED)
+    print(f"{'c':>7}{'sep':>6}{'TPR':>7}{'forward':>9}{'reverse':>9}{'sum':>8}{'excess':>9}")
+    worst = 0.0
+    for c in RATES:
+        for sep in SEPARATIONS:
+            fwd, rev, tpr = arms(rng, c, sep)
+            worst = max(worst, abs(fwd + rev - 2.0))
+            print(f"{c:>7.3f}{sep:>6.1f}{tpr:>7.2f}{fwd:>9.3f}{rev:>9.3f}{fwd + rev:>8.3f}{fwd + rev - 2:>9.3f}")
+    print(f"\nlargest departure from 2 anywhere in this grid: {worst:.3f}")
+    print("measured on the real cells: 2.35 (siglip), 2.36 (clip), 2.42 (siglip2_l)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/experiments/pile/provenance_shortcut.py
+++ b/scripts/experiments/pile/provenance_shortcut.py
@@ -42,7 +42,7 @@ Two further arms separate them, and neither needs new labelling:
 
   What that buys instead is better than what it cost: under PURE contamination
   the two arms must satisfy **forward + reverse = 2**, for any contamination rate
-  and any TPR (verified by simulation: 2.00-2.02 for rates up to 2.5%). The sum
+  and any TPR (`contamination_identity.py`: 2.00-2.02 for rates up to 2.5%). The sum
   is therefore a **contamination-free diagnostic**. It does not size the
   asymmetry -- `1/reverse` is a lower bound, and a Gaussian shift model that
   reproduces the forward arm gives reverse 0.65 against a measured 0.895, so the

--- a/scripts/experiments/pile/provenance_shortcut.py
+++ b/scripts/experiments/pile/provenance_shortcut.py
@@ -22,11 +22,14 @@ A ratio of 1 means provenance buys nothing. #3667's cross-class shortcut measure
 
 **The forward ratio is an UPPER bound and it came back 1.46 +/- 0.10, so it did
 NOT settle the question.** The silent negatives also carry genuine VG-silence
-contamination (0.3-2.8% per class): some really do hold the class, and a head
-SHOULD score those high. At c = 2.5% contamination among the silent negatives and
-a TPR near 0.7 at this threshold, contamination alone predicts a ratio of about
-0.975 x 0.05 + 0.025 x 0.7 = 0.066, i.e. **1.32** -- most of what was measured. So
-the forward arm alone cannot tell a provenance shortcut from a dirty stratum.
+contamination: some really do hold the class, and a head SHOULD score those high.
+At #3666's measured 1.40% [0.68, 2.86] pooled over the shipped twelve, and a TPR
+near 0.7 at this threshold, contamination alone predicts
+``1 + 0.0140 x (0.70/0.05 - 1)`` = **1.18** -- much of what was measured. So the
+forward arm alone cannot tell a provenance shortcut from a dirty stratum. (An
+earlier version of this docstring used 2.5%, the top of #3635's *predicted*
+per-class range, and got 1.32; that overstated the contamination and was what
+made the trade look decisive.)
 
 Two further arms separate them, and neither needs new labelling:
 
@@ -58,11 +61,13 @@ depressed by it, the clean-only arm is limited by review coverage -- so
 agreement between them is worth more than either alone. **Agreement between
 forward and reverse is worth nothing**, for the reason above.
 
-**Read `ratio` and `ratio_reverse` PER CLASS, never pooled.** The pooled sum hides
-a near-tenfold spread in the excess over 2: `bus` 2.65 and `bicycle` 2.60 against
-`knife` 2.07 and `boat` 2.13, which are indistinguishable from pure
-contamination. A pooled number was read as evidence that the artifact is uniform
-across classes, and that reading is what #3670's composition was justified on.
+**Read `ratio` and `ratio_reverse` PER CLASS, never pooled**, and read the
+EXCESS over 2 rather than the sum -- as sums the rows below read 2.65 against
+2.07 and look like a 28% spread. `forward + reverse - 2` runs `bus` **0.65** and
+`bicycle` **0.60** against `knife` **0.07** and `boat` **0.13**, the last two
+indistinguishable from pure contamination. A pooled number was read as evidence
+that the artifact is uniform across classes, and that reading is what #3670's
+composition was justified on (#3702).
 
 Run on `clip` as well as the shipped `siglip`: CLIP reads provenance most
 strongly of the five columns, so it is the adversarial case.

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -817,3 +817,47 @@ class TestCorrectionsOutsideC:
         )
 
         assert "car" in labels[7]
+
+
+class TestContaminationIdentity:
+    """`forward + reverse = 2` under pure contamination (#3702).
+
+    #3670 read the two probe arms as independent routes and quoted their
+    agreement as evidence. They are one route: contamination inflates the
+    forward arm and depresses the reverse one by the same mechanism. The
+    identity is what makes their SUM a contamination-free diagnostic, and the
+    report's whole corrected argument rests on it, so it is asserted rather
+    than left in a script nobody runs.
+    """
+
+    def _arms(self, c: float, sep: float, n: int = 200_000, fpr: float = 0.05):
+        np = pytest.importorskip("numpy")
+        rng = np.random.default_rng(0)
+        provable = rng.normal(0.0, 1.0, n)
+        hidden = int(round(c * n))
+        # Same distribution as `provable` apart from the hidden positives: there
+        # is deliberately NO provenance effect to find.
+        silent = np.concatenate([rng.normal(0.0, 1.0, n - hidden), rng.normal(sep, 1.0, hidden)])
+        t_f = float(np.quantile(provable, 1 - fpr))
+        t_r = float(np.quantile(silent, 1 - fpr))
+        return float((silent > t_f).mean()) / fpr, float((provable > t_r).mean()) / fpr
+
+    @pytest.mark.parametrize("c", [0.005, 0.014, 0.025])
+    @pytest.mark.parametrize("sep", [1.5, 2.6])
+    def test_the_arms_sum_to_two_whatever_the_rate_and_tpr(self, c, sep):
+        forward, reverse = self._arms(c, sep)
+
+        assert abs(forward + reverse - 2.0) < 0.05
+
+    def test_contamination_moves_both_arms_in_opposite_directions(self):
+        """The claim that replaced 'the reverse arm is contamination-free'."""
+        clean_f, clean_r = self._arms(0.0, 2.0)
+        dirty_f, dirty_r = self._arms(0.025, 2.0)
+
+        assert dirty_f > clean_f and dirty_r < clean_r
+
+    def test_the_measured_sums_are_outside_what_contamination_explains(self):
+        """2.35 is why #3670's asymmetry is real rather than dirt."""
+        worst = max(sum(self._arms(c, sep)) for c in (0.005, 0.014, 0.025) for sep in (1.5, 2.0, 2.6))
+
+        assert worst < 2.35


### PR DESCRIPTION
Three commits that missed #3703's merge — it landed while the suite was still
running on them. Same branch, no rework; opening a fresh PR per the usual
practice when a PR merges out from under a branch.

**The one that matters.** #3702's corrected argument turns on
`forward + reverse = 2` under pure contamination, and the report says that is
"verified by simulation" — while the script that verified it was sitting in
`/tmp`. A report whose script never got committed cannot be reproduced or
extended, and this one is load-bearing three times over: the identity is what
makes the sum a contamination-free diagnostic, what demotes `1/reverse` to a
lower bound, and what says the measured 2.35 cannot be dirt.

It lands twice, deliberately:

- `contamination_identity.py` produces the table the report quotes, with the
  answer planted — both negative strata are drawn from the *same* distribution,
  so any departure from 2 is the first-order approximation's error and nothing
  else. Largest departure anywhere in the grid is 0.02 at rates up to 2.5%.
- `TestContaminationIdentity` asserts the three properties the argument actually
  uses: the arms sum to 2 across rates and TPRs, contamination moves them in
  *opposite* directions, and no rate this dataset plausibly has can reach the
  measured 2.35. A claim a report leans on should not rest on a script nobody
  runs.

**Two stale numbers in `provenance_shortcut.py`'s docstring**, both artefacts of
the reasoning #3702 corrected:

- it still priced contamination at **1.32×** from the top of #3635's *predicted*
  per-class range. #3666 has measured 1.40% pooled over the shipped twelve, which
  is **1.18×** — and the overstatement is precisely what made the trade look
  decisive when it is not;
- its per-class warning introduced an *excess* and then listed *sums* (2.65,
  2.07). The same trap the report had, caught there by a peer session: as sums
  those rows read like a 28% spread when the finding is a tenfold one.

Suite green on this exact ref before the merge raced it: **10,879 passed**, all
gates.

Refs #3702, #3670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAnc7gMSFh43SCLGBM3zCv