### PR TITLE
Plan: make vg_scale a fully annotated set, not a single-question benchmark

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -52,6 +52,7 @@ to go stale. Keep the grouping in sync when you add or delete a plan — one lin
 - [`set-scorer-experiment.md`](set-scorer-experiment.md)
 - [`coverage-atlas.md`](coverage-atlas.md)
 - [`vg-scale-bands-and-corrections.md`](vg-scale-bands-and-corrections.md)
+- [`vg-scale-exhaustive-annotation.md`](vg-scale-exhaustive-annotation.md)
 - [`stopping-rules-in-eval.md`](stopping-rules-in-eval.md)
 
 ## Platform / CLI

--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -1,0 +1,193 @@
+# Make `vg_scale` a fully annotated set, not a single-question benchmark
+
+## What this changes
+
+`vg_scale` is built as a **designation**: a class list, a band rule, and a fixed
+count of positives and negatives per cell, sampled to make one contrast
+(small-vs-large, within a class) paired and clean. That was the right shape for
+#3156 and it answered it.
+
+It is the wrong shape for the actual goal, which is a set like COCO's — every
+`(image, class)` pair answered — that many questions can be asked of. Under a
+designation, prevalence, band definition, class list and pool composition are
+all *build-time* choices, so changing any of them is a rebuild and a re-embed.
+Under an exhaustively annotated set they are **queries**.
+
+This plan closes the gap. It is small, because most of it is already done.
+
+## What is already exhaustive, and what the debt is
+
+Every class in `SCALE_CLASSES` is also a COCO-2017 class — chosen that way
+deliberately, so COCO's exhaustive annotation can answer for all of them at once
+on the images the two sources share. `scripts/experiments/pile/coco_anchor.py`
+reads both `instances_train2017.json` and `instances_val2017.json`, so the
+anchored half is the whole VG∩COCO overlap rather than val alone.
+
+Since #3670 drew the negative pool entirely from that anchored half, the only
+stratum lacking exhaustive labels is the **off-COCO positives**:
+
+| stratum | 12-class build | exhaustive today |
+|---|---:|---|
+| negative pool | 9,900 | yes — COCO |
+| spares | 1,000 | yes — COCO |
+| positives, COCO-anchored | 2,037 (57.45%) | yes — COCO |
+| **positives, off-COCO** | **1,509 (42.55%)** | **no — this is the whole debt** |
+
+Scaled to the 25-class roster that is roughly **3,100–3,200 images**, and it is
+**one exhaustive pass per image** — a reviewer naming which of the 25 classes
+are present — rather than 25 binary votes. For scale, the pass already committed
+to for #3702 is ~400 cleared negatives per class, ~10,000 images. Counts from
+[the #3670 study](../experiments/2026-09-06-provable-negatives-3670/REPORT.md).
+
+**The zero-annotation version was measured and does not reach.**
+`scripts/experiments/pile/exact_supply.py` asks whether the COCO half alone
+supplies the cells; 20 of 36 shipped cells and 17 of 39 candidate cells fall
+short of 300 COCO-anchored positives (`dog@small` 114, `spoon@large` 106), so
+the off-COCO half cannot simply be dropped — it has to be answered. See
+[the class-list study](../experiments/2026-09-03-vg-scale-classes/REPORT.md).
+
+## Why it is worth more than the pass costs
+
+The annotation retires the machinery that exists **only** to substitute
+inference for an answer on the off-COCO half. Each of these is a measured,
+shipped subsystem whose reason for existing is VG's silence:
+
+- the VG name tables and the two-search candidate hunt behind them
+  (`scripts/experiments/pile/name_evidence.py`, `SCALE_VG_NAMES`,
+  `SCALE_VG_AMBIGUOUS`) — spellings stop mattering once a human answered;
+- pooled name adjudication and its homogeneity gate;
+- pool-contamination measurement
+  (`scripts/experiments/pile/pool_contamination.py`) — contamination goes to 0
+  on *both* halves, not just COCO's;
+- the `provable` / `matched` pool-composition choice, whose published
+  justification has been retracted in `pile_config.SCALE_NEG_COMPOSITION` and is
+  open as #3702 — it dissolves rather than being resolved, because the trade it
+  makes (contamination against a provenance artifact) only exists while one half
+  is unanswered;
+- the global ambiguous exclusion (#3655), which costs every class an image
+  because one spelling was ambiguous for one class;
+- `anchor_to_coco`'s silent un-banding (#3659), which becomes a reconciliation
+  between two human-grade answers rather than an overwrite.
+
+It also ends the rebuild treadmill: membership currently drifts when rulings
+change, 41 positives out and 40 in on a rebuild with nothing relevant altered
+([the #3667 rebuild study](../experiments/2026-09-06-cross-class-negatives-3667/REPORT.md)).
+
+## Two decisions this forces
+
+**The band statistic.** Banding is currently the **union** box over a class's
+instances, on the stated ground that a union is what one Good vote drags in the
+app. An exhaustively annotated set carries every instance, so union, largest,
+smallest and count are all derivable and the summary can move to eval time. That
+is a change to what #3156 measured, and it is a decision, not a detail: pick it
+deliberately and say so where the band is defined.
+
+**Two label sources of unequal quality.** COCO on one half and our annotators on
+the other means provenance would correlate with *label noise* instead of with
+*label* — a new form of #3702 rather than its elimination. The mitigation is
+free and already available: the class list was chosen so annotator accuracy can
+be scored against COCO on the anchored half without extra review. Build that
+scoring into the pass rather than discovering the drift afterwards.
+
+## Open work
+
+<!-- item-sep -->
+
+- **Measure the real debt against the 25-class roster.** The 3,100–3,200 figure
+  is scaled from the 12-class build. Run
+  `scripts/experiments/pile/measure_supply.py` and
+  `scripts/experiments/pile/exact_supply.py` against the shipped 25 and report
+  the off-COCO positive count per class and per band, plus the per-cell
+  COCO-anchored shortfall table. Needs a compute node — the full VG source does
+  not fit on a laptop. Nothing else here should be scoped until this lands.
+  (Sonnet 5)
+
+<!-- item-sep -->
+
+- **Freeze the roster, and say what freezing means.** The debt is ~3,200 images
+  only if the designated set stops moving; otherwise rebuild churn keeps pulling
+  in unannotated images. Decide what pins the roster (an explicit id list beside
+  the config, versioned), what may still change it, and how a rebuild proves it
+  did not. `scripts/experiments/pile/check_review_coverage.py` is the existing
+  partial answer and is not sufficient on its own. The policy is the owner's
+  call; the mechanism is Opus 4.8 work, since it is the invariant everything
+  else rests on. (human + Opus 4.8)
+
+<!-- item-sep -->
+
+- **Pilot the exhaustive interaction before committing the pass.** Naming which
+  of 25 classes are present is a materially harder task than a binary vote, and
+  COCO itself used a staged per-class protocol rather than one sweep over 80.
+  Run a pilot on a few hundred anchored images where COCO is the answer key, and
+  report per-class recall and the time per image. That measurement decides
+  whether the pass is one sweep, a staged protocol, or a shortlist-then-confirm
+  flow.
+  `scripts/experiments/lessons/2026-09-02-one-pilot-cell-cleared-a-hazard-the-full-wave-hit.md`
+  is the standing reason to pilot first. (human + Sonnet 5)
+
+<!-- item-sep -->
+
+- **Score the annotators against COCO, continuously.** On the anchored half the
+  answer key already exists, so every pass can carry a measured accuracy per
+  annotator and per class at no extra review cost. Emit it with the pass rather
+  than as a one-off audit; it is what keeps the two-source noise asymmetry
+  visible. (Sonnet 5)
+
+<!-- item-sep -->
+
+- **Decide the band statistic, and record the decision where the band is
+  defined.** Union (today), largest, or per-instance with a summary chosen at
+  eval time. Carrying every instance box is the option that keeps the choice
+  open, and is what makes band a query. See the two-decisions section above.
+  (human)
+
+<!-- item-sep -->
+
+- **Run the pass, and rebuild once.** Off-COCO positives only, one exhaustive
+  judgement per image, recorded as verdicts rather than corrections in VG's own
+  shape (`scripts/experiments/pile/verdicts_to_corrections.py`'s existing
+  contract). One rebuild at the end, not one per ruling. (human + Sonnet 5)
+
+<!-- item-sep -->
+
+- **Retire the inference machinery, and delete it.** After the pass, the name
+  tables, the pooled adjudication, the contamination measurement and the pool
+  composition switch are all answering a question that no longer exists. They
+  are experiment-tier code, so the backwards-compatibility rules do not protect
+  them — delete rather than deprecate, and prune the plan pointers and README
+  sections that describe them. Retire the published numbers conditioned on the
+  old construction at the same time, or say plainly which construction they were
+  measured under. The risk is deleting something still load-bearing for a
+  published result. (Opus 4.8)
+
+<!-- item-sep -->
+
+- **Move prevalence, band and class list to eval-time queries.** The point of
+  the exercise. `SCALE_N_POS` / `SCALE_N_NEG` / `SCALE_PREVALENCE` are
+  build-time designations today, and `SCALE_PREVALENCE` is already documented as
+  *designed, not realised*. With exhaustive labels a cell is a filter over a
+  fixed set, so prevalence becomes a sampling parameter the harness applies and
+  a class-list change stops being a re-embed. This is the item that turns the
+  benchmark into a dataset. (Opus 4.8)
+
+<!-- item-sep -->
+
+- **Ask the questions the set was built for.** Co-occurrence (does a class get
+  harder when a same-scene partner is present?), natural-composition negatives
+  instead of a designed ratio, multi-label arms, and calibration at a prevalence
+  chosen per question rather than pinned at build time. None of these are
+  reachable under a designation; all of them are one query away under an
+  annotated set. File them as they become concrete rather than listing them
+  here. (Sonnet 5)
+
+<!-- item-sep -->
+
+## Related
+
+- [`vg-scale-bands-and-corrections.md`](vg-scale-bands-and-corrections.md) — the
+  band construction and the correction loop this builds on. Its open review
+  items are about bounding the error on the *inferred* half; several stop being
+  owed if that half is answered instead, so re-read it when the pass lands.
+- #3668 — the origin of this idea, filed from the reviewer's side: a 13-way
+  judgement recorded as one bit, with twelve thrown away.
+- #3702, #3655, #3659 — open issues that dissolve rather than being fixed.

--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -39,6 +39,12 @@ are present — rather than 25 binary votes. For scale, the pass already committ
 to for #3702 is ~400 cleared negatives per class, ~10,000 images. Counts from
 [the #3670 study](../experiments/2026-09-06-provable-negatives-3670/REPORT.md).
 
+**That estimate is here to say whether this is worth starting, and does not need
+refining.** The work has to be done whatever the number turns out to be, so
+sizing it more precisely buys nothing; the exact per-class counts arrive for
+free with the queue, as a byproduct of building the worklist rather than as a
+run of their own.
+
 **The zero-annotation version was measured and does not reach.**
 `scripts/experiments/pile/exact_supply.py` asks whether the COCO half alone
 supplies the cells; 20 of 36 shipped cells and 17 of 39 candidate cells fall
@@ -93,14 +99,16 @@ scoring into the pass rather than discovering the drift afterwards.
 
 <!-- item-sep -->
 
-- **Measure the real debt against the 25-class roster.** The 3,100–3,200 figure
-  is scaled from the 12-class build. Run
-  `scripts/experiments/pile/measure_supply.py` and
-  `scripts/experiments/pile/exact_supply.py` against the shipped 25 and report
-  the off-COCO positive count per class and per band, plus the per-cell
-  COCO-anchored shortfall table. Needs a compute node — the full VG source does
-  not fit on a laptop. Nothing else here should be scoped until this lands.
-  (Sonnet 5)
+- **Emit the annotation queue.** Not a measurement — the worklist. A reviewer
+  cannot start without knowing which images are off-COCO positives, and that is
+  a join between VG and COCO ids rather than something visible in the image. It
+  is cheap: `_emit_medias` stamps `coco_scored` on every media, so where the
+  shipped cell carries it the queue is `categories and not coco_scored` read
+  off the pickle, and where it does not the fallback is `image_data.json`'s
+  `coco_id` field (~100 MB) joined against the pickle's positives. Neither
+  needs `objects.json` or a compute node; `scripts/experiments/pile/exact_supply.py`
+  does, which is why it is the wrong tool here. The per-class counts fall out of
+  the queue for free — do not run anything extra to produce them. (Sonnet 5)
 
 <!-- item-sep -->
 
@@ -115,15 +123,17 @@ scoring into the pass rather than discovering the drift afterwards.
 
 <!-- item-sep -->
 
-- **Pilot the exhaustive interaction before committing the pass.** Naming which
-  of 25 classes are present is a materially harder task than a binary vote, and
-  COCO itself used a staged per-class protocol rather than one sweep over 80.
-  Run a pilot on a few hundred anchored images where COCO is the answer key, and
-  report per-class recall and the time per image. That measurement decides
-  whether the pass is one sweep, a staged protocol, or a shortlist-then-confirm
-  flow.
+- **Treat the first batch as the pilot, rather than piloting separately.**
+  Naming which of 25 classes are present is a materially harder task than a
+  binary vote, and COCO itself used a staged per-class protocol rather than one
+  sweep over 80 — so the interaction may well need changing. That is an argument
+  for looking at the first few hundred judgements before running the other three
+  thousand, not for annotating throwaway images first: start on the real queue,
+  and read the first batch as the pilot. What to read off it is per-class recall
+  and time per image, both against COCO on whatever part of the batch is
+  anchored.
   `scripts/experiments/lessons/2026-09-02-one-pilot-cell-cleared-a-hazard-the-full-wave-hit.md`
-  is the standing reason to pilot first. (human + Sonnet 5)
+  is the standing reason to look before committing the rest. (human + Sonnet 5)
 
 <!-- item-sep -->
 

--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -339,7 +339,7 @@ def anchor_to_coco(
             own = labels[iid][cls]
             if not own:
                 continue
-            was = band_for(own, vw, vh)
+            was = band_for(own, *dims[iid])
             if was not in pc.BOX_BANDS:
                 continue
             now = band_for(ref[cls], *wh) if ref.get(cls) else None


### PR DESCRIPTION
`vg_scale` is built as a **designation** — a class list, a band rule, and a fixed count of positives and negatives per cell, sampled to make the small-vs-large contrast paired. That shape answered #3156. It is the wrong shape for the stated goal, which is a COCO-like set that many questions can be asked of: under a designation, prevalence, band definition, class list and pool composition are all build-time choices, so changing any of them is a rebuild and a re-embed.

This adds `docs/plans/vg-scale-exhaustive-annotation.md` scoping the move to an exhaustively annotated set, and indexes it.

## The gap is smaller than it looks

Every class in *C* is a COCO-2017 class, and since #3670 the negative pool and spares are drawn entirely from the COCO-anchored half. So the only stratum without exhaustive labels is the **off-COCO positives** — 1,509 of 3,546 (42.55%) in the 12-class build, roughly 3,100–3,200 at 25 — and it is one exhaustive pass per image rather than 25 binary votes. For scale, the pass already committed to for #3702 is ~10,000 images.

The zero-annotation alternative is already measured and does not reach: `exact_supply.py` found 20 of 36 shipped cells and 17 of 39 candidate cells short of 300 COCO-anchored positives (`dog@small` 114, `spoon@large` 106), so the off-COCO half has to be answered rather than dropped.

The plan records what the pass retires (the VG name tables, pooled adjudication, contamination measurement, the `provable`/`matched` choice open as #3702, the global ambiguous exclusion #3655, `anchor_to_coco`'s un-banding #3659), the two decisions it forces (the band statistic; two label sources of unequal quality), and the open work in dependency order.

Origin is #3668, filed from the reviewer's side: *"a 13-way judgement is recorded as one bit, and twelve are thrown away."*

## Also: a NameError fix on `dev`

`./run-tests.sh` failed on this branch before any of my changes, at the `ruff` gate. `anchor_to_coco` reads `band_for(own, vw, vh)` against two variables that do not exist in the function (two `F821`s), so it raises `NameError` on the first anchored image carrying a wanted class — every real build. Introduced by #3713, merged today; the gate cannot have been green when it landed.

Fixed by reading VG's own boxes in VG's own pixel space, `dims[iid]`, before `box_dims[iid] = wh` swaps in COCO's frame — the same two values the aspect guard two lines above compares. `TestReband` already pins this, framing a 400×400 VG copy against a 1200×1200 COCO one precisely so a band read in the wrong frame lands in a neighbouring band.

Unrelated to the plan doc, fixed here per the repo's fix-all-errors rule.

## Testing

Full `./run-tests.sh`: **RUN PASSED**, 10,965 passed / 6 skipped / 2 xpassed, all gates green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

Refs #3668, refs #3702, refs #3655, refs #3659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArT56CaAFaR4aa2ZxBYWXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArT56CaAFaR4aa2ZxBYWXd)_