### PR TITLE
Plan: the verdicts themselves are a pre-pass blocker

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -110,6 +110,10 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
 
 <!-- item-sep -->
 
+- [ ] #3729 — every human verdict exists only on purgeable scratch, with no second copy anywhere
+
+<!-- item-sep -->
+
 - [ ] #3727 — a confirmed verdict writes no correction, so the build cannot tell an answered image from an unopened one
 
 <!-- item-sep -->


### PR DESCRIPTION
The pre-pass list carried everything that could move the designated set. It did not carry the risk to **the answers**.

`corrections.json` (640 verdicts, 130 KB), `vg_scale_roster.json` (228 KB) and every adjudication and slate record exist only under `/expscratch` — which `pile_config`'s own module docstring calls purgeable:

> The pile lives on scratch, which is treated as purgeable, so every cell must be rebuildable from sources that are *not* on scratch.

That rule was written for cells, and cells satisfy it: a purge costs GPU hours. It was never extended to the one input that cannot satisfy it, because a human verdict is not rebuildable from anything. `find` over `/exp/sgreenberg` and `/exp/scale26` returns no second copy.

The pass takes that exposure from 640 verdicts to roughly **85,000**, at which point the file *is* the dataset and the pickle is derived from it. Filed as **#3729**, with the three things to decide: the canonical home, which direction is authoritative, and whether the read-modify-write needs a `flock` (several sessions share one pile).

## Testing

`./run-tests.sh` on the GRID (job 624785): **RUN PASSED**, markdown-only narrowing, every cheap gate green, 1,053 passed.