### PR TITLE
Stamp and gate the checkout a pile launch imports (#3693)

### DIFF
--- a/scripts/experiments/LESSONS.md
+++ b/scripts/experiments/LESSONS.md
@@ -72,6 +72,7 @@ correct union of the two branches with no judgement involved.
 
 | Date | Lesson | Issue |
 |---|---|---|
+| 2026-09-07 | [the launch output never named the checkout](lessons/2026-09-07-the-launch-output-never-named-the-checkout.md) | #3693 |
 | 2026-09-06 | [a backup glob that did not match the sibling](lessons/2026-09-06-a-backup-glob-that-did-not-match-the-sibling.md) | #3667 |
 | 2026-09-06 | [a force-push left the suite silently testing the old commit](lessons/2026-09-06-a-force-push-left-the-suite-testing-the-old-commit.md) | #3666 |
 | 2026-09-06 | [a truncating pipe killed the script before it wrote its output](lessons/2026-09-06-a-truncating-pipe-killed-the-json-write.md) | #3667 |

--- a/scripts/experiments/lessons/2026-09-07-the-launch-output-never-named-the-checkout.md
+++ b/scripts/experiments/lessons/2026-09-07-the-launch-output-never-named-the-checkout.md
@@ -1,0 +1,69 @@
+# 2026-09-07 — the launch output never named the checkout (#3693)
+
+**Study:** the shared pile (`launch_pile.sh`), while building `vg_scale` for
+#3670. **Cost:** none, by luck. The stale tree happened to be old enough to lack
+`build_pile.py --rebuildable`, which the launcher's own canary calls, so it
+failed loudly on a missing flag. Any *younger* stale tree would have rebuilt
+every cell and reported success.
+
+`launch_pile.sh` set the checkout its jobs import from a fixed path:
+
+```sh
+REPO="${VTS_REPO:-/exp/$USER/projects/vts-pile}"
+```
+
+So `bash launch_pile.sh vg_scale`, run from any other worktree, submitted jobs
+that built the pile out of `/exp/$USER/projects/vts-pile` — 1,420 commits behind
+`origin/dev`, predating the `vg_scale` dataset entirely. Deriving `REPO` from the
+script's own location fixes the default in one line.
+
+**The one-line fix is not the lesson.** The default had been wrong for months and
+nobody saw it, because the launcher printed
+
+```
+submitted vg_scale -> job 4412291
+```
+
+and never said *which tree at which commit*. There was nothing on screen to be
+wrong. A launcher that names its checkout is one a human can catch reading the
+scrollback; a launcher that names nothing can only be caught by an unrelated
+crash, which is exactly how this one surfaced.
+
+The same blind spot ran one layer deeper. Each cell's provenance sidecar recorded
+the *machine* in detail — GPU, CPU model, kernel dispatch, transformers version
+— and a bare commit hash, but not the **path**. A cell built by the stale tree
+and one built by the tree you were reading were therefore indistinguishable in
+the record unless somebody resolved the hash by hand. It is the same shape as
+[a fresh worktree ran the *other* worktree's
+code](2026-08-07-a-fresh-worktree-ran-the-other-worktrees-code.md) and
+[a launcher default outlives the directory it
+names](2026-08-12-a-launcher-default-outlives-the-directory-it-names.md): the
+error is invisible, not improbable.
+
+**Prevented.** `scripts/experiments/repo_stamp.sh` does two things a default
+cannot, and `launch_pile.sh` calls it before it submits anything:
+
+```
+=== code under launch ===
+repo:    /exp/sgreenberg/projects/VTSearch
+head:    a9dd62ff (dev)
+base:    level with origin/dev
+```
+
+and it **refuses** a checkout `VTS_MAX_BEHIND` (default 100) or more commits
+behind `origin/dev` — the bar `preflight.sh` check 4 already applied to study
+worktrees, now applied to the pile, which is the artifact every study reads.
+`VTS_MAX_BEHIND=0` waives it for a build that means to run old code. Each cell's
+sidecar now carries a `code` block (repo, commit, branch, dirty) and
+`--provenance` says so out loud when a pile's cells came from more than one tree.
+
+**The audit the fix asks for.** Every other GRID launcher that pins a fixed
+`VTS_REPO` names a *study-specific* worktree on purpose, and all but a handful
+run `preflight.sh`, whose check 4 already applies this bar. The pile launcher was
+the outlier precisely because it is shared: no study "owns" it, so no study's
+preflight covered it.
+
+**The general rule:** a launcher's output must name every resolved default that
+changes what runs — #3269's lesson was "record a resolved default as data, not
+just as a launcher argument", and a checkout is the largest such default there
+is. If the banner cannot be wrong, nothing on screen can be checked.

--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -33,6 +33,29 @@ before you do it, both learned in #3667:
 - **Copy the cells first, and check your glob.** `vg_scale__*` does not match
   `vg_scale_deep__*`.
 
+## Which checkout built it
+
+`launch_pile.sh` names the tree it will import before it submits anything, and
+refuses one more than `VTS_MAX_BEHIND` (default 100) commits behind `origin/dev`
+— `preflight.sh` check 4's bar, applied to the artifact every study reads:
+
+```
+=== code under launch ===
+repo:    /exp/sgreenberg/projects/VTSearch
+head:    a9dd62ff (dev)
+base:    level with origin/dev
+```
+
+`VTS_MAX_BEHIND=0` waives the refusal for a build that means to run old code.
+The same facts are stamped into each cell's sidecar under `code` (repo, commit,
+branch, dirty, and the commit the launcher saw — which differs if the worktree
+moved while the job queued), and `--provenance` calls out a pile whose cells came
+from more than one tree.
+
+This exists because the launcher used to build from a **fixed path**: run from
+any other worktree it embedded the pile out of a checkout 1,420 commits behind
+`dev`, predating `vg_scale` entirely, and printed nothing that said so (#3693).
+
 ## Where the code lives
 
 `build_pile.py` is the CLI and the per-cell build loop; everything it does
@@ -44,7 +67,7 @@ before you do it, both learned in #3667:
 | `pilebuild/vgsource.py`, `boxscan.py` | reading the VG source; choosing a band's categories from the box scan |
 | `pilebuild/corrections.py` | human verdicts, and the one place their boxes cross from normalised into pixel space |
 | `pilebuild/geometry.py` | geometry no honest region box can have; the derived-label digest |
-| `pilebuild/provenance.py` | which machine produced a cell, and its vector hash |
+| `pilebuild/provenance.py` | which machine **and which checkout** produced a cell, and its vector hash |
 | `pilebuild/audit.py`, `manifest.py`, `provenance_report.py` | the read-only modes |
 
 **Both halves of a dataset live in one module on purpose.** They used to be two

--- a/scripts/experiments/pile/launch_pile.sh
+++ b/scripts/experiments/pile/launch_pile.sh
@@ -6,6 +6,7 @@
 #   bash launch_pile.sh coco_val     # just one dataset's job
 #   VTS_GPU_NODE=rack7n03 bash launch_pile.sh visual_genome_m   # pin the device
 #   VTS_BUILD_ARGS=--force bash launch_pile.sh vg_scale         # REBUILD, not fill
+#   VTS_MAX_BEHIND=0 bash launch_pile.sh vg_scale   # build from an OLD checkout
 #
 # Weights are prefetched in a separate CPU step because parallel GPU jobs would
 # otherwise race to populate the same shared HF cache (see prefetch_models.py).
@@ -42,8 +43,24 @@ CPUS="${VTS_CPUS:-8}"
 
 mkdir -p "$LOGS"
 
+# Name the checkout before anything is submitted, and refuse one that is stale.
+# The fixed default above was only half of #3693: the other half is that the
+# launch output said `submitted vg_scale -> job NNN` and never named the tree or
+# the commit, so a build from a checkout 1,420 commits behind dev had nothing on
+# screen to be wrong. This prints both and applies preflight.sh check 4's bar
+# (VTS_MAX_BEHIND, default 100) to the pile -- the artifact every study reads.
+# shellcheck source=../repo_stamp.sh
+source "$SELF_DIR/../repo_stamp.sh"
+repo_stamp "$REPO" || exit 1
+echo
+
 ENVSET="module load python/3.12.3 && source /exp/$USER/projects/VTSearch/.venv/bin/activate"
 ENVSET="$ENVSET && export VTS_REPO=$REPO VTS_PILE=$PILE"
+# The commit as it stood at LAUNCH time, carried into the job so the cell's
+# provenance can compare it against the commit the build actually resolves. A
+# pile job sits in the queue for hours; a worktree that changes branch in the
+# meantime builds from code the launch banner never showed anyone.
+ENVSET="$ENVSET && export VTS_LAUNCH_COMMIT=${REPO_STAMP_COMMIT:-}"
 # Keep HF off /exp: one model download there fills the 50G quota.
 ENVSET="$ENVSET && export HF_HOME=$PILE/models VTSEARCH_MODELS_DIR=$PILE/models"
 ENVSET="$ENVSET && export VTSEARCH_DATA_DIR=$PILE/datadir && cd $HERE"
@@ -166,5 +183,6 @@ for ds in "${DATASETS[@]}"; do
 done
 
 echo
+echo "built from: $REPO @ ${REPO_STAMP_COMMIT:0:9} (${REPO_STAMP_BRANCH:-unknown})"
 echo "watch:   squeue -u $USER"
 echo "verify:  cd $HERE && python build_pile.py --verify"

--- a/scripts/experiments/pile/pilebuild/manifest.py
+++ b/scripts/experiments/pile/pilebuild/manifest.py
@@ -13,13 +13,18 @@ def _manifest_provenance(dataset: str, embedder: str) -> dict:
     """The provenance fields the manifest carries per cell, or nulls if unknown."""
     path = pc.provenance_path(dataset, embedder)
     if not path.exists():
-        return {"gpu_name": None, "built_by": None, "commit": None, "vectors_sha256": None}
+        return {"gpu_name": None, "built_by": None, "repo": None, "commit": None, "vectors_sha256": None}
     rec = json.loads(path.read_text())
     dev = rec.get("device", {})
+    # `code` since #3693; before that the commit lived under `device` and no
+    # sidecar recorded the checkout at all. Read both, so a pile holding cells
+    # from either era reports what each one actually knows.
+    code = rec.get("code", {})
     return {
         "gpu_name": dev.get("gpu_name"),
         "built_by": dev.get("hostname"),
-        "commit": dev.get("commit"),
+        "repo": code.get("repo"),
+        "commit": code.get("commit") or dev.get("commit"),
         "vectors_sha256": rec.get("fingerprint", {}).get("vectors_sha256"),
     }
 

--- a/scripts/experiments/pile/pilebuild/provenance.py
+++ b/scripts/experiments/pile/pilebuild/provenance.py
@@ -1,4 +1,4 @@
-"""Which machine produced a cell, and a hash that outlives the cell itself (#3160)."""
+"""Which machine and which *code* produced a cell, and a hash that outlives it (#3160, #3693)."""
 
 from __future__ import annotations
 
@@ -57,7 +57,6 @@ def _device_record() -> dict:
         # written for. Recording the version and the class that actually loaded
         # costs nothing and makes that axis visible too.
         "transformers": _transformers_version(),
-        "commit": _git_commit(),
     }
     if not torch.cuda.is_available():
         rec["gpu_name"] = None
@@ -133,14 +132,13 @@ def _processor_record(embedder: str) -> dict:
         return {"processor_class": None, "image_processor_class": None, "error": repr(exc)[:120]}
 
 
-def _git_commit() -> str | None:
-    """The commit of the checkout that is about to embed, or None outside git."""
+def _git(repo: Path, *args: str) -> str | None:
+    """One `git -C repo ...`, or None when git or the repo is not usable."""
     import subprocess  # noqa: PLC0415, S404 -- fixed argv, no shell
 
-    repo = Path(os.environ.get("VTS_REPO") or Path(__file__).resolve().parents[4])
     try:
         out = subprocess.run(  # noqa: S603
-            ["git", "-C", str(repo), "rev-parse", "HEAD"],  # noqa: S607
+            ["git", "-C", str(repo), *args],  # noqa: S607
             capture_output=True,
             text=True,
             timeout=15,
@@ -148,7 +146,43 @@ def _git_commit() -> str | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
+    if out.returncode != 0:
+        return None
     return out.stdout.strip() or None
+
+
+def _code_record() -> dict:
+    """The checkout that is about to embed: which tree, at which commit.
+
+    The commit alone was here before #3693, and it was not enough. The launcher
+    built the pile from a **fixed path** rather than its own location, so
+    `bash launch_pile.sh vg_scale` from any other worktree submitted jobs that
+    imported `/exp/$USER/projects/vts-pile` -- 1,420 commits behind `dev`,
+    predating `vg_scale` entirely. A commit hash records *what* ran and cannot
+    say *which tree it came from*, so a cell built by a stale checkout and a cell
+    built by a current one were indistinguishable in the sidecar until someone
+    resolved the hash by hand. The path is the field that makes the mix-up
+    legible; `provenance_report` calls out a pile built from more than one.
+
+    ``commit_at_launch`` is the launcher's own reading of HEAD, carried in by
+    `launch_pile.sh`. A pile job queues for hours: a worktree that changes branch
+    between submit and start builds from code the launch banner never showed
+    anyone, and the two fields disagreeing is the only trace of it.
+    """
+    repo = Path(os.environ.get("VTS_REPO") or Path(__file__).resolve().parents[4])
+    commit = _git(repo, "rev-parse", "HEAD")
+    launched = os.environ.get("VTS_LAUNCH_COMMIT") or None
+    return {
+        "repo": str(repo),
+        "commit": commit,
+        "branch": _git(repo, "rev-parse", "--abbrev-ref", "HEAD"),
+        # Uncommitted tracked changes mean the commit above does not describe
+        # what ran. Recorded rather than refused: a build is not the moment to
+        # discover it, and a null (git unavailable) is not the same as clean.
+        "dirty": (None if commit is None else bool(_git(repo, "status", "--porcelain", "--untracked-files=no"))),
+        "commit_at_launch": launched,
+        "matches_launch": (None if not launched or not commit else launched == commit),
+    }
 
 
 def cell_fingerprint(dataset: str, embedder: str, medias: dict | None = None) -> dict:
@@ -190,6 +224,7 @@ def write_provenance(dataset: str, embedder: str, summary: dict, medias: dict | 
         "cell": pc.cell_path(dataset, embedder).name,
         "built_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
         "device": _device_record(),
+        "code": _code_record(),
         "preprocessing": _processor_record(embedder),
         "cell_summary": {k: v for k, v in summary.items() if k != "status"},
         "fingerprint": cell_fingerprint(dataset, embedder, medias),
@@ -197,5 +232,16 @@ def write_provenance(dataset: str, embedder: str, summary: dict, medias: dict | 
     path = pc.provenance_path(dataset, embedder)
     path.write_text(json.dumps(record, indent=2) + "\n")
     dev = record["device"]
+    code = record["code"]
     log(f"  provenance: {dev.get('gpu_name')} on {dev.get('hostname')} -> {path.name}")
+    # Which code, said out loud in the build log too: the sidecar is only read
+    # by someone who already suspects something (#3693).
+    log(f"  built from: {code.get('repo')} @ {(code.get('commit') or 'unknown')[:9]} ({code.get('branch')})")
+    if code.get("dirty"):
+        log("  WARNING: that checkout had uncommitted tracked changes -- this cell is not reproducible")
+    if code.get("matches_launch") is False:
+        log(
+            f"  WARNING: launched from {(code.get('commit_at_launch') or '')[:9]}, built at "
+            f"{(code.get('commit') or '')[:9]} -- the checkout MOVED while this job was queued"
+        )
     return path

--- a/scripts/experiments/pile/pilebuild/provenance_report.py
+++ b/scripts/experiments/pile/pilebuild/provenance_report.py
@@ -54,6 +54,7 @@ def provenance_report(backfill: bool = False) -> int:
     the cell?" from an unanswerable question into a hash comparison.
     """
     rows, missing, devices = [], [], defaultdict(list)
+    checkouts: defaultdict[str, list[str]] = defaultdict(list)
     recovered = _sacct_build_nodes() if backfill else {}
     for ds, emb in pc.cells():
         cell = pc.cell_path(ds, emb)
@@ -85,6 +86,10 @@ def provenance_report(backfill: bool = False) -> int:
                 continue
         rec = json.loads(path.read_text())
         dev = rec.get("device", {})
+        # `code` since #3693; older sidecars kept the commit under `device` and
+        # recorded no checkout at all, so a null repo here means "unrecorded",
+        # not "same tree as everything else".
+        code = rec.get("code", {})
         if backfill and not dev.get("hostname") and not dev.get("hostname_recovered") and recovered.get(ds):
             dev["hostname_recovered"] = recovered[ds]
             dev["recovered_from"] = "sacct pile-<dataset> job"
@@ -98,11 +103,12 @@ def provenance_report(backfill: bool = False) -> int:
                 dev.get("gpu_name") or "unknown",
                 dev.get("hostname") or (f"{dev['hostname_recovered']}?" if dev.get("hostname_recovered") else "-"),
                 str(dev.get("cpu_capability") or "-"),
-                (dev.get("commit") or "-")[:9],
+                (code.get("commit") or dev.get("commit") or "-")[:9],
                 rec.get("fingerprint", {}).get("vectors_sha256", "")[:12],
             )
         )
         devices[(dev.get("gpu_name") or "unknown", dev.get("cpu_capability"))].append(f"{ds}x{emb}")
+        checkouts[code.get("repo") or "unrecorded"].append(f"{ds}x{emb}")
 
     log(f"{'dataset':<18} {'embedder':<14} {'device':<26} {'node':<10} {'dispatch':<9} {'commit':<10} vectors")
     for row in sorted(rows):
@@ -114,4 +120,15 @@ def provenance_report(backfill: bool = False) -> int:
         log("hosts is 1.5e-04 median 1-cos on siglip2_l when CPU dispatch is unpinned (#3160):")
         for (name, cap), cells in sorted(devices.items(), key=lambda kv: str(kv[0])):
             log(f"  {str(name):<26} dispatch={cap or 'unrecorded':<10} {len(cells)} cell(s)")
+    # The same warning one axis over. A pile built from two checkouts is what
+    # #3693 was: a launcher whose fixed default pointed at a tree 1,420 commits
+    # behind dev, while the tree you were reading built everything else. Nothing
+    # said so, because nothing recorded the path -- and the cells look identical
+    # from outside. Now they do not.
+    if len(checkouts) > 1:
+        log(f"\nthis pile was built from {len(checkouts)} DIFFERENT checkouts:")
+        for repo, cells in sorted(checkouts.items()):
+            log(f"  {repo:<52} {len(cells)} cell(s)")
+        log("cells built from different trees ran different code; compare their commits")
+        log("before reading them as one pile (#3693).")
     return 0

--- a/scripts/experiments/repo_stamp.sh
+++ b/scripts/experiments/repo_stamp.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Say which checkout a GRID launch will import, and refuse one that is stale.
+#
+# Source it, then call once per launch, before anything is submitted:
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/../repo_stamp.sh"
+#   repo_stamp "$REPO" || exit 1
+#
+# Why this exists. `launch_pile.sh` set the checkout its jobs import from a
+# fixed path (`/exp/$USER/projects/vts-pile`), so running it from any other
+# worktree submitted jobs that built the pile from a DIFFERENT tree -- 1,420
+# commits behind `dev` by 2026-09-06, predating the `vg_scale` dataset entirely
+# (#3693). The path default is fixed now, but the reason nobody noticed for
+# months is the part a default cannot fix: **the launch output never named the
+# checkout**. It printed `submitted vg_scale -> job NNN` and nothing else, so
+# there was nothing on screen to be wrong. Had the stale tree been any closer in
+# age it would have rebuilt every cell from code nobody was looking at and
+# reported success, the way #3269 measured a retired head from a worktree 321
+# commits behind.
+#
+# Two things, therefore, and they are different:
+#
+#   1. **Print it.** A launch that names its checkout and commit is one a human
+#      can catch. This costs nothing and catches the cases the gate cannot
+#      (right distance from `dev`, wrong tree).
+#   2. **Gate it.** `preflight.sh` check 4 fails a study worktree more than
+#      `PREFLIGHT_MAX_BEHIND` commits behind `origin/dev`; nothing applied that
+#      to the pile, which is the artifact every study reads. Same bar, same
+#      default, so the two agree about what "stale" means.
+#
+# Knobs:
+#   VTS_MAX_BEHIND    commits behind origin/<base> that REFUSES the launch
+#                     (default 100, matching PREFLIGHT_MAX_BEHIND). `0` disables
+#                     the gate -- for a run that deliberately builds from an old
+#                     checkout. The banner still prints; only the refusal goes.
+#   VTS_BASE_BRANCH   integration branch to measure against (default `dev`).
+#
+# On success it exports, for a caller that wants to stamp the launch into the
+# job it submits: REPO_STAMP_COMMIT (full sha), REPO_STAMP_BRANCH,
+# REPO_STAMP_BEHIND. Each is empty when it could not be measured.
+
+repo_stamp() {
+  local repo="${1:?repo_stamp: pass the checkout the jobs will import}"
+  local max_behind="${VTS_MAX_BEHIND:-100}"
+  local base="${VTS_BASE_BRANCH:-dev}"
+
+  REPO_STAMP_COMMIT=""
+  REPO_STAMP_BRANCH=""
+  REPO_STAMP_BEHIND=""
+
+  echo "=== code under launch ==="
+  echo "repo:    $repo"
+
+  if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "head:    NOT A GIT CHECKOUT -- the build can stamp no commit"
+    if [[ "$max_behind" == "0" ]]; then
+      echo "gate:    disabled (VTS_MAX_BEHIND=0)"
+      return 0
+    fi
+    echo >&2
+    echo "refusing to submit: a cell built from an unidentifiable tree cannot be" >&2
+    echo "reproduced, and nothing later can say what code produced it." >&2
+    echo "  -> launch from a git worktree, or set VTS_MAX_BEHIND=0 if you mean it." >&2
+    return 1
+  fi
+
+  local sha short branch dirty=""
+  sha="$(git -C "$repo" rev-parse HEAD 2>/dev/null || true)"
+  short="$(git -C "$repo" rev-parse --short HEAD 2>/dev/null || true)"
+  branch="$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [[ -n "$(git -C "$repo" status --porcelain --untracked-files=no 2>/dev/null)" ]]; then
+    dirty="  +uncommitted tracked changes"
+  fi
+  REPO_STAMP_COMMIT="$sha"
+  REPO_STAMP_BRANCH="$branch"
+  echo "head:    ${short:-unknown} (${branch:-unknown})$dirty"
+
+  # Best effort: a login node without the remote still gets the banner, and the
+  # unmeasured distance is said out loud rather than passing as "level".
+  git -C "$repo" fetch -q origin "$base" >/dev/null 2>&1 || true
+  if ! git -C "$repo" rev-parse --verify -q "origin/$base" >/dev/null 2>&1; then
+    echo "base:    origin/$base unavailable -- staleness UNMEASURED"
+    return 0
+  fi
+
+  local behind
+  behind="$(git -C "$repo" rev-list --count "HEAD..origin/$base" 2>/dev/null || echo "")"
+  if [[ -z "$behind" ]]; then
+    echo "base:    could not measure distance from origin/$base"
+    return 0
+  fi
+  REPO_STAMP_BEHIND="$behind"
+
+  if [[ "$max_behind" == "0" ]]; then
+    echo "base:    $behind commits behind origin/$base (gate disabled, VTS_MAX_BEHIND=0)"
+    return 0
+  fi
+  if [[ "$behind" -ge "$max_behind" ]]; then
+    echo "base:    $behind commits behind origin/$base  (gate: $max_behind)"
+    echo >&2
+    echo "refusing to submit: this checkout is $behind commits behind origin/$base." >&2
+    echo "  -> the jobs would build from code that old, and report success." >&2
+    echo "     Rebase the worktree, point VTS_REPO at a current one, or set" >&2
+    echo "     VTS_MAX_BEHIND=0 if building from this commit is the point." >&2
+    return 1
+  fi
+  if [[ "$behind" -gt 0 ]]; then
+    echo "base:    $behind commits behind origin/$base (under the $max_behind gate)"
+  else
+    echo "base:    level with origin/$base"
+  fi
+  return 0
+}

--- a/tests_lib/meta/test_pile_provenance_code.py
+++ b/tests_lib/meta/test_pile_provenance_code.py
@@ -1,0 +1,100 @@
+"""The ``code`` block of a pile cell's provenance sidecar (#3693).
+
+Every cell already recorded the *machine* that built it. It did not record the
+**checkout**, and that is the axis that actually went wrong: ``launch_pile.sh``
+built the pile from a fixed path 1,420 commits behind ``dev``, and a cell built
+by that tree was indistinguishable in the sidecar from one built by the tree you
+were reading. These pin the fields that make the difference legible -- which
+tree, at which commit, on which branch, dirty or not -- and the launch-time
+comparison that catches a worktree moving while the job sat in the queue.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_PILE_DIR = REPO_ROOT / "scripts" / "experiments" / "pile"
+
+
+@pytest.fixture(scope="module")
+def provenance():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pilebuild.provenance as mod
+
+    return mod
+
+
+def _git(cwd: Path, *args: str) -> str:
+    out = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        ["git", *args],  # noqa: S607 - git resolved from PATH
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "dev", ".")
+    (repo / "file.txt").write_text("one")
+    _git(repo, "add", "file.txt")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "one")
+    return repo
+
+
+class TestCodeRecord:
+    def test_records_the_checkout_the_job_imports(self, provenance, worktree, monkeypatch):
+        monkeypatch.setenv("VTS_REPO", str(worktree))
+        monkeypatch.delenv("VTS_LAUNCH_COMMIT", raising=False)
+        rec = provenance._code_record()
+        assert rec["repo"] == str(worktree)
+        assert rec["commit"] == _git(worktree, "rev-parse", "HEAD")
+        assert rec["branch"] == "dev"
+        assert rec["dirty"] is False
+
+    def test_uncommitted_changes_are_recorded_not_hidden(self, provenance, worktree, monkeypatch):
+        monkeypatch.setenv("VTS_REPO", str(worktree))
+        (worktree / "file.txt").write_text("edited")
+        assert provenance._code_record()["dirty"] is True
+
+    def test_a_tree_without_git_records_nulls_rather_than_failing(self, provenance, tmp_path, monkeypatch):
+        """Provenance must never sink a build that has already produced a cell."""
+        plain = tmp_path / "no-git"
+        plain.mkdir()
+        monkeypatch.setenv("VTS_REPO", str(plain))
+        rec = provenance._code_record()
+        assert rec["repo"] == str(plain)
+        assert rec["commit"] is None
+        assert rec["branch"] is None
+        # None, not False: "git could not say" is not "clean".
+        assert rec["dirty"] is None
+
+
+class TestLaunchComparison:
+    def test_flags_a_checkout_that_moved_while_the_job_queued(self, provenance, worktree, monkeypatch):
+        monkeypatch.setenv("VTS_REPO", str(worktree))
+        monkeypatch.setenv("VTS_LAUNCH_COMMIT", "0" * 40)
+        rec = provenance._code_record()
+        assert rec["commit_at_launch"] == "0" * 40
+        assert rec["matches_launch"] is False
+
+    def test_agrees_when_the_tree_stood_still(self, provenance, worktree, monkeypatch):
+        monkeypatch.setenv("VTS_REPO", str(worktree))
+        monkeypatch.setenv("VTS_LAUNCH_COMMIT", _git(worktree, "rev-parse", "HEAD"))
+        assert provenance._code_record()["matches_launch"] is True
+
+    def test_unknown_rather_than_false_when_the_launcher_stamped_nothing(self, provenance, worktree, monkeypatch):
+        """A hand-run build has no launch commit; that is not a mismatch."""
+        monkeypatch.setenv("VTS_REPO", str(worktree))
+        monkeypatch.delenv("VTS_LAUNCH_COMMIT", raising=False)
+        assert provenance._code_record()["matches_launch"] is None

--- a/tests_lib/meta/test_repo_stamp.py
+++ b/tests_lib/meta/test_repo_stamp.py
@@ -1,0 +1,153 @@
+"""Tests for ``scripts/experiments/repo_stamp.sh``.
+
+The helper is what stops a GRID launch importing a checkout nobody is looking
+at. #3693: ``launch_pile.sh`` built the pile from a fixed path 1,420 commits
+behind ``dev``, and the launch output never named the tree or the commit, so
+there was nothing on screen to be wrong. The path default is fixed; this is the
+half that keeps it fixed -- it prints the checkout and refuses one that is stale.
+
+A shell gate is only worth having if it fails when it should, so these drive the
+real script against real temp git repositories: a fresh clone, one left behind,
+one that is not a checkout at all, and the deliberate-old-build escape hatch.
+No SLURM and no network -- ``origin`` is a local repo on disk.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAMP = REPO_ROOT / "scripts" / "experiments" / "repo_stamp.sh"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    out = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        ["git", *args],  # noqa: S607 - git resolved from PATH
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(cwd), "GIT_CONFIG_GLOBAL": "/dev/null"},
+    )
+    return out.stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> None:
+    (repo / "file.txt").write_text(message)
+    _git(repo, "add", "file.txt")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", message)
+
+
+def _run_stamp(repo: Path, **env: str) -> subprocess.CompletedProcess[str]:
+    """Source the helper and call ``repo_stamp`` on ``repo``; return the result."""
+    script = f'set -euo pipefail\nsource "{STAMP}"\nrepo_stamp "{repo}"\n'
+    return subprocess.run(  # noqa: S603 - repo-local script path, no user input
+        ["bash", "-c", script],  # noqa: S607 - bash resolved from PATH
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": str(repo), **env},
+    )
+
+
+@pytest.fixture
+def origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
+    """A bare ``origin`` with a ``dev`` branch, and a clone level with it."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _git(upstream, "init", "-q", "-b", "dev", ".")
+    _commit(upstream, "one")
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(upstream), str(clone))
+    return upstream, clone
+
+
+class TestBanner:
+    def test_names_the_checkout_and_its_commit(self, origin_and_clone):
+        _, clone = origin_and_clone
+        res = _run_stamp(clone)
+        assert res.returncode == 0, res.stderr
+        assert str(clone) in res.stdout
+        assert _git(clone, "rev-parse", "--short", "HEAD") in res.stdout
+        assert "level with origin/dev" in res.stdout
+
+    def test_reports_uncommitted_changes_without_refusing(self, origin_and_clone):
+        """A dirty tree is unreproducible, but it is also how the pile gets built
+        while its build code is being changed. Say so; do not refuse."""
+        _, clone = origin_and_clone
+        (clone / "file.txt").write_text("edited")
+        res = _run_stamp(clone)
+        assert res.returncode == 0, res.stderr
+        assert "uncommitted" in res.stdout
+
+    def test_says_so_when_the_distance_cannot_be_measured(self, tmp_path: Path):
+        """A repo with no ``origin/dev`` gets a banner and an explicit
+        'UNMEASURED', never a silent pass that reads like 'level'."""
+        repo = tmp_path / "solo"
+        repo.mkdir()
+        _git(repo, "init", "-q", "-b", "main", ".")
+        _commit(repo, "one")
+        res = _run_stamp(repo)
+        assert res.returncode == 0, res.stderr
+        assert "UNMEASURED" in res.stdout
+        assert "level with" not in res.stdout
+
+
+class TestStalenessGate:
+    def _leave_behind(self, upstream: Path, clone: Path, n: int) -> None:
+        for i in range(n):
+            _commit(upstream, f"upstream {i}")
+        _git(clone, "fetch", "-q", "origin")
+
+    def test_refuses_a_checkout_past_the_gate(self, origin_and_clone):
+        upstream, clone = origin_and_clone
+        self._leave_behind(upstream, clone, 4)
+        res = _run_stamp(clone, VTS_MAX_BEHIND="3")
+        assert res.returncode == 1
+        assert "4 commits behind origin/dev" in res.stdout
+        assert "refusing to submit" in res.stderr
+
+    def test_allows_a_checkout_under_the_gate_and_names_the_lag(self, origin_and_clone):
+        upstream, clone = origin_and_clone
+        self._leave_behind(upstream, clone, 2)
+        res = _run_stamp(clone, VTS_MAX_BEHIND="3")
+        assert res.returncode == 0, res.stderr
+        assert "2 commits behind origin/dev" in res.stdout
+
+    def test_zero_disables_the_refusal_but_keeps_the_banner(self, origin_and_clone):
+        """Building from an old commit on purpose stays possible -- loudly."""
+        upstream, clone = origin_and_clone
+        self._leave_behind(upstream, clone, 4)
+        res = _run_stamp(clone, VTS_MAX_BEHIND="0")
+        assert res.returncode == 0, res.stderr
+        assert "4 commits behind origin/dev" in res.stdout
+        assert "gate disabled" in res.stdout
+
+    def test_measures_against_the_branch_the_caller_names(self, origin_and_clone):
+        upstream, clone = origin_and_clone
+        _git(upstream, "branch", "release")
+        self._leave_behind(upstream, clone, 4)
+        # origin/release is still at the shared commit, so the same clone that
+        # is 4 behind dev is level with it.
+        res = _run_stamp(clone, VTS_BASE_BRANCH="release", VTS_MAX_BEHIND="3")
+        assert res.returncode == 0, res.stderr
+        assert "level with origin/release" in res.stdout
+
+    def test_refuses_a_tree_that_is_not_a_checkout(self, tmp_path: Path):
+        """No git means no commit stamp, which means a cell nothing can identify."""
+        plain = tmp_path / "rsynced-copy"
+        plain.mkdir()
+        res = _run_stamp(plain)
+        assert res.returncode == 1
+        assert "NOT A GIT CHECKOUT" in res.stdout
+        assert "refusing to submit" in res.stderr
+
+    def test_zero_also_waives_the_not_a_checkout_refusal(self, tmp_path: Path):
+        plain = tmp_path / "rsynced-copy"
+        plain.mkdir()
+        res = _run_stamp(plain, VTS_MAX_BEHIND="0")
+        assert res.returncode == 0, res.stderr


### PR DESCRIPTION
The `REPO` default in `launch_pile.sh` is already derived from the script's own
location. This adds the two things the issue asks for, which a corrected default
cannot do: **say which checkout is being launched**, and **refuse one that is
stale**.

The reason the fixed default survived months is that the launcher printed

```
submitted vg_scale -> job 4412291
```

and never named the tree or the commit. There was nothing on screen to be wrong.

## The launch banner + staleness gate

New `scripts/experiments/repo_stamp.sh`, sourced by `launch_pile.sh` before
anything is submitted:

```
=== code under launch ===
repo:    /exp/sgreenberg/projects/VTSearch
head:    a9dd62ff (dev)
base:    level with origin/dev
```

It **refuses** a checkout `VTS_MAX_BEHIND` (default 100) or more commits behind
`origin/dev` — the bar `preflight.sh` check 4 already applies to study
worktrees, now applied to the pile, which is the artifact every study reads. It
also refuses a tree that is not a git checkout at all (nothing could stamp it).
`VTS_MAX_BEHIND=0` waives both for a build that means to run old code; the banner
still prints. `VTS_BASE_BRANCH` picks a different integration branch. Distance
that cannot be measured (no `origin/dev`) is printed as `UNMEASURED` rather than
passing as "level".

It is a sourceable helper rather than inline bash so the next launcher gets it
for free.

## Provenance now records the code, not just the machine

Each cell's sidecar grows a `code` block: `repo`, `commit`, `branch`, `dirty`,
plus `commit_at_launch` / `matches_launch`. The commit used to sit under
`device`; the **path** — the axis that actually went wrong — was recorded
nowhere, so a cell built by the stale tree and one built by the tree you were
reading were indistinguishable unless someone resolved the hash by hand.

`commit_at_launch` is the launcher's own reading of HEAD, carried into the job as
`VTS_LAUNCH_COMMIT`. A pile job queues for hours; a worktree that changes branch
in between builds from code the banner never showed anyone, and the two fields
disagreeing is the only trace of it. The build log says both out loud, and warns
on a dirty tree or a mismatch.

`build_pile.py --provenance` now reports a pile whose cells came from **more than
one checkout**, beside the existing "mixes N build environments" warning.
`manifest.py` and `provenance_report.py` read `code` with a fallback to the old
`device.commit`, so a pile holding cells from both eras still reports what each
one knows.

## The audit the issue asks for

`launch_scale.sh` already derives its worktree from its own location;
`launch_bands.sh` does not exist. Ten calibration launchers do pin a fixed
`VTS_REPO`, but each names its own *study* worktree deliberately, and all but a
handful run `preflight.sh`, whose check 4 already applies this bar. The pile
launcher was the outlier precisely because it is shared: no study owns it, so no
study's preflight covered it. Those are left alone.

## Tests

`tests_lib/meta/test_repo_stamp.py` drives the real shell gate against temp git
repositories (fresh clone, one left behind, a non-checkout, the `VTS_MAX_BEHIND=0`
escape hatch, a named base branch) — no SLURM, no network.
`tests_lib/meta/test_pile_provenance_code.py` pins the sidecar fields, including
`dirty: null` (git could not say) vs `false` (clean) and the launch comparison.
Full `./run-tests.sh`: 10909 passed, all gates green.

Also: a lesson under `scripts/experiments/lessons/` (index regenerated) and a
"Which checkout built it" section in the pile README.

Closes #3693

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119oMeo6Kh2aVJMEbGm21gE

---
_Generated by [Claude Code](https://claude.ai/code/session_0119oMeo6Kh2aVJMEbGm21gE)_