### PR TITLE
run-tests.sh: size the xdist pool from the cgroup, not the machine (#3721)

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -156,6 +156,22 @@ fi
 # the child from re-wrapping itself. Set VTSEARCH_TEST_TIMEOUT=0 to opt out (for
 # a deliberately long run, e.g. GPU tests or a full coverage sweep).
 VTSEARCH_TEST_TIMEOUT=${VTSEARCH_TEST_TIMEOUT:-1800}
+
+# `-n auto` does NOT mean "one worker per CPU I was given". pytest-xdist asks
+# psutil for the MACHINE's physical cores and never looks at the cgroup, so a
+# SLURM job with --cpus-per-task=8 on a 40-thread node starts ~20 workers, each
+# importing torch. Measured (#3721): 90 oom_kill events in a 32G allocation, the
+# workers dying one at a time so the run WEDGES rather than fails, and the only
+# thing printed is the wall-clock cap above -- whose message then sends the
+# reader hunting for a hung network step. Two runs lost 30 minutes each to it.
+#
+# The env var beats every detection path in xdist/plugin.py. On an unconstrained
+# box the affinity mask is every core, so this is a no-op there; it only bites
+# where the cgroup is narrower than the machine, which is exactly the GRID.
+if [[ -z "${PYTEST_XDIST_AUTO_NUM_WORKERS:-}" ]]; then
+    PYTEST_XDIST_AUTO_NUM_WORKERS=$(python -c 'import os; print(len(os.sched_getaffinity(0)))' 2>/dev/null || echo "")
+    [[ -n "$PYTEST_XDIST_AUTO_NUM_WORKERS" ]] && export PYTEST_XDIST_AUTO_NUM_WORKERS
+fi
 if [[ -z "${_VT_TIMEOUT_WRAPPED:-}" && "$VTSEARCH_TEST_TIMEOUT" != "0" ]] \
     && command -v timeout >/dev/null 2>&1; then
     export _VT_TIMEOUT_WRAPPED=1


### PR DESCRIPTION
Closes #3721.

`-n auto` does not mean "one worker per CPU I was given". pytest-xdist resolves it from `psutil.cpu_count(logical=False)` — the **machine's** physical cores — and never looks at the affinity mask:

```
os.cpu_count()             40     the node
sched_getaffinity           8     what --cpus-per-task=8 granted
psutil.cpu_count(False)    20     what xdist used
```

So a suite job starts ~20 workers, each importing torch, in a 32G allocation. Measured on job 624170: **90 oom_kill events**, `State: OUT_OF_MEMORY` — and because the killer takes workers one at a time, the run **wedges rather than fails**. The only thing printed is the 1800s wall-clock cap, whose own message then sends the reader hunting for a hung network step. Two runs lost thirty minutes each before anyone read `sacct`.

`PYTEST_XDIST_AUTO_NUM_WORKERS` beats every detection path in `xdist/plugin.py`, so the fix is one export near the timeout wrapper. On an unconstrained box the affinity mask is every core and this changes nothing; it only bites where the cgroup is narrower than the machine, which is exactly the GRID.

## Testing

Verified inside an 8-CPU allocation: `workers=8`.

**The suite run for this PR is the proof.** Job 625723 used the stock `suite.sbatch` — 32G, 8 CPUs, no `--export` override — which is the exact configuration that OOMed twice: **RUN PASSED**, 11,034 passed / 6 skipped / 2 xpassed, `sacct` `COMPLETED`, 5:01 of pytest.
