### PR TITLE
Ask the aspect-drift guard in one place, with one reading

### DIFF
--- a/scripts/experiments/pile/band_fold.py
+++ b/scripts/experiments/pile/band_fold.py
@@ -170,7 +170,7 @@ def phase_truth(anchor: Path, records: list, inflations: list[float], examples: 
         if vd is None or cid is None or cid not in cdims:
             continue
         cd = cdims[cid]
-        if abs((vd[0] / vd[1]) - (cd[0] / cd[1])) > pc.MAX_ASPECT_DRIFT:
+        if not pc.aspect_transferable(vd, cd):
             skipped_aspect += 1
             continue
         n_overlap += 1

--- a/scripts/experiments/pile/coco_folds.py
+++ b/scripts/experiments/pile/coco_folds.py
@@ -48,11 +48,6 @@ pc.setup_env()
 
 VG_ROOT = pc.DEMO_CACHE / "visual_genome"
 
-#: A VG copy whose aspect ratio drifts further than this from the COCO original
-#: has been re-cropped or rotated, not merely rescaled, and normalised
-#: coordinates do not transfer across it (`pile_config.MAX_ASPECT_DRIFT`).
-MAX_ASPECT_DRIFT = pc.MAX_ASPECT_DRIFT
-
 
 def log(msg: str) -> None:
     print(f"[folds] {msg}", flush=True)
@@ -173,7 +168,7 @@ def main() -> int:
         if not vd:
             continue
         # A re-crop or rotation breaks normalised transfer; a pure rescale does not.
-        if abs((vd[0] / vd[1]) - (cd[0] / cd[1])) > MAX_ASPECT_DRIFT:
+        if not pc.aspect_transferable(vd, cd):
             skipped_aspect += 1
             continue
         considered += 1

--- a/scripts/experiments/pile/name_coverage.py
+++ b/scripts/experiments/pile/name_coverage.py
@@ -200,7 +200,7 @@ def main() -> int:
 
         # --- the overlap: score the proposal against COCO -------------------
         cd = cdims[cid]
-        if abs((vd[0] / vd[1]) - (cd[0] / cd[1])) > pc.MAX_ASPECT_DRIFT:
+        if not pc.aspect_transferable(vd, cd):
             skipped_aspect += 1
             continue
         # `coco_boxes` carries the whole COCO vocabulary (#3640); only the

--- a/scripts/experiments/pile/name_evidence.py
+++ b/scripts/experiments/pile/name_evidence.py
@@ -337,7 +337,7 @@ def main() -> int:
             continue
 
         cd = cdims[cid]
-        if abs((vd[0] / vd[1]) - (cd[0] / cd[1])) > pc.MAX_ASPECT_DRIFT:
+        if not pc.aspect_transferable(vd, cd):
             skipped_aspect += 1
             continue
         overlap_images += 1

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -2181,11 +2181,51 @@ SCALE_DEEP_N_NEG_SPARE = int(os.environ.get("VTS_SCALE_DEEP_N_NEG_SPARE", "300")
 
 
 #: How far a VG copy's aspect ratio may drift from the COCO original before its
-#: boxes are considered untransferable. Normalised coordinates survive a rescale
-#: but not a re-crop or a rotation, and 49 of the 51,497 overlaps are one of
-#: those -- small enough to ignore by accident, which is why it is a constant
-#: with a check rather than an assumption.
+#: boxes are considered untransferable, as a fraction of the COCO ratio.
+#: Normalised coordinates survive a rescale but not a re-crop or a rotation, and
+#: 49 of the 51,497 overlaps are one of those -- small enough to ignore by
+#: accident, which is why it is a constant with a check rather than an
+#: assumption.
+#:
+#: The threshold is *relative*, and only :func:`aspect_transferable` may read
+#: it: see that function for why a bare comparison against this number is a bug
+#: rather than a shorthand (#3657).
 MAX_ASPECT_DRIFT = float(os.environ.get("VTS_MAX_ASPECT_DRIFT", "0.01"))
+
+
+def aspect_drift(vg_wh: tuple[int, int], coco_wh: tuple[int, int]) -> float:
+    """How far a VG copy's aspect ratio has drifted from its COCO original.
+
+    Relative to COCO's ratio, because COCO's is the reference: the question is
+    whether COCO's normalised box still describes VG's pixels, so the drift is
+    measured as a fraction of the framing the box was recorded in.
+    """
+    coco_ratio = coco_wh[0] / coco_wh[1]
+    return abs((vg_wh[0] / vg_wh[1]) - coco_ratio) / coco_ratio
+
+
+def aspect_transferable(vg_wh: tuple[int, int], coco_wh: tuple[int, int]) -> bool:
+    """May a normalised COCO box transfer to the VG copy of the same image?
+
+    One implementation, so that anything asking "do these two copies frame the
+    same thing?" asks it the same way -- the treatment
+    :func:`pilebuild.loaders.vg_scale.band_for` got for the banding question.
+
+    It is a function rather than a bare ``> MAX_ASPECT_DRIFT`` because the two
+    readings of that constant are indistinguishable at a glance and were both
+    live: the loader divided by COCO's ratio, three analysis scripts compared an
+    absolute difference of ratios, and the disagreement ran in *both* directions
+    depending on orientation. A landscape 4:3 original (ratio 1.333) let the
+    loader tolerate |delta| up to 0.0133 where the scripts stopped at 0.0100; a
+    portrait 3:4 (0.75) had the loader stop at 0.0075 while the scripts still
+    allowed 0.0100. So the set of images the *measurement* called adjudicable
+    was not the set the *build* anchored, and it was skewed by orientation
+    rather than by a uniform margin (#3657).
+
+    The relative reading is the one that shipped the dataset, so it is the one
+    that survives; the absolute call sites moved to it.
+    """
+    return aspect_drift(vg_wh, coco_wh) <= MAX_ASPECT_DRIFT
 
 
 #: The coordinate space a correction box is recorded in. VG's and COCO's boxes

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -288,8 +288,7 @@ def anchor_to_coco(
         # VG's pixels at all. Those keep VG's own labels and stay unanchored
         # rather than importing a box that points at the wrong part of a
         # different framing.
-        vw, vh = dims[iid]
-        if abs((vw / vh) - (wh[0] / wh[1])) / (wh[0] / wh[1]) > pc.MAX_ASPECT_DRIFT:
+        if not pc.aspect_transferable(dims[iid], wh):
             n_reframed += 1
             continue
         box_dims[iid] = wh

--- a/scripts/experiments/pile/pool_contamination.py
+++ b/scripts/experiments/pile/pool_contamination.py
@@ -171,7 +171,7 @@ def main() -> int:
         vd, cd = vdims.get(iid), cdims.get(cid)
         if vd is None or cd is None:
             continue
-        if abs((vd[0] / vd[1]) - (cd[0] / cd[1])) / (cd[0] / cd[1]) > pc.MAX_ASPECT_DRIFT:
+        if not pc.aspect_transferable(vd, cd):
             reframed += 1
             continue
         adjudicable[iid] = cid

--- a/tests_lib/meta/test_pile_aspect_drift.py
+++ b/tests_lib/meta/test_pile_aspect_drift.py
@@ -1,0 +1,155 @@
+"""One aspect-drift guard, read one way, at every call site (#3657).
+
+Whether a COCO box may transfer to the VG copy of the same image is decided by
+comparing the two aspect ratios against ``pile_config.MAX_ASPECT_DRIFT``. That
+one constant was being read two ways:
+
+* the loader (``pilebuild/loaders/vg_scale.py``) divided by COCO's ratio, i.e.
+  took it as a **relative** drift;
+* ``coco_folds.py``, ``name_evidence.py``, ``name_coverage.py`` and
+  ``band_fold.py`` compared a bare difference of ratios, i.e. took it as an
+  **absolute** one.
+
+Neither is uniformly stricter: the two disagree in *both* directions depending
+on the original's orientation, so the set of images the measurement called
+adjudicable was not the set the build anchored, and the gap between them was
+skewed by orientation. The population is small -- the loader reports 49 of
+51,497 overlaps re-framed -- which is exactly why it wanted fixing before a
+number rested on it.
+
+These pin the resolution: the relative reading (the one that shipped the
+dataset) is the only one, it lives in ``pile_config.aspect_transferable``, and
+no call site may spell the comparison out again.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+
+@pytest.fixture(scope="module")
+def pc():
+    """``pile_config``, which is constants only -- ``setup_env()`` is explicit."""
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pile_config
+
+    return pile_config
+
+
+# --- the reading ---------------------------------------------------------
+
+#: A landscape 4:3 original against a VG copy 6 px wider. The ratios differ by
+#: 0.0125 absolute, which the old scripts rejected, and by 0.009375 relative,
+#: which the loader accepted: the build anchored this image and the measurement
+#: did not count it.
+_LANDSCAPE = ((646, 480), (640, 480))
+
+#: The exact mirror, at 3:4. The same two numbers swap roles -- 0.009375
+#: absolute, 0.0125 relative -- so here it is the *scripts* that were looser:
+#: they counted an image the build refused to anchor.
+_PORTRAIT = ((486, 640), (480, 640))
+
+
+def test_drift_is_relative_to_the_coco_ratio(pc):
+    """The denominator is COCO's ratio, because COCO's is the framing the box came in."""
+    assert pc.aspect_drift(*_LANDSCAPE) == pytest.approx(0.009375)
+    assert pc.aspect_drift(*_PORTRAIT) == pytest.approx(0.012500)
+
+
+def test_the_two_readings_disagreed_in_both_directions(pc):
+    """Not a uniform margin: which spelling is stricter depends on orientation."""
+    assert pc.MAX_ASPECT_DRIFT == pytest.approx(0.01), "the fixtures are sized to the shipped 0.01"
+
+    for vg_wh, coco_wh in (_LANDSCAPE, _PORTRAIT):
+        absolute = abs((vg_wh[0] / vg_wh[1]) - (coco_wh[0] / coco_wh[1]))
+        relative = pc.aspect_drift(vg_wh, coco_wh)
+        # Each fixture straddles the threshold, and does so the opposite way.
+        assert (absolute > pc.MAX_ASPECT_DRIFT) != (relative > pc.MAX_ASPECT_DRIFT)
+
+    # And the surviving reading is the loader's, on both.
+    assert pc.aspect_transferable(*_LANDSCAPE) is True
+    assert pc.aspect_transferable(*_PORTRAIT) is False
+
+
+def test_identical_framings_transfer_and_transposed_ones_do_not(pc):
+    """The two ends the guard exists for."""
+    assert pc.aspect_transferable((640, 480), (640, 480)) is True
+    # The re-framed copies the loader's comment names: VG 500x375 against COCO
+    # 375x500 is a rotation, and COCO's box describes none of VG's pixels.
+    assert pc.aspect_transferable((500, 375), (375, 500)) is False
+
+
+def test_the_threshold_is_a_ceiling_not_a_floor(pc):
+    """``> MAX_ASPECT_DRIFT`` rejected; a drift at the threshold is kept.
+
+    Sampled just either side rather than exactly on it: no pair of dimensions
+    puts the quotient exactly on 0.01 in binary, so an "exact boundary" fixture
+    would be pinning a rounding accident rather than the comparison.
+    """
+    coco_wh = (640, 480)
+    coco_ratio = coco_wh[0] / coco_wh[1]
+    for fraction, transfers in ((0.999, True), (1.001, False)):
+        vg_ratio = coco_ratio * (1 + pc.MAX_ASPECT_DRIFT * fraction)
+        assert pc.aspect_transferable((vg_ratio, 1.0), coco_wh) is transfers
+
+
+def test_it_reproduces_the_arithmetic_that_shipped_the_dataset(pc):
+    """The loader's former expression, verbatim, over a spread of framings.
+
+    The relative reading is not a coin toss between two defensible forms: it is
+    the one the built pile was anchored under, so the predicate has to agree
+    with it everywhere, not merely near the threshold.
+    """
+    coco_dims = [(640, 480), (480, 640), (500, 375), (375, 500), (1024, 1024), (1280, 720)]
+    vg_dims = [(w + d, h) for w, h in coco_dims for d in (-40, -6, 0, 6, 40)]
+    for wh in coco_dims:
+        for vw, vh in vg_dims:
+            shipped = abs((vw / vh) - (wh[0] / wh[1])) / (wh[0] / wh[1]) > pc.MAX_ASPECT_DRIFT
+            assert pc.aspect_transferable((vw, vh), wh) is (not shipped), f"{(vw, vh)} vs {wh}"
+
+
+# --- one implementation --------------------------------------------------
+
+
+def _files_naming_the_constant() -> dict[str, list[int]]:
+    """Every ``scripts/experiments/pile`` file that reads ``MAX_ASPECT_DRIFT``.
+
+    Read from the AST rather than the text so a mention in a comment or a
+    docstring -- of which the fix left several, deliberately -- does not count
+    as a second implementation.
+    """
+    hits: dict[str, list[int]] = {}
+    for path in sorted(_PILE_DIR.rglob("*.py")):
+        if path.name == "pile_config.py":
+            continue  # the definition, and the one function allowed to read it
+        for node in ast.walk(ast.parse(path.read_text())):
+            named = (isinstance(node, ast.Name) and node.id == "MAX_ASPECT_DRIFT") or (
+                isinstance(node, ast.Attribute) and node.attr == "MAX_ASPECT_DRIFT"
+            )
+            if named:
+                hits.setdefault(str(path.relative_to(_PILE_DIR)), []).append(node.lineno)
+    return hits
+
+
+def test_no_call_site_reads_the_constant_directly():
+    """A second reading of the threshold is a second guard, however it is spelled.
+
+    This is the check that keeps the fix from decaying: reconciling six call
+    sites once is worth nothing if the seventh is written inline, and an inline
+    comparison is indistinguishable at a glance from the correct one -- which is
+    how the split lasted four call sites and two orientations.
+    """
+    hits = _files_naming_the_constant()
+    assert not hits, (
+        "these files read pile_config.MAX_ASPECT_DRIFT directly instead of asking "
+        f"pile_config.aspect_transferable(vg_wh, coco_wh): {hits}. The constant is "
+        "a *relative* drift; comparing a bare difference of ratios against it is "
+        "the #3657 bug, and it disagrees with the build by orientation."
+    )

--- a/tests_lib/meta/test_pile_aspect_drift.py
+++ b/tests_lib/meta/test_pile_aspect_drift.py
@@ -130,9 +130,12 @@ def _files_naming_the_constant() -> dict[str, list[int]]:
         if path.name == "pile_config.py":
             continue  # the definition, and the one function allowed to read it
         for node in ast.walk(ast.parse(path.read_text())):
-            named = (isinstance(node, ast.Name) and node.id == "MAX_ASPECT_DRIFT") or (
-                isinstance(node, ast.Attribute) and node.attr == "MAX_ASPECT_DRIFT"
-            )
+            if isinstance(node, ast.Name):
+                named = node.id == "MAX_ASPECT_DRIFT"
+            elif isinstance(node, ast.Attribute):
+                named = node.attr == "MAX_ASPECT_DRIFT"
+            else:
+                continue
             if named:
                 hits.setdefault(str(path.relative_to(_PILE_DIR)), []).append(node.lineno)
     return hits


### PR DESCRIPTION
`pile_config.MAX_ASPECT_DRIFT` (0.01) decides whether a COCO box may transfer to the VG copy of the same image. It was being read **two ways against the same constant**: the loader divided by COCO's ratio (a *relative* drift), while the analysis scripts compared a bare difference of ratios (an *absolute* one).

Neither is uniformly stricter — they disagree in **both** directions depending on orientation:

| COCO original | loader tolerates \|Δ\| up to | scripts stopped at | stricter |
|---|---|---|---|
| landscape 4:3 (1.333) | 0.0133 | 0.0100 | the scripts |
| portrait 3:4 (0.750) | 0.0075 | 0.0100 | the loader |

So the set of images the *measurement* called adjudicable was not the set the *build* anchored, and the gap between them was skewed by orientation rather than being a uniform margin.

## What changed

`pile_config.aspect_transferable(vg_wh, coco_wh)` is now the only implementation, sitting next to the constant — the treatment `band_for` got when it was split out of `band_candidates`, so that anything asking "do these two copies frame the same thing?" asks one function. `aspect_drift` exposes the quantity behind it.

**The relative reading survives**, because it is the one that actually shipped the dataset.

All **six** call sites route through it. The issue names four; the sweep found two more:

| Call site | Was |
|---|---|
| `pilebuild/loaders/vg_scale.py` | relative |
| `coco_folds.py` | absolute |
| `name_evidence.py` | absolute |
| `name_coverage.py` | absolute |
| `band_fold.py` | absolute — **not in the issue** |
| `pool_contamination.py` | relative — **not in the issue** |

`coco_folds.py`'s module-level `MAX_ASPECT_DRIFT` alias is unused once its call site moves, and goes with it. `check_review_coverage.py`'s documented decision *not* to apply the filter is untouched — it is a deliberate, explained superset.

## Tests

`tests_lib/meta/test_pile_aspect_drift.py`:

- the drift is relative to COCO's ratio;
- the two old spellings straddled the threshold **in opposite directions** — pinned with a mirrored pair of fixtures (646×480 vs 640×480 and 486×640 vs 480×640, whose absolute and relative drifts are 0.0125 / 0.009375 and exactly swap roles);
- identical framings transfer, transposed ones do not;
- the threshold is a ceiling, not a floor (sampled either side: no pair of dimensions lands exactly on 0.01 in binary, so an "exact boundary" fixture would pin a rounding accident);
- the predicate reproduces the loader's former arithmetic verbatim over a spread of framings — the relative reading isn't a coin toss between two defensible forms, it's what the built pile was anchored under;
- **a source-level gate**: outside `pile_config.py`, nothing under `scripts/experiments/pile/` may name `MAX_ASPECT_DRIFT` at all. Read from the AST, so the several deliberate prose mentions don't count. Reconciling six call sites once is worth nothing if the seventh gets written inline, and an inline comparison is indistinguishable at a glance from the correct one — which is how this split lasted four call sites and two orientations.

## Behavioural effect

No published number moves much: the loader reports 49 re-framed of 51,497 overlaps and the loader's own behaviour is unchanged. What changes is that the four absolute scripts now adjudicate exactly the population the build anchors. That is the point — it was worth fixing before a number rested on it.

`./run-tests.sh` full run green: 10,905 passed, all gates OK.

Closes #3657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KC4gzHrfQeQpuzi5SRiYF

---
_Generated by [Claude Code](https://claude.ai/code/session_013KC4gzHrfQeQpuzi5SRiYF)_