### PR TITLE
Read the `not-an-experiment` marker's reason instead of only its prefix

### DIFF
--- a/.claude/hooks/require-issue-labels.py
+++ b/.claude/hooks/require-issue-labels.py
@@ -69,8 +69,26 @@ fails closed would wedge every unrelated GitHub call.
 
 Escape hatch for the `experiment` heuristic (see `_looks_like_an_experiment`):
 put `<!-- not-an-experiment: <reason> -->` in the issue body. It renders as
-nothing on GitHub, greps cleanly, and forces the reason to be stated rather
-than letting the check be dodged by rewording the body.
+nothing on GitHub and greps cleanly.
+
+**The reason is read** (see `_reason_problem`). For its first weeks the marker
+matched on its prefix alone, so the text after the colon was never looked at by
+anything -- it forced a reason to be *typed*, not to be *true*. Issue #3708
+counted the result: four markers in three days had to be corrected by hand, and
+in every one of them the sentence that disproves the marker was inside the
+marker itself. #3683 promised "no GPU, no sweep" while closing on
+`build_pile.py --provenance` over a newly built cell; #3693 closed on
+"confirming the submitted job imports THAT worktree"; #3694 closed on `cat`ing
+a file that exists only on the GRID plus one submitted cpu job. So a reason
+that describes a run is now refused, and the refusal quotes the offending
+phrase back.
+
+That costs a wrongly-blocked issue one sentence of rewording at filing time. A
+wrongly-passed one costs a whole session: `label:experiment` is a *scheduling*
+queue, so a false marker puts GRID-only work into the pick-up-now queue, and
+the session that takes it gets as far as the acceptance check and stops -- or
+invents the missing half. The gate is deliberately biased toward the cheap
+failure.
 """
 
 from __future__ import annotations
@@ -174,7 +192,68 @@ GH_CLOSE_VALUE_FLAGS = frozenset({"-c", "--comment", "-r", "--reason", "-R", "--
 GH_LOOKUP_TIMEOUT_ENV = "VTSEARCH_GH_LOOKUP_TIMEOUT"
 GH_LOOKUP_TIMEOUT_DEFAULT = 5.0
 
-OPT_OUT = re.compile(r"<!--\s*not-an-experiment\s*:", re.IGNORECASE)
+# The marker, with its reason captured. Non-greedy up to the terminator rather
+# than `[^>]*`, so a reason containing `>` (a shell redirect, an arrow, a
+# quoted diff line) still parses as a marker instead of silently ceasing to be
+# one -- a marker the hook cannot see is reported as a missing marker, which is
+# the one denial message a filer who wrote one cannot act on.
+OPT_OUT = re.compile(r"<!--\s*not-an-experiment\s*:(?P<reason>.*?)-->", re.IGNORECASE | re.DOTALL)
+
+# Phrases that describe machine time. These are read against the *marker's own
+# reason*, not the issue body -- the body of an issue about a sweep will always
+# talk about sweeps, so scanning it would make the marker unusable on exactly
+# the issues that legitimately need it. The four corrections in #3708 are all
+# catchable inside the marker, which is what makes this mechanical rather than
+# a matter of taste.
+RUN_SHAPED = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bsbatch\b",
+        r"\bsqueue\b",
+        r"\bsrun\b",
+        r"\bscancel\b",
+        # "the submitted job", "submit one cpu job to prove it". Bounded to one
+        # clause so a marker ending "nothing is submitted." cannot reach a
+        # "job" in the next sentence.
+        r"\bsubmit\w*\b[^.;]{0,60}?\bjobs?\b",
+        r"\b(?:cpu|gpu)\s+jobs?\b",
+        r"\bnewly\s+built\s+\w+",
+        r"\bre-?build\w*",
+        r"\bbuild(?:ing|s)?\s+(?:a|the|every|one)\s+cells?\b",
+        r"\bpile cells?\b",
+        r"\bbuild_pile\.py\b",
+        r"\blaunch_\w+\.sh\b",
+        r"\bpreflight\.sh\b",
+        r"\bslate import\b",
+        r"\bimport\w*\s+(?:a\s+|the\s+)?(?:slate|pile|dataset)s?\b",
+        r"\bsweeps?\b",
+        r"\beval arms?\b",
+        r"\bcalibration runs?\b",
+        r"\bvtscore\.eval\b",
+        r"scripts/experiments",
+    )
+]
+
+# Case-sensitive, unlike everything above: a lowercase "grid" is a CSS grid far
+# more often than it is this cluster, and a false block whose quoted phrase is
+# `grid` from "the grid layout" reads as a bug rather than as a rule.
+RUN_SHAPED += [re.compile(r"\bGRID\b"), re.compile(r"\bSLURM\b")]
+
+# A run-shaped word inside a denial ("no sweep", "no GRID/eval run is
+# involved") is the marker doing its job, not failing it. Bounded to the same
+# clause -- no `.`, `;` or `:` between the negator and the phrase -- so
+# "nothing measured. Submit one cpu job" is not read as a denial of the job.
+NEGATED = re.compile(r"\b(?:no|not|never|nothing|none|neither|nor|without|n't)\b[^.;:]{0,24}$", re.IGNORECASE)
+
+# A reason with fewer than this many non-space characters is not a reason.
+# Deliberately a low floor: its whole job is the degenerate case (#3669's
+# marker claimed only "not an experiment", which is the marker's own name), and
+# a floor high enough to judge a *short but real* reason would be a floor high
+# enough to block one. The run-shaped check above is what does the actual work.
+MIN_REASON_CHARS = 12
+
+# ...and the restatement itself, which clears any floor low enough to be safe.
+BARE_RESTATEMENT = re.compile(r"^(?:it'?s |this is |it is )?not (?:an )?experiment[.!]?$", re.IGNORECASE)
 
 # One of these alone means the issue cannot be closed without machine time.
 # They are repo-specific enough that a false positive is a real surprise.
@@ -215,6 +294,53 @@ def _looks_like_an_experiment(text: str) -> bool:
         return True
     hits = sum(1 for p in WEAK_SIGNALS if re.search(p, text, re.IGNORECASE))
     return hits >= 2
+
+
+def _run_shaped_phrase(reason: str) -> str | None:
+    """The first phrase in `reason` that describes machine time, if any."""
+    for pattern in RUN_SHAPED:
+        for match in pattern.finditer(reason):
+            if NEGATED.search(reason[: match.start()]):
+                continue
+            return match.group(0).strip()
+    return None
+
+
+def _reason_problem(reason: str) -> str | None:
+    """Why this marker does not count as a stated reason, or `None` if it does.
+
+    Two refusals, in the order that produces the more useful message. A
+    run-shaped reason gets the phrase quoted back, because that phrase *is* the
+    argument against the marker and the filer wrote it themselves. A reason too
+    thin to disagree with gets the criterion instead.
+    """
+    stripped = " ".join(reason.split())
+
+    phrase = _run_shaped_phrase(stripped)
+    if phrase is not None:
+        return RUN_SHAPED_REASON.format(phrase=phrase)
+
+    if len(stripped.replace(" ", "")) < MIN_REASON_CHARS or BARE_RESTATEMENT.match(stripped):
+        return THIN_REASON.format(reason=stripped or "(empty)")
+
+    return None
+
+
+def _opt_out_refusal(text: str) -> str | None:
+    """`None` if some marker in `text` releases the heuristic; else why none does.
+
+    Every marker is judged and any one acceptable marker is enough, because a
+    body can carry the real marker *and* a fenced example of the syntax (the
+    body of an issue about this very rule does). Judging only the first would
+    turn writing about the marker into a block.
+    """
+    refusals = []
+    for match in OPT_OUT.finditer(text):
+        problem = _reason_problem(match.group("reason"))
+        if problem is None:
+            return None
+        refusals.append(problem)
+    return refusals[0] if refusals else MISSING_EXPERIMENT
 
 
 def _close_problems(args: dict) -> list[str]:
@@ -264,12 +390,46 @@ MISSING_CLAUDE = (
     "(`is:issue is:open -label:claude`). It is never optional."
 )
 
+# The criterion, stated once and reused by all three refusals below.
+#
+# It deliberately does NOT say "closeable from a laptop with the test suite",
+# which is what this message said until #3708. That named a configuration that
+# does not exist: per #3694, `run-tests.sh` runs nowhere but the GRID, because
+# the laptop has 3 GB of RAM -- so a filer applying the old wording literally
+# got the wrong answer, and every issue would have read as an experiment. The
+# criterion the four hand corrections actually used is narrower and true.
+CRITERION = (
+    "The test is whether the issue can be closed WITHOUT running the product -- "
+    "an app, a dataset, an embedder, a pile cell, a submitted job."
+)
+
 MISSING_EXPERIMENT = (
-    "MISSING `experiment`: this reads like an issue nobody can close from a "
-    "laptop with the test suite -- it needs measured results first. Add the "
-    "label so it lands in the queue of work that needs machine time booked.\n"
-    "  If closing it genuinely needs no run, say so explicitly instead of "
-    "rewording the body: add `<!-- not-an-experiment: <reason> -->`."
+    "MISSING `experiment`: this reads like an issue that cannot be closed without a run. "
+    "Add the label so it lands in the queue of work that needs machine time booked.\n"
+    f"  {CRITERION}\n"
+    "  If closing it genuinely needs none of that, say so explicitly instead of "
+    "rewording the body: add `<!-- not-an-experiment: <reason> -->`. The reason is READ, "
+    "not merely counted."
+)
+
+RUN_SHAPED_REASON = (
+    "MISSING `experiment`, AND THE `not-an-experiment` MARKER DESCRIBES A RUN: the reason "
+    'you gave says "{phrase}", which is machine time.\n'
+    f"  {CRITERION}\n"
+    "  So the marker argues against itself, and the marker is not what decides this -- the "
+    "closing condition is. Either add `experiment` (the usual answer when the reason reads "
+    "like that), or, if the phrase is incidental and nothing has to be run, say what the "
+    "closing condition IS without naming a run.\n"
+    "  #3708 has the four markers that were wrong this way; each was disproved by its own text."
+)
+
+THIN_REASON = (
+    '`not-an-experiment` MARKER STATES NO REASON: the marker reads "{reason}", which '
+    "restates the marker's name instead of giving a reason.\n"
+    f"  {CRITERION}\n"
+    "  Answer that question in the marker -- name the closing condition, so the next reader "
+    "can check the claim instead of taking it. If you cannot name one that avoids a run, the "
+    "answer is the `experiment` label."
 )
 
 
@@ -286,8 +446,10 @@ def _label_problems(labels: set[str], text: str) -> list[str]:
     if "claude" not in labels:
         found.append(MISSING_CLAUDE)
 
-    if "experiment" not in labels and not OPT_OUT.search(text) and _looks_like_an_experiment(text):
-        found.append(MISSING_EXPERIMENT)
+    if "experiment" not in labels and _looks_like_an_experiment(text):
+        refusal = _opt_out_refusal(text)
+        if refusal is not None:
+            found.append(refusal)
 
     return found
 

--- a/tests_lib/meta/test_issue_label_hook.py
+++ b/tests_lib/meta/test_issue_label_hook.py
@@ -17,6 +17,12 @@ actually used, so `TestGhCli` carries the shell shapes those sessions really
 emit -- compound commands, heredoc bodies, `--body-file`, `ssh grid '...'` --
 rather than a tidy flag list that would pass without proving anything.
 
+The `experiment` half of the rule has an escape hatch, and `TestOptOutMarkerReason`
+is the check that the hatch is a hatch rather than a hole: its fixtures are the
+real markers off GitHub -- four that had to be corrected by hand and three that
+are right -- rather than invented ones, because a pattern list tuned against
+invented markers proves nothing about the mistake sessions actually make.
+
 The `solved`-strip guard at the other end of an issue's life has the same two
 paths, and the `gh` half of it (`TestGhCloseSolved`) is the one place this hook
 does I/O: `gh issue close` has no `--label` flag to restate a label set with, so
@@ -130,6 +136,153 @@ class TestExperimentLabel:
         assert result.returncode == BLOCK
         assert "MISSING `claude`" in result.stderr
         assert "MISSING `experiment`" in result.stderr
+
+
+# The markers that were corrected by hand, as issue #3708 catalogued them. The
+# first three are the marker text verbatim off GitHub; #3669's was rewritten in
+# place when it was corrected, so it is reconstructed from what #3708 records
+# of it ("the marker claimed `not an experiment`") -- which is why it is the
+# one row here that tests the no-reason-at-all path rather than the
+# run-shaped-reason path.
+#
+# The value of using the real ones is that they were written by sessions trying
+# to be honest, not by someone inventing a bad marker for a test. A pattern
+# list tuned against invented markers proves nothing; these four are the actual
+# distribution of the mistake.
+WRONG_MARKERS = {
+    "3669": "not an experiment",
+    "3683": (
+        "the measurements are already done and are in the #3667 report; what is left is a "
+        "provenance field and a sentence in the README. Closes with `python build_pile.py "
+        "--provenance` showing `embed_batch_size` on a newly built cell, plus "
+        "`./run-tests.sh meta` for the test that asserts the key is written. No GPU, no "
+        "sweep. The one genuinely run-shaped question -- whether a 1e-4 perturbation changes "
+        "any study's conclusion -- is deliberately NOT part of the closing condition; see "
+        "the last section."
+    ),
+    "3693": (
+        "a launcher default and a guard around it; closed by running `bash launch_pile.sh "
+        "vg_scale` from a worktree and confirming the submitted job imports THAT worktree"
+    ),
+    "3694": (
+        "closing this is `git mv`-shaped: a file move plus `bash -n` and a text test. No "
+        "arms, no cells, no GPU, nothing measured; `cat` the live script and submit one cpu "
+        "job to prove it."
+    ),
+}
+
+# ...and the markers that are right, which is the half that stops the pattern
+# list from being tuned until it matches nothing. All three are verbatim: two
+# from #3708's own "must still pass" list, and one from #3708 itself -- the
+# issue asking for this check was filed under a marker, so a gate that blocks
+# its own filing is not shippable.
+GOOD_MARKERS = {
+    "3657": "one formula, four call sites, same constant; the fix and its test are a laptop change.",
+    "3452": ("an investigation with external developers plus documentation; no GRID/eval run is involved."),
+    "3708": (
+        "a regex, a hook message and a `tests_lib/meta/` test over "
+        "`.claude/hooks/require-issue-labels.py`. The hook is pure string logic with no I/O "
+        "on the create path, and `tests_lib/meta/` already tests it, so the gate is its own "
+        "test. Nothing is measured, nothing is submitted."
+    ),
+}
+
+
+def marked(reason: str, body: str = EXPERIMENT_BODY) -> str:
+    return f"{body}\n\n<!-- not-an-experiment: {reason} -->"
+
+
+class TestOptOutMarkerReason:
+    """The marker's reason is read, not merely counted (issue #3708).
+
+    `OPT_OUT` used to match the marker's prefix only, so any text at all after
+    the colon satisfied the gate. That made the escape hatch an unchecked free
+    pass, and it was wrong four times in three days -- every one of them
+    disproved by a sentence inside the marker itself, which is what makes it
+    mechanically catchable rather than a matter of taste.
+
+    Each fixture body pairs a real marker with `EXPERIMENT_BODY`, so the
+    heuristic definitely fires and the marker is the only thing under test.
+    Every issue's real body also trips the heuristic; pinning the body here
+    keeps a later edit to `STRONG_SIGNALS` from quietly turning these into
+    assertions about nothing.
+    """
+
+    @pytest.mark.parametrize("number", sorted(WRONG_MARKERS))
+    def test_a_marker_that_describes_a_run_is_refused(self, number):
+        result = run_hook(create(body=marked(WRONG_MARKERS[number]), labels=["claude"]))
+        assert result.returncode == BLOCK, f"#{number}'s marker was accepted"
+        assert "MISSING `experiment`" in result.stderr or "STATES NO REASON" in result.stderr
+
+    @pytest.mark.parametrize("number", sorted(GOOD_MARKERS))
+    def test_a_laptop_shaped_marker_still_releases_the_heuristic(self, number):
+        result = run_hook(create(body=marked(GOOD_MARKERS[number]), labels=["claude"]))
+        assert result.returncode == ALLOW, f"#{number}'s marker was refused:\n{result.stderr}"
+
+    @pytest.mark.parametrize(
+        ("number", "phrase"),
+        [("3683", "newly built cell"), ("3693", "submitted job"), ("3694", "submit one cpu job")],
+    )
+    def test_the_denial_quotes_the_offending_phrase_back(self, number, phrase):
+        """The filer wrote the argument against their own marker; show it to them."""
+        result = run_hook(create(body=marked(WRONG_MARKERS[number]), labels=["claude"]))
+        assert phrase in result.stderr
+
+    def test_a_marker_restating_its_own_name_is_not_a_reason(self):
+        result = run_hook(create(body=marked(WRONG_MARKERS["3669"]), labels=["claude"]))
+        assert result.returncode == BLOCK
+        assert "STATES NO REASON" in result.stderr
+
+    @pytest.mark.parametrize("reason", ["", "  ", "n/a", "no", "obvious", "This is not an experiment."])
+    def test_an_empty_or_token_reason_is_not_a_reason(self, reason):
+        assert run_hook(create(body=marked(reason), labels=["claude"])).returncode == BLOCK
+
+    def test_a_run_shaped_word_inside_a_denial_is_not_held_against_the_marker(self):
+        """#3452 says "no GRID/eval run is involved" -- that is the marker working."""
+        for reason in ("no sweep is involved", "closes without any sbatch job", "nothing is submitted"):
+            body = marked(f"one constant, four call sites; {reason}.")
+            assert run_hook(create(body=body, labels=["claude"])).returncode == ALLOW, reason
+
+    def test_a_reason_containing_an_angle_bracket_is_still_read_as_a_marker(self):
+        """`[^>]*` would stop at the `>` and report the marker as missing.
+
+        That is the one denial a filer who wrote a marker cannot act on: the
+        message asks for the thing already on the screen.
+        """
+        body = marked("one call site; the fix is `a > b` and its test, both a laptop change.")
+        assert run_hook(create(body=body, labels=["claude"])).returncode == ALLOW
+
+    def test_a_multi_line_marker_is_read_whole(self):
+        body = marked("closes by\nsubmitting one cpu job\non the GRID")
+        result = run_hook(create(body=body, labels=["claude"]))
+        assert result.returncode == BLOCK
+
+    def test_a_fenced_example_of_the_syntax_does_not_block_a_real_marker(self):
+        """#3708's own body carries both, and it had to be fileable."""
+        body = f"{marked(GOOD_MARKERS['3708'])}\n\n```\n<!-- not-an-experiment: <reason> -->\n```"
+        assert run_hook(create(body=body, labels=["claude"])).returncode == ALLOW
+
+    def test_the_label_still_beats_the_marker(self):
+        """A wrong marker on an issue that carries `experiment` is nobody's problem."""
+        body = marked(WRONG_MARKERS["3693"])
+        assert run_hook(create(body=body, labels=["claude", "experiment"])).returncode == ALLOW
+
+    def test_a_refused_marker_does_not_swallow_the_claude_problem(self):
+        result = run_hook(create(body=marked(WRONG_MARKERS["3694"])))
+        assert result.returncode == BLOCK
+        assert "MISSING `claude`" in result.stderr
+
+    def test_the_criterion_names_running_the_product_not_a_laptop_test_suite(self):
+        """#3694: `run-tests.sh` runs nowhere but the GRID, so the old wording was unusable."""
+        result = run_hook(create(body=EXPERIMENT_BODY, labels=["claude"]))
+        assert "WITHOUT running the product" in result.stderr
+        assert "laptop with the test suite" not in result.stderr
+
+    def test_the_gh_path_reads_the_reason_too(self):
+        """Both call paths share `_label_problems`; prove it rather than assume it."""
+        command = f'gh issue create --title "T" --body "{marked(WRONG_MARKERS["3693"])}" --label claude'
+        payload = {"tool_name": "Bash", "tool_input": {"command": command}}
+        assert run_hook(payload).returncode == BLOCK
 
 
 class TestSolvedLabelOnClose:


### PR DESCRIPTION
`OPT_OUT` was `re.compile(r"<!--\s*not-an-experiment\s*:", re.IGNORECASE)` — the prefix only. Nothing ever read the text after the colon, so any characters at all satisfied the gate. The marker forced a reason to be *typed*, not to be *true*, and it was wrong four times in three days.

## What changed

**1. The reason is captured and read.** `OPT_OUT` now captures `(?P<reason>.*?)` non-greedily up to `-->`, and `_reason_problem` judges it.

Non-greedy rather than the `[^>]*` the issue suggested: a reason containing a `>` (a shell redirect, an arrow, a quoted diff line) would stop matching the marker *entirely*, so the hook would report a missing marker to someone looking at the marker on their screen — the one denial that cannot be acted on.

**2. A run-shaped reason is refused**, with the offending phrase quoted back. ~22 patterns over `sbatch` / `squeue` / `submit … job` / `cpu job` / `newly built cell` / `rebuild` / `build_pile.py` / `launch_*.sh` / `slate import` / `sweep` / `GRID` / `SLURM` and friends.

Two judgment calls worth naming:

- **Scope is the marker's own reason, not the body.** The body of an issue about a sweep will always talk about sweeps, so scanning it would make the marker unusable on exactly the issues that legitimately need one. All four corrections are catchable inside the marker, which is what the issue's "mechanically catchable rather than a matter of taste" claim rests on.
- **A negated phrase does not count.** #3452's marker says "no GRID/eval run is involved" and #3683's says "no sweep" — that is the marker working. `NEGATED` looks back within one clause (no `.`, `;` or `:` crossed, ≤24 chars), so "nothing measured; … submit one cpu job" is still caught. Without this, #3452 — one of the two markers the issue names as *must still pass* — would have been blocked, and the quoted phrase would have been `GRID` from "no GRID".
- `GRID` and `SLURM` are the only case-sensitive patterns: a lowercase `grid` is a CSS grid far more often than it is this cluster.

**3. A reason that only restates the marker's name is refused.** This is #3669's row, and it is the one the phrase list cannot see — per the issue's own table its marker claimed simply "not an experiment". Deliberately a *low* floor (12 non-space chars, plus an exact-restatement pattern): a floor high enough to judge a short-but-real reason would be a floor high enough to block one, and the run-shaped check is what does the actual work. Every existing test fixture ("already measured", 16 chars) still passes.

**4. The criterion in the denial is restated.** It said the test was whether the issue closes "from a laptop with the test suite". Per #3694 `run-tests.sh` runs nowhere but the GRID, because the laptop has 3 GB of RAM — so the message named a configuration that does not exist, and a filer applying it literally got the wrong answer. It now asks whether the issue closes **without running the product — an app, a dataset, an embedder, a pile cell, a submitted job**, which is the criterion the four hand corrections actually used.

## Verification

`TestOptOutMarkerReason` in `tests_lib/meta/test_issue_label_hook.py` — 21 new tests, fixtures are the **real markers off GitHub**, not invented ones:

| fixture | source | verdict |
|---|---|---|
| #3683, #3693 | marker text verbatim (still live on the issues) | refused |
| #3694 | reconstructed from #3708's quotes; its marker was rewritten to `<!-- experiment: … -->` when corrected | refused |
| #3669 | reconstructed; #3708 records the marker as claiming only "not an experiment" | refused — no reason |
| #3657, #3452 | verbatim; #3708's "must still pass" list | allowed |
| **#3708** | verbatim — the issue asking for this check was itself filed under a marker | allowed |

That last row is the load-bearing one: a gate that blocks its own filing is not shippable. The negative half is also what stops the pattern list from being tuned until it matches nothing.

Also covered: the denial quotes the phrase; the `>`-in-reason case; multi-line markers; a body carrying both a fenced example of the syntax *and* a real marker (#3708's own shape); `experiment` still beating a bad marker; the refusal not swallowing the `MISSING claude` problem; and the `gh issue create` path, since both paths share `_label_problems`.

Mutation-checked: neutering `_reason_problem` to `return None` (the old behaviour) fails 16 of the new tests. `./run-tests.sh` full: **RUN PASSED**, 10924 passed.

Closes #3708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeRWEtWgz2u3ofw8wzZkvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeRWEtWgz2u3ofw8wzZkvJ)_