### PR TITLE
Report what `anchor_to_coco` does to the bands it overwrites

### DIFF
--- a/scripts/experiments/pile/audit_band_drift.py
+++ b/scripts/experiments/pile/audit_band_drift.py
@@ -138,7 +138,9 @@ def main() -> int:
     vg_labels = {iid: {n: list(bs) for n, bs in by_name.items()} for iid, by_name in labels.items()}
     withheld = lift_ambiguous(vg_labels, pc.SCALE_VG_AMBIGUOUS, set())
 
-    box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, n_anchored, n_reframed, _reband = anchor_to_coco(
+        labels, dims, coco_of, truth, ca.COCO_DIMS, wanted
+    )
     log(f"  labels: {len(labels)} VG images, {n_anchored} anchored to COCO, {n_reframed} skipped as re-framed")
     if not exhaustive:
         raise SystemExit("no image anchored to COCO; there is no control group to measure against")

--- a/scripts/experiments/pile/band_fold.py
+++ b/scripts/experiments/pile/band_fold.py
@@ -313,9 +313,9 @@ def phase_supply(anchor: Path) -> dict:
         labels = vs.read_vg_labels(records, paths, dims, wanted_vg)
         if mode == LEGACY:
             folded, contested = vs.canonicalise(labels, pc.SCALE_VG_NAMES)
-            box_dims, exhaustive, _, _ = vs.anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+            box_dims, exhaustive, *_ = vs.anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
         else:
-            box_dims, exhaustive, _, _ = vs.anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+            box_dims, exhaustive, *_ = vs.anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
             folded, contested = vs.canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, mode)
         unbanded = vs.apply_corrections(labels, corrections, box_dims, exhaustive)
         unbanded |= vs.lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)

--- a/scripts/experiments/pile/exact_supply.py
+++ b/scripts/experiments/pile/exact_supply.py
@@ -42,7 +42,7 @@ for label, (classes, table) in GROUPS.items():
     labels = read_vg_labels(records, paths, dims, wanted)
     canonicalise(labels, dict(vg_names))
     truth = coco_truth(instances, set(classes))
-    box_dims, exhaustive, _n, _r = anchor_to_coco(labels, dims, coco_of, truth, coco_anchor.COCO_DIMS, set(classes))
+    box_dims, exhaustive, *_ = anchor_to_coco(labels, dims, coco_of, truth, coco_anchor.COCO_DIMS, set(classes))
     supply, _boxes, _clean = band_candidates(labels, box_dims, set(), classes=classes)
 
     print(f"\n=== {label} ===")

--- a/scripts/experiments/pile/make_class_slate.py
+++ b/scripts/experiments/pile/make_class_slate.py
@@ -139,7 +139,7 @@ def main() -> int:
     # `coco_truth` fills this as a side effect of reading the instances files,
     # so it is only populated after the call above -- read it off the module
     # rather than binding the name at import time.
-    box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(
+    box_dims, exhaustive, n_anchored, n_reframed, _reband = anchor_to_coco(
         labels, dims, coco_of, truth, coco_anchor.COCO_DIMS, set(classes)
     )
     log(f"anchored {n_anchored} images to COCO ({n_reframed} skipped as re-framed copies)")

--- a/scripts/experiments/pile/measure_supply.py
+++ b/scripts/experiments/pile/measure_supply.py
@@ -63,7 +63,9 @@ def main() -> None:
     # evidence is a name that means two things. The reason this matters beyond
     # tidiness is that #3547 sized SCALE_DEEP_N_POS off this script's output.
     labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
-    box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, n_anchored, n_reframed, _reband = anchor_to_coco(
+        labels, dims, coco_of, truth, ca.COCO_DIMS, wanted
+    )
     folded, contested = canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, pc.SCALE_FOLD_MODE)
     unbanded = apply_corrections(labels, corrections, box_dims, exhaustive)
     unbanded |= lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)

--- a/scripts/experiments/pile/negpool_coverage.py
+++ b/scripts/experiments/pile/negpool_coverage.py
@@ -102,7 +102,7 @@ def main() -> None:
 
     corrections = load_corrections()
     labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
-    box_dims, exhaustive, _n_anchored, _n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, *_ = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
     # Captured before `apply_corrections` widens `exhaustive`, exactly as the
     # loader does it. Using the widened set here would stratify on a different
     # fact from the build and quietly answer a different question.

--- a/scripts/experiments/pile/negpool_supply.py
+++ b/scripts/experiments/pile/negpool_supply.py
@@ -83,7 +83,7 @@ def main() -> None:
 
     corrections = load_corrections()
     labels = read_vg_labels(records, paths, dims, wanted_vg)
-    box_dims, exhaustive, _n_anchored, _n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, *_ = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
     canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, pc.SCALE_FOLD_MODE)
     unbanded = apply_corrections(labels, corrections, box_dims, exhaustive)
     unbanded |= lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -236,6 +236,15 @@ def lift_ambiguous(
     return pairs
 
 
+#: The four things the anchor can do to a ``(image, class)`` pair whose VG boxes
+#: put the image in a band -- the keys of each class's row in
+#: :func:`anchor_to_coco`'s ``rebanded`` ledger, in the order the log prints
+#: them. ``absent`` is not a fifth kind of band change but its own fact: COCO
+#: looked at the image exhaustively and the class is not there, so the pair
+#: leaves the class's cells as a *negative* rather than moving between them.
+REBAND_OUTCOMES = ("kept", "moved", "unbanded", "absent")
+
+
 def anchor_to_coco(
     labels: dict[int, dict[str, list[list[float]]]],
     dims: dict[int, tuple[int, int]],
@@ -243,11 +252,11 @@ def anchor_to_coco(
     truth: dict[int, dict[str, list[list[float]]]],
     coco_dims: dict[int, tuple[int, int]],
     wanted: set[str],
-) -> tuple[dict[int, tuple[int, int]], set[int], int, int]:
+) -> tuple[dict[int, tuple[int, int]], set[int], int, int, dict[str, dict[str, int]]]:
     """Replace VG's labels with COCO's wherever COCO annotates the same image.
 
-    Returns ``(box_dims, exhaustive, n_anchored, n_reframed)`` and edits
-    *labels* in place.
+    Returns ``(box_dims, exhaustive, n_anchored, n_reframed, rebanded)`` and
+    edits *labels* in place.
 
     VG's own annotation is not exhaustive: measured against COCO its recall over
     C is 0.61, and 1.35% of the images it treats as negatives actually hold the
@@ -268,9 +277,37 @@ def anchor_to_coco(
     COCO box normalised by the VG file's dimensions lands in the wrong place and
     with the wrong extent. Every box is normalised by the dimensions of the
     image its coordinates were measured on.
+
+    ``rebanded`` is what that replacement did, per class, over the pairs where
+    **VG's own spelling put the image in a band** -- one row of
+    :data:`REBAND_OUTCOMES` counts each. It is the anchor's half of the ledger
+    :func:`canonicalise` prints for the fold, and it is the larger half by eight
+    times: measured in #3637, over the 11,156 such pairs the anchor keeps the
+    band on 67%, MOVES it on 6.2%, UN-BANDS the image on 17%, and finds the
+    class absent on 10% -- so a third of the anchored half's band memberships
+    change on every build, and the line above this one has only ever said how
+    many images the pass touched (#3659).
+
+    That is not a defect to be fixed: COCO's boxes are the exhaustive reference
+    the banding rule was validated against, and #3637's finding is that they are
+    right where VG's disagree. It is a defect to leave *unreported*, because a
+    class whose anchored half is mostly un-banded is a class whose VG spelling
+    frames a different thing from COCO's -- a signal
+    :data:`pile_config.SCALE_VG_NAMES_AUDITED` cannot give, since it measures
+    the spellings against each other rather than against a band.
+
+    Counting has to read ``band_for`` over VG's boxes BEFORE the replacement
+    overwrites them, which is why it happens here rather than in a later pass
+    reading the result: after the assignment below, VG's reading of an anchored
+    image is gone. This is the same rule as the fold's -- count where the work
+    lands, not where it is attempted -- read from the other end.
+    ``scripts/experiments/pile/band_fold.py --phase truth`` computes the same
+    four numbers off the raw source, so the two can be checked against each
+    other.
     """
     box_dims: dict[int, tuple[int, int]] = dict(dims)
     exhaustive: set[int] = set()
+    rebanded: dict[str, dict[str, int]] = {c: dict.fromkeys(REBAND_OUTCOMES, 0) for c in sorted(wanted)}
     n_anchored = 0
     n_reframed = 0
     for iid in labels:
@@ -293,6 +330,26 @@ def anchor_to_coco(
             n_reframed += 1
             continue
         box_dims[iid] = wh
+        # Read VG's verdict while it still exists. Only the class's OWN spelling
+        # is consulted, and that is not an omission: the fold runs after this
+        # pass and is discarded on an anchored image, so an alias box has no
+        # effect here to count. Pairs VG does not band are skipped rather than
+        # counted as a fifth outcome -- the question is what the replacement does
+        # to a band that exists, and an image VG left scattered has none to lose.
+        for cls in wanted & labels[iid].keys():
+            own = labels[iid][cls]
+            if not own:
+                continue
+            was = band_for(own, vw, vh)
+            if was not in pc.BOX_BANDS:
+                continue
+            now = band_for(ref[cls], *wh) if ref.get(cls) else None
+            if now is None:
+                rebanded[cls]["absent"] += 1
+            elif now not in pc.BOX_BANDS:
+                rebanded[cls]["unbanded"] += 1
+            else:
+                rebanded[cls]["moved" if now != was else "kept"] += 1
         # COCO's annotation REPLACES VG's for this image rather than merging
         # with it: the two disagree in both directions, and only one of them is
         # exhaustive. Keeping VG's extra boxes would reintroduce exactly the
@@ -300,7 +357,7 @@ def anchor_to_coco(
         labels[iid] = {name: bs for name, bs in ref.items() if name in wanted}
         exhaustive.add(iid)
         n_anchored += 1
-    return box_dims, exhaustive, n_anchored, n_reframed
+    return box_dims, exhaustive, n_anchored, n_reframed, rebanded
 
 
 def apply_corrections(
@@ -794,7 +851,9 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     log(f"  {len(coco_of)} VG images carry a coco_id; {len(corrections)} human verdicts on file")
 
     labels = read_vg_labels(records, paths, dims, wanted_vg)
-    box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, n_anchored, n_reframed, rebanded = anchor_to_coco(
+        labels, dims, coco_of, truth, ca.COCO_DIMS, wanted
+    )
     # Taken HERE, before `apply_corrections` folds every reviewed image into
     # `exhaustive`. The two are different claims and #3670 turns on the
     # difference: `exhaustive` says "someone or something answered for this
@@ -822,6 +881,21 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
         f"  labels: {len(labels)} VG images, {n_anchored} repaired from COCO, "
         f"{len(exhaustive)} with a verified pair, {n_reframed} skipped as re-framed copies"
     )
+    if any(any(row.values()) for row in rebanded.values()):
+        # The anchor's half of the same ledger, and the larger half: it changes a
+        # third of the anchored images' band memberships against the fold's 2.1%
+        # off-COCO, and said nothing about it for a release (#3659). Read a class
+        # by the share of its row that is NOT `kept`: a class mostly un-banded
+        # here has a VG spelling that frames a different thing from COCO's, which
+        # is a defect in the name and not in the band.
+        totals = {k: sum(row[k] for row in rebanded.values()) for k in REBAND_OUTCOMES}
+        log(
+            "  COCO's boxes re-band the anchored half as `class "
+            + "/".join(REBAND_OUTCOMES)
+            + "` -- VG's own spelling banded these images and the anchor overwrote it: "
+            + ", ".join(f"{c}={'/'.join(str(row[k]) for k in REBAND_OUTCOMES)}" for c, row in sorted(rebanded.items()))
+            + f"; all classes={'/'.join(str(totals[k]) for k in REBAND_OUTCOMES)}"
+        )
     if folded:
         # Both halves of the ledger on one line. A class whose fold contests more
         # images than it repairs is being made worse by its own name table, and

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale_deep.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale_deep.py
@@ -176,7 +176,12 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     # `bicycle` negative while `vg_scale` excludes it, which is precisely the
     # "only depth changed" premise breaking.
     labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
-    box_dims, exhaustive, n_anchored, n_reframed = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    # The re-banding ledger is `vg_scale.load`'s to print (#3659): deep shares
+    # this pass and the shallow cell's labels, so the two builds' rows would be
+    # identical and the second copy would only invite a reader to diff them.
+    box_dims, exhaustive, n_anchored, n_reframed, _reband = anchor_to_coco(
+        labels, dims, coco_of, truth, ca.COCO_DIMS, wanted
+    )
     # Before corrections widen it -- see `vg_scale.load`. Deep's own pool is not
     # stratified on it (#3690 pins deep to the pre-#3670 construction), but the
     # medias carry the flag so a reader of either dataset can ask the same

--- a/scripts/experiments/pile/replay_evaluable.py
+++ b/scripts/experiments/pile/replay_evaluable.py
@@ -105,7 +105,7 @@ def main() -> int:
         coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
 
     labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
-    box_dims, exhaustive, _na, _nr = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, *_ = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
     coco_scored = set(exhaustive)
     canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, pc.SCALE_FOLD_MODE)
     apply_corrections(labels, corrections, box_dims, exhaustive)

--- a/scripts/experiments/pile/replay_selection.py
+++ b/scripts/experiments/pile/replay_selection.py
@@ -150,7 +150,7 @@ def main() -> int:
         coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
 
     labels = read_vg_labels(records, paths, dims, pc.scale_vg_wanted())
-    box_dims, exhaustive, _na, _nr = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
+    box_dims, exhaustive, *_ = anchor_to_coco(labels, dims, coco_of, truth, ca.COCO_DIMS, wanted)
     coco_scored = set(exhaustive)
     canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, pc.SCALE_FOLD_MODE)
     unbanded = apply_corrections(labels, corrections, box_dims, exhaustive)

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -130,7 +130,7 @@ class TestAnchorToCoco:
 
     def test_anchored_image_takes_cocos_labels_and_cocos_pixel_space(self, vgs, pc):
         labels = {7: {"dog": [[1.0, 1.0, 2.0, 2.0]]}}
-        box_dims, exhaustive, n_anchored, n_reframed = vgs.anchor_to_coco(
+        box_dims, exhaustive, n_anchored, n_reframed, _reband = vgs.anchor_to_coco(
             labels,
             dims={7: (500, 375)},
             coco_of={7: 100},
@@ -147,7 +147,7 @@ class TestAnchorToCoco:
     def test_reframed_copy_keeps_vgs_own_labels(self, vgs):
         """A transposed copy is a different framing; COCO's box does not describe it."""
         labels = {7: {"dog": [[1.0, 1.0, 2.0, 2.0]]}}
-        box_dims, exhaustive, n_anchored, n_reframed = vgs.anchor_to_coco(
+        box_dims, exhaustive, n_anchored, n_reframed, _reband = vgs.anchor_to_coco(
             labels,
             dims={7: (375, 500)},  # transposed against COCO's 640x480
             coco_of={7: 100},
@@ -173,10 +173,161 @@ class TestAnchorToCoco:
 
     def test_unanchored_images_keep_vg_dims(self, vgs):
         labels = {7: {}, 8: {}}
-        box_dims, _, n_anchored, _ = vgs.anchor_to_coco(
+        box_dims, _, n_anchored, *_ = vgs.anchor_to_coco(
             labels, dims={7: (500, 375), 8: (600, 400)}, coco_of={}, truth={}, coco_dims={}, wanted={"bus"}
         )
         assert box_dims == {7: (500, 375), 8: (600, 400)} and n_anchored == 0
+
+
+def _square(frac: float, W: int, H: int) -> list[float]:
+    """A box covering *frac* of a *W* x *H* frame, in that frame's pixels."""
+    side = (frac * W * H) ** 0.5
+    return [0.0, 0.0, side, side]
+
+
+class TestAnchorRebandLedger:
+    """What the replacement does to a band VG's own spelling had already given.
+
+    The anchor overwrites VG's labels wholesale on the ~48% of VG that COCO
+    annotates, and a third of that half's band memberships change when it does:
+    over the 11,156 pairs VG bands there, 67% keep the band, 6.2% move, 17% leave
+    every band and 10% turn out not to hold the class at all (#3637). The build
+    reported none of it -- only how many images the pass touched -- which is
+    #3659, and the same defect `canonicalise`'s ``contested`` was filed for at
+    an eighth of the size.
+
+    Correctness is not what these pin: COCO's boxes are the exhaustive reference
+    the banding rule was validated against, so the anchor's answer is the right
+    one. What they pin is that the four outcomes stay **told apart**, and that
+    each band is read in the pixel space its own boxes were measured in -- VG
+    ships downscaled copies, so a band read in the wrong frame is off by the
+    square of the scale factor and lands in a neighbouring band without
+    complaint.
+    """
+
+    #: A VG frame and a COCO copy of it nine times its area, so a band read in
+    #: the wrong one of the two is a *different* band rather than the same one.
+    VG_WH = (400, 400)
+    COCO_WH = (1200, 1200)
+
+    def _anchor(self, vgs, vg_boxes: dict, coco_boxes: dict, wanted=("bus", "dog")):
+        labels = {7: dict(vg_boxes)}
+        *_, rebanded = vgs.anchor_to_coco(
+            labels,
+            dims={7: self.VG_WH},
+            coco_of={7: 100},
+            truth={100: dict(coco_boxes)},
+            coco_dims={100: self.COCO_WH},
+            wanted=set(wanted),
+        )
+        return rebanded
+
+    def _vg(self, frac: float) -> list[list[float]]:
+        return [_square(frac, *self.VG_WH)]
+
+    def _coco(self, frac: float) -> list[list[float]]:
+        return [_square(frac, *self.COCO_WH)]
+
+    def test_a_kept_band_is_counted_as_kept(self, vgs):
+        reband = self._anchor(vgs, {"bus": self._vg(0.01)}, {"bus": self._coco(0.01)})
+        assert reband["bus"] == {"kept": 1, "moved": 0, "unbanded": 0, "absent": 0}
+
+    def test_a_band_change_is_counted_as_moved(self, vgs):
+        """Both boxes band; they disagree about which band."""
+        reband = self._anchor(vgs, {"bus": self._vg(0.01)}, {"bus": self._coco(0.3)})
+        assert vgs.band_for(self._vg(0.01), *self.VG_WH) == "medium"
+        assert vgs.band_for(self._coco(0.3), *self.COCO_WH) == "large"
+        assert reband["bus"] == {"kept": 0, "moved": 1, "unbanded": 0, "absent": 0}
+
+    def test_leaving_every_band_is_counted_as_unbanded(self, vgs):
+        """The 17%: COCO's boxes scatter, or outgrow a region, where VG's banded."""
+        oversize = self._anchor(vgs, {"bus": self._vg(0.01)}, {"bus": self._coco(0.9)})
+        assert oversize["bus"]["unbanded"] == 1
+        # Two instances too far apart to be one region -- the other way out of
+        # every band, and the one an exhaustive annotation reaches most often.
+        w, h = self.COCO_WH
+        scattered = self._anchor(
+            vgs,
+            {"bus": self._vg(0.01)},
+            {"bus": [[0.0, 0.0, 20.0, 20.0], [w - 20.0, h - 20.0, float(w), float(h)]]},
+        )
+        assert scattered["bus"]["unbanded"] == 1
+
+    def test_a_class_coco_does_not_hold_is_counted_as_absent(self, vgs):
+        """Not a band change: the pair leaves the class's cells as a negative."""
+        reband = self._anchor(vgs, {"bus": self._vg(0.01)}, {"dog": self._coco(0.01)})
+        assert reband["bus"] == {"kept": 0, "moved": 0, "unbanded": 0, "absent": 1}
+
+    def test_cocos_band_is_read_in_cocos_pixel_space(self, vgs):
+        """VG's copy is downscaled, so the same pixel box is a different band.
+
+        The COCO box below covers 1% of the COCO frame (medium) and 9% of the VG
+        frame (large). Reading it against ``dims`` rather than ``coco_dims``
+        reports a move that the build never makes -- the same off-by-a-scale-
+        factor that makes ``box_dims`` the whole reason this pass returns
+        anything.
+        """
+        coco_box = _square(0.01, *self.COCO_WH)
+        assert vgs.band_for([coco_box], *self.COCO_WH) == "medium"
+        assert vgs.band_for([coco_box], *self.VG_WH) == "large"
+        reband = self._anchor(vgs, {"bus": self._vg(0.01)}, {"bus": [coco_box]})
+        assert reband["bus"]["kept"] == 1
+
+    def test_vgs_band_is_read_in_vgs_pixel_space(self, vgs):
+        """The same trap from the other side: VG's boxes are in VG's frame."""
+        vg_box = _square(0.09, *self.VG_WH)
+        assert vgs.band_for([vg_box], *self.VG_WH) == "large"
+        assert vgs.band_for([vg_box], *self.COCO_WH) == "medium"
+        reband = self._anchor(vgs, {"bus": [vg_box]}, {"bus": self._coco(0.09)})
+        assert reband["bus"]["kept"] == 1
+
+    def test_a_pair_vg_does_not_band_is_not_counted_at_all(self, vgs):
+        """There is no band to keep, move or lose, so it is not a fifth outcome."""
+        w, h = self.VG_WH
+        scattered = [[0.0, 0.0, 20.0, 20.0], [w - 20.0, h - 20.0, float(w), float(h)]]
+        assert vgs.band_for(scattered, w, h) == vgs.SCATTERED
+        reband = self._anchor(vgs, {"bus": scattered}, {"bus": self._coco(0.01)})
+        assert sum(reband["bus"].values()) == 0
+        # Nor does a class VG never saw: the ledger's denominator is what VG
+        # banded, not what COCO holds.
+        assert sum(reband["dog"].values()) == 0
+
+    def test_only_the_classes_own_spelling_is_read(self, vgs):
+        """Aliases are folded after this pass and discarded here, so they count nothing.
+
+        `read_vg_labels` reads wider than *C* (#3605), so an alias spelling is
+        sitting in ``labels`` when the anchor runs. Counting it would report a
+        band the build never derives: `canonicalise` runs afterwards and its
+        merge is thrown away on an anchored image.
+        """
+        reband = self._anchor(
+            vgs,
+            {"bus": self._vg(0.01), "minibus": self._vg(0.3)},
+            {"bus": self._coco(0.01)},
+        )
+        assert reband["bus"]["kept"] == 1 and "minibus" not in reband
+
+    def test_an_unanchored_image_contributes_nothing(self, vgs):
+        """A re-framed copy keeps VG's labels, so nothing re-bands there."""
+        labels = {7: {"bus": [_square(0.01, 400, 400)]}}
+        *_, rebanded = vgs.anchor_to_coco(
+            labels,
+            dims={7: (375, 500)},  # transposed against COCO's 400x300
+            coco_of={7: 100},
+            truth={100: {"bus": [_square(0.3, 400, 300)]}},
+            coco_dims={100: (400, 300)},
+            wanted={"bus"},
+        )
+        assert sum(rebanded["bus"].values()) == 0
+
+    def test_every_wanted_class_gets_a_row(self, vgs):
+        """A class with an all-zero row is a fact about the class, not a gap."""
+        reband = self._anchor(vgs, {}, {}, wanted=("bus", "dog", "clock"))
+        assert sorted(reband) == ["bus", "clock", "dog"]
+        assert all(sorted(row) == sorted(vgs.REBAND_OUTCOMES) for row in reband.values())
+
+    def test_the_ledgers_outcomes_are_the_documented_four(self, vgs):
+        assert vgs.REBAND_OUTCOMES == ("kept", "moved", "unbanded", "absent")
 
 
 class TestBandFor:


### PR DESCRIPTION
Closes #3659

`anchor_to_coco` replaces VG's labels with COCO's on the ~48% of VG that COCO annotates, and **a third of that half's band memberships change when it does**. Measured in #3637 over the 11,156 pairs VG's own spelling bands there: 67% keep the band, 6.2% move, 17% leave every band, 10% turn out not to hold the class at all. The build's log said only `N repaired from COCO` — how many images the pass touched, and nothing about what it did to them.

This is #3637's defect at eight times the magnitude and in the same shape. That issue made `canonicalise` return `(folded, contested)` and print both per class; the anchor is the larger of the two and was unreported for the same reason — nobody had counted it.

## What changed

- **`anchor_to_coco` returns a fifth value**, `rebanded`: a per-class ledger over the pairs where VG's own spelling put the image in a band, counting the four outcomes named in `REBAND_OUTCOMES` — `kept` / `moved` / `unbanded` / `absent`. `absent` is not a fifth kind of band change but its own fact: COCO looked exhaustively and the class is not there, so the pair leaves the class's cells as a negative rather than moving between them.
- **`vg_scale.load` prints it on one line beside the fold's**, per class plus an all-classes total:

  ```
    COCO's boxes re-band the anchored half as `class kept/moved/unbanded/absent` -- VG's own
    spelling banded these images and the anchor overwrote it: bicycle=512/40/160/88,
    bus=700/60/170/100, clock=0/0/0/0; all classes=1212/100/330/188
  ```

- **Counting happens inside the pass**, because it has to read `band_for` over VG's boxes *before* the replacement overwrites them — afterwards VG's reading of an anchored image is gone. That is #3637's "count where the work lands" rule read from the other end, and the docstring says so.
- **Each band is read in the pixel space its own boxes were measured in.** VG ships downscaled copies of the COCO originals, so a band read in the wrong frame is off by the square of the scale factor and lands in a neighbouring band without complaint. Both directions of that trap are pinned by tests.
- Callers that only want `box_dims` / `exhaustive` now unpack with `*_`; `vg_scale_deep` takes the ledger and drops it, with a comment saying why (it shares this pass and the shallow cell's labels, so its rows would be identical).

## What did not change

**Correctness is not in question**, and nothing about the built dataset moves — this is reporting only. COCO's boxes are the exhaustive reference the banding rule was validated against, and #3637's whole finding is that they are right where VG's disagree. What the ledger adds is a signal `SCALE_VG_NAMES_AUDITED` cannot give: a class whose anchored half is mostly un-banded has a VG spelling that frames a different thing from COCO's, which is a defect in the name rather than in the band.

## Tests

Eleven new tests in `tests_lib/meta/test_pile_vg_scale.py` (`TestAnchorRebandLedger`): the four outcomes told apart, both routes out of every band (oversize and scattered), a pair VG does not band counted as nothing at all, aliases not read (the fold runs later and is discarded here), an unanchored image contributing nothing, and every wanted class getting a row. The two pixel-space tests were checked by mutation — swapping either frame for the other fails them.

`scripts/experiments/pile/band_fold.py --phase truth` computes the same four numbers off the raw source, so the implementation has a reference to check itself against.

Full `./run-tests.sh`: **10,910 passed**, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r193UUVho9GNtAkUt2ZCQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011r193UUVho9GNtAkUt2ZCQ)_