### PR TITLE
Emit the annotation queue for vg_scale off-COCO positives (#3720)

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -33,17 +33,13 @@ stratum lacking exhaustive labels is the **off-COCO positives**:
 | positives, COCO-anchored | 2,037 (57.45%) | yes — COCO |
 | **positives, off-COCO** | **1,509 (42.55%)** | **no — this is the whole debt** |
 
-Scaled to the 25-class roster that is roughly **3,100–3,200 images**, and it is
-**one exhaustive pass per image** — a reviewer naming which of the 25 classes
-are present — rather than 25 binary votes. For scale, the pass already committed
-to for #3702 is ~400 cleared negatives per class, ~10,000 images. Counts from
+On the shipped 25-class cell the debt is **3,391 images**, 47.43% of its 7,150
+positives — counted by `scripts/experiments/pile/annotation_queue.py`, which
+emits the worklist itself (#3720). It is **one exhaustive pass per image** — a
+reviewer naming which of the 25 classes are present — rather than 25 binary
+votes. For scale, the pass already committed to for #3702 is ~400 cleared
+negatives per class, ~10,000 images. The 12-class counts above are from
 [the #3670 study](../experiments/2026-09-06-provable-negatives-3670/REPORT.md).
-
-**That estimate is here to say whether this is worth starting, and does not need
-refining.** The work has to be done whatever the number turns out to be, so
-sizing it more precisely buys nothing; the exact per-class counts arrive for
-free with the queue, as a byproduct of building the worklist rather than as a
-run of their own.
 
 **The zero-annotation version was measured and does not reach.**
 `scripts/experiments/pile/exact_supply.py` asks whether the COCO half alone
@@ -99,16 +95,7 @@ scoring into the pass rather than discovering the drift afterwards.
 
 <!-- item-sep -->
 
-- **Emit the annotation queue.** Not a measurement — the worklist. A reviewer
-  cannot start without knowing which images are off-COCO positives, and that is
-  a join between VG and COCO ids rather than something visible in the image. It
-  is cheap: `_emit_medias` stamps `coco_scored` on every media, so where the
-  shipped cell carries it the queue is `categories and not coco_scored` read
-  off the pickle, and where it does not the fallback is `image_data.json`'s
-  `coco_id` field (~100 MB) joined against the pickle's positives. Neither
-  needs `objects.json` or a compute node; `scripts/experiments/pile/exact_supply.py`
-  does, which is why it is the wrong tool here. The per-class counts fall out of
-  the queue for free — do not run anything extra to produce them. (Sonnet 5)
+- [ ] #3720 — Emit the annotation queue (Sonnet 5)
 
 <!-- item-sep -->
 

--- a/scripts/experiments/pile/annotation_queue.py
+++ b/scripts/experiments/pile/annotation_queue.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""The worklist for `vg_scale`'s exhaustive annotation pass (#3720, #3668).
+
+`docs/plans/vg-scale-exhaustive-annotation.md` moves `vg_scale` from a
+designation to an exhaustively annotated set, and its debt is one stratum: the
+**off-COCO positives**. Every class in *C* is a COCO-2017 class and since #3670
+the negative pool and the spares are drawn from the COCO-anchored half alone, so
+COCO already answers for everything except the positives VG contributed on the
+half COCO never annotated.
+
+A reviewer cannot start on that stratum without being handed it. **Whether COCO
+also annotated an image is not visible in the image** -- it is a join between VG
+and COCO ids -- so the worklist has to be emitted rather than eyeballed. That is
+all this does.
+
+**One row per image, not per cell.** The pass asks "which of *C* is present?"
+once per image, so an image designated in three cells is one row carrying three
+cell names, not three judgements. Counting cells instead of images would
+over-state the pass by the multiply-designated share.
+
+**Two ways to answer "did COCO score this image?", and they are not
+interchangeable.**
+
+* The cell's own ``coco_scored`` stamp, which the build writes from the
+  post-`anchor_to_coco` `exhaustive` set. This is the same fact #3670's pool
+  composition is defined on, and it is what the build actually acted on.
+* The **fallback**, for a cell built before the stamp: `coco_anchor`'s
+  ``image_data.json``, joined on its ``coco_id`` field. That pairing is a slight
+  *superset* of what the build anchors, because it does not re-apply the
+  aspect-drift filter that drops 49 of 51,497 pairs -- so it can call an image
+  anchored that the build did not, which **drops a row that needs annotating**.
+  That is the unsafe direction here, and the exact opposite of how
+  `check_review_coverage.eligible_under` uses the same join, where a superset
+  inflates a denominator and understates coverage. Measured against the stamp on
+  the shipped 25-class cell: the pairing drops 3 of the 3,391 owed images and
+  adds none -- small, and one-sided in the direction that hides work. So every
+  row says which source answered for it, and the summary says how much of the
+  queue rests on the fallback: read a queue that is mostly ``pairing`` as a
+  lower bound, and rebuild the cell rather than living with it.
+
+**A missing stamp is not a `False` stamp.** ``coco_scored`` absent means no
+answer; ``coco_scored`` false means COCO was asked and did not annotate this
+image. The two are only distinguishable by testing for the *key*, which is why
+this checks membership rather than truthiness -- the deep sibling silently
+inherited #3667's cross-class rule with an empty world by making exactly this
+mistake one level down (`vg_scale._emit_medias`).
+
+**The order is a seeded shuffle, and that is the pilot's doing.** The plan reads
+the first batch of the real queue as the pilot rather than annotating throwaway
+images first, and what it reads off that batch is per-class recall. That is only
+meaningful if the first N rows are a sample of the queue rather than of whatever
+the id order happens to group together, so the queue is shuffled once under a
+fixed seed: reproducible, and unbiased in class, band and source.
+
+**What the queue cannot carry is an answer key.** Every row is off-COCO by
+construction, so no row in it can be scored against COCO. That is not a gap in
+the worklist -- it is why the review tooling mixes a minority of anchored images
+into a slate rather than into the worklist (`make_audit_slate.py`: "the reviewer
+cannot tell them apart: files are named by image id alone"). Scoring the
+annotators is the plan's own item and it acts at slate-build time, on top of
+this file.
+
+Usage::
+
+    python annotation_queue.py                       # the shipped siglip cell
+    python annotation_queue.py --cell <path.pkl> --out queue.jsonl
+    python annotation_queue.py --summary summary.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pile_config as pc
+
+#: Fixed so two people emitting the queue get the same first batch, and so a
+#: re-emission after a rebuild can be diffed against the old one row by row.
+QUEUE_SEED = 3720
+
+
+def log(msg: str) -> None:
+    print(f"[queue] {msg}", flush=True)
+
+
+def class_of(cell: str) -> str:
+    """``"chair@large"`` -> ``"chair"``; a bare class name passes through.
+
+    ``vg_scale`` keys cells on ``class@band`` and ``vg_scale_deep`` keys them on
+    the bare class, and the annotation pass does not care which -- it asks about
+    the class. Splitting on the separator reads both without being told which
+    dataset it was handed.
+    """
+    return cell.split("@", 1)[0]
+
+
+def coco_answer(iid: int, media: dict, paired: set[int] | None) -> tuple[bool, str]:
+    """``(did COCO score this image, which source said so)``.
+
+    Raises when the media carries no stamp and no pairing was supplied, because
+    the alternative -- treating "no answer" as "not scored" -- would put every
+    anchored image in the queue and silently triple the pass.
+    """
+    if "coco_scored" in media:
+        return bool(media["coco_scored"]), "stamp"
+    if paired is None:
+        raise ValueError(
+            f"media {iid} carries no `coco_scored` stamp and no COCO pairing was supplied; "
+            "pass the `image_data.json` join (see `paired_image_ids`)"
+        )
+    return iid in paired, "pairing"
+
+
+def paired_image_ids(image_data: Path) -> set[int]:
+    """VG image ids that COCO also holds, read from `coco_anchor/image_data.json`.
+
+    The same file and the same field `check_review_coverage` and the loader read,
+    deliberately: a second way of spelling "this image is in COCO" is a second
+    thing to keep in sync.
+    """
+    if not image_data.exists():
+        raise SystemExit(f"missing {image_data}; run `coco_anchor.py --fetch` before emitting a queue for this cell")
+    return {int(m["image_id"]) for m in json.loads(image_data.read_text()) if m.get("coco_id")}
+
+
+def queue_rows(medias: dict[int, dict], paired: set[int] | None = None, seed: int = QUEUE_SEED) -> list[dict]:
+    """The off-COCO positives of *medias*, one row per image, shuffled once.
+
+    A positive is an image with a non-empty ``categories`` -- what it was
+    *designated* for. That is not what the image holds (the pickle never records
+    that, which is #3678's whole finding), but it is the right population here:
+    the pass is owed on the images the set contains.
+    """
+    rows = []
+    for iid in sorted(medias):
+        media = medias[iid]
+        cells = list(media.get("categories") or [])
+        if not cells:
+            continue
+        anchored, source = coco_answer(iid, media, paired)
+        if anchored:
+            continue
+        rows.append(
+            {
+                "image_id": iid,
+                "path": media.get("origin_name") or "",
+                "filename": media.get("filename") or "",
+                "cells": sorted(cells),
+                "classes": sorted({class_of(c) for c in cells}),
+                "coco_source": source,
+            }
+        )
+    random.Random(seed).shuffle(rows)
+    return rows
+
+
+def counts(rows: list[dict]) -> tuple[Counter[str], Counter[str], Counter[str]]:
+    """``(per class, per cell, per source)`` over the queue.
+
+    Per *class* counts an image once however many of its cells name that class,
+    so the columns of a class's row sum to its total only when no image is
+    designated in two bands of one class.
+    """
+    per_class: Counter[str] = Counter()
+    per_cell: Counter[str] = Counter()
+    per_source: Counter[str] = Counter()
+    for row in rows:
+        per_class.update(row["classes"])
+        per_cell.update(row["cells"])
+        per_source[row["coco_source"]] += 1
+    return per_class, per_cell, per_source
+
+
+def band_columns(rows: list[dict], bands: tuple[str, ...]) -> tuple[str, ...]:
+    """The bands actually designated in *rows*, in the config's order.
+
+    `vg_scale_deep` keys its cells on the bare class, so its queue has no bands
+    at all -- and a table printing three columns of zeros for it would read as a
+    class list with nothing in it rather than as a dataset that is not banded.
+    """
+    _, per_cell, _ = counts(rows)
+    seen = {cell.split("@", 1)[1] for cell in per_cell if "@" in cell}
+    return tuple(b for b in bands if b in seen)
+
+
+def print_table(rows: list[dict], bands: tuple[str, ...]) -> None:
+    """Per-class counts, banded -- the numbers the plan says arrive for free."""
+    per_class, per_cell, _ = counts(rows)
+    cols = band_columns(rows, bands)
+    by_class_band: dict[str, dict[str, int]] = defaultdict(dict)
+    for cell, n in per_cell.items():
+        if "@" in cell:
+            by_class_band[class_of(cell)][cell.split("@", 1)[1]] = n
+    width = 14 + 10 * (len(cols) + 1)
+    print(f"\n{'class':<14}" + "".join(f"{b:>10}" for b in cols) + f"{'images':>10}")
+    print("-" * width)
+    for cls, total in sorted(per_class.items(), key=lambda kv: (-kv[1], kv[0])):
+        cells = by_class_band.get(cls, {})
+        print(f"{cls:<14}" + "".join(f"{cells.get(b, 0):>10}" for b in cols) + f"{total:>10}")
+    print("-" * width)
+    print(f"{'images owed':<14}" + " " * (10 * len(cols)) + f"{len(rows):>10}")
+
+
+def main() -> int:
+    # Deferred, like `check_review_coverage`'s: `setup_env` rewrites the import
+    # machinery process-wide, and the selection above is worth a unit test that
+    # does not pay for that.
+    pc.setup_env()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    base = pc.PILE.parent / "vgscale-3156"
+    ap.add_argument(
+        "--cell",
+        default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"),
+        help="any embedder's cell: membership is the same in all of them, only the vectors differ",
+    )
+    ap.add_argument("--out", default=str(base / "annotation_queue.jsonl"), help="the worklist, one JSON object a line")
+    ap.add_argument("--summary", default=str(base / "annotation_queue.summary.json"))
+    ap.add_argument("--image-data", default=str(pc.PILE / "coco_anchor" / "image_data.json"))
+    ap.add_argument("--seed", type=int, default=QUEUE_SEED)
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    cell = Path(args.cell)
+    medias = load_medias(cell)
+    positives = {i: m for i, m in medias.items() if m.get("categories")}
+    log(f"{cell.name}: {len(medias)} medias, {len(positives)} positives")
+
+    # Read the ~100 MB join only when the cell cannot answer for itself.
+    unstamped = sum(1 for m in positives.values() if "coco_scored" not in m)
+    paired = None
+    if unstamped:
+        log(f"{unstamped} positives carry no `coco_scored` stamp; falling back to the COCO pairing")
+        paired = paired_image_ids(Path(args.image_data))
+        log(f"{len(paired)} VG images carry a coco_id")
+
+    rows = queue_rows(medias, paired, seed=args.seed)
+    per_class, per_cell, per_source = counts(rows)
+    anchored = len(positives) - len(rows)
+
+    print_table(rows, tuple(pc.BOX_BANDS))
+    print()
+    if not positives:
+        log("NOTE: this cell designates no positives at all -- the wrong cell, or a build that produced none.")
+        return 1
+    log(
+        f"{len(rows)} of {len(positives)} positives are off-COCO "
+        f"({len(rows) / len(positives):.2%}); {anchored} are answered by COCO already"
+    )
+    log("source: " + ", ".join(f"{n} by {s}" for s, n in sorted(per_source.items())))
+    if per_source.get("pairing"):
+        # Loud, and next to the number it qualifies: the pairing over-counts
+        # anchored images, so a queue resting on it is a lower bound on the pass.
+        log(
+            f"NOTE: {per_source['pairing']} rows were classified by the COCO pairing, which is a superset "
+            "of what the build anchors -- those rows under-count the queue. Rebuild the cell to remove the doubt."
+        )
+    off_roster = sorted(set(per_class) - set(pc.SCALE_CLASSES))
+    if off_roster:
+        # The cell is the authority on what it holds and the config is the
+        # authority on what C is; when they disagree the queue is the *build's*
+        # debt, and saying so is cheaper than discovering it at review time
+        # (#3678: nothing else tells you a cell predates a ruling).
+        log(
+            f"NOTE: {len(off_roster)} class(es) here are not in the config's roster ({', '.join(off_roster)}) "
+            "-- this cell was built against a different class list."
+        )
+    if not rows:
+        log("NOTE: no off-COCO positives -- every positive in this cell is already answered by COCO.")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+    summary = {
+        "cell": str(cell),
+        "seed": args.seed,
+        "roster": list(pc.SCALE_CLASSES),
+        "bands": list(pc.BOX_BANDS),
+        "n_medias": len(medias),
+        "n_positives": len(positives),
+        "n_positives_coco_scored": anchored,
+        "n_queue": len(rows),
+        "by_source": dict(per_source),
+        "per_class": dict(per_class),
+        "per_cell": dict(per_cell),
+    }
+    Path(args.summary).write_text(json.dumps(summary, indent=2) + "\n")
+    log(f"wrote {out} and {args.summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/core/test_import_metadata_seed.py
+++ b/tests_lib/core/test_import_metadata_seed.py
@@ -93,10 +93,20 @@ class TestFastPackagesDistributions:
         can only *add* names, and which extras appear depends on what the venv
         happens to record (and on the stdlib's own per-version inference).
         Losing an entry would be a real break; gaining one is not.
+
+        ``__pycache__`` is the one name held out, and it is not an import name.
+        A single-module distribution records ``__pycache__/<mod>.cpython-*.pyc``
+        beside its ``.py``, so the stdlib's inference reports ``__pycache__`` as
+        a top-level name of every such package -- three of them on the GRID venv
+        (`typing_extensions`, `threadpoolctl`, `matplotlib`), and none in the
+        container this test was written in, which is why it passed there and
+        fails here. :func:`_inferred_top_level` drops the name on purpose,
+        because nothing can import it; asserting it survives would pin a stdlib
+        artifact as a contract.
         """
         fast = fast_packages_distributions()
-        real = original_packages_distributions()
-        assert {name: fast.get(name) for name in real} == dict(real)
+        real = {n: d for n, d in original_packages_distributions().items() if n != "__pycache__"}
+        assert {name: fast.get(name) for name in real} == real
 
 
 class TestSeed:

--- a/tests_lib/meta/test_pile_annotation_queue.py
+++ b/tests_lib/meta/test_pile_annotation_queue.py
@@ -1,0 +1,210 @@
+"""The annotation queue's selection rule, exercised without the pile (#3720).
+
+`annotation_queue.py` decides which images the exhaustive pass owes a judgement
+on. Everything expensive about that decision is in two places, and neither is
+visible in the output it produces:
+
+* **which source answered "did COCO score this image?"** -- the cell's own stamp
+  or the COCO pairing. The pairing is a superset of what the build anchors, so
+  reaching for it when the stamp is present would drop rows that need
+  annotating, and a dropped row looks exactly like an image nobody owed;
+* **an absent stamp against a false one.** They are the same value under
+  `.get()` and opposite facts: no answer versus COCO answered and said no. The
+  loader lost the deep sibling's cross-class rule to this shape (#3667), so it
+  gets a test here rather than a comment.
+
+The rest is arithmetic that has to hold for the counts to mean anything: one row
+per image, a class counted once per image however many bands it spans.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+
+@pytest.fixture(scope="module")
+def aq():
+    """``annotation_queue``, which defers ``setup_env`` into ``main``."""
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import annotation_queue
+
+    return annotation_queue
+
+
+def _positive(cells: list[str], *, coco_scored: bool | None = False, iid: int = 1) -> dict:
+    """A designated positive as the loader writes one.
+
+    ``coco_scored=None`` spells a cell built before the stamp existed -- the key
+    absent, not present and false.
+    """
+    media = {
+        "id": iid,
+        "categories": list(cells),
+        "filename": f"{iid}.jpg",
+        "origin_name": f"/vg/VG_100K/{iid}.jpg",
+    }
+    if coco_scored is not None:
+        media["coco_scored"] = coco_scored
+    return media
+
+
+def _negative(*, coco_scored: bool | None = True, iid: int = 900) -> dict:
+    """A shared negative: no categories, so the pass owes it nothing."""
+    media = {"id": iid, "categories": [], "filename": f"{iid}.jpg", "origin_name": f"/vg/VG_100K/{iid}.jpg"}
+    if coco_scored is not None:
+        media["coco_scored"] = coco_scored
+    return media
+
+
+class TestClassOf:
+    def test_a_banded_cell_yields_its_class(self, aq):
+        assert aq.class_of("stop sign@large") == "stop sign"
+
+    def test_a_bare_class_passes_through(self, aq):
+        """``vg_scale_deep`` keys cells on the class alone, and reads the same."""
+        assert aq.class_of("stop sign") == "stop sign"
+
+
+class TestCocoAnswer:
+    def test_the_stamp_is_read_when_present(self, aq):
+        assert aq.coco_answer(1, _positive(["bus@small"], coco_scored=True), None) == (True, "stamp")
+
+    def test_a_false_stamp_is_an_answer_not_a_gap(self, aq):
+        """The regression this exists to stop.
+
+        The image is stamped ``False`` -- COCO was asked and does not hold it --
+        *and* it is in the COCO pairing, because the pairing is a superset of
+        what the build anchors (it skips the aspect-drift filter). Re-asking the
+        pairing would call it anchored and silently drop a row the pass owes.
+        """
+        answer = aq.coco_answer(1, _positive(["bus@small"], coco_scored=False), paired={1})
+
+        assert answer == (False, "stamp")
+
+    def test_an_unstamped_media_falls_back_to_the_pairing(self, aq):
+        media = _positive(["bus@small"], coco_scored=None)
+
+        assert aq.coco_answer(1, media, paired={1}) == (True, "pairing")
+        assert aq.coco_answer(1, media, paired=set()) == (False, "pairing")
+
+    def test_an_unstamped_media_with_no_pairing_refuses_to_guess(self, aq):
+        """Defaulting to "not scored" would put the anchored half in the queue."""
+        with pytest.raises(ValueError, match="no `coco_scored` stamp"):
+            aq.coco_answer(1, _positive(["bus@small"], coco_scored=None), None)
+
+
+class TestPairedImageIds:
+    def test_only_images_carrying_a_coco_id_are_paired(self, aq, tmp_path):
+        p = tmp_path / "image_data.json"
+        p.write_text(json.dumps([{"image_id": 1, "coco_id": 42}, {"image_id": 2, "coco_id": None}, {"image_id": 3}]))
+
+        assert aq.paired_image_ids(p) == {1}
+
+    def test_a_missing_join_says_how_to_get_it(self, aq, tmp_path):
+        with pytest.raises(SystemExit, match="coco_anchor.py --fetch"):
+            aq.paired_image_ids(tmp_path / "absent.json")
+
+
+class TestQueueRows:
+    def test_only_off_coco_positives_are_owed(self, aq):
+        medias = {
+            1: _positive(["bus@small"], coco_scored=False, iid=1),
+            2: _positive(["bus@small"], coco_scored=True, iid=2),
+            900: _negative(iid=900),
+        }
+
+        assert [r["image_id"] for r in aq.queue_rows(medias)] == [1]
+
+    def test_a_negative_is_never_asked_for_an_answer(self, aq):
+        """A pool built before the stamp must not make the queue unemittable.
+
+        Negatives are drawn from the COCO-scored half by rule (#3670) and the
+        pass owes them nothing either way, so they are skipped *before* the
+        source question is asked -- not answered by the pairing and discarded.
+        """
+        medias = {900: _negative(coco_scored=None, iid=900)}
+
+        assert aq.queue_rows(medias, paired=None) == []
+
+    def test_one_row_carries_every_cell_the_image_was_designated_in(self, aq):
+        """One exhaustive judgement per image, not one per cell."""
+        medias = {1: _positive(["bus@small", "car@large", "bus@medium"], iid=1)}
+
+        (row,) = aq.queue_rows(medias)
+
+        assert row["cells"] == ["bus@medium", "bus@small", "car@large"]
+        assert row["classes"] == ["bus", "car"]
+
+    def test_a_row_carries_what_a_reviewer_needs_to_open_it(self, aq):
+        (row,) = aq.queue_rows({1: _positive(["bus@small"], iid=1)})
+
+        assert row["path"] == "/vg/VG_100K/1.jpg"
+        assert row["filename"] == "1.jpg"
+        assert row["coco_source"] == "stamp"
+
+    def test_the_order_is_a_function_of_the_seed_alone(self, aq):
+        """The first batch is the pilot, so it must be reproducible and unbiased."""
+        medias = {i: _positive([f"c{i % 5}@small"], iid=i) for i in range(200)}
+
+        first = [r["image_id"] for r in aq.queue_rows(medias, seed=7)]
+        again = [r["image_id"] for r in aq.queue_rows(medias, seed=7)]
+        other = [r["image_id"] for r in aq.queue_rows(medias, seed=8)]
+
+        assert first == again
+        assert first != other
+        assert sorted(first) == sorted(other) == list(range(200))
+
+    def test_the_queue_is_not_in_id_order(self, aq):
+        """An id-ordered queue makes the pilot a sample of VG's id space, not of C."""
+        medias = {i: _positive(["bus@small"], iid=i) for i in range(200)}
+
+        assert [r["image_id"] for r in aq.queue_rows(medias)] != list(range(200))
+
+
+class TestBandColumns:
+    def test_only_designated_bands_get_a_column(self, aq):
+        rows = aq.queue_rows({1: _positive(["bus@small"], iid=1)})
+
+        assert aq.band_columns(rows, ("small", "medium", "large")) == ("small",)
+
+    def test_an_unbanded_cell_gets_no_band_columns(self, aq):
+        """`vg_scale_deep` keys cells on the bare class, and three zero columns lie."""
+        rows = aq.queue_rows({1: _positive(["bus"], iid=1)})
+
+        assert aq.band_columns(rows, ("small", "medium", "large")) == ()
+
+    def test_the_columns_keep_the_config_order(self, aq):
+        """Not the order the cells happened to be counted in."""
+        rows = aq.queue_rows({1: _positive(["bus@large"], iid=1), 2: _positive(["bus@small"], iid=2)})
+
+        assert aq.band_columns(rows, ("small", "medium", "large")) == ("small", "large")
+
+
+class TestCounts:
+    def test_a_class_is_counted_once_per_image_and_a_cell_once_per_designation(self, aq):
+        """Two bands of one class are two cells and one image owing one judgement."""
+        rows = aq.queue_rows({1: _positive(["bus@small", "bus@large"], iid=1)})
+
+        per_class, per_cell, per_source = aq.counts(rows)
+
+        assert per_class == {"bus": 1}
+        assert per_cell == {"bus@small": 1, "bus@large": 1}
+        assert per_source == {"stamp": 1}
+
+    def test_the_sources_are_counted_separately(self, aq):
+        """How much of the queue rests on the fallback is the queue's own caveat."""
+        medias = {
+            1: _positive(["bus@small"], coco_scored=False, iid=1),
+            2: _positive(["bus@small"], coco_scored=None, iid=2),
+        }
+
+        _class, _cell, per_source = aq.counts(aq.queue_rows(medias, paired=set()))
+
+        assert per_source == {"stamp": 1, "pairing": 1}


### PR DESCRIPTION
Closes #3720. First item of `docs/plans/vg-scale-exhaustive-annotation.md`, merged in #3717.

The exhaustive pass cannot start until a reviewer is handed the images it owes, and that is the one thing about those images that is not visible in them: whether COCO also annotated a VG image is a join between two id spaces. `scripts/experiments/pile/annotation_queue.py` emits it.

## What it found

On the shipped 25-class cell, **3,391 images** are owed — 47.43% of its 7,150 positives; the other 3,759 COCO already answers for. The plan estimated ~3,100–3,200 by scaling the 12-class build's 42.55%; the off-COCO share went **up** with the promotion, so the estimate is replaced by the measurement (one line in the plan).

Read off the pickle in **1.7s on a login node** — no `objects.json`, no compute node, no GPU.

| | |
|---|---:|
| positives in the cell | 7,150 |
| answered by COCO | 3,759 |
| **owed to the pass** | **3,391** |
| carrying more than one class | 155 |
| most / least owed | `car` 191, `stop sign` 69 |

Per-class counts come with the worklist rather than from a run of their own, as the plan asks. `stop sign`'s 69 is the supply problem #3635 measured showing up again; `car` and `chair` are the two heaviest.

## Three things the rule has to get right

**One row per image, not per cell.** The pass asks "which of *C* is present?" once per image, so an image designated in three cells is one row carrying three cell names. Counting cells would over-state the pass by the multiply-designated share: 3,556 designations against 3,391 judgements, with 155 images carrying more than one class.

**Two sources answer "did COCO score this image?", and they are not interchangeable.** The cell's own `coco_scored` stamp is what the build acted on. The fallback, for a cell built before the stamp, is `image_data.json`'s `coco_id` join — a *superset* of what the build anchors, because it does not re-apply the aspect-drift filter. A superset **drops rows the pass owes**, which is the unsafe direction here and the exact opposite of `check_review_coverage.eligible_under`, where the same join inflates a denominator and understates coverage. So each row records which source answered it and the summary counts them. The caveat is checkable, so it is measured rather than asserted: against the stamp on the shipped cell, the pairing calls **3** of the 3,391 anchored and none the other way. The shipped cells all carry the stamp, so the fallback is not exercised in practice.

**An absent stamp is not a false stamp**, and `.get()` spells them the same. A `False` stamp means COCO was asked and does not hold the image — precisely a row the pass owes — so re-asking the pairing about it would drop it. The source is therefore chosen on the presence of the key, and a positive with neither raises rather than defaulting: defaulting to "not scored" would put the anchored half in the queue and triple the pass. That is #3667's shape one level down, which is why it is a test and not a comment.

## The order is the pilot's doing

The plan reads the first batch of the *real* queue as the pilot rather than annotating throwaway images first, and what it reads off that batch is per-class recall. That only means something if the first N rows sample the queue rather than VG's id order, so the queue is shuffled once under a fixed seed — same first batch for whoever emits it, and diffable row-by-row after a rebuild.

The queue cannot carry an answer key: every row is off-COCO by construction. That is not a gap in the worklist — it is why `make_audit_slate.py` mixes a minority of anchored images into a *slate* ("the reviewer cannot tell them apart: files are named by image id alone"). Scoring the annotators against COCO stays the plan's own item, acting at slate-build time on top of this file.

## Output

```
/expscratch/$USER/vgscale-3156/annotation_queue.jsonl          # 3,391 rows
/expscratch/$USER/vgscale-3156/annotation_queue.summary.json   # roster, counts, sources
```

One JSON object a line: `image_id`, `path`, `filename`, `cells`, `classes`, `coco_source`. Regenerated in seconds from the cell, so nothing durable rests on scratch.

## Testing

`tests_lib/meta/test_pile_annotation_queue.py` — 16 tests over the selection rule without the pile, in the idiom of `test_pile_vg_scale.py`'s `coverage` fixture (the module defers `setup_env` into `main`). The two that matter are the false-stamp-is-an-answer case and the unstamped-with-no-pairing refusal.

Full `./run-tests.sh` on the GRID (job 624397): **RUN PASSED**, 10,996 passed / 6 skipped / 2 xpassed, every gate green (pyright, pip-audit, vulture whitelist, npm audit, Vitest).

## Also: `dev` was red, and a suite job that lies about why

Two things this run turned up, neither related to the queue.

**`dev` fails its own suite on this venv.** #3716's live-venv test asserts `fast_packages_distributions` loses nothing the stdlib reports, while the implementation drops exactly one name on purpose (`name != "__pycache__"`). A single-module distribution records `__pycache__/<mod>.cpython-312.pyc` beside its `.py`, so the stdlib reports `__pycache__` as a top-level name of every such package — three here (`typing_extensions`, `threadpoolctl`, `matplotlib`), none in the container the test was written in, which is why it passed there. Nothing can import `__pycache__`, so the exclusion is right and the assertion is wrong; it is now held out by name. Reproduced on a clean `origin/dev` (58f2587) before blaming a branch, and fixed here per the fix-all-errors rule.

**The suite job OOMed twice before that, and said "timeout".** `run-tests.sh` runs `-n auto`, and xdist resolves that from `psutil.cpu_count()` — the machine's 20 physical cores — ignoring the 8-CPU cgroup. ~20 torch-loading workers in a 32G allocation get their workers OOM-killed one at a time, so the run wedges rather than fails and the only message is the 1800s wall-clock cap. Filed as #3721; these runs pass `PYTEST_XDIST_AUTO_NUM_WORKERS=8`.


Refs #3668.
