### PR TITLE
Plan: name what has to be settled before the hand-annotation starts

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -91,6 +91,55 @@ free and already available: the class list was chosen so annotator accuracy can
 be scored against COCO on the anchored half without extra review. Build that
 scoring into the pass rather than discovering the drift afterwards.
 
+## Settle before the pass starts
+
+Each of these is an open issue, carried here as a pointer because the *order*
+matters and nothing else records it. They move the designated set, change what
+the pass is asked to cover, or bill it for work it does not need. None is large
+on its own — tens of images each. The cost is that every one of them forces a
+**rebuild**, and a rebuild reshuffles which images fill a cell: #3667 measured 41
+positives out and 40 in with nothing relevant altered, and three rebuilds once
+retired 577 of 743 reviewed images. Human answers are the only input here that
+cannot be regenerated, so a rebuild *after* the pass throws some of them away.
+
+Land or dismiss all of them, rebuild once, then freeze the roster — in that
+order. The VG-name audit itself is no longer among them: `SCALE_VG_NAMES_AUDITED`
+now covers all 25 classes, so #3618's "before the next rebuild" warning is spent.
+
+<!-- item-sep -->
+
+- [ ] #3663 — misspellings and typed variants never reached the candidate list (moves membership)
+
+<!-- item-sep -->
+
+- [ ] #3662 — one polysemous member sinks `boat`'s pooled group (moves membership)
+
+<!-- item-sep -->
+
+- [ ] #3605 — `bike` is still unresolved for `bicycle`, and most of it is not a bicycle (moves membership)
+
+<!-- item-sep -->
+
+- [ ] #3655 — the ambiguous exclusion is global where `evaluable_categories` could make it per-class (moves membership)
+
+<!-- item-sep -->
+
+- [ ] #3696 — whether a named off-COCO negative stratum is drawn in (changes what the pass covers)
+
+<!-- item-sep -->
+
+- [ ] #3616 — a reviewer's rebox silently moves an image between bands (the band statistic above, arriving as a bug)
+
+<!-- item-sep -->
+
+- [ ] #3669 — slate import re-embeds vectors the pile already holds (bills the pass three times over for its own images)
+
+<!-- item-sep -->
+
+- [ ] #3686 — the text-sort false-negative hunt covers the stratum this pass answers outright (do one, not both)
+
+<!-- item-sep -->
+
 ## Open work
 
 <!-- item-sep -->


### PR DESCRIPTION
The plan (#3717) says what the pass costs and how to run it, but nothing in it records the **order** — and the order is where this loses work.

Eight open issues either move the designated set, change what the pass is asked to cover, or bill it for work it does not need. Each is small on its own, tens of images. The cost is not their size: each forces a **rebuild**, and a rebuild reshuffles which images fill a cell — #3667 measured 41 positives out and 40 in with nothing relevant altered, and three rebuilds once retired 577 of 743 reviewed images. A human answer is the only input in this pipeline that cannot be regenerated, so a rebuild *after* the pass throws some of them away.

| pointer | why it gates the pass |
|---|---|
| #3663, #3662, #3605, #3655 | move membership on the off-COCO half — the exact stratum being annotated |
| #3696 | decides whether off-COCO negatives are in scope at all |
| #3616 | a reviewer's rebox silently moves an image between bands; the pass will generate reboxes |
| #3669 | slate import re-embeds vectors the pile already holds — 600 embeddings for 200 distinct images |
| #3686 | covers the stratum the pass answers outright; do one, not both |

Carried as **pointers**, per the issues-vs-plans rule: the bodies stay in the issues, and the plan records only that they are owed before the freeze rather than whenever someone gets to them.

Also recorded: **the VG-name audit is no longer among them.** #3618 is still open and reads as a live blocker ("measure the other eleven before the next rebuild"), but `SCALE_VG_NAMES_AUDITED` now covers all 25 classes — the promotion audit spent it.

## Where the list came from

A sweep of the 46 open un-solved issues after #3720 and #3701 landed. Two findings from that sweep are deliberately *not* in the plan, because they do not gate the pass:

- **#3674** (360 positive taps for the shipped twelve) is on COCO-anchored positives, disjoint from the queue's off-COCO population. Still worth its cost; not a blocker.
- **#3675** is overtaken by #3670 and I said so on the issue. It was filed when 45% of a uniform negative draw was already settled by COCO; the pool is now drawn from the COCO half entirely (`vg_scale: pool vs COCO -- 9900/9900 negatives answerable`), so the frame it proposes — `labels_exhaustive == False` images inside the pool — is empty.

## Testing

`./run-tests.sh` on the GRID (job 624738): **RUN PASSED**, markdown-only narrowing, every cheap gate green including `check-docs` (326 files, 7 invariants), 1,053 tests passed.
