### PR TITLE
Gate the cross-class rule on who answered, not who looked (#3697)

### DIFF
--- a/scripts/experiments/pile/negpool_coverage.py
+++ b/scripts/experiments/pile/negpool_coverage.py
@@ -184,7 +184,14 @@ def main() -> None:
     per_cell: dict[str, int] = dict.fromkeys(cells, 0)
     for iid in set(positive_in) | neg_set:
         ev = _evaluable(
-            iid, sorted(positive_in.get(iid, [])), cells, neg_set, labels, coco_scored, reviewed_absent, reviewed_present
+            iid,
+            sorted(positive_in.get(iid, [])),
+            cells,
+            neg_set,
+            labels,
+            coco_scored,
+            reviewed_absent,
+            reviewed_present,
         )
         for cell in ev:
             if cell in per_cell and cell not in positive_in.get(iid, []):

--- a/scripts/experiments/pile/negpool_coverage.py
+++ b/scripts/experiments/pile/negpool_coverage.py
@@ -169,6 +169,11 @@ def main() -> None:
     # the thing being counted, and a second implementation of it here is exactly
     # how the deep sibling got a rule nobody had checked (#3667).
     cells = [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in pc.BOX_BANDS]
+    # Same per-(image, class) split `vg_scale.load` makes: a one-class review
+    # answers for that class alone (#3697). Counted here because this script
+    # reads `_evaluable` itself rather than restating the rule.
+    reviewed_absent = {k for k, v in corrections.items() if k[1] in set(pc.SCALE_CLASSES) and not v.get("present")}
+    reviewed_present = {k for k, v in corrections.items() if k[1] in set(pc.SCALE_CLASSES) and v.get("present")}
     provable_pool, _sp = draw_negatives(clean, roster, coco_scored, 1.0)
     neg_set = set(provable_pool)
     positive_in: dict[int, list[str]] = {}
@@ -178,7 +183,10 @@ def main() -> None:
 
     per_cell: dict[str, int] = dict.fromkeys(cells, 0)
     for iid in set(positive_in) | neg_set:
-        for cell in _evaluable(iid, sorted(positive_in.get(iid, [])), cells, neg_set, labels, exhaustive):
+        ev = _evaluable(
+            iid, sorted(positive_in.get(iid, [])), cells, neg_set, labels, coco_scored, reviewed_absent, reviewed_present
+        )
+        for cell in ev:
             if cell in per_cell and cell not in positive_in.get(iid, []):
                 per_cell[cell] += 1
 

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -609,7 +609,9 @@ def _evaluable(
     cells: list[str],
     neg_set: set[int],
     labels: dict[int, dict[str, list[list[float]]]],
-    exhaustive: set[int],
+    coco_scored: set[int],
+    reviewed_absent: set[tuple[int, str]],
+    reviewed_present: set[tuple[int, str]],
 ) -> list[str]:
     """Which cells this image can be SCORED in -- positive or negative.
 
@@ -624,11 +626,37 @@ def _evaluable(
     not hold contributes all of its cells, and the image scores there as the
     negative it is.
 
-    Gated on ``exhaustive``. On a COCO-annotated image "holds no bus" is a fact
-    about all eighty classes. Off COCO it is VG's silence, which #3588 measured
-    wrong 0.5-2.5% of the time, and importing that into the negatives is a
-    separate decision -- ``SCALE_CROSS_CLASS_NEGATIVES`` turns the whole thing
-    off rather than pretending the two halves are alike.
+    **Gated per class on who actually answered, which is not the same as who
+    looked.** On a COCO-annotated image "holds no bus" is a fact about all eighty
+    classes at once, so ``coco_scored`` admits every class. Off COCO it is VG's
+    silence, which #3588 measured wrong 0.5-2.5% of the time, and importing that
+    into the negatives is a separate decision -- ``SCALE_CROSS_CLASS_NEGATIVES``
+    turns the whole thing off rather than pretending the two halves are alike.
+
+    This used to read ``exhaustive``, and that set has **two** populations in it:
+    images COCO answered, and *any image a human looked at*, because
+    :func:`apply_corrections` adds every reviewed image to it. A reviewer asked
+    "does this hold a `car`?" established a fact about `car` and nothing about
+    `bus` -- so the rule promoted 467 review-only images into cross-class
+    negatives they had not earned, 322 of them designated positives, 4.5% of the
+    designated positive set (#3697). The error ran in the flattering direction:
+    an image reviewed as holding a `car` scored as a *confirmed* negative for
+    `truck`, which is exactly the hard negative a detector has not been shown.
+
+    ``reviewed_absent`` keeps what a review really did establish, per class: a
+    verdict of absent on ``(image, class)`` admits that class's cells and no
+    others. That matters because a **group** pass -- the #3588 negative pass
+    asked "do you see NONE of these twenty-five?" -- legitimately answers for
+    every member it named, and dropping human evidence wholesale would throw
+    those away to fix the one-class case.
+
+    ``reviewed_present`` is the guard the other way, and it is not hypothetical.
+    A **boxless** ``present`` verdict -- "it is here, I cannot draw one box for
+    it" -- makes :func:`apply_corrections` POP the class from ``labels``, so the
+    image then looks to this function exactly like an image that does not hold
+    it. On a COCO-anchored image that would admit the class as a *confirmed
+    negative* on the strength of a human saying it is present. A pair a reviewer
+    touched is never admitted by absence, whatever the anchor says.
 
     **The cells a class owns are read off ``cells``, never spelled.** This
     function serves two datasets that name their cells differently --
@@ -643,10 +671,13 @@ def _evaluable(
     if not cats:
         return list(cells) if iid in neg_set else []
     out = set(cats)
-    if pc.SCALE_CROSS_CLASS_NEGATIVES and iid in exhaustive:
+    if pc.SCALE_CROSS_CLASS_NEGATIVES:
         held = set(labels.get(iid, {}))
+        anchored = iid in coco_scored
         for c, owned in _cells_by_class(cells).items():
-            if c not in held:
+            if c in held or (iid, c) in reviewed_present:
+                continue
+            if anchored or (iid, c) in reviewed_absent:
                 out |= owned
     return sorted(out)
 
@@ -664,6 +695,8 @@ def _emit_medias(
     embedder_name: str,
     labels: dict[int, dict[str, list[list[float]]]],
     coco_scored: set[int],
+    reviewed_absent: set[tuple[int, str]],
+    reviewed_present: set[tuple[int, str]],
 ) -> None:
     """Read the pixels and write one media dict per designated image.
 
@@ -720,7 +753,9 @@ def _emit_medias(
             # A designated cell membership, not a closed world: a positive is
             # scorable only in the cells it was drawn for, and the shared
             # negatives are scorable everywhere.
-            "evaluable_categories": _evaluable(iid, cats, cells, neg_set, labels, exhaustive),
+            "evaluable_categories": _evaluable(
+                iid, cats, cells, neg_set, labels, coco_scored, reviewed_absent, reviewed_present
+            ),
             # Whether this image's labels rest on an exhaustive reference (COCO,
             # or a human who looked). False means VG's silence is the only
             # evidence of absence -- which is what the review slates target.
@@ -766,6 +801,14 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     # image", `coco_scored` says "all eighty classes were answered at once".
     # Only the second makes "holds none of C" a fact.
     coco_scored = set(exhaustive)
+    # What a human actually established, per (image, class) -- NOT per image.
+    # `apply_corrections` folds every reviewed image into `exhaustive`, which is
+    # the right claim for the pool draw and the wrong one for #3667's
+    # cross-class rule: a reviewer asked about `car` said nothing about `bus`
+    # (#3697). Absence admits that class alone; presence bars it, because a
+    # boxless `present` leaves no box behind to make the class visible as held.
+    reviewed_absent = {k for k, v in corrections.items() if k[1] in wanted and not v.get("present")}
+    reviewed_present = {k for k, v in corrections.items() if k[1] in wanted and v.get("present")}
     # The fold runs AFTER the anchor, not before it. On an anchored image COCO's
     # labels replace VG's wholesale, so folding there was always discarded --
     # the order is a no-op on what gets built (verified cell-by-cell in #3637)
@@ -871,6 +914,8 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
         embedder_name,
         labels,
         coco_scored,
+        reviewed_absent,
+        reviewed_present,
     )
 
     # Refuse to embed a pickle whose boxes are impossible. `--verify` runs the

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale_deep.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale_deep.py
@@ -182,6 +182,13 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     # medias carry the flag so a reader of either dataset can ask the same
     # question of both.
     coco_scored = set(exhaustive)
+    # Per (image, class), what a human established -- the same distinction
+    # `vg_scale.load` draws, and deep needs it for the same reason: it shares
+    # `_emit_medias` and therefore `_evaluable`, so a one-class review would
+    # otherwise promote an image into cross-class negatives for the other
+    # twenty-four here too (#3697).
+    reviewed_absent = {k for k, v in corrections.items() if k[1] in wanted and not v.get("present")}
+    reviewed_present = {k for k, v in corrections.items() if k[1] in wanted and v.get("present")}
     # After the anchor and with the pixel space, exactly as `vg_scale` runs it:
     # the fold's treatment of a scattered union is part of "what a positive is",
     # so a sibling that folded differently would break the only-depth-changed
@@ -250,6 +257,8 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
         embedder_name,
         labels,
         coco_scored,
+        reviewed_absent,
+        reviewed_present,
     )
     for d in medias.values():
         d["origin"] = {

--- a/scripts/experiments/pile/replay_evaluable.py
+++ b/scripts/experiments/pile/replay_evaluable.py
@@ -8,25 +8,28 @@ apart in the direction that hurts -- a cell can load perfectly, carry the right
 media count and the right vectors, and encode a rule that was superseded three
 merges ago, with nothing anywhere saying so (#3678).
 
-Answering that in general needs the VG source. Answering it for
-``evaluable_categories`` does not, and that is the field where the rules actually
-churn: #3667 rewrote it, #3697 rewrote it again. Everything the rule reads is
-already in the pickle --
+**A pickle cannot answer this about itself, and finding that out is half the
+point.** The first cut of this script reconstructed "what the image holds" from
+``categories`` and compared the rule's output against the stored field, on the
+theory that everything the rule reads is already in the media dict. It is not.
+``categories`` is what the image was **designated** for -- 100 images per cell --
+and an image can hold a `car` perfectly well without ever being drawn into a
+`car` cell. So the reconstruction under-counts what is held, the rule admits
+cells it should not, and the replay reports thousands of spurious ADDITIONS
+against a change that can only ever remove them. That is a property of the
+schema, not a bug in the idea: **`evaluable_categories` is not self-checking,
+because the pickle never records what an image holds.**
 
-* ``categories`` -- the cells the image is a positive for;
-* ``evaluable_categories`` -- what the build decided, i.e. the thing under test;
-* ``labels_exhaustive`` -- someone or something answered for this image;
-* ``coco_scored`` -- COCO answered for all eighty classes at once (#3670);
+So this reads the source. It runs the loader's own front half -- the same passes
+in the same order, called rather than restated -- to recover ``labels``, then
+asks :func:`~pilebuild.loaders.vg_scale._evaluable` what it would write today and
+diffs that against what the cell holds. A minute of CPU, no pixels, no GPU, and
+it can be run against a cell other studies are reading right now.
 
--- plus ``corrections.json``, which says per ``(image, class)`` what a human
-established. So the replay costs seconds, reads no pixels, and can be run
-against a cell other studies are using right now.
-
-**What it cannot see.** Only the images the pickle contains. If a rule change
-would designate a *different* set of images, this reports nothing about the ones
-that are not there -- that is the selection replay #3678 also wants, and it needs
-the source. Read a clean report here as "the rule agrees on the images we have",
-never as "the cell is current".
+**What it still cannot see: selection.** It compares the rule on the images the
+cell contains. If a change would designate a *different* set, the images that are
+not there are invisible to it. Read a clean report as "the rule agrees on the
+images we have", never as "the cell is current".
 
 Usage::
 
@@ -49,9 +52,18 @@ import pile_config as pc  # noqa: E402
 
 pc.setup_env()
 
+import coco_anchor as ca  # noqa: E402
 from _cells_io import load_medias  # noqa: E402
 from pilebuild.corrections import load_corrections  # noqa: E402
-from pilebuild.loaders.vg_scale import _evaluable  # noqa: E402
+from pilebuild.loaders.vg_scale import (  # noqa: E402
+    _evaluable,
+    anchor_to_coco,
+    apply_corrections,
+    canonicalise,
+    lift_ambiguous,
+    read_vg_labels,
+)
+from pilebuild.vgsource import vg_image_paths, vg_source  # noqa: E402
 
 
 def log(msg: str) -> None:
@@ -83,16 +95,30 @@ def main() -> int:
     reviewed_present = {k for k, v in corrections.items() if k[1] in in_c and v.get("present")}
     log(f"{len(corrections)} verdicts on file: {len(reviewed_absent)} absent, {len(reviewed_present)} present")
 
-    # The pickle stores what a class HOLDS only as `categories`, which is the
-    # cells it was designated for. That is what the rule reads too, so the
-    # replay reconstructs `labels` from it rather than from the VG source: a
-    # class appears iff the image is a positive for one of its cells.
+    # The loader's own front half, in the loader's own order, so a rule change in
+    # the build cannot drift away from this check. `labels` is the thing the
+    # pickle cannot give us -- see the module docstring.
+    wanted = set(pc.SCALE_CLASSES)
+    paths = vg_image_paths()
+    _, records, dims = vg_source()
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    truth = ca.coco_truth(instances, wanted)
+    with image_data.open() as fh:
+        coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
+
+    labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
+    box_dims, exhaustive, _na, _nr = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    coco_scored = set(exhaustive)
+    canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, pc.SCALE_FOLD_MODE)
+    apply_corrections(labels, corrections, box_dims, exhaustive)
+    lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)
+
     neg_set = {i for i, d in medias.items() if not d.get("categories") and d.get("evaluable_categories")}
-    coco_scored = {i for i, d in medias.items() if d.get("coco_scored")}
-    exhaustive = {i for i, d in medias.items() if d.get("labels_exhaustive")}
+    stamped = {i for i, d in medias.items() if d.get("coco_scored")}
     log(
-        f"{len(neg_set)} shared negatives; {len(coco_scored)} COCO-scored, "
-        f"{len(exhaustive - coco_scored)} exhaustive by REVIEW alone"
+        f"{len(neg_set)} shared negatives; {len(coco_scored & set(medias))} COCO-scored by replay "
+        f"({len(stamped)} stamped in the cell); "
+        f"{len((exhaustive - coco_scored) & set(medias))} exhaustive by REVIEW alone"
     )
 
     added: Counter[str] = Counter()
@@ -100,8 +126,6 @@ def main() -> int:
     changed_medias = 0
     for iid, d in medias.items():
         cats = list(d.get("categories") or [])
-        held = {c.split("@", 1)[0] for c in cats}
-        labels = {iid: dict.fromkeys(held, [[0.0, 0.0, 1.0, 1.0]])}
         want = set(_evaluable(iid, cats, cells, neg_set, labels, coco_scored, reviewed_absent, reviewed_present))
         have = set(d.get("evaluable_categories") or [])
         if want == have:

--- a/scripts/experiments/pile/replay_evaluable.py
+++ b/scripts/experiments/pile/replay_evaluable.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Would a rebuild produce THIS cell's `evaluable_categories`? (#3678, #3697)
+
+`--verify` asks whether a built cell is internally consistent and whether it
+matches two declared constants. It does not ask the question this script asks:
+**would running the selection again produce what the pickle holds?** Those come
+apart in the direction that hurts -- a cell can load perfectly, carry the right
+media count and the right vectors, and encode a rule that was superseded three
+merges ago, with nothing anywhere saying so (#3678).
+
+Answering that in general needs the VG source. Answering it for
+``evaluable_categories`` does not, and that is the field where the rules actually
+churn: #3667 rewrote it, #3697 rewrote it again. Everything the rule reads is
+already in the pickle --
+
+* ``categories`` -- the cells the image is a positive for;
+* ``evaluable_categories`` -- what the build decided, i.e. the thing under test;
+* ``labels_exhaustive`` -- someone or something answered for this image;
+* ``coco_scored`` -- COCO answered for all eighty classes at once (#3670);
+
+-- plus ``corrections.json``, which says per ``(image, class)`` what a human
+established. So the replay costs seconds, reads no pixels, and can be run
+against a cell other studies are using right now.
+
+**What it cannot see.** Only the images the pickle contains. If a rule change
+would designate a *different* set of images, this reports nothing about the ones
+that are not there -- that is the selection replay #3678 also wants, and it needs
+the source. Read a clean report here as "the rule agrees on the images we have",
+never as "the cell is current".
+
+Usage::
+
+    python replay_evaluable.py                          # the shipped siglip cell
+    python replay_evaluable.py --cell <path.pkl> --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "calibration"))
+
+import pile_config as pc  # noqa: E402
+
+pc.setup_env()
+
+from _cells_io import load_medias  # noqa: E402
+from pilebuild.corrections import load_corrections  # noqa: E402
+from pilebuild.loaders.vg_scale import _evaluable  # noqa: E402
+
+
+def log(msg: str) -> None:
+    print(f"[replay] {msg}", flush=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"))
+    ap.add_argument("--json", default="", help="write the per-cell delta as JSON")
+    ap.add_argument(
+        "--deep",
+        action="store_true",
+        help="the cell keys on the bare class (`vg_scale_deep`) rather than `class@band`",
+    )
+    args = ap.parse_args()
+
+    medias = load_medias(Path(args.cell))
+    cells = (
+        list(pc.SCALE_CLASSES)
+        if args.deep
+        else [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in pc.BOX_BANDS]
+    )
+    log(f"{Path(args.cell).name}: {len(medias)} medias, {len(cells)} cells")
+
+    corrections = load_corrections()
+    in_c = set(pc.SCALE_CLASSES)
+    reviewed_absent = {k for k, v in corrections.items() if k[1] in in_c and not v.get("present")}
+    reviewed_present = {k for k, v in corrections.items() if k[1] in in_c and v.get("present")}
+    log(f"{len(corrections)} verdicts on file: {len(reviewed_absent)} absent, {len(reviewed_present)} present")
+
+    # The pickle stores what a class HOLDS only as `categories`, which is the
+    # cells it was designated for. That is what the rule reads too, so the
+    # replay reconstructs `labels` from it rather than from the VG source: a
+    # class appears iff the image is a positive for one of its cells.
+    neg_set = {i for i, d in medias.items() if not d.get("categories") and d.get("evaluable_categories")}
+    coco_scored = {i for i, d in medias.items() if d.get("coco_scored")}
+    exhaustive = {i for i, d in medias.items() if d.get("labels_exhaustive")}
+    log(
+        f"{len(neg_set)} shared negatives; {len(coco_scored)} COCO-scored, "
+        f"{len(exhaustive - coco_scored)} exhaustive by REVIEW alone"
+    )
+
+    added: Counter[str] = Counter()
+    dropped: Counter[str] = Counter()
+    changed_medias = 0
+    for iid, d in medias.items():
+        cats = list(d.get("categories") or [])
+        held = {c.split("@", 1)[0] for c in cats}
+        labels = {iid: dict.fromkeys(held, [[0.0, 0.0, 1.0, 1.0]])}
+        want = set(_evaluable(iid, cats, cells, neg_set, labels, coco_scored, reviewed_absent, reviewed_present))
+        have = set(d.get("evaluable_categories") or [])
+        if want == have:
+            continue
+        changed_medias += 1
+        for cell in want - have:
+            added[cell] += 1
+        for cell in have - want:
+            dropped[cell] += 1
+
+    total_add, total_drop = sum(added.values()), sum(dropped.values())
+    print("\n" + "=" * 78)
+    print("REPLAY: what the CURRENT rule would write, against what the cell HOLDS")
+    print("=" * 78)
+    print(f"medias whose evaluable set would change: {changed_medias} of {len(medias)}")
+    print(f"  cell memberships ADDED by a replay:   {total_add}")
+    print(f"  cell memberships DROPPED by a replay: {total_drop}")
+    if not changed_medias:
+        print("\nAGREES -- on the images this cell contains. Selection is not checked here.")
+    else:
+        print("\nSTALE -- this cell encodes a rule the current code would not write.")
+        worst = (dropped + added).most_common(12)
+        if worst:
+            print(f"\n{'cell':<24}{'added':>8}{'dropped':>9}")
+            for cell, _n in worst:
+                print(f"{cell:<24}{added[cell]:>8}{dropped[cell]:>9}")
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    "cell": str(args.cell),
+                    "medias": len(medias),
+                    "changed_medias": changed_medias,
+                    "added_total": total_add,
+                    "dropped_total": total_drop,
+                    "review_only_exhaustive": len(exhaustive - coco_scored),
+                    "added": dict(added),
+                    "dropped": dict(dropped),
+                },
+                indent=1,
+            )
+            + "\n"
+        )
+        log(f"wrote {args.json}")
+    return 1 if changed_medias else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/replay_evaluable.py
+++ b/scripts/experiments/pile/replay_evaluable.py
@@ -83,9 +83,7 @@ def main() -> int:
 
     medias = load_medias(Path(args.cell))
     cells = (
-        list(pc.SCALE_CLASSES)
-        if args.deep
-        else [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in pc.BOX_BANDS]
+        list(pc.SCALE_CLASSES) if args.deep else [pc.scale_cell(c, b) for c in pc.SCALE_CLASSES for b in pc.BOX_BANDS]
     )
     log(f"{Path(args.cell).name}: {len(medias)} medias, {len(cells)} cells")
 

--- a/tests_lib/meta/test_vg_scale_cross_class_negatives.py
+++ b/tests_lib/meta/test_vg_scale_cross_class_negatives.py
@@ -27,22 +27,22 @@ BOOK_MED = pc.scale_cell("book", "medium")
 
 
 def test_shared_negative_is_evaluable_everywhere():
-    assert _evaluable(1, [], CELLS, {1}, {}, set()) == CELLS
+    assert _evaluable(1, [], CELLS, {1}, {}, set(), set(), set()) == CELLS
 
 
 def test_image_that_is_neither_is_evaluable_nowhere():
-    assert _evaluable(1, [], CELLS, set(), {}, set()) == []
+    assert _evaluable(1, [], CELLS, set(), {}, set(), set(), set()) == []
 
 
 def test_positive_still_excluded_from_its_own_other_bands():
     """The exclusion #3156 exists for, which #3667 must not undo."""
-    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1})
+    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1}, set(), set())
     assert BUS_MED in out
     assert BUS_SMALL not in out, "a large-bus image must not be a small-bus negative"
 
 
 def test_positive_becomes_a_negative_for_classes_it_does_not_hold():
-    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1})
+    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1}, set(), set())
     for band in pc.BOX_BANDS:
         assert pc.scale_cell("book", band) in out
     assert len(out) > 1, "#3667: a bus image is a perfectly good book negative"
@@ -50,27 +50,83 @@ def test_positive_becomes_a_negative_for_classes_it_does_not_hold():
 
 def test_a_second_held_class_is_also_excluded():
     labels: dict[int, dict[str, list[list[float]]]] = {1: {"bus": BOX, "book": BOX}}
-    out = _evaluable(1, [BUS_MED], CELLS, set(), labels, {1})
+    out = _evaluable(1, [BUS_MED], CELLS, set(), labels, {1}, set(), set())
     assert BOOK_MED not in out, "it holds a book; it cannot be a book negative"
     assert pc.scale_cell("dog", "small") in out
 
 
 def test_off_coco_images_are_left_alone():
     """VG's silence is not a fact. Absence is only free on the exhaustive half."""
-    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, set())
+    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, set(), set(), set())
     assert out == [BUS_MED]
+
+
+class TestWhoActuallyAnswered:
+    """A one-class review is not an exhaustive answer (#3697).
+
+    `apply_corrections` adds every reviewed image to `exhaustive`, and #3667's
+    rule used to read that set -- so a reviewer asked *"does this hold a car?"*
+    promoted the image into cross-class negatives for the twenty-four classes
+    nobody asked about. Measured on the shipped pile: 467 images were exhaustive
+    by review alone, 322 of them designated positives, 4.5% of the designated
+    positive set. The error ran in the flattering direction, since an image
+    reviewed as holding a `car` scored as a *confirmed* negative for `truck`.
+    """
+
+    def test_a_review_of_one_class_does_not_answer_for_another(self):
+        """The regression: no anchor, one verdict, and it must not spread."""
+        reviewed_absent = {(1, "bus")}
+        out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, set(), reviewed_absent, set())
+
+        assert out == [BUS_MED], "a `bus` verdict says nothing about `book`"
+
+    def test_a_review_that_did_answer_for_a_class_still_counts(self):
+        """The group pass asked "do you see NONE of these?" and really did answer.
+
+        Dropping human evidence wholesale would have been the easy fix and would
+        have thrown these away to correct the one-class case.
+        """
+        reviewed_absent = {(1, "book")}
+        out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, set(), reviewed_absent, set())
+
+        for band in pc.BOX_BANDS:
+            assert pc.scale_cell("book", band) in out
+        assert pc.scale_cell("dog", "small") not in out, "nobody asked about `dog`"
+
+    def test_a_coco_anchor_still_answers_for_everything(self):
+        """The half the rule was written for is untouched."""
+        out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1}, set(), set())
+
+        assert len(out) > 1
+        for band in pc.BOX_BANDS:
+            assert pc.scale_cell("book", band) in out
+
+    def test_a_boxless_present_is_never_read_as_absence(self):
+        """The second-order case, and the one that bites on the anchored half.
+
+        A boxless `present` -- "it is here, I cannot draw one box" -- makes
+        `apply_corrections` POP the class from `labels`, so the image then looks
+        exactly like one that does not hold it. On a COCO-anchored image that
+        would score it as a confirmed negative for a class a human just said was
+        present.
+        """
+        out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1}, set(), {(1, "book")})
+
+        for band in pc.BOX_BANDS:
+            assert pc.scale_cell("book", band) not in out, "a human said the book IS there"
+        assert pc.scale_cell("dog", "small") in out, "and said nothing about `dog`"
 
 
 def test_the_knob_turns_it_off(monkeypatch):
     monkeypatch.setattr(pc, "SCALE_CROSS_CLASS_NEGATIVES", False)
-    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1})
+    out = _evaluable(1, [BUS_MED], CELLS, set(), {1: {"bus": BOX}}, {1}, set(), set())
     assert out == [BUS_MED]
 
 
 @pytest.mark.parametrize("held", [(), ("bus",), ("bus", "book"), tuple(pc.SCALE_CLASSES)])
 def test_never_evaluable_in_a_cell_of_a_class_it_holds(held):
     labels: dict[int, dict[str, list[list[float]]]] = {1: {c: BOX for c in held}}
-    out = set(_evaluable(1, [BUS_MED], CELLS, set(), labels, {1}))
+    out = set(_evaluable(1, [BUS_MED], CELLS, set(), labels, {1}, set(), set()))
     for c in held:
         if c == "bus":
             continue
@@ -89,11 +145,11 @@ class TestTheCellKeyingIsReadRatherThanSpelled:
 
     @pytest.mark.parametrize("cells", [CELLS, DEEP_CELLS], ids=["banded", "bare"])
     def test_no_name_outside_the_caller_s_own_cells_is_ever_emitted(self, cells):
-        out = _evaluable(1, [cells[0]], cells, set(), {1: {"bus": BOX}}, {1})
+        out = _evaluable(1, [cells[0]], cells, set(), {1: {"bus": BOX}}, {1}, set(), set())
         assert not set(out) - set(cells), "a cell of some other dataset's keying"
 
     def test_a_bare_cell_list_gets_bare_cross_class_negatives(self):
-        out = _evaluable(1, ["bus"], DEEP_CELLS, set(), {1: {"bus": BOX}}, {1})
+        out = _evaluable(1, ["bus"], DEEP_CELLS, set(), {1: {"bus": BOX}}, {1}, set(), set())
         assert "book" in out, "#3667 must reach the deep sibling too"
         assert not [c for c in out if "@" in c]
 
@@ -104,7 +160,7 @@ class TestTheCellKeyingIsReadRatherThanSpelled:
         exactly why it survived: `bus@small` on a bare-keyed pickle matches
         nothing, so the guarantee was written backwards and nothing failed.
         """
-        out = _evaluable(1, ["bus"], DEEP_CELLS, set(), {1: {"bus": BOX, "book": BOX}}, {1})
+        out = _evaluable(1, ["bus"], DEEP_CELLS, set(), {1: {"bus": BOX, "book": BOX}}, {1}, set(), set())
         assert "book" not in out
         assert [c for c in out if c.startswith("bus")] == ["bus"]
 


### PR DESCRIPTION
Gates #3667's cross-class rule on **who answered**, not **who looked**, and adds the cheap replay that prices it.

## The defect

`labels_exhaustive` carries two populations: images COCO annotated (all eighty classes answered at once) and *any image a human looked at*, because `apply_corrections` calls `exhaustive.add(iid)` for every verdict. #3667's rule read that set — so a reviewer asked *"does this hold a `car`?"* promoted the image into cross-class negatives for the twenty-four classes nobody asked about.

Measured on the shipped pile: **467 images** are exhaustive by review alone, **322** of them designated positives — **4.5%** of the designated positive set. The error runs in the flattering direction, since an image reviewed as holding a `car` scored as a *confirmed* negative for `truck`, which is exactly the hard negative a detector has not been shown.

## The fix

`_evaluable` now admits a class when **COCO anchored the image** (which answers for all eighty) or when **a human verdict established absence for that class**. Dropping human evidence wholesale would have been the easy fix and would have thrown away what a group pass legitimately answered — the #3588 negative pass asked "do you see NONE of these twenty-five?" and really does answer for every member it named.

It also guards a second-order case that bites on the anchored half: a **boxless `present`** makes `apply_corrections` pop the class from `labels`, so the image then looks exactly like one that does not hold it, and would have scored as a *confirmed negative* for a class a human had just said was present.

`vg_scale_deep` shares `_emit_medias` and therefore had the same defect; both loaders are fixed.

## What it is worth, measured

`replay_evaluable.py` against the live pile:

| cell | medias changed | memberships added | memberships dropped |
|---|---:|---:|---:|
| `vg_scale__siglip` | 323 of 18,050 | **0** | **22,443** |
| `vg_scale_deep__siglip` | 335 of 31,832 | **0** | **7,742** |

**The zero is the check that the method is right**: this change can only ever narrow admission, so any addition would mean the replay was wrong. Two more internal consistency checks pass — the replay's `coco_scored` count matches the cell's stamps exactly (14,659), and the drop lands on ~70 cells for each of the 322 review-only images.

Per cell that is ~322 of ~13,700 evaluable negatives, **~2.4%** — and systematically the *reviewed* images, which are the most expensive in the dataset and the ones a study is most likely to lean on.

## The replay, and what it taught me about the schema

`replay_evaluable.py` answers #3678's question for the field where the rules actually churn: **would a rebuild produce this?** `--verify` asks whether a cell is internally consistent and matches two declared constants; it never asks whether the selection would come out the same.

**The first cut of this script was wrong in a way worth recording.** It reconstructed "what the image holds" from `categories` and compared against the stored field, on the theory that everything the rule reads is already in the media dict. It is not: `categories` is what an image was **designated** for, and an image can hold a `car` without ever being drawn into a `car` cell. The replay therefore under-counted `held`, admitted cells it should not, and reported **14,595 spurious ADDITIONS** against a change that can only remove them. That is a property of the schema rather than a bug in the idea, and it is the finding: **`evaluable_categories` is not self-checking, because the pickle never records what an image holds.**

So the script reads the source — the loader's own front half, called rather than restated — which makes the diff exact at a cost of about a minute of CPU, no pixels and no GPU. It still cannot see **selection**: it compares the rule on the images the cell contains, and says so rather than letting a clean report read as "the cell is current".

## What this does NOT do

**It does not change the built pile.** `evaluable_categories` is written at build time, so the 22,443 unearned memberships are still in the cells on scratch until they are rebuilt. That is a decision rather than an oversight — the price is now measured, and a rebuild is 33 minutes of A100 — so it is left for the owner. Worth noting that #3678's replay is one short step from a *patch* tool that rewrites the field without re-embedding, which would make this a relabel rather than a rebuild.

Suite green on the GRID: **10,836 passed**, all gates.

Closes #3697
Refs #3678 — the general selection replay (which images would be designated) still needs the source and is not built here; this covers `evaluable_categories` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7H4iWkN3f91feX5n3EY6q
