### PR TITLE
Plan: #3696 reads the pass, so it is not a blocker for it

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -124,7 +124,6 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
 
 <!-- item-sep -->
 
-- [ ] #3696 — whether a named off-COCO negative stratum is drawn in (changes what the pass covers)
 
 <!-- item-sep -->
 
@@ -193,6 +192,10 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
   judgement per image, recorded as verdicts rather than corrections in VG's own
   shape (`scripts/experiments/pile/verdicts_to_corrections.py`'s existing
   contract). One rebuild at the end, not one per ruling. (human + Sonnet 5)
+
+<!-- item-sep -->
+
+- [ ] #3696 — emit VG's silence rate from the pass's own answers, as an upper bound (Sonnet 5)
 
 <!-- item-sep -->
 


### PR DESCRIPTION
The pre-pass list asked whether a named off-COCO negative stratum gets drawn in. Answered: no.

Such a stratum has to be hand-annotated to be a reference, and the pass produces the same quantity for free — 3,391 off-COCO images each answered for all 25 classes, so every class VG did *not* name in them measures VG's silence against a human reference. What that buys is an **upper bound** on the uniform rate rather than an estimate: the queue's images are selected for holding a class of *C*, so they are cluttered scenes, and clutter correlates with holding more classes (#3667; #3679's 2.5x shortcut at `@small`). A bound is enough for the only consumer left — `vg_scale_deep`, whose 6,264 unprovable negatives feed #3319/#3547.

So the pointer moves out of *settle before the pass starts* and in beside the pass itself. #3696 is re-scoped on the issue, including a section recording what was given up, so the stratum idea is recoverable if a question arrives that a bound cannot answer.

## Testing

`./run-tests.sh` on the GRID (job 624750): **RUN PASSED**, markdown-only narrowing, every cheap gate green, 1,053 passed.