### PR TITLE
Record the embed batch size in the pile's provenance sidecar (#3683)

### DIFF
--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -448,6 +448,46 @@ reports `REBUILD-BROKEN` on any difference. Verified against the live pile on
 2026-08-28: all three bands reproduce exactly, 40/40 categories, agreeing
 across all three cells present at the time (#3299).
 
+## What a rebuilt cell reproduces (#3683)
+
+Three different guarantees, and the difference between them is the difference
+between a rebuild you can ignore and one that redefines a study's inputs. All
+three are measured in
+[the #3667 report](../../../docs/experiments/2026-09-06-cross-class-negatives-3667/REPORT.md).
+
+| Rebuild | Agreement | Measured |
+|---|---|---|
+| same node, same code, **same membership** | **bit-identical** | 0 of 7,746 vectors differ, `siglip2_l` and `dinov3_patch`, twice each |
+| different host, different device, same membership | **~3e-07** max abs | `clip` 2.53e-07, `clip_l` 3.16e-07 across two parts of one `gres/gpu:v100` |
+| same node, **membership moved by one image** | **~1e-4** on a handful of images | `siglip2_l` 3.21e-04, `dinov3_patch` 3.03e-04, August → September |
+
+The third row is the one to know about, because it looks like the first. A
+membership change is **not** a relabel: a merged `pile_config` ruling that drops
+one image shifts every later image's position in the batch stream, and a
+per-image embedding turns out not to be independent of what it was batched
+with. Rebuilding `siglip2_l` at batch 31 instead of 32 — same images, same node
+— reproduces the signature: 27 of 7,746 vectors move, median difference 0,
+maximum **1.6e-04**. The batched GEMM's reduction order is what does it, in
+fp32, on hardware that is otherwise producing bit-identical results.
+
+That is the guarantee to state rather than to engineer away. Removing one image
+necessarily shifts every later one, so the only way to keep the vectors fixed
+across a ruling would be to stop the rulings — and 1e-4 on ~30 of 7,746 images
+is small. It is *not* nothing: it is 400× the same-node floor and larger than
+the fp16 difference #3143
+measured and rejected. Whether it changes any study's conclusion is a separate
+question that needs a paired re-run, not an opinion; file it if the answer starts
+to matter.
+
+What did need fixing is that nothing recorded the batch size.
+`VTSEARCH_EMBED_BATCH_SIZE` is a build parameter that changes the output — the
+same class of gap as the un-pinned CPU dispatch in #3160 — so the per-cell
+sidecar now carries `embed_batch_size`, and `--provenance` shows it in a `batch`
+column. A `-` there means the cell predates the key. Two cells of one
+`(dataset, embedder)` built at different sizes disagree by ~1e-4 with every
+other recorded field identical, which is exactly the comparison the sidecar
+exists to make possible.
+
 ## Building on the GRID
 
 ```bash

--- a/scripts/experiments/pile/build_pile.py
+++ b/scripts/experiments/pile/build_pile.py
@@ -61,7 +61,11 @@ from pilebuild.env import assert_vtscore_is_this_checkout, cells_io, log  # noqa
 from pilebuild.geometry import region_geometry_problems, scale_label_digest  # noqa: E402
 from pilebuild.loaders import loader_for  # noqa: E402
 from pilebuild.manifest import write_manifest  # noqa: E402
-from pilebuild.provenance import cell_fingerprint, write_provenance  # noqa: E402
+from pilebuild.provenance import (  # noqa: E402
+    cell_fingerprint,
+    effective_embed_batch_size,
+    write_provenance,
+)
 from pilebuild.provenance_report import provenance_report  # noqa: E402
 from pilebuild.vgsource import vg_image_paths  # noqa: E402
 
@@ -74,6 +78,7 @@ __all__ = [
     "band_categories",
     "build_cell",
     "cell_fingerprint",
+    "effective_embed_batch_size",
     "list_cells",
     "load_box_scan_categories",
     "main",
@@ -103,15 +108,20 @@ def _embed_batch_size(embedder: str):
     process can run each embedder at its own size rather than every model at
     the shipped default of 32. An explicit env var wins: someone who set one
     is tuning for the card in front of them, and the table cannot know that.
+
+    Yields the size the pass will actually run at, for the provenance sidecar
+    (#3683). It has to be read here rather than at write time: this is the only
+    window in which the env var is set, and the number is not recoverable from
+    the table afterwards once an explicit override is in play.
     """
     want = pc.embed_batch_size(embedder)
     if want is None or os.environ.get("VTSEARCH_EMBED_BATCH_SIZE", "").strip():
-        yield
+        yield effective_embed_batch_size(embedder)
         return
     os.environ["VTSEARCH_EMBED_BATCH_SIZE"] = str(want)
     log(f"  embed batch size {want}")
     try:
-        yield
+        yield effective_embed_batch_size(embedder)
     finally:
         os.environ.pop("VTSEARCH_EMBED_BATCH_SIZE", None)
 
@@ -138,7 +148,7 @@ def build_cell(dataset: str, embedder: str, force: bool = False) -> dict:
     from vtscore.datasets.stages.embedding import embed_missing  # noqa: PLC0415
 
     t1 = time.time()
-    with _embed_batch_size(embedder):
+    with _embed_batch_size(embedder) as batch_size:
         embed_missing(medias, embedder)
     embed_s = time.time() - t1
 
@@ -159,7 +169,7 @@ def build_cell(dataset: str, embedder: str, force: bool = False) -> dict:
         "embed_seconds": round(embed_s, 1),
         "wall_seconds": round(total_s, 1),
     }
-    write_provenance(dataset, embedder, summary, medias)
+    write_provenance(dataset, embedder, summary, medias, embed_batch_size=batch_size)
     return summary
 
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -2249,9 +2249,17 @@ def scale_cell(category: str, band: str) -> str:
 #: SO400M/384 model at 32 is already the heavy end. Sizes are per model, not per
 #: run, so a fatter card only means the whole table can move up.
 #:
-#: Batch size does not change what is embedded: in fp32 it shifts vectors by
-#: ~1e-7 through kernel selection, orders of magnitude below anything the
-#: studies resolve.
+#: Batch size does not change *which* images are embedded, but it does change
+#: their vectors, by more than this comment used to claim. #3683 rebuilt
+#: ``siglip2_l`` at 31 instead of 32 -- same images, same node, everything else
+#: equal -- and 27 of 7,746 vectors moved, by up to **1.6e-04**: the batched
+#: GEMM's reduction order is not independent of what an image was batched with,
+#: even in fp32. Median 0, and 7,719 of 7,746 bit-identical, so the effect is a
+#: few images rather than a shift; but 1.6e-04 is 400x the same-node rebuild
+#: floor and larger than the fp16 difference #3143 measured and rejected. Which
+#: is why the size a cell was built at is now in its provenance sidecar
+#: (``embed_batch_size``): changing an entry below silently redefines every cell
+#: it is rebuilt into, and the sidecar is the only place that says so.
 #: Deliberately three, not five. ``siglip`` is the shipped default and
 #: ``siglip2_l`` the premium end; the middles (``siglip_l``, ``siglip2``) were
 #: dropped because a study learns little from interpolating between them, and

--- a/scripts/experiments/pile/pilebuild/provenance.py
+++ b/scripts/experiments/pile/pilebuild/provenance.py
@@ -12,8 +12,8 @@ import pile_config as pc
 from pilebuild.env import cells_io, log
 
 
-def _device_record() -> dict:
-    """Everything about the machine that a later reader needs to compare cells.
+def _device_record(embed_batch_size: int | None = None) -> dict:
+    """Everything about the build that a later reader needs to compare cells.
 
     ``gres/gpu:v100`` is a *type*, and #3143 measured that a type is not a
     device: two nodes both answering to it produced ``siglip2_l`` vectors 1.5e-04
@@ -42,6 +42,16 @@ def _device_record() -> dict:
         # written; a reader can see a request that did not land.
         "cpu_capability": _cpu_capability(),
         "aten_cpu_capability_requested": os.environ.get("ATEN_CPU_CAPABILITY"),
+        # Not a property of the machine, and here anyway for the same reason the
+        # line above is: it is a build parameter that moves the vectors. A
+        # per-image embedding is supposed to be independent of what it was
+        # batched with, and #3683 measured that it is not -- rebuilding
+        # `siglip2_l` at batch 31 instead of 32, same images and same node,
+        # changed 27 of 7,746 vectors by up to 1.6e-04, because the batched
+        # GEMM's reduction order is not. That is 400x the same-node floor and
+        # larger than the fp16 difference #3143 rejected, and until this key
+        # existed nothing in the sidecar said what a cell had been batched at.
+        "embed_batch_size": embed_batch_size,
         "slurm_job": os.environ.get("SLURM_JOB_ID"),
         "slurm_gres": os.environ.get("SLURM_JOB_GRES") or os.environ.get("SBATCH_GRES"),
         "precision_requested": EMBED_PRECISION,
@@ -84,6 +94,29 @@ def _device_record() -> dict:
         }
     )
     return rec
+
+
+def effective_embed_batch_size(embedder: str) -> int | None:
+    """The batch size *embedder* will forward at, given the environment right now.
+
+    Read the embedder rather than the env var, because the env var is only the
+    default: a subclass with a tighter VRAM budget passes its own smaller one to
+    ``resolve_embed_batch_size``, and it is the number the GEMM sees that moves
+    the vectors. Registry lookup only -- no weights load, so this is free to
+    call before the pass it describes.
+
+    **Call it while the build's ``VTSEARCH_EMBED_BATCH_SIZE`` is still set.**
+    ``build_pile`` applies the per-embedder size for the duration of the embed
+    pass and pops it afterwards, so asking at provenance-write time would answer
+    with the shipped default -- recording a size the pass never ran at, which is
+    the failure the ``aten_cpu_capability_requested`` comment above warns about.
+    """
+    try:
+        from vtscore.media import get_embedder  # noqa: PLC0415
+
+        return int(get_embedder(embedder).embed_batch_size)
+    except Exception:  # noqa: BLE001 -- provenance must never fail a build
+        return None
 
 
 def _cpu_capability() -> str | None:
@@ -182,14 +215,25 @@ def cell_fingerprint(dataset: str, embedder: str, medias: dict | None = None) ->
     }
 
 
-def write_provenance(dataset: str, embedder: str, summary: dict, medias: dict | None = None) -> Path:
-    """Write the per-cell provenance sidecar."""
+def write_provenance(
+    dataset: str,
+    embedder: str,
+    summary: dict,
+    medias: dict | None = None,
+    embed_batch_size: int | None = None,
+) -> Path:
+    """Write the per-cell provenance sidecar.
+
+    *embed_batch_size* is what the embed pass actually ran at; see
+    :func:`effective_embed_batch_size` for why the caller has to measure it
+    rather than this function reading the environment.
+    """
     record = {
         "dataset": dataset,
         "embedder": embedder,
         "cell": pc.cell_path(dataset, embedder).name,
         "built_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
-        "device": _device_record(),
+        "device": _device_record(embed_batch_size),
         "preprocessing": _processor_record(embedder),
         "cell_summary": {k: v for k, v in summary.items() if k != "status"},
         "fingerprint": cell_fingerprint(dataset, embedder, medias),

--- a/scripts/experiments/pile/pilebuild/provenance_report.py
+++ b/scripts/experiments/pile/pilebuild/provenance_report.py
@@ -98,15 +98,23 @@ def provenance_report(backfill: bool = False) -> int:
                 dev.get("gpu_name") or "unknown",
                 dev.get("hostname") or (f"{dev['hostname_recovered']}?" if dev.get("hostname_recovered") else "-"),
                 str(dev.get("cpu_capability") or "-"),
+                str(dev.get("embed_batch_size") or "-"),
                 (dev.get("commit") or "-")[:9],
                 rec.get("fingerprint", {}).get("vectors_sha256", "")[:12],
             )
         )
         devices[(dev.get("gpu_name") or "unknown", dev.get("cpu_capability"))].append(f"{ds}x{emb}")
 
-    log(f"{'dataset':<18} {'embedder':<14} {'device':<26} {'node':<10} {'dispatch':<9} {'commit':<10} vectors")
+    # `batch` is here because it is a build parameter that moves the vectors and
+    # was invisible until #3683: two cells of the same (dataset, embedder) built
+    # at different batch sizes disagree by ~1e-4 on a handful of images, with
+    # every other recorded field identical. A `-` means the cell predates the key.
+    log(
+        f"{'dataset':<18} {'embedder':<14} {'device':<26} {'node':<10} "
+        f"{'dispatch':<9} {'batch':<6} {'commit':<10} vectors"
+    )
     for row in sorted(rows):
-        log("{:<18} {:<14} {:<26} {:<10} {:<9} {:<10} {}".format(*row))
+        log("{:<18} {:<14} {:<26} {:<10} {:<9} {:<6} {:<10} {}".format(*row))
     if missing:
         log(f"\n{len(missing)} cell(s) with NO provenance (run --backfill-provenance): {', '.join(missing)}")
     if len(devices) > 1:

--- a/tests_lib/meta/test_pile_provenance_batch_size.py
+++ b/tests_lib/meta/test_pile_provenance_batch_size.py
@@ -1,0 +1,151 @@
+"""The embed batch size has to reach the provenance sidecar (#3683).
+
+``VTSEARCH_EMBED_BATCH_SIZE`` is a build parameter that changes the vectors.
+Rebuilding ``siglip2_l`` at 31 instead of its configured 32 -- same images, same
+node, everything else equal -- moved 27 of 7,746 vectors by up to 1.6e-04,
+because the batched GEMM's reduction order is not independent of what an image
+was batched with. That is 400x the same-node rebuild floor, and larger than the
+fp16 difference #3143 measured and rejected, so a cell built at one size and a
+cell built at another are not the same cell -- and until #3683 the sidecar said
+nothing about which one you were holding.
+
+The plumbing is what these tests pin, because the value is only *legible* for
+the length of one ``with`` block. ``build_pile._embed_batch_size`` sets the env
+var for the embed pass and pops it afterwards, so a later reader -- provenance
+is written afterwards -- asking the environment gets the shipped default of 32
+back and records a size the pass never ran at. That is the same failure the
+``aten_cpu_capability_requested`` comment warns about: a recorded pin that never
+took is worse than no record, because it reads as evidence.
+
+Source-level, so it costs nothing and needs neither a GPU nor the 100 GB of
+sources a real build reads. Importing ``build_pile`` would run
+``pile_config.setup_env()``, which edits ``sys.meta_path`` process-wide; parsing
+is what lets this live beside the other cheap pile checks.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_PILE = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+_PROVENANCE = _PILE / "pilebuild" / "provenance.py"
+_REPORT = _PILE / "pilebuild" / "provenance_report.py"
+_BUILD = _PILE / "build_pile.py"
+
+KEY = "embed_batch_size"
+
+
+def _func(path: Path, name: str) -> ast.FunctionDef:
+    """The named top-level function, or a failure that says which file lacked it."""
+    for node in ast.parse(path.read_text()).body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    pytest.fail(f"{path.name} no longer defines {name}()")
+
+
+def _params(fn: ast.FunctionDef) -> list[str]:
+    a = fn.args
+    return [p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)]
+
+
+def _calls(fn: ast.FunctionDef, name: str) -> list[ast.Call]:
+    return [n for n in ast.walk(fn) if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == name]
+
+
+def test_device_record_writes_the_key_from_its_argument():
+    """The sidecar carries the size, and carries the one it was *handed*.
+
+    Reading the environment here instead would answer with the default, because
+    the build pops the env var before provenance is written.
+    """
+    fn = _func(_PROVENANCE, "_device_record")
+    assert KEY in _params(fn), f"_device_record() must take {KEY}; it takes {_params(fn)}"
+
+    values = [
+        v
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Dict)
+        for k, v in zip(node.keys, node.values, strict=True)
+        if isinstance(k, ast.Constant) and k.value == KEY
+    ]
+    assert values, f"_device_record() writes no {KEY!r} key into the record"
+    assert all(isinstance(v, ast.Name) and v.id == KEY for v in values), (
+        f"_device_record() must record the {KEY} it was passed, not one it "
+        "re-derives: the env var is gone by the time provenance is written, so "
+        "any local re-read records the shipped default rather than the size the "
+        "embed pass actually ran at."
+    )
+
+
+def test_write_provenance_threads_the_size_into_the_device_record():
+    fn = _func(_PROVENANCE, "write_provenance")
+    assert KEY in _params(fn), f"write_provenance() must take {KEY}; it takes {_params(fn)}"
+
+    calls = _calls(fn, "_device_record")
+    assert calls, "write_provenance() no longer builds a device record"
+    passed = {
+        arg.id
+        for call in calls
+        for arg in [*call.args, *(kw.value for kw in call.keywords)]
+        if isinstance(arg, ast.Name)
+    }
+    assert KEY in passed, f"write_provenance() does not pass {KEY} to _device_record()"
+
+
+def test_the_size_is_read_inside_the_window_where_the_env_var_is_set():
+    """``effective_embed_batch_size`` belongs to the context manager, not the caller.
+
+    ``_embed_batch_size`` is the only scope in which ``VTSEARCH_EMBED_BATCH_SIZE``
+    holds the value the build chose; ``build_cell`` reading it afterwards would
+    get 32 back for every embedder whose table entry is not 32.
+    """
+    cm = _func(_BUILD, "_embed_batch_size")
+    assert _calls(cm, "effective_embed_batch_size"), (
+        "_embed_batch_size() must resolve the size itself -- it owns the only "
+        "window in which VTSEARCH_EMBED_BATCH_SIZE is set."
+    )
+    assert all(isinstance(n.value, ast.Call) for n in ast.walk(cm) if isinstance(n, ast.Yield) and n.value), (
+        "every yield in _embed_batch_size() must hand back the resolved size"
+    )
+
+    build = _func(_BUILD, "build_cell")
+    assert not _calls(build, "effective_embed_batch_size"), (
+        "build_cell() must not resolve the batch size itself: outside the "
+        "context manager the env var is unset, so it would record the default."
+    )
+
+
+def test_build_cell_passes_the_yielded_size_to_write_provenance():
+    """The `with ... as` target, and nothing else, is what reaches the sidecar."""
+    build = _func(_BUILD, "build_cell")
+    targets = {
+        item.optional_vars.id
+        for node in ast.walk(build)
+        if isinstance(node, ast.With)
+        for item in node.items
+        if isinstance(item.context_expr, ast.Call)
+        and isinstance(item.context_expr.func, ast.Name)
+        and item.context_expr.func.id == "_embed_batch_size"
+        and isinstance(item.optional_vars, ast.Name)
+    }
+    assert targets, "build_cell() must bind the size _embed_batch_size() yields (`with ... as size:`)"
+
+    calls = _calls(build, "write_provenance")
+    assert calls, "build_cell() no longer writes provenance"
+    handed = {kw.value.id for call in calls for kw in call.keywords if kw.arg == KEY and isinstance(kw.value, ast.Name)}
+    assert handed & targets, (
+        f"build_cell() must pass the yielded size as {KEY}=; it passes "
+        f"{handed or 'nothing'} while the context manager binds {targets}."
+    )
+
+
+def test_provenance_report_shows_the_size():
+    """``--provenance`` is where a human compares two cells; the size has to be in it."""
+    src = _REPORT.read_text()
+    assert f'"{KEY}"' in src, (
+        f"provenance_report.py never reads {KEY} out of the sidecar, so "
+        "`build_pile.py --provenance` cannot show what a cell was batched at."
+    )


### PR DESCRIPTION
`VTSEARCH_EMBED_BATCH_SIZE` is a build parameter that changes the vectors, and nothing wrote it down. #3667 measured why that matters: rebuilding `siglip2_l` at batch **31** instead of its configured 32 — same images, same node, everything else equal — moved **27 of 7,746** vectors by up to **1.6e-04**, because the batched GEMM's reduction order is not independent of what an image was batched with. That is 400× the same-node rebuild floor and larger than the fp16 difference #3143 measured and rejected, so two cells built at different sizes are not the same cell — with every other recorded field identical.

## What changed

**The provenance field.** `pilebuild/provenance.py` grows `effective_embed_batch_size()` and records `embed_batch_size` in the device record, beside `aten_cpu_capability_requested`. Two decisions worth stating:

- It reads the **embedder**, not the env var, so a subclass that passes its own smaller default to `resolve_embed_batch_size` is counted. It is a registry lookup, no weights load.
- It is **passed in** rather than re-derived. `build_pile._embed_batch_size` sets the env var for the embed pass and pops it afterwards, so a read at provenance-write time would answer with the shipped default of 32 and record a size the pass never ran at — the exact failure the neighbouring `aten_cpu_capability_requested` comment warns about, where a pin that never took reads as evidence.

**The plumbing.** `_embed_batch_size` now yields the resolved size and `build_cell` binds it (`with _embed_batch_size(embedder) as batch_size:`), handing it to `write_provenance`. That context manager owns the only window in which the env var holds the build's choice.

**`--provenance` grows a `batch` column**, so the comparison the sidecar exists to make is visible without opening JSON. A `-` means the cell predates the key.

**A comment that had become false.** `pile_config.EMBEDDERS` claimed batch size "shifts vectors by ~1e-7 ... orders of magnitude below anything the studies resolve". The measurement is 1.6e-04. Corrected to say what was measured, and to say that changing an entry in the table silently redefines every cell rebuilt at the new size.

**The README states the guarantee** rather than engineering it away, as a three-row table: bit-identical at fixed membership (0 of 7,746 differ, twice, on both divergent embedders), ~3e-07 across hosts and devices, and — the row that looks like the first but isn't — a membership change moves a handful of images by ~1e-4. Removing one image necessarily shifts every later one, so that is the honest guarantee.

## Tests

`tests_lib/meta/test_pile_provenance_batch_size.py` — five source-level checks, no GPU and no sources. They pin the key *and* the window: `_device_record` must record the value it was handed (not one it re-derives), `effective_embed_batch_size` must be called from inside the context manager and not from `build_cell`, and the `with ... as` target must be what reaches `write_provenance`. Getting that wrong is silent — it writes `32` for every embedder whose table entry is not 32 — which is why it is what the tests watch.

Full `./run-tests.sh` green: 10,899 passed, all gates OK.

## Explicitly not here

Whether a 1e-4 perturbation on ~30 of 7,746 images changes any study's conclusion is a separate question and a genuine experiment — it needs a paired re-run, not an opinion. Per the issue, it is deliberately not part of closing this.

Closes #3683

Refs #3667, #3160, #3143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144kVB8CyQsPDmHxVisa89t

---
_Generated by [Claude Code](https://claude.ai/code/session_0144kVB8CyQsPDmHxVisa89t)_