### PR TITLE
branch-protection.md: describe the repo that exists, not the Free-plan one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -724,6 +724,6 @@ def slow_load():
 - [`slides/STYLE.md`](slides/STYLE.md) — house rules for every slide deck (no running footer, real subscripts, colour reserved for meaning, the 20px type floor, the opening outline); [`slides/README.md`](slides/README.md) is the build mechanics.
 - [`docs/plans/`](docs/plans/) — future-work design docs (open/proposed; shipped work is pruned out, not archived); check here before adding a "Phase N" feature.
 - [`docs/RELEASE.md`](docs/RELEASE.md) — the `dev` → `main` release runbook (the procedure the Dev2Main Routine follows: vulture audit, release summary, punch-card refresh, release PR, issue close-out, plan-pointer prune).
-- [`docs/branch-protection.md`](docs/branch-protection.md) — who can land on `main` vs `dev`, and what the Free-plan private repo can and cannot enforce.
+- [`docs/branch-protection.md`](docs/branch-protection.md) — who can land on `main` vs `dev`, the branch protection in force on each, and why `dev` survives the Dev2Main release PR now that merged head branches are auto-deleted.
 - [`docs/style-guide.md`](docs/style-guide.md) — frontend SCSS conventions (the styling half of [`docs/FRONTEND.md`](docs/FRONTEND.md)).
 - [`CHANGELOG.md`](CHANGELOG.md) — curated record of notable user-facing app changes ([`vtscore/CHANGELOG.md`](vtscore/CHANGELOG.md) is the library's).

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -3,78 +3,101 @@
 Goal: **only @samggreenberg should land changes on `main`.** `dev` is the shared
 integration branch and stays open to collaborators via PRs.
 
-## Reality check: this repo is private on the Free plan
+## Current state (verified 2026-09-08)
 
-Two GitHub limitations apply here, and they shape everything below:
+This repository is **public**, so branch protection and rulesets are available at
+no cost, and both long-lived branches carry protection:
 
-1. **No branch protection or rulesets.** On the Free plan, protected branches and
-   repository rulesets are only available on **public** repositories. A private
-   repo on Free **cannot** enforce "require a PR," "require my review," or
-   "restrict who pushes to `main`." Those settings are simply unavailable.
-2. **No granular collaborator roles.** On a **personal-account** repo (this one),
-   every collaborator you add has **write/push** access. The Read / Triage /
-   Write / Maintain roles only exist inside **organizations**. So you can't make
-   any of the 7 collaborators (`xofm31`, `sbwilli3`, `matsunagateitoku`,
-   `trevoradriaanse`, `qr1338`, `GCHQDev42081`, `drew-synergist-computing`)
-   read-only either.
+| | |
+|---|---|
+| visibility | **public** (`"private": false`) |
+| default branch | `main` |
+| `main` | **protected** |
+| `dev` | **protected** |
+| collaborators | 4 — @samggreenberg (admin), @xofm31, @MatthewELucio, @CarHorseBatteryStaple (write) |
 
-Net effect: **right now, nothing GitHub-side can hard-*prevent* a collaborator
-from pushing to `main`.** Enforcement requires changing the plan or visibility
-(see the last section). Until then, the controls below are *soft* — they signal,
-notify, and rely on team convention, but do not block.
+That is the *existence* of protection, which is what the branch API reports. It
+does not say what each rule enforces — see
+[Reading the rules that are actually set](#reading-the-rules-that-are-actually-set)
+below, and read them before relying on any specific guarantee.
 
-## Soft controls in effect today
+### The one limitation that has not changed
 
-### 1. CODEOWNERS auto-requests your review
+**Every collaborator on a personal-account repo has write access.** The
+Read / Triage / Write / Maintain roles exist only inside organizations, so the
+three collaborators above cannot be made read-only while the repo lives under a
+personal account. Restricting *who may push to `main`* is therefore done by the
+branch rule's push restriction, not by giving anyone a weaker role.
 
-`.github/CODEOWNERS` is `* @samggreenberg`. Even without branch protection,
-GitHub uses it to **automatically request your review** on every PR. This does
-not *block* a merge on the Free/private plan, but it makes your sign-off the
-visible, expected step on anything heading toward `main`.
+## Why `dev` survives a Dev2Main release
 
-### 2. Team convention (the actual gate, for now)
+Worth stating explicitly, because the repo now has **"Automatically delete head
+branches"** enabled and the [Dev2Main](RELEASE.md) release PR is `dev` → `main` —
+which makes `dev` the *head* branch of a PR that gets merged every release.
 
-The enforced rules don't exist, so the working agreement is the gate. The
-project already encodes it in `CLAUDE.md`:
+`dev` is not deleted, for two independent reasons:
+
+1. **It is protected.** GitHub's automatic head-branch deletion skips protected
+   branches. A protection carrying `allow_deletions: false` blocks the deletion
+   outright rather than merely declining to initiate it.
+2. **It is the base of other open PRs.** GitHub does not auto-delete a branch
+   that another open PR is targeting, and on any ordinary day `dev` is the base
+   of several.
+
+If it were ever deleted anyway, nothing is lost: after the release merge `dev`'s
+tip is an ancestor of `main`, and the merged PR page offers **Restore branch** to
+recreate it at the same commit. The cost would be disruption — the
+`.claude/hooks/session-start.sh` hook and every open PR's base break until it is
+restored — not lost work.
+
+## Soft controls, which still do useful work
+
+Protection rules are the hard gate; these remain worth keeping because they shape
+behaviour before anyone reaches the gate.
+
+### CODEOWNERS auto-requests review
+
+[`.github/CODEOWNERS`](../.github/CODEOWNERS) is `* @samggreenberg`, so GitHub
+automatically requests that review on every PR. Combined with a `main` rule that
+requires Code Owner review, it makes @samggreenberg the only valid approver for
+anything landing on `main`.
+
+### Team convention
+
+`CLAUDE.md` encodes the working agreement, and it is what keeps `main` quiet in
+practice — nobody working off `dev` has a routine reason to touch `main`:
 
 - All work branches off `dev`; all PRs target `dev`, **never** `main`.
 - `main` is updated **only by @samggreenberg**, by promoting `dev` → `main`.
 - Collaborators do not push directly to `main`.
 
-Keep `main` as the stable/release branch and do all day-to-day merging on `dev`.
-Because everyone works off `dev`, no one has a routine reason to touch `main`.
+### Notifications
 
-### 3. Notifications so you'd *see* an unwanted push
+So an unwanted push to `main` is visible rather than silent: **Watch → All
+Activity** (or **Custom → Pushes**), or subscribe to the `main` commit feed at
+`https://github.com/samggreenberg/vtsearch/commits/main.atom`.
 
-Since you can't block pushes, make sure you'd notice one:
+## Reading the rules that are actually set
 
-- **Watch** the repo (top-right **Watch → All Activity**, or **Custom → Pushes**)
-  so direct pushes to `main` generate a notification.
-- Optionally subscribe to the `main` branch's commit feed (Atom):
-  `https://github.com/samggreenberg/vtsearch/commits/main.atom`.
-
-This turns "someone changed `main`" from invisible into an alert you can act on
-(revert + a conversation), which is the best available recourse without
-enforcement.
-
-## When you want real enforcement
-
-The soft controls above can't *prevent* a push. To actually restrict `main` so
-only you can land changes, pick one of these — then the enforced steps further
-below become available:
-
-| Path | Cost | Result |
-|------|------|--------|
-| **GitHub Pro** | ~$4/mo | Keep repo private; classic branch protection works on private repos. Cheapest real fix. |
-| **Make repo public** | Free | Branch protection + rulesets become available for free. (Code becomes public.) |
-| **Move into an Organization** | Free org / paid Team | Granular member roles (read-only members, contribute via fork+PR). Private-branch *protection* still needs the org **Team** plan. |
-
-### Enforced setup (once on Pro, or public)
-
-Classic branch protection via `gh` (run as `samggreenberg`):
+The branch listing reports only whether a branch is protected. To see what the
+protection contains:
 
 ```bash
-# Lock main: PR + your Code Owner review required, only you may push.
+gh api repos/samggreenberg/vtsearch/branches/main/protection
+gh api repos/samggreenberg/vtsearch/branches/dev/protection
+```
+
+The UI equivalent is **Settings → Rules → Rulesets**, or the classic
+**Settings → Branches** editor.
+
+## The intended rules
+
+Recorded here as the reference for what protection *should* say. Check the live
+rules against this rather than assuming they match.
+
+Lock `main` — PR plus Code Owner review required, only @samggreenberg may push:
+
+```bash
 gh api -X PUT repos/samggreenberg/vtsearch/branches/main/protection \
   --input - <<'JSON'
 {
@@ -92,12 +115,12 @@ gh api -X PUT repos/samggreenberg/vtsearch/branches/main/protection \
 JSON
 ```
 
-With `.github/CODEOWNERS` = `* @samggreenberg`, `require_code_owner_reviews`
-means only *your* review satisfies the gate; `restrictions.users` limits pushes
-to you. Set `enforce_admins: true` to bind yourself to the same rules.
+With CODEOWNERS as above, `require_code_owner_reviews` means only
+@samggreenberg's review satisfies the gate, and `restrictions.users` limits
+pushes. Set `enforce_admins: true` to bind yourself to the same rules.
 
-For `dev`, keep it lighter — a PR guardrail with no mandatory approver so routine
-work (and Claude PRs) keeps flowing:
+Keep `dev` lighter — a PR guardrail with no mandatory approver, so routine work
+and Claude PRs keep flowing:
 
 ```bash
 gh api -X PUT repos/samggreenberg/vtsearch/branches/dev/protection \
@@ -116,6 +139,18 @@ gh api -X PUT repos/samggreenberg/vtsearch/branches/dev/protection \
 JSON
 ```
 
-Verify with `gh api repos/samggreenberg/vtsearch/branches/main/protection`.
-The equivalent UI lives under **Settings → Rules → Rulesets** (or the classic
-**Settings → Branches** editor) once your plan/visibility allows it.
+`allow_deletions: false` on `dev` is the setting that makes the release flow
+above safe. It is worth confirming it is actually set.
+
+## History
+
+This document previously described the repo as **private on the Free plan**,
+where protected branches and rulesets are unavailable, and concluded that
+"nothing GitHub-side can hard-*prevent* a collaborator from pushing to `main`."
+It carried a cost table of ways to *obtain* enforcement — GitHub Pro, making the
+repo public, or moving to an organization.
+
+The repo has since taken the free option in that table and gone public, so
+enforcement is available and in place, and the sections describing its absence
+were removed rather than left to be reasoned from. The collaborator list in that
+version (seven accounts) no longer matches either.


### PR DESCRIPTION
`docs/branch-protection.md` opened with a *"Reality check: this repo is private on the Free plan"* section concluding that protected branches and rulesets are unavailable here, and that **"nothing GitHub-side can hard-*prevent* a collaborator from pushing to `main`."** It then priced three ways to *obtain* enforcement.

The repo has since taken the free option in its own cost table and gone public. Protection is available and in place.

## The staleness was load-bearing

Asked whether enabling **"Automatically delete head branches"** would delete `dev` when the Dev2Main release PR merges — a real question, since that PR is `dev` → `main` and so makes `dev` the *head* branch — this doc is what would have produced the wrong answer. It states that protection cannot exist here, which makes the branch API's `"protected": true` on `dev` read as a flag to distrust rather than as the guarantee it is.

Same shape as the stale Chromium note in `CLAUDE.md`: a claim that quietly stopped being true and kept getting reasoned from.

So the answer that question needed is now written down, under **"Why `dev` survives a Dev2Main release"** — protection, plus `dev` being the base of other open PRs, plus the **Restore branch** path if it ever is deleted (after the release merge `dev`'s tip is an ancestor of `main`, so nothing is lost).

## What changed

| | before | now |
|---|---|---|
| visibility | private, Free plan | **public** (`"private": false`) |
| protection | "simply unavailable" | **in force** on `main` and `dev` |
| collaborators | seven accounts named | **four** — one name in common |

## What is and isn't asserted

Everything stated as current was verified through the API: visibility, which branches are protected, and the collaborator roster.

The branch listing reports only *that* a branch is protected, never what the rule enforces, and no branch-protection read is available through the GitHub MCP tools in this session. So the rule bodies are kept as **"The intended rules"** — the reference to check the live ones against — with a section on reading what is actually set (`gh api .../protection`) rather than assuming they match. The `allow_deletions: false` line on `dev` is flagged as worth confirming, since it is what makes the release flow safe outright.

The obsolete premise and cost table are removed rather than left in place, per the repo's rule against docs that record superseded state; a short **History** section records what they said and why they went.

`CLAUDE.md`'s pointer to the doc is updated in the same commit — it described the file as covering "what the Free-plan private repo can and cannot enforce".

## Checks

- `./run-tests.sh` → **RUN PASSED**, 1,025 passed / 5 skipped. Markdown-only change, so the run auto-narrowed to the docs gate — the complete gate for this diff. Every cheap gate ran, `check-docs.py` included (relative links, anchors, backticked repo paths, code fences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXxYfzENfenjWHgGJWsrrH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXxYfzENfenjWHgGJWsrrH)_