### PR TITLE
Record the band decision: the band is a view, the instances stay

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -77,12 +77,14 @@ change, 41 positives out and 40 in on a rebuild with nothing relevant altered
 
 ## Two decisions this forces
 
-**The band statistic.** Banding is currently the **union** box over a class's
-instances, on the stated ground that a union is what one Good vote drags in the
-app. An exhaustively annotated set carries every instance, so union, largest,
-smallest and count are all derivable and the summary can move to eval time. That
-is a change to what #3156 measured, and it is a decision, not a detail: pick it
-deliberately and say so where the band is defined.
+**The band statistic — decided 2026-09-07: the band stays the union, and every
+instance stays behind it.** The union is what one Good vote drags in the app and
+is what #3156 measured, so the shipped statistic does not move; the instances
+are kept because the union is derivable from them and they are not derivable
+from it, which leaves largest, smallest, count and density available at eval
+time for free. Recorded beside `BOX_BANDS` in `pile_config`. The build already
+stores every instance — what this now commits us to defending is that **review**
+does not quietly collapse the set (#3726).
 
 **Two label sources of unequal quality.** COCO on one half and our annotators on
 the other means provenance would correlate with *label noise* instead of with
@@ -105,6 +107,14 @@ cannot be regenerated, so a rebuild *after* the pass throws some of them away.
 Land or dismiss all of them, rebuild once, then freeze the roster — in that
 order. The VG-name audit itself is no longer among them: `SCALE_VG_NAMES_AUDITED`
 now covers all 25 classes, so #3618's "before the next rebuild" warning is spent.
+
+<!-- item-sep -->
+
+- [ ] #3727 — a confirmed verdict writes no correction, so the build cannot tell an answered image from an unopened one
+
+<!-- item-sep -->
+
+- [ ] #3726 — a rebox replaces the class's whole instance set, spending the band decision above
 
 <!-- item-sep -->
 
@@ -181,11 +191,6 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
 
 <!-- item-sep -->
 
-- **Decide the band statistic, and record the decision where the band is
-  defined.** Union (today), largest, or per-instance with a summary chosen at
-  eval time. Carrying every instance box is the option that keeps the choice
-  open, and is what makes band a query. See the two-decisions section above.
-  (human)
 
 <!-- item-sep -->
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -157,6 +157,23 @@ SCALE_CROSS_CLASS_NEGATIVES = True
 
 #: The upper cut mirrors ``MAX_VOTED_AREA``: a box covering >80% of the image
 #: is not a region, it is the image.
+#:
+#: **The band is a VIEW over every instance, not a replacement for them, and
+#: that is a decision** (2026-09-07, ``docs/plans/vg-scale-exhaustive-annotation.md``).
+#: :func:`~pilebuild.loaders.vg_scale.band_for` summarises a class's boxes in an
+#: image by their **union**, which is what one Good vote drags in the app and is
+#: what #3156 measured -- and the build keeps every instance box behind it
+#: (``band_candidates`` stores them all; ``_emit_medias`` writes one region per
+#: box). Keep it that way. The union is derivable from the instances and the
+#: instances are not derivable from the union, so a summary chosen at eval time
+#: -- largest, smallest, count, density -- stays available at no cost, while
+#: collapsing the set at build time would end that permanently and silently.
+#:
+#: The shipped band statistic does **not** move as a result: changing it now
+#: would restate what #3156 measured under its own name. What the decision buys
+#: is the option, and what it costs is one invariant to defend -- a review that
+#: replaces a class's instance set with one drawn box spends the option without
+#: anyone deciding to (#3726).
 PATCH_AREA = 1 / 196
 LEAF_AREA = 1 / 12
 MAX_VOTED_AREA = 0.80


### PR DESCRIPTION
Owner's call on the plan's band item: **the union stays the shipped band statistic, and every instance box stays behind it.**

The union is what one Good vote drags in the app and what #3156 measured, so changing it now would restate that study under its own name. The instances are kept because the union is derivable from them and they are not derivable from the union — largest, smallest, count and density stay available at eval time for nothing.

**This changes no code.** The build already stores every instance (`band_candidates` fills `boxes_for` with all of them, `_emit_medias` writes one region per box, `band_for` takes their union with the scatter guard comparing union against largest). What the decision does is name an invariant that was holding by accident, and record it beside `BOX_BANDS` in `pile_config` rather than in a plan file nobody has open while editing the config.

## Naming it found where it is already being spent

`apply_corrections` merges by **replacement** — `labels[iid][name] = boxes` — and `verdicts_to_corrections` writes a rebox as a single box. So a reviewer retargeting the box to a better example silently discards every other instance of that class in that image. Filed as **#3726**; it lands on exactly the images the annotation pass is about to touch, and #3616 already measured 13 reboxes in the first four classes.

## Plan changes

- the *Decide the band statistic* item is deleted — the decision it asked for is made;
- the two-decisions section records the answer instead of the question;
- two new pre-pass blockers: **#3726** above, and **#3727** — a confirmed-unchanged verdict writes no correction row at all, so `designate_cells` cannot tell an answered image from an unopened one. That is what *freeze the roster* has to fix before 3,391 answers become evictable.

## Testing

Full `./run-tests.sh` on the GRID (job 624765): **RUN PASSED**, 11,005 passed / 6 skipped / 2 xpassed, all gates green.