### PR TITLE
Ask COCO whether the provable pool holds any class of C (#3701)

### DIFF
--- a/scripts/experiments/pile/pilebuild/audit.py
+++ b/scripts/experiments/pile/pilebuild/audit.py
@@ -10,6 +10,7 @@ verified clean (#3297).
 
 from __future__ import annotations
 
+import json
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -94,6 +95,105 @@ def negative_pool_problems(ds: str, medias: dict) -> list[str]:
     return problems
 
 
+def coco_held_by() -> dict[int, list[str]]:
+    """``VG image id -> the classes of C COCO annotates it with``, empty for none.
+
+    Keyed on VG's ids because that is what a cell carries, and *absent* rather
+    than empty for an image COCO never scored: "annotated and holds none" and
+    "never annotated" are the two facts this whole pool rests on distinguishing,
+    so they must not be the same value here either.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import coco_anchor as ca  # noqa: PLC0415
+
+    try:
+        image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    except SystemExit:
+        # Missing sources must not abort the whole of --verify; the pool check
+        # reports the gap itself, and says the claim went untested.
+        log("NOTE: coco_anchor sources are not staged, so the pool cannot be checked against COCO")
+        return {}
+    truth = ca.coco_truth(instances, set(pc.SCALE_CLASSES))
+    with image_data.open() as fh:
+        coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
+    return {i: sorted(c for c, boxes in truth[cid].items() if boxes) for i, cid in coco_of.items() if cid in truth}
+
+
+def pool_coco_counts(medias: dict, held_by: dict[int, list[str]]) -> tuple[int, int, list[tuple[int, list[str]]]]:
+    """``(designated negatives, how many COCO can answer for, the dirty ones)``.
+
+    Split out from the message below so the clean case still has numbers to
+    print: "the pool is clean" and "the check could not run" are the same empty
+    list of problems, and a measurement that cannot be told from its own absence
+    is the failure this directory keeps re-learning (#3667, #3299).
+
+    Spares are excluded exactly as in :func:`negative_pool_problems` -- they are
+    designated into no cell, so they make no claim -- and so are positives,
+    which hold their class by definition.
+
+    **Only images the build itself anchored are checked**, which is what the
+    ``coco_scored`` stamp says. A ``coco_id`` in `image_data.json` is a *wider*
+    claim than the build acts on: `anchor_to_coco` refuses a pairing whose
+    aspect ratio drifts by more than `MAX_ASPECT_DRIFT`, precisely because a
+    drifted pair is evidence the two files are not the same picture. Reading the
+    raw join instead reported three dirty negatives in `vg_scale_deep` on the
+    first run of this check, and all three were drift rejects -- drift 0.025,
+    0.119 and 0.552 against a 0.01 limit, the last pairing a 298x500 portrait
+    with a 450x338 landscape. Those images entered the pool on VG's silence,
+    which is what deep's composition allows, and COCO was never asked about
+    them. Asserting COCO's answer for a pairing the build rejected does not test
+    the pool's claim; it invents a different one.
+    """
+    pool = [(i, m) for i, m in medias.items() if not m.get("categories") and m.get("evaluable_categories")]
+    checked = [i for i, m in pool if m.get("coco_scored") and i in held_by]
+    dirty = sorted((i, held_by[i]) for i in checked if held_by[i])
+    return len(pool), len(checked), dirty
+
+
+def provable_pool_problems(ds: str, medias: dict, held_by: dict[int, list[str]]) -> list[str]:
+    """Does the pool hold none of *C*, by COCO's own annotation? (#3701)
+
+    :func:`negative_pool_problems` tests the pool's **provenance** -- every
+    designated negative carries a ``coco_scored`` stamp -- and a true stamp is
+    not the claim. An image can be COCO-scored, hold a `truck`, and still be
+    designated a negative for every class, if a pass upstream of the draw
+    removed the label: an ambiguous-table entry naming another class in *C* pops
+    that class's boxes, and on an anchored image the ``exhaustive`` exemption
+    suppresses the compensating ``unbanded`` pair, so ``band_candidates`` files
+    a COCO-confirmed truck as clean (#3588). A config guard now blocks that one
+    route; this tests the *property*, which holds however it was violated.
+
+    **Named, not repaired, and deliberately not dropped.** An image that reaches
+    the pool holding a class of *C* means an upstream pass is wrong; removing it
+    leaves the pool clean and the cause invisible. The ids are what turn "the
+    pool is dirty" into a diagnosis -- in the #3588 case they said `truck` at
+    once.
+    """
+    n_pool, n_checked, dirty = pool_coco_counts(medias, held_by)
+    if not n_pool:
+        return []
+    if not n_checked:
+        # Under `provable` every negative is COCO-scored by construction, so
+        # nothing to check means the join is missing -- not that the pool is
+        # fine. `vg_scale_deep` is pinned to the pre-#3670 draw (#3690) and may
+        # legitimately have little COCO can answer for.
+        if pc.SCALE_NEG_COMPOSITION == "provable" and ds != "vg_scale_deep":
+            return [
+                f"{ds}: composition=provable, but COCO could answer for none of the {n_pool} designated "
+                "negatives -- the pool's claim went untested. Either `coco_anchor/image_data.json` is not "
+                "staged, or this cell predates the `coco_scored` stamp; rebuild it"
+            ]
+        return []
+    if not dirty:
+        return []
+    shown = ", ".join(f"{i} ({'/'.join(cs)})" for i, cs in dirty[:5])
+    return [
+        f"{ds}: {len(dirty)} of {n_checked} designated negatives hold a class of C by COCO's own "
+        f"annotation -- e.g. {shown}{', ...' if len(dirty) > 5 else ''}. A pass upstream of the draw "
+        "put them there; find it rather than dropping them"
+    ]
+
+
 def verify() -> int:
     """Load every present cell and check it is usable. Returns an exit code."""
     io = cells_io()
@@ -176,12 +276,21 @@ def verify() -> int:
 
     # One cell per vg_scale-family dataset: the pool is the same set of images in
     # every embedder's copy, so a second one would only repeat the finding.
+    held_by: dict[int, list[str]] | None = None
     for ds in pc.DATASETS:
         if not str(pc.DATASETS[ds].get("kind", "")).startswith("vg_scale"):
             continue
         path = next((p for p in (pc.cell_path(ds, e) for _d, e in pc.cells() if _d == ds) if p.exists()), None)
         if path is not None:
-            problems += negative_pool_problems(ds, io.load_medias(path))
+            pool_medias = io.load_medias(path)
+            problems += negative_pool_problems(ds, pool_medias)
+            # Read once for every dataset: `coco_truth` parses 490 MB of COCO
+            # annotation, and the pool is the same population in each of them.
+            if held_by is None:
+                held_by = coco_held_by()
+            problems += provable_pool_problems(ds, pool_medias, held_by)
+            n_pool, n_checked, dirty = pool_coco_counts(pool_medias, held_by)
+            log(f"{ds}: pool vs COCO -- {n_checked}/{n_pool} negatives answerable, {len(dirty)} hold a class of C")
 
     # A derived cell that no longer matches its parent. `vg_scale_any` is a
     # relabel of the built `vg_scale` pickle and shares its vectors, so it

--- a/tests_lib/core/test_import_metadata_seed.py
+++ b/tests_lib/core/test_import_metadata_seed.py
@@ -93,10 +93,20 @@ class TestFastPackagesDistributions:
         can only *add* names, and which extras appear depends on what the venv
         happens to record (and on the stdlib's own per-version inference).
         Losing an entry would be a real break; gaining one is not.
+
+        ``__pycache__`` is the one name held out, and it is not an import name.
+        A single-module distribution records ``__pycache__/<mod>.cpython-*.pyc``
+        beside its ``.py``, so the stdlib's inference reports ``__pycache__`` as
+        a top-level name of every such package -- three of them on the GRID venv
+        (`typing_extensions`, `threadpoolctl`, `matplotlib`), and none in the
+        container this test was written in, which is why it passed there and
+        fails here. :func:`_inferred_top_level` drops the name on purpose,
+        because nothing can import it; asserting it survives would pin a stdlib
+        artifact as a contract.
         """
         fast = fast_packages_distributions()
-        real = original_packages_distributions()
-        assert {name: fast.get(name) for name in real} == dict(real)
+        real = {n: d for n, d in original_packages_distributions().items() if n != "__pycache__"}
+        assert {name: fast.get(name) for name in real} == real
 
 
 class TestSeed:

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -985,6 +985,91 @@ class TestNegativePoolProblems:
         assert audit.negative_pool_problems("vg_scale_deep", medias) == []
 
 
+class TestProvablePoolHoldsC:
+    """Whether the pool's claim is TRUE, not whether its provenance is (#3701).
+
+    `negative_pool_problems` asks who answered for a negative. This asks what
+    the answer was: a genuine `coco_scored` stamp and a COCO-confirmed `truck`
+    are perfectly compatible, and that pair is what #3588's ambiguous-table
+    route actually produced.
+    """
+
+    def _pool(self, n: int = 5) -> dict:
+        return {i: _pool_media() for i in range(n)}
+
+    def test_a_clean_pool_is_silent(self, audit):
+        held = dict.fromkeys(range(5), [])
+
+        assert audit.provable_pool_problems("vg_scale", self._pool(), held) == []
+
+    def test_a_negative_coco_says_holds_a_class_is_named(self, audit):
+        """The id and the class, because those are what diagnose the cause."""
+        held = dict.fromkeys(range(5), [])
+        held[3] = ["truck"]
+
+        (problem,) = audit.provable_pool_problems("vg_scale", self._pool(), held)
+
+        assert "1 of 5" in problem
+        assert "3 (truck)" in problem
+
+    def test_a_negative_the_build_did_not_anchor_is_not_checked(self, audit):
+        """The build's stamp, not the raw `coco_id` join -- measured, not assumed.
+
+        `anchor_to_coco` refuses a pairing whose aspect ratio drifts past
+        `MAX_ASPECT_DRIFT`, because a drifted pair is evidence the two files are
+        not the same picture. The first run of this check read the join instead
+        and reported three dirty negatives in `vg_scale_deep`; every one was a
+        drift reject, the worst pairing a 298x500 portrait with a 450x338
+        landscape. Such an image is in the pool on VG's silence, which is what
+        that composition allows, and COCO was never asked about it.
+        """
+        medias = {1: _pool_media(coco_scored=False)}
+
+        assert audit.provable_pool_problems("vg_scale_deep", medias, {1: ["dog"]}) == []
+
+    def test_a_positive_holding_its_own_class_is_not_a_pool_problem(self, audit):
+        """Every positive holds its class; reading them as pool members fires on all of them."""
+        medias = {1: {"categories": ["truck@small"], "evaluable_categories": ["truck@small"], "coco_scored": True}}
+
+        assert audit.provable_pool_problems("vg_scale", medias, {1: ["truck"]}) == []
+
+    def test_a_spare_makes_no_claim(self, audit):
+        """A spare is designated into no cell, so it asserts nothing to falsify."""
+        medias = {1: _pool_media(designated=False)}
+
+        assert audit.provable_pool_problems("vg_scale", medias, {1: ["truck"]}) == []
+
+    def test_the_examples_are_capped_and_the_count_is_not(self, audit):
+        held = dict.fromkeys(range(9), ["bus"])
+
+        (problem,) = audit.provable_pool_problems("vg_scale", self._pool(9), held)
+
+        assert "9 of 9" in problem
+        assert problem.count("(bus)") == 5
+        assert ", ..." in problem
+
+    def test_a_pool_coco_cannot_answer_for_is_untested_not_clean(self, audit):
+        """0 dirty out of 0 checked is the absence of a measurement, not a pass.
+
+        Under `provable` every designated negative is COCO-scored by
+        construction, so an empty join means the check did not run -- and a
+        check that cannot be told from a clean result is the shape that has cost
+        this directory a day more than once.
+        """
+        problems = audit.provable_pool_problems("vg_scale", self._pool(), {})
+
+        assert any("went untested" in p for p in problems)
+
+    def test_deep_is_exempt_from_the_untested_message(self, audit):
+        """`vg_scale_deep` is pinned to the pre-#3670 draw (#3690), so COCO may hold little of it."""
+        assert audit.provable_pool_problems("vg_scale_deep", self._pool(), {}) == []
+
+    def test_counts_separate_answerable_from_dirty(self, audit):
+        n_pool, n_checked, dirty = audit.pool_coco_counts(self._pool(4), {0: [], 1: ["bus", "car"]})
+
+        assert (n_pool, n_checked, dirty) == (4, 2, [(1, ["bus", "car"])])
+
+
 class TestCoverageRow:
     """Which retirements the coverage gate forgives, and which it must not (#3670)."""
 


### PR DESCRIPTION
Closes #3701.

`--verify`'s existing pool check tests the pool's **provenance** — every designated negative carries a `coco_scored` stamp — and a true stamp is not the claim. An image can be COCO-scored, hold a `truck`, and still be designated a negative for every class, if a pass upstream of the draw removed the label. That is the #3588 route: an ambiguous-table entry naming another class in *C* pops that class's boxes, and on an anchored image the `exhaustive` exemption suppresses the compensating `unbanded` pair, so `band_candidates` files a COCO-confirmed truck as clean. The config guard added then covers that one route; this tests the property, which holds however it was violated.

It reads what the repo already reads — `coco_truth` over `SCALE_CLASSES`, joined to VG ids through `image_data.json` — so it is an intersection rather than new machinery, and it lands beside #3670's two pool checks because that is where a rebuild is trusted.

## On the shipped pile it is clean

```
vg_scale       9900/9900 negatives answerable, 0 hold a class of C
vg_scale_any   9900/9900 negatives answerable, 0 hold a class of C
vg_scale_deep  5436/11700 negatives answerable, 0 hold a class of C
```

`build_pile.py --verify` exits 0. `provable` is 100% answerable by construction; `vg_scale_deep`'s pinned pre-#3670 draw is 46%, and **the remaining 6,264 negatives rest on VG's silence with nothing able to check them** — which is #3696's point, now printed on every verify instead of being a thing one has to know.

The counts print in the clean case on purpose. A clean pool and a check that could not run are the same empty problem list otherwise, and under `provable` "nothing was answerable" *is* the failure — so that case is a problem in its own right, naming both causes (unstaged join, or a cell predating the stamp).

## The stamp gate, which the first run earned

The first version read the raw `coco_id` join and reported **three** dirty negatives in `vg_scale_deep`. All three were pairings `anchor_to_coco` had refused:

| VG image | COCO | VG dims | COCO dims | aspect drift | COCO says |
|---|---|---|---|---:|---|
| 2326312 | 279804 | 500×383 | 640×478 | 0.025 | `car` |
| 2343894 | 316016 | 500×329 | 640×371 | 0.119 | `bird` |
| 2344531 | 522996 | 298×500 | 450×338 | **0.552** | `bowl`, `dog` |

`MAX_ASPECT_DRIFT` is 0.01. The last row pairs a portrait with a landscape — two files that are not the same picture, which is exactly what the drift filter exists to catch. All three are in the pool on VG's silence, which deep's composition allows, and COCO was never asked about them: `coco_scored` and `labels_exhaustive` are both false on all three.

So a check that asserts COCO's answer through a pairing the build rejected does not test the pool's claim, it invents a different one. `pool_coco_counts` now checks the images the build itself anchored — which is what the stamp says — and the three false alarms go away while `provable`'s coverage stays 100%.

This is the same one-sided-error shape as #3720's fallback join, in the opposite direction: there a superset *hides* work, here it *invents* failures. In both cases the fix is to read the build's own answer rather than a wider one.

## Named, not repaired

An image that reaches the pool holding a class of *C* means an upstream pass is wrong; dropping it leaves the pool clean and the cause invisible. The message carries up to five ids with the class each one holds — the ids are what turn "the pool is dirty" into a diagnosis, and in the #3588 case they would have said `truck` at once.

## Testing

`TestProvablePoolHoldsC` in `tests_lib/meta/test_pile_vg_scale.py` — 9 tests: the clean case, a named dirty negative, positives and spares excluded (a positive holds its class by definition, and reading them as pool members fires on every one), the example cap, the unanswerable-is-untested case, deep's exemption, and the drift-reject case above.

Full `./run-tests.sh` on the GRID (job 624398): **RUN PASSED**, 10,986 passed / 6 skipped / 2 xpassed, every gate green.

`build_pile.py --verify` against the live pile exits 0 with the three lines quoted above. It also carries the same one-line `dev` fix as #3720 (#3716's live-venv test asserts `__pycache__` is an import name; see that PR), so this branch is green on its own; the duplicate patch is identical and merges cleanly either order.
