### PR TITLE
Audit a merged class as the union it is (#3700)

### DIFF
--- a/docs/experiments/2026-09-06-vg-scale-promotion-3588/REPORT.md
+++ b/docs/experiments/2026-09-06-vg-scale-promotion-3588/REPORT.md
@@ -92,7 +92,7 @@ to **182** and **254**.
 | `truck` | 25.6% | 29.4% | +191 (on 1,499) | 167 |
 | `chair` | 22.2% | 24.9% | +361 (on 3,712) | 297 |
 | `bottle` | 23.3% | 27.8% | +375 (on 2,085) | 320 |
-| `cup` | 16.7% | 22.2% | +386 (on 1,616) | 345 |
+| `cup` | 12.6% | 18.8% | +581 (on 1,616) | 345 |
 | `bowl` | 30.5% | 32.1% | +51 (on 1,828) | 44 |
 | `fork` | 41.9% | 42.9% | +34 (on 1,037) | 34 |
 
@@ -140,6 +140,17 @@ scorer is not looking at. `mug`, whose object COCO really does call a cup,
 scores normally — so the blind spot is specific to the merged half and silent
 everywhere else. The six stemware spellings are carried by hand on #3588's own
 measurement against COCO `wine glass` boxes. Filed as **#3700**.
+
+> **Fixed, and the `cup` row above is restated accordingly.** #3700 made both
+> scripts resolve the class through `coco_classes_for`, and re-running the audit
+> confirms the two spellings that carry the mass — `wine glass` at **98%**
+> precision over 151 sole images and **85%** box agreement, `wine glasses` at
+> 95% — where the merge-blind run scored them 38% and 18% and refused both.
+> `cup`'s coverage row moves with it: its COCO denominator is **11,393** boxes
+> rather than 8,242, so the class name alone covers **12.6%** (not 16.7%) and
+> the alias table takes it to **18.8%** (not 22.2%). The numbers in this table's
+> `cup` row are the corrected ones; the rest are unaffected, because
+> `coco_classes_for` returns the class itself for the other twenty-four.
 
 ## 3. Adopting a per-class audit deleted a class
 

--- a/scripts/experiments/pile/name_coverage.py
+++ b/scripts/experiments/pile/name_coverage.py
@@ -98,6 +98,14 @@ def main() -> int:
             wanted.update(ns)
     log(f"{len(classes)} classes; {len(wanted)} VG names to match")
 
+    #: The COCO classes whose boxes count as *c* -- its whole footprint, not its
+    #: namesake alone. `cup` is `cup` U `wine glass`
+    #: (:data:`pile_config.SCALE_CLASS_MERGES`), so reading its coverage off COCO
+    #: `cup` omits every `wine glass` box the merge claims: the denominator is
+    #: short AND the stemware spellings appear to recover nothing (#3700).
+    #: Returns ``{c}`` for an unmerged class, so nothing else moves.
+    coco_for = {c: pc.coco_classes_for(c) for c in classes}
+
     cboxes, cdims, _ = cf.coco_boxes(Path(args.anchor_dir))
 
     log("loading VG image_data.json")
@@ -197,9 +205,14 @@ def main() -> int:
             continue
         # `coco_boxes` carries the whole COCO vocabulary (#3640); only the
         # classes under proposal are scored, and the counters are keyed on them.
+        #
+        # A class this project defines as a UNION is scored against its whole
+        # COCO footprint: reading `cup`'s coverage off COCO `cup` alone omits
+        # every `wine glass` box the merge claims, understating the denominator
+        # AND missing what the stemware spellings recover (#3700).
         on_image = cboxes.get(cid, {})
         for c in classes:
-            boxes = on_image.get(c, [])
+            boxes = [b for k in coco_for[c] for b in on_image.get(k, [])]
             if not boxes:
                 continue
             own = by_name.get(c, [])

--- a/scripts/experiments/pile/name_evidence.py
+++ b/scripts/experiments/pile/name_evidence.py
@@ -284,6 +284,23 @@ def main() -> int:
     overlap_images = 0
     base_hit = dict.fromkeys(classes, 0)
 
+    #: The COCO classes whose annotation counts as *c*, resolved once.
+    #:
+    #: This is the difference between asking about the class and asking about
+    #: the COCO class of the same name, and for a class this project defines as
+    #: a UNION (:data:`pile_config.SCALE_CLASS_MERGES`) those are not the same
+    #: question. `cup` is `cup` U `wine glass`, and scoring a stemware spelling
+    #: against COCO `cup` alone reads its boxes as landing on nothing: `wine
+    #: glass` measured 38% precision and **2%** box agreement that way, a
+    #: `neither` verdict produced entirely by the scorer looking at the wrong
+    #: half. `mug`, whose object COCO really does call a cup, scored normally --
+    #: which is what made the defect specific to the merged class and silent
+    #: everywhere else (#3700).
+    #:
+    #: :func:`pile_config.coco_classes_for` returns ``{c}`` for an unmerged
+    #: class, so this changes nothing for the other twenty-four.
+    coco_for = {c: pc.coco_classes_for(c) for c in classes}
+
     skipped_aspect = 0
     for rec in records:
         iid = int(rec["image_id"])
@@ -326,9 +343,11 @@ def main() -> int:
         overlap_images += 1
         here = cpresent.get(cid, set())
         for c in classes:
-            base_hit[c] += c in here
+            base_hit[c] += bool(here & coco_for[c])
         for c, names in cands.items():
-            truth = cboxes.get(cid, {}).get(c, [])
+            # Both the presence question and the box question are asked of the
+            # class's WHOLE COCO footprint, not of its namesake alone (#3700).
+            truth = [b for k in coco_for[c] for b in cboxes.get(cid, {}).get(k, [])]
             for n in names:
                 vb = by_name.get(n)
                 if not vb:
@@ -336,7 +355,7 @@ def main() -> int:
                 if c not in by_name:
                     # exactly the state that becomes a false negative off-COCO
                     sole[c, n] += 1
-                    sole_hit[c, n] += c in here
+                    sole_hit[c, n] += bool(here & coco_for[c])
                 boxes[c, n] += len(vb)
                 boxes_hit[c, n] += sum(1 for b in vb if any(cf.iou(t, b) >= args.iou for t in truth))
             for g, members in groups.get(c, {}).items():
@@ -345,7 +364,7 @@ def main() -> int:
                     continue
                 if c not in by_name:
                     gsole[c, g] += 1
-                    gsole_hit[c, g] += c in here
+                    gsole_hit[c, g] += bool(here & coco_for[c])
                 for m in present:
                     gboxes[c, g] += len(by_name[m])
                     gboxes_hit[c, g] += sum(1 for b in by_name[m] if any(cf.iou(t, b) >= args.iou for t in truth))

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -560,14 +560,27 @@ SCALE_VG_NAMES: dict[str, tuple[str, ...]] = {
     "clock": ("clock face", "clockface", "clocks"),
     # +386 repaired on the non-COCO half, 345 of them banded.
     #
-    # The stemware half is the CLASS MERGE (see SCALE_CLASS_MERGES) and had to be
-    # carried by hand: `name_evidence.py` scores every candidate against COCO
-    # `cup` alone, so `wine glass` reads 38% precision and 2% box agreement and
-    # lands in `neither` -- not because the name is bad but because the audit
-    # cannot ask about `cup` U `wine glass` (#3700). Those six keep their #3588
-    # measurement against COCO `wine glass` boxes. `mug` is the cup half's own
-    # missing spelling, and the audit confirms it independently: 88% over 193
-    # sole images, 82% over 290 boxes.
+    # The stemware half is the CLASS MERGE (see SCALE_CLASS_MERGES). It was
+    # carried by hand at the #3588 promotion because the audit scored every
+    # candidate against COCO `cup` alone -- `wine glass` read 38% precision and
+    # 2% box agreement and landed in `neither`, a refusal produced by the scorer
+    # looking at the wrong half of the class.
+    #
+    # #3700 made the audit merge-aware, and it now CONFIRMS the two spellings
+    # that carry the mass: `wine glass` at **98%** precision over 151 sole images
+    # and **85%** box agreement over 253 boxes, `wine glasses` at 95% / 57%.
+    # The other four stay on #3588's direct measurement against COCO
+    # `wine glass` boxes, because they sit below the audit's own floors rather
+    # than being refused by it: `goblet` clears precision at 70% with 12 boxes
+    # against a floor of 20, and `wineglass`, `champagne glass` and
+    # `champagne flute` fall under `--min-sole` entirely. `unmeasured` is not
+    # `refuted`.
+    #
+    # `mug` is the cup half's own missing spelling and was never affected: 88%
+    # over 193 sole images, 82% over 290 boxes, before and after.
+    #
+    # `glass` is NOT here, and the audit now proposes that it should be. See
+    # SCALE_VG_AMBIGUOUS["cup"] for why it is refused anyway.
     "cup": (
         "black cup",
         "brown cup",
@@ -893,6 +906,28 @@ SCALE_VG_AMBIGUOUS: dict[str, tuple[str, ...]] = {
     ),
     # `numerals` and `clock faces` each inherit from their own singular (#3636).
     "clock": ("alarm clock", "clock faces", "numeral", "numerals", "roman numerals"),
+    # `glass` is the entry that named this table, and it is the one entry the
+    # audit actively DISAGREES with.
+    #
+    # It is 62.2% good by fold-out (1,146 of 3,224 VG boxes on COCO `cup`, 861
+    # on `wine glass`), well clear of `bike`'s 40.1%, which is why it was first
+    # tried as a plain alias. A fold-out rate is not a positive-precision rate:
+    # fold-out is measured only on the COCO-annotated half, while POSITIVES are
+    # drawn from all of VG, and there the ~35% of `glass` boxes that land on no
+    # COCO class -- windowpanes, eyeglasses -- arrive as positives unexamined.
+    # The review measured the damage: the merged `cup` slate rejected **9 of 30**
+    # boxed positives (30%) against 0-17% for every other class of the thirteen,
+    # and worst in the LARGE band at 40%, which is where a windowpane lands.
+    #
+    # **#3700 raised the case for folding it, and changed nothing that matters.**
+    # Once the scorer counted COCO `wine glass` too, `glass`, `glass.` and
+    # `clear glass` all cleared the cuts and `name_evidence.py` began proposing
+    # them as aliases. That is the same evidence measured better on the half
+    # where `glass` was never the problem -- repair precision is computed on the
+    # overlap, and the windowpanes are on the half with no reference at all. The
+    # measurement that decides is a human one and no script produces it, so the
+    # exclusion is a hand exclusion with a test behind it, exactly like `sign`
+    # for `stop sign` (`test_glass_is_withheld_from_cup_rather_than_folded`).
     "cup": (
         "beer",
         "beer glass",

--- a/tests_lib/meta/test_pile_merged_class_names.py
+++ b/tests_lib/meta/test_pile_merged_class_names.py
@@ -176,8 +176,7 @@ class TestTheMergeIsPartOfTheClass:
         row = evidence["names"]["cup"]["wine glass"]
         assert row["sole"] == _N_IMAGES, "every image has the name and not the class name"
         assert row["sole_present"] == _N_IMAGES, (
-            "COCO annotates the object on every one of them -- as `wine glass`, "
-            "which IS `cup` for this class"
+            "COCO annotates the object on every one of them -- as `wine glass`, which IS `cup` for this class"
         )
         assert row["boxes_on_class"] == row["boxes"] == _N_IMAGES
         assert row["verdict"] == "alias"

--- a/tests_lib/meta/test_pile_merged_class_names.py
+++ b/tests_lib/meta/test_pile_merged_class_names.py
@@ -1,0 +1,231 @@
+"""A class defined as a UNION of COCO classes must be audited as that union (#3700).
+
+`cup` is `cup` ∪ `wine glass` (:data:`pile_config.SCALE_CLASS_MERGES`), and until
+this was fixed both name-audit scripts resolved "the class" to the COCO class of
+the same name. So a stemware spelling was scored against COCO `cup` alone:
+`wine glass` measured 38% repair precision and **2%** box agreement over 151 sole
+images and landed in `neither` — a refusal produced entirely by the scorer
+looking at the wrong half of the class. `mug`, whose object COCO really does call
+a cup, scored 88% / 82% and passed, which is what kept the defect specific to the
+merged class and silent everywhere else.
+
+It cost the #3588 promotion six spellings that had to be carried into
+`SCALE_VG_NAMES["cup"]` **by hand**, against the audit's own verdict. That is the
+right answer reached the wrong way, and the next merged class would repeat it.
+
+Both halves are planted here against a synthetic VG-COCO overlap whose answers
+are known by construction, and both fail without the fix:
+
+* `name_evidence.py` — a spelling whose object COCO files under the *partner*
+  class must reach `alias`, not `neither`;
+* `name_coverage.py` — the class's COCO box count must include the partner's
+  boxes, or the coverage denominator is short and the spelling appears to
+  recover nothing.
+
+Like `test_pile_pooled_names.py` these run the real scripts in a subprocess:
+`pile_config.setup_env()` rewrites `os.environ` and `sys.meta_path` at import,
+which is not something to do to the test process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+_W, _H = 640, 480
+
+#: COCO's own ids for the two halves of the merged class, and an unrelated
+#: object to put a box on when a name must NOT agree with either half.
+_CAT_CUP, _CAT_WINE_GLASS, _CAT_BENCH = 47, 46, 15
+
+_OBJECT_BOX = [100.0, 100.0, 200.0, 200.0]
+
+#: `--min-boxes` defaults to 20: an alias claims every box under the name IS the
+#: object, and five boxes cannot carry that claim. So the fixture plants enough
+#: images to clear it, or the verdict falls to `ambiguous` for a reason that has
+#: nothing to do with the merge.
+_N_IMAGES = 22
+
+
+def _obj(name: str, box: list[float]) -> dict:
+    x, y, w, h = box
+    return {"names": [name], "x": x, "y": y, "w": w, "h": h}
+
+
+class _Overlap:
+    """A synthetic VG-COCO overlap, built one image at a time.
+
+    ``coco_category`` is what COCO files the object under — the whole point of
+    these fixtures is that it is the merge PARTNER rather than the class itself.
+    """
+
+    def __init__(self) -> None:
+        self.images: list[dict] = []
+        self.annotations: list[dict] = []
+        self.vg: list[dict] = []
+        self.meta: list[dict] = []
+        self._n = 0
+
+    def add(self, vg_names: list[tuple[str, list[float]]], *, coco_category: int, coco_box: list[float]) -> None:
+        i = self._n
+        self._n += 1
+        cid, vid = 1000 + i, 2000 + i
+        self.vg.append({"image_id": vid, "objects": [_obj(n, b) for n, b in vg_names]})
+        self.meta.append({"image_id": vid, "coco_id": cid, "width": _W, "height": _H})
+        self.images.append({"id": cid, "width": _W, "height": _H})
+        self.annotations.append(
+            {"id": 10 * i + 1, "image_id": cid, "category_id": coco_category, "bbox": list(coco_box)}
+        )
+
+    def stage(self, root: Path) -> tuple[Path, dict[str, str]]:
+        anchor = root / "coco_anchor"
+        anchor.mkdir(parents=True)
+        (anchor / "instances_val2017.json").write_text(
+            json.dumps(
+                {
+                    "categories": [
+                        {"id": _CAT_CUP, "name": "cup"},
+                        {"id": _CAT_WINE_GLASS, "name": "wine glass"},
+                        {"id": _CAT_BENCH, "name": "bench"},
+                    ],
+                    "images": self.images,
+                    "annotations": self.annotations,
+                }
+            )
+        )
+        (anchor / "image_data.json").write_text(json.dumps(self.meta))
+        demo = root / "demos"
+        (demo / "visual_genome").mkdir(parents=True)
+        (demo / "visual_genome" / "objects.json").write_text(json.dumps(self.vg))
+        env = {
+            **os.environ,
+            "VTS_PILE": str(root / "pile"),
+            "VTS_DEMO_CACHE": str(demo),
+            "VTSEARCH_DATA_DIR": str(root / "pile" / "datadir"),
+            "VTSEARCH_MODELS_DIR": str(root / "pile" / "models"),
+            "HF_HOME": str(root / "pile" / "models"),
+        }
+        return anchor, env
+
+
+def _run(script: str, root: Path, overlap: _Overlap, *args: str) -> dict:
+    anchor, env = overlap.stage(root)
+    out = root / "out.json"
+    result = subprocess.run(  # noqa: S603  # interpreter + test-controlled args
+        [sys.executable, script, "--anchor-dir", str(anchor), "--out", str(out), *args],
+        cwd=str(_PILE_DIR),
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=env,
+    )
+    assert result.returncode == 0, f"{script} failed:\n{result.stdout}\n{result.stderr}"
+    return json.loads(out.read_text())
+
+
+@pytest.fixture(scope="module")
+def pc():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pile_config
+
+    return pile_config
+
+
+def _stemware_overlap() -> _Overlap:
+    """Images where VG says `wine glass`, COCO says `wine glass`, and no `cup`.
+
+    Exactly the state the real data is in: the spelling is right, the object is
+    right, and the COCO class carrying it is the merge partner rather than the
+    class's namesake.
+    """
+    overlap = _Overlap()
+    for _ in range(_N_IMAGES):
+        overlap.add(
+            [("wine glass", _OBJECT_BOX)],
+            coco_category=_CAT_WINE_GLASS,
+            coco_box=_OBJECT_BOX,
+        )
+    return overlap
+
+
+class TestTheMergeIsPartOfTheClass:
+    def test_the_merge_is_declared_for_cup(self, pc):
+        """Guards the guard: these tests say nothing if `cup` stops being a union."""
+        assert pc.coco_classes_for("cup") == {"cup", "wine glass"}
+        assert pc.coco_classes_for("bench") == {"bench"}, "an unmerged class must resolve to itself"
+
+    def test_a_partner_class_spelling_reaches_alias(self, tmp_path, pc):
+        """The regression. Scored against COCO `cup` alone this is `neither`.
+
+        Precision and box agreement are both 1.0 here by construction, so the
+        only thing that can produce a refusal is the scorer asking about the
+        wrong half of the class.
+        """
+        cands = tmp_path / "cands.json"
+        cands.write_text(json.dumps({"cup": ["wine glass"]}))
+        evidence = _run("name_evidence.py", tmp_path, _stemware_overlap(), "--candidates", str(cands))
+
+        row = evidence["names"]["cup"]["wine glass"]
+        assert row["sole"] == _N_IMAGES, "every image has the name and not the class name"
+        assert row["sole_present"] == _N_IMAGES, (
+            "COCO annotates the object on every one of them -- as `wine glass`, "
+            "which IS `cup` for this class"
+        )
+        assert row["boxes_on_class"] == row["boxes"] == _N_IMAGES
+        assert row["verdict"] == "alias"
+
+    def test_the_partner_counts_toward_the_base_rate_too(self, tmp_path, pc):
+        """A precision is read against the class's base rate, so both must move.
+
+        Fixing the numerator alone would leave the class looking absent on every
+        image its partner carries, and every name would read as beating a base
+        rate of zero.
+        """
+        cands = tmp_path / "cands.json"
+        cands.write_text(json.dumps({"cup": ["wine glass"]}))
+        evidence = _run("name_evidence.py", tmp_path, _stemware_overlap(), "--candidates", str(cands))
+
+        assert evidence["base_rate"]["cup"] == pytest.approx(1.0), (
+            "COCO annotates a wine glass on every overlap image, and a wine glass is a cup here"
+        )
+
+    def test_an_unmerged_class_is_unaffected(self, tmp_path, pc):
+        """The fix must be inert for the other twenty-four classes.
+
+        A `bench` spelling scored against a COCO `wine glass` stays refuted --
+        `coco_classes_for` returns `{bench}`, so nothing widens.
+        """
+        overlap = _Overlap()
+        for _ in range(_N_IMAGES):
+            overlap.add([("park bench", _OBJECT_BOX)], coco_category=_CAT_WINE_GLASS, coco_box=_OBJECT_BOX)
+        cands = tmp_path / "cands.json"
+        cands.write_text(json.dumps({"bench": ["park bench"]}))
+        evidence = _run("name_evidence.py", tmp_path, overlap, "--candidates", str(cands))
+
+        row = evidence["names"]["bench"]["park bench"]
+        assert row["sole_present"] == 0
+        assert row["verdict"] == "neither"
+
+    def test_coverage_counts_the_partners_boxes_in_the_denominator(self, tmp_path, pc):
+        """`name_coverage.py`'s half of the same defect.
+
+        The denominator is "the class's COCO boxes". For a union that is both
+        halves; counting the namesake alone understates what the class has to
+        cover AND hides what the spelling recovers.
+        """
+        proposal = tmp_path / "proposal.json"
+        proposal.write_text(json.dumps({"alias": {"cup": ["wine glass"]}, "ambiguous": {}}))
+        coverage = _run("name_coverage.py", tmp_path, _stemware_overlap(), "--propose", str(proposal))
+
+        row = coverage["overlap"]["cup"]
+        assert row["coco_boxes"] == _N_IMAGES, "every wine-glass box is a box this class must cover"
+        assert row["own"] == 0, "the spelling `cup` is on none of these images"
+        assert row["alias"] == _N_IMAGES, "and the alias table recovers all of them"

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -346,6 +346,33 @@ class TestVgNameTables:
                 for name in names:
                     assert name == name.strip().lower(), name
 
+    def test_glass_is_withheld_from_cup_rather_than_folded(self, pc):
+        """The audit ARGUES FOR folding this one, and it must still not be folded.
+
+        `glass` is ambiguous for `cup` on a measurement no script makes: the
+        merged `cup` slate rejected **9 of 30** boxed positives (30%), against
+        0-17% for every other class of the thirteen, and worst in the LARGE band
+        at 40% -- which is where a windowpane lands (#3588).
+
+        Making the audit merge-aware (#3700) *raised* the case for folding it,
+        because the scorer now counts COCO `wine glass` too and `glass` clears
+        the cuts. That is not new evidence, it is the same evidence measured
+        better on the half where `glass` was never the problem: repair precision
+        is computed on the COCO-annotated overlap, and the windowpanes arrive as
+        positives on the half with **no reference at all**. A fold-out rate is
+        not a positive-precision rate, and neither is a merge-aware one.
+
+        So this test guards a hand exclusion against a script that disagrees
+        with it -- the same shape as `sign` for `stop sign` below.
+        """
+        assert "glass" in pc.SCALE_VG_AMBIGUOUS["cup"]
+        for spelling in ("glass", "glass.", "clear glass"):
+            assert spelling not in pc.SCALE_VG_NAMES.get("cup", ()), (
+                f"`{spelling}` folded into `cup`: the merge-aware audit proposes this and the "
+                "human review refutes it -- 30% of the merged slate's boxed positives were "
+                "rejected when it was treated as an alias (#3588, #3700)."
+            )
+
     def test_sign_is_not_listed_for_stop_sign(self, pc):
         """The largest fold-in column in C, and the one that must not be acted on.
 


### PR DESCRIPTION
Makes the VG-name audit resolve "the class" through `pile_config.coco_classes_for`, so a class this project defines as a **union** of COCO classes is audited as that union.

## The defect

`cup` is `cup` ∪ `wine glass` (`SCALE_CLASS_MERGES`), and both audit scripts resolved the class to the COCO class of the same name. So the stemware spellings were scored against COCO **`cup`** alone — and their boxes land on COCO **`wine glass`** boxes, which the scorer was not looking at:

| name | sole | precision | box agreement | verdict |
|---|---:|---:|---:|---|
| `wine glass` | 151 | 38% | **2%** | `neither` |
| `mug` | 193 | 88% | 82% | `alias` |

The 2% is the tell. `mug`, whose object COCO really does call a cup, scored normally — which is what kept the defect specific to the merged class and silent everywhere else. It cost the #3588 promotion six spellings that had to be carried into `SCALE_VG_NAMES["cup"]` by hand, against the audit's own verdict.

## What the fix measures

Re-running #3588's audit at the same cuts (`--pooled --include-context`), merge-aware:

| spelling | before | after | verdict |
|---|---|---|---|
| `wine glass` | 38% / 2% | **98% prec (151 sole) / 85% box (253 boxes)** | `neither` → **alias** |
| `wine glasses` | 18% / 3% | **95% / 57%** | `neither` → **alias** |
| `goblet` | — | 70% / 67%, 12 boxes | → `ambiguous` (under the 20-box floor) |
| `wineglass`, `champagne glass`, `champagne flute` | — | below `--min-sole` | `unmeasured` |

**The control holds: nothing outside `cup` moves.** `coco_classes_for` returns `{c}` for an unmerged class, so the other twenty-four are untouched — verified by diffing the whole proposal, and by a test that an unmerged class scored against a partner's boxes stays refuted.

So the issue's close condition is met for the two spellings that carry the mass (253 of 283 boxes), and the remaining four stay on #3588's direct measurement because they sit **below the audit's floors rather than being refused by it** — `unmeasured` is not `refuted`. The issue anticipated this outcome explicitly.

`cup`'s coverage row moves with the denominator: **11,393** COCO boxes rather than 8,242, so the class name alone covers **12.6%** (not 16.7%) and the alias table takes it to **18.8%** (not 22.2%). The promotion report's `cup` row is restated in place; `bowl` and `bottle` are unchanged, as controls.

## The part that is not just a fix

**The corrected audit argues for folding `glass`** — the one entry #3588 spent a review refusing. Merge-aware, `glass`, `glass.` and `clear glass` all clear the cuts and the script proposes them as aliases.

They are refused anyway, because that is the same evidence measured better on the half where `glass` was never the problem. Repair precision is computed on the COCO-annotated overlap; the windowpanes and eyeglasses arrive as positives on the half with **no reference at all**. The measurement that decides is a human one and no script produces it: the merged `cup` slate rejected **9 of 30** boxed positives (30%) against 0–17% for every other class of the thirteen, and worst in the LARGE band at 40%, which is where a windowpane lands.

So the exclusion becomes a hand exclusion with a test behind it — the same shape as `sign` for `stop sign`. Fixing this issue makes that guard *more* necessary, not less.

While writing it I found that **#3704's table splice had silently dropped the `glass` rationale** from `pile_config`, leaving the exclusion with no stated reason in the file that implements it. Restored, and updated to say why the script now disagrees with it.

## Scope

**Every data table is byte-identical to `dev`** — `SCALE_CLASSES`, `SCALE_VG_NAMES`, `SCALE_VG_AMBIGUOUS`, `SCALE_CLASS_MERGES`, `SCALE_VG_NAMES_AUDITED`, all verified by loading both revisions and comparing. This changes what the audit *measures*, not what the build *reads*, so **no rebuild is implied** and the pile stands.

## Tests

`tests_lib/meta/test_pile_merged_class_names.py` — five tests against a synthetic VG-COCO overlap whose answers are known by construction, run against the real scripts in a subprocess. Verified to be a real regression test rather than a passing decoration: with the two scripts reverted, the three substantive tests fail (`coco_boxes` reads 0 instead of 22, and the `alias` and base-rate assertions fail), while the two guard tests correctly stay green.

Plus `test_glass_is_withheld_from_cup_rather_than_folded` in the existing suite.

Suite green on the GRID: **10,832 passed**, all gates.

Closes #3700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7H4iWkN3f91feX5n3EY6q
