### PR TITLE
Seed a stat-free packages_distributions before importing transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,19 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **Startup no longer stalls for minutes on a cold NFS install** (issue #3715).
+  `transformers` builds `importlib.metadata.packages_distributions()` when it is
+  imported, and the stdlib version of that stats every file recorded by every
+  installed distribution - ~85,000 of them in a venv carrying torch, onnx and
+  RAPIDS. With the venv's metadata in page cache that is milliseconds; on an
+  NFS-mounted venv whose dentries have been evicted it is 85,000 serialized
+  round trips, measured at 78/sec on the GRID: **16 minutes 23 seconds** during
+  which the process sat in `D` state after printing
+  `Running in PRODUCTION mode` and looked hung. Startup now installs a
+  stat-free replacement that reads each distribution's `top_level.txt` (falling
+  back to parsing `RECORD` as text) before anything can import transformers, so
+  the walk never happens.
+
 - **A mixed-media dataset is no longer scored against another embedding space's
   vectors.** Asking the matrix layer for a specific embedder checked only the
   *first* media to decide whether that name was the dataset's primary - and if

--- a/tests/core/test_structured_logging.py
+++ b/tests/core/test_structured_logging.py
@@ -475,6 +475,38 @@ class TestTransformersLoggingBridge:
             setup_logging()
 
 
+class TestTransformersImportIsNotAStatWalk:
+    """The bridge seeds the stat-free ``packages_distributions`` first.
+
+    transformers builds the mapping at module import, and the stdlib version of
+    it stats every file recorded by every installed distribution - 16 minutes of
+    silent startup on a cold NFS venv (issue #3715).
+    """
+
+    def test_bridge_seeds_before_importing_transformers(self):
+        import importlib.metadata
+
+        from vtscore.utils.import_metadata import fast_packages_distributions
+
+        stdlib = importlib.metadata.packages_distributions
+        called = []
+
+        def tripwire():
+            called.append(True)
+            return {}
+
+        importlib.metadata.packages_distributions = tripwire
+        try:
+            install_transformers_logging_bridge()
+            assert called == [], "startup walked every recorded file of every distribution"
+            assert importlib.metadata.packages_distributions is fast_packages_distributions
+        finally:
+            importlib.metadata.packages_distributions = stdlib
+            hf_logging = importlib.import_module("transformers.utils.logging")
+            hf_logging._reset_library_root_logger()
+            hf_logging._configure_library_root_logger()
+
+
 class TestRequestIdHelper:
     def test_new_request_id_is_unique(self):
         ids = {new_request_id() for _ in range(100)}

--- a/tests_lib/core/test_import_metadata_seed.py
+++ b/tests_lib/core/test_import_metadata_seed.py
@@ -1,0 +1,134 @@
+"""The stat-free ``packages_distributions`` seed (issue #3715).
+
+``transformers`` calls ``importlib.metadata.packages_distributions()`` at
+module import; the stdlib implementation stats every file recorded by every
+installed distribution, which on a cold NFS venv is minutes of silent startup.
+These tests pin both halves of the fix: the replacement mapping is built
+without touching the recorded files, and startup installs it before anything
+can import transformers.
+"""
+
+import importlib.metadata
+from unittest.mock import patch
+
+import pytest
+
+from vtscore.utils.import_metadata import (
+    fast_packages_distributions,
+    original_packages_distributions,
+    seed_packages_distributions,
+)
+
+
+@pytest.fixture
+def restore_stdlib(monkeypatch):
+    """Put the stdlib implementation back for the duration of a test.
+
+    Both conftests call ``initialize_models()`` at import, so by the time any
+    test runs the seed is already installed process-wide.
+    """
+    monkeypatch.setattr(importlib.metadata, "packages_distributions", original_packages_distributions)
+
+
+@pytest.fixture
+def synthetic_site(tmp_path, monkeypatch):
+    """A site-packages dir with two dist-infos whose recorded files don't exist."""
+    site = tmp_path / "site"
+    declared = site / "foo-1.0.dist-info"
+    declared.mkdir(parents=True)
+    (declared / "METADATA").write_text("Metadata-Version: 2.1\nName: foo\nVersion: 1.0\n")
+    (declared / "top_level.txt").write_text("foo\n_foo_ext\n")
+
+    inferred = site / "bar-2.0.dist-info"
+    inferred.mkdir(parents=True)
+    (inferred / "METADATA").write_text("Metadata-Version: 2.1\nName: bar\nVersion: 2.0\n")
+    (inferred / "RECORD").write_text(
+        "bar/__init__.py,sha256=x,10\n"
+        "bar/sub/mod.py,sha256=x,10\n"
+        "barmod.py,sha256=x,10\n"
+        "bar-2.0.dist-info/METADATA,sha256=x,10\n"
+        "../../include/bar.h,sha256=x,10\n"
+    )
+    monkeypatch.syspath_prepend(str(site))
+    return site
+
+
+class TestFastPackagesDistributions:
+    def test_reads_declared_top_level_names(self, synthetic_site):
+        mapping = fast_packages_distributions()
+        assert mapping["foo"] == ["foo"]
+        assert mapping["_foo_ext"] == ["foo"]
+
+    def test_infers_top_level_names_from_record(self, synthetic_site):
+        mapping = fast_packages_distributions()
+        assert mapping["bar"] == ["bar"]
+        assert mapping["barmod"] == ["bar"]
+        # The ``.dist-info`` row and the ``../`` data-path escape are not import
+        # names, and neither is the nested module.
+        assert "bar-2" not in mapping
+        assert ".." not in mapping
+        assert "mod" not in mapping
+
+    def test_does_not_stat_recorded_files(self, synthetic_site):
+        """None of the recorded files exist, yet their names still map.
+
+        The stdlib drops them: ``Distribution.files`` filters through
+        ``os.path.exists()``, and that filter *is* the 85k-stat walk.
+        """
+        assert not (synthetic_site / "bar").exists()
+        assert "bar" in fast_packages_distributions()
+
+    def test_never_touches_distribution_files(self, synthetic_site):
+        def boom(self):
+            raise AssertionError("Distribution.files stats every recorded path")
+
+        with patch.object(importlib.metadata.Distribution, "files", property(boom)):
+            mapping = fast_packages_distributions()
+        assert "bar" in mapping
+
+    def test_loses_nothing_the_stdlib_reports_on_the_live_venv(self):
+        """Every stdlib entry survives, with the same distributions behind it.
+
+        Equality is deliberately not asserted: skipping the missing-file filter
+        can only *add* names, and which extras appear depends on what the venv
+        happens to record (and on the stdlib's own per-version inference).
+        Losing an entry would be a real break; gaining one is not.
+        """
+        fast = fast_packages_distributions()
+        real = original_packages_distributions()
+        assert {name: fast.get(name) for name in real} == dict(real)
+
+
+class TestSeed:
+    def test_installs_and_is_idempotent(self, restore_stdlib):
+        assert importlib.metadata.packages_distributions is original_packages_distributions
+        assert seed_packages_distributions() is True
+        assert importlib.metadata.packages_distributions is fast_packages_distributions
+        assert seed_packages_distributions() is True
+        assert importlib.metadata.packages_distributions is fast_packages_distributions
+
+    def test_reports_failure_when_the_function_is_absent(self, monkeypatch):
+        monkeypatch.delattr(importlib.metadata, "packages_distributions", raising=False)
+        assert seed_packages_distributions() is False
+
+
+class TestStartupSeedsBeforeTransformers:
+    def test_initialize_models_installs_the_seed(self, restore_stdlib):
+        from vtscore.embedding.loader import initialize_models
+
+        called = []
+        monkeyed = importlib.metadata.packages_distributions
+
+        def tripwire():
+            called.append(True)
+            return monkeyed()
+
+        with (
+            patch.object(importlib.metadata, "packages_distributions", tripwire),
+            patch("vtscore.embedding.loader._warm_threadpool_controller"),
+            patch("vtscore.embedding.loader._install_transformers_logging_bridge"),
+        ):
+            initialize_models()
+            assert importlib.metadata.packages_distributions is fast_packages_distributions
+
+        assert called == [], "startup invoked the stat-walking stdlib implementation"

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -10,6 +10,15 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Added
 
+- **`vtscore.utils.import_metadata`** (issue #3715) - `seed_packages_distributions()`
+  installs a stat-free stand-in for `importlib.metadata.packages_distributions`,
+  which `transformers` calls at module import. The stdlib version stats every
+  file recorded by every installed distribution (~85k on a torch + RAPIDS venv);
+  on an NFS install with a cold cache that was 16 minutes of silent startup.
+  `initialize_models()` now seeds it before anything can import transformers.
+  Purely additive: the seed is idempotent and best-effort, and the replacement
+  reports every entry the stdlib does.
+
 - **A timing profile can price a forked step per branch** (issue #3594).
   `vtscore.timing.step_weights` and `step_terms` take an optional `branch=` -
   a branch name from `CHEAP_BRANCHES` / `DEAR_BRANCHES`, or a `{step: branch}`

--- a/vtscore/embedding/loader.py
+++ b/vtscore/embedding/loader.py
@@ -79,6 +79,7 @@ def _fit_label(base: str) -> str:
 from vtscore.config import MODELS_CACHE_DIR, resolve_device
 from vtscore.media.base import ProgressCallback
 from vtscore.media.torch_setup import ensure_torch_configured
+from vtscore.utils.import_metadata import seed_packages_distributions
 
 logger = logging.getLogger(__name__)
 
@@ -312,6 +313,13 @@ def initialize_models(on_progress: ProgressCallback | None = None) -> None:
     preload bars printed later in startup.  When ``None`` (the default, used
     by tests and the eval CLI) the imports run silently as before.
     """
+    # Before anything can import transformers: transformers builds
+    # ``importlib.metadata.packages_distributions()`` at module import, and the
+    # stdlib version of that stats every file recorded by every installed
+    # distribution.  On an NFS venv with a cold cache that is minutes of silent
+    # startup (issue #3715); the seed makes it ~224 small reads instead.
+    seed_packages_distributions()
+
     MODELS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     ensure_torch_configured()
 

--- a/vtscore/utils/__init__.py
+++ b/vtscore/utils/__init__.py
@@ -11,6 +11,10 @@ Remaining here:
   non-security declaration stays in one place (keeps MD5 working on
   FIPS-enabled hosts).
 - :mod:`vtscore.utils.hits` - ``build_media_hit`` helper for scoring/route hit dicts.
+- :mod:`vtscore.utils.import_metadata` - ``seed_packages_distributions``, the
+  stat-free stand-in for ``importlib.metadata.packages_distributions`` that
+  keeps transformers' module-level call from walking every installed
+  distribution's file list at startup.
 - :mod:`vtscore.utils.optional_deps` - actionable messages for the opt-out AGPL
   packages (``ultralytics``, ``PyMuPDF``), which a default install has but an
   ``VTSEARCH_NO_AGPL=1`` install deliberately lacks.

--- a/vtscore/utils/import_metadata.py
+++ b/vtscore/utils/import_metadata.py
@@ -35,7 +35,7 @@ __all__ = ["fast_packages_distributions", "seed_packages_distributions"]
 #: The stdlib function displaced by :func:`seed_packages_distributions`, kept so
 #: callers (and tests) can tell whether the seed is installed and can put the
 #: original back.
-original_packages_distributions = getattr(importlib.metadata, "packages_distributions", None)
+original_packages_distributions = importlib.metadata.packages_distributions
 
 
 def _declared_top_level(dist: importlib.metadata.Distribution) -> list[str]:
@@ -65,7 +65,7 @@ def _inferred_top_level(dist: importlib.metadata.Distribution) -> set[str]:
         if not row or not row[0]:
             continue
         parts = PurePosixPath(row[0]).parts
-        name = parts[0] if len(parts) > 1 else inspect.getmodulename(parts[0])
+        name = parts[0] if len(parts) > 1 else inspect.getmodulename(row[0])
         # A dotted name is not an import name: it is a ``*.dist-info`` directory,
         # a ``../`` escape to a data path, or a file with an unrecognised suffix.
         if name and "." not in name and name != "__pycache__":

--- a/vtscore/utils/import_metadata.py
+++ b/vtscore/utils/import_metadata.py
@@ -1,0 +1,113 @@
+"""Stat-free replacement for :func:`importlib.metadata.packages_distributions`.
+
+``transformers`` builds a top-level-name -> distribution mapping at *module
+import* time, unconditionally and with no env guard::
+
+    # transformers/utils/import_utils.py
+    PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
+
+The stdlib implementation asks every installed distribution for its file list,
+and ``Distribution.files`` filters that list through ``os.path.exists()`` - one
+``stat()`` per *file recorded by every installed package*.  On a venv carrying
+torch + onnx + RAPIDS that is ~85,000 stats across ~224 distributions.  Locally
+that is a page-cache hit and costs milliseconds; on an NFS-mounted venv whose
+dentries have been evicted it is 85,000 serialized round trips.  Measured on the
+GRID (issue #3715): 78 stats/sec, so **16 minutes** of startup during which the
+process sits in ``D`` state printing nothing and looking hung.
+
+:func:`seed_packages_distributions` swaps in an implementation that reads each
+distribution's ``top_level.txt`` (falling back to parsing ``RECORD`` as text)
+and never touches the recorded files at all - ~224 small reads instead of 85k
+stats.  Call it once, early, **before anything imports transformers**; the
+module-level call above then finds our function under the name it looks up and
+the walk never happens.
+"""
+
+import collections
+import csv
+import importlib.metadata
+import inspect
+from collections.abc import Iterable, Mapping
+from pathlib import PurePosixPath
+
+__all__ = ["fast_packages_distributions", "seed_packages_distributions"]
+
+#: The stdlib function displaced by :func:`seed_packages_distributions`, kept so
+#: callers (and tests) can tell whether the seed is installed and can put the
+#: original back.
+original_packages_distributions = getattr(importlib.metadata, "packages_distributions", None)
+
+
+def _declared_top_level(dist: importlib.metadata.Distribution) -> list[str]:
+    """Top-level names a distribution declares in ``top_level.txt`` (may be empty)."""
+    try:
+        return (dist.read_text("top_level.txt") or "").split()
+    except Exception:
+        return []
+
+
+def _inferred_top_level(dist: importlib.metadata.Distribution) -> set[str]:
+    """Top-level names inferred from ``RECORD``, without stat-ing the files.
+
+    Mirrors the stdlib's ``_top_level_inferred`` - first path component for a
+    nested path, module name for a top-level file - but reads ``RECORD`` as
+    text rather than going through ``Distribution.files``, whose
+    ``skip_missing_files`` filter is the ``stat()`` storm this module exists to
+    avoid.  Dropping that filter can only *add* names (those of files recorded
+    but since deleted), which is harmless for the mapping's consumers.
+    """
+    try:
+        record = dist.read_text("RECORD") or ""
+    except Exception:
+        return set()
+    names: set[str] = set()
+    for row in csv.reader(record.splitlines()):
+        if not row or not row[0]:
+            continue
+        parts = PurePosixPath(row[0]).parts
+        name = parts[0] if len(parts) > 1 else inspect.getmodulename(parts[0])
+        # A dotted name is not an import name: it is a ``*.dist-info`` directory,
+        # a ``../`` escape to a data path, or a file with an unrecognised suffix.
+        if name and "." not in name and name != "__pycache__":
+            names.add(name)
+    return names
+
+
+def fast_packages_distributions() -> Mapping[str, list[str]]:
+    """Return ``{import_name: [distribution_name, ...]}`` without stat-ing files.
+
+    Drop-in for :func:`importlib.metadata.packages_distributions`.
+    """
+    pkg_to_dist: dict[str, list[str]] = collections.defaultdict(list)
+    for dist in importlib.metadata.distributions():
+        try:
+            dist_name = dist.metadata["Name"]
+        except Exception:
+            continue
+        if not dist_name:
+            continue
+        names: Iterable[str] = _declared_top_level(dist) or _inferred_top_level(dist)
+        for pkg in names:
+            pkg_to_dist[pkg].append(dist_name)
+    return dict(pkg_to_dist)
+
+
+def seed_packages_distributions() -> bool:
+    """Install :func:`fast_packages_distributions` over the stdlib's version.
+
+    Idempotent and best-effort: returns ``True`` when the fast implementation is
+    in place afterwards, ``False`` when the swap could not be made (a Python
+    without the function, or an ``importlib.metadata`` that refuses attribute
+    assignment).  Nothing downstream depends on the return value - a ``False``
+    only means startup pays the original cost.
+    """
+    current = getattr(importlib.metadata, "packages_distributions", None)
+    if current is fast_packages_distributions:
+        return True
+    if current is None:
+        return False
+    try:
+        importlib.metadata.packages_distributions = fast_packages_distributions  # type: ignore[assignment]
+    except Exception:
+        return False
+    return True

--- a/vtsearch/logging_config.py
+++ b/vtsearch/logging_config.py
@@ -316,11 +316,27 @@ def install_transformers_logging_bridge() -> None:
     filters like every other library's.
 
     Deferred from ``setup_logging`` because importing ``transformers.utils.logging``
-    pulls in the full ``transformers`` package (~0.7s), which we don't want
-    to pay for in unit tests that stub embedders. Call once during app
-    startup before any model load; :func:`vtscore.embedding.loader.initialize_models`
-    is the canonical call site.
+    pulls in the full ``transformers`` package, which we don't want to pay for
+    in unit tests that stub embedders. Call once during app startup before any
+    model load; :func:`vtscore.embedding.loader.initialize_models` is the
+    canonical call site.
+
+    That import costs ~0.7s with the venv's metadata in page cache, but it is
+    **not** bounded by that: transformers builds
+    ``importlib.metadata.packages_distributions()`` at module import, which
+    stats every file recorded by every installed distribution (~85k of them
+    here). On an NFS venv with a cold dentry cache that took 16 minutes of
+    silent startup on the GRID (issue #3715), which is why this call seeds the
+    stat-free replacement first. The seed is idempotent, so paying for it here
+    as well as in ``initialize_models`` costs nothing and covers callers that
+    reach this bridge by another route.
     """
+    # Imported lazily: ``logging_config`` is app.py's very first import, and a
+    # module-level ``vtscore`` import here would pull the library package in
+    # before logging is configured.
+    from vtscore.utils.import_metadata import seed_packages_distributions  # noqa: PLC0415
+
+    seed_packages_distributions()
     try:
         import transformers.utils.logging as hf_logging  # noqa: PLC0415
     except Exception:


### PR DESCRIPTION
`transformers` builds `importlib.metadata.packages_distributions()` at module import, unconditionally and with no env guard. The stdlib implementation asks every installed distribution for its file list, and `Distribution.files` filters that list through `os.path.exists()` — one `stat()` per file recorded by *every* installed package, ~85,000 of them in a venv carrying torch, onnx and RAPIDS.

With the venv's metadata in page cache that costs milliseconds. On an NFS-mounted venv whose dentries have been evicted it is 85,000 serialized round trips: measured at 78/sec on the GRID, so **16 minutes 23 seconds** of startup in `D` state with nothing printed since `Running in PRODUCTION mode`, which reads as a hang.

## What changed

- **`vtscore/utils/import_metadata.py`** (new) — `fast_packages_distributions()` builds the same `{import_name: [dist_name, …]}` mapping by reading each distribution's `top_level.txt`, falling back to parsing `RECORD` as text, and never touching the recorded files: ~224 small reads instead of 85k stats. `seed_packages_distributions()` installs it over the stdlib attribute, idempotently and best-effort.
- **`vtscore/embedding/loader.py`** — `initialize_models()` seeds first thing, before anything downstream can import transformers.
- **`vtsearch/logging_config.py`** — `install_transformers_logging_bridge()` (the call site in the traceback) seeds too, so the guard holds on any route into it. Its docstring claimed the transformers import costs "~0.7s", which is what kept this invisible; it now says what the cold-cache case actually costs.

## Fidelity

Skipping the missing-file filter can only *add* names (those of files recorded but since deleted), never lose one. `test_loses_nothing_the_stdlib_reports_on_the_live_venv` pins that direction against the running environment's real mapping; equality is deliberately not asserted, since which extras appear depends on what the venv records and on the stdlib's own per-version inference.

## Testing

`./run-tests.sh` — all gates green, 10908 passed.

New tests: `tests_lib/core/test_import_metadata_seed.py` (mapping built from declared and inferred names, no `Distribution.files` access, seed idempotence, and `initialize_models()` never invoking the stdlib walk) and `TestTransformersImportIsNotAStatWalk` in `tests/core/test_structured_logging.py` for the bridge.

End-to-end in a fresh process, with a tripwire over the stdlib function installed *before* the first vtscore import:

```
transformers imported: True
stdlib walk invoked: 0
packages_distributions now: vtscore.utils.import_metadata
```

Closes #3715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FbBtLebdBPcHsBFat4yN4a

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbBtLebdBPcHsBFat4yN4a)_