### PR TITLE
Measure the misspelling residue, and refute #3663 premise

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -105,7 +105,15 @@ retired 577 of 743 reviewed images. Human answers are the only input here that
 cannot be regenerated, so a rebuild *after* the pass throws some of them away.
 
 Land or dismiss all of them, rebuild once, then freeze the roster — in that
-order. The VG-name audit itself is no longer among them: `SCALE_VG_NAMES_AUDITED`
+order.
+
+Two have already left the list on measurement rather than on work. **#3663** is
+refuted: the misspellings it named are in VG and reachable by an edit-distance
+search, they were scored by the same three cuts, and **none clears them** — the
+real ones carry 3–5 images each. **#3655** moves the *negative* pool, which the
+pass does not annotate, so it is not a blocker for it at all; its stated cost is
+also a use the datasheet already refuses, and its stated benefit is nearly inert
+against a pool that is 18x over-subscribed. The VG-name audit itself is no longer among them: `SCALE_VG_NAMES_AUDITED`
 now covers all 25 classes, so #3618's "before the next rebuild" warning is spent.
 
 <!-- item-sep -->
@@ -122,7 +130,6 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
 
 <!-- item-sep -->
 
-- [ ] #3663 — misspellings and typed variants never reached the candidate list (moves membership)
 
 <!-- item-sep -->
 
@@ -130,11 +137,10 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
 
 <!-- item-sep -->
 
-- [ ] #3605 — `bike` is still unresolved for `bicycle`, and most of it is not a bicycle (moves membership)
+- [ ] #3605 — `bike` is still unresolved for `bicycle`; measured 2026-09-07 as too big to fold into the pass (+9,963 images, ~4x)
 
 <!-- item-sep -->
 
-- [ ] #3655 — the ambiguous exclusion is global where `evaluable_categories` could make it per-class (moves membership)
 
 <!-- item-sep -->
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -442,4 +442,4 @@ skip = "*.lock,*.svg,*.json,*.pkl,*.npz,*.min.js,*.min.css,*node_modules*,data,s
 # (#3636); `vas` is VG's truncated spelling of `vase` and joined
 # SCALE_VG_AMBIGUOUS at the #3588 promotion. Correcting any of them would break
 # a lookup against the data.
-ignore-words-list = "bouy,busses,dalmation,vas,clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,repid,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,lod,usera,teh,provence,mane,tread,shepard,trough"
+ignore-words-list = "bouy,busses,dalmation,vas,clap,siglip,xclip,wrest,caller,recaller,medias,numer,denom,goup,repid,invokable,unparseable,copys,re-use,re-used,re-uses,re-using,re-declaring,pre-select,pre-selects,pre-selected,fpr,ths,ot,te,lod,usera,teh,provence,mane,tread,shepard,trough,umbrealla,umberella,unbrella,umbella,umbrela,bicyle,hyrdant"

--- a/scripts/experiments/pile/name_misspellings.py
+++ b/scripts/experiments/pile/name_misspellings.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""VG spellings a head-noun family cannot reach: the misspellings (#3663).
+
+`vg_name_families.py` enumerates a class's candidates by **head noun** --
+`beach umbrella` and `umbrella's` share `umbrella` as their final token. That
+search cannot reach a *misspelling* by construction: `umberella` has no token in
+common with `umbrella`, so no head-noun family will ever contain it, and
+`name_evidence.py` has therefore never scored one.
+
+#3663 is the observation that this leaves a residue nobody has measured, and it
+names five examples for `umbrella` alone. This closes that hole from the other
+side: enumerate VG's primary names within a small **edit distance** of a class
+name or one of its shipped aliases, and emit them as a `--candidates` file so
+the existing evidence machinery scores them exactly like any other name.
+
+**Edit distance is a recall aid and nothing else**, exactly as the head-noun
+family is. `bowl` is one edit from `bow`, `bill`, `ball` and `boil`; `car` is
+one from `cat`, `bar`, `care` and `cart`. Every one of those is a different
+object, and the point is not to fold them -- it is to put them in front of the
+same three cuts (`precision`, its Wilson lower bound, and box agreement) that
+decide every other name. A candidate list is a list to *measure*.
+
+Two guards keep the list honest rather than long:
+
+* **a length floor**, because at four characters an edit distance of one is most
+  of the vocabulary -- `cup` would drag in `cap`, `cut`, `can`, `cop`, `up`;
+* **the shipped tables are excluded**, so what comes out is only what the
+  curation actually dropped, which is the number #3663 asks for.
+
+Usage::
+
+    python name_misspellings.py --out cands.json
+    python name_evidence.py --candidates cands.json --out evidence_misspellings.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+import pile_config as pc
+
+pc.setup_env()
+
+VG_ROOT = pc.DEMO_CACHE / "visual_genome"
+
+
+def log(msg: str) -> None:
+    print(f"[misspell] {msg}", flush=True)
+
+
+def edit_distance(a: str, b: str, cap: int = 3) -> int:
+    """Levenshtein distance, stopped once it exceeds *cap*.
+
+    Small and local rather than a dependency: the strings are VG names, the cap
+    makes the early exit cheap, and the alternative is adding a package to a
+    script that runs once.
+    """
+    if abs(len(a) - len(b)) > cap:
+        return cap + 1
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        cur = [i]
+        for j, cb in enumerate(b, 1):
+            cur.append(min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (ca != cb)))
+        if min(cur) > cap:
+            return cap + 1
+        prev = cur
+    return prev[-1]
+
+
+def near_misses(
+    vocabulary: dict[str, int],
+    targets: dict[str, set[str]],
+    shipped: set[str],
+    max_edits: int,
+    min_len: int,
+    min_images: int,
+) -> dict[str, list[str]]:
+    """``{class: [candidate names]}`` -- VG names close to a target spelling.
+
+    *targets* is the spellings to be close **to**: the class name and whatever
+    the shipped tables already declare for it, so `umberella` is reachable from
+    `umbrella` and `bicyle` from `bicycle` without either being listed by hand.
+    """
+    out: dict[str, list[str]] = {}
+    for cls, spellings in targets.items():
+        hits: set[str] = set()
+        for name, imgs in vocabulary.items():
+            if imgs < min_images or name in shipped or name in spellings:
+                continue
+            for target in spellings:
+                if len(target) < min_len:
+                    continue
+                if edit_distance(name, target, max_edits) <= max_edits:
+                    hits.add(name)
+                    break
+        out[cls] = sorted(hits)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--anchor-dir", default=str(pc.PILE / "coco_anchor"))
+    ap.add_argument("--max-edits", type=int, default=2)
+    ap.add_argument("--min-len", type=int, default=5, help="ignore targets shorter than this (an edit is too cheap)")
+    ap.add_argument("--min-images", type=int, default=3)
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+
+    log("loading VG image_data.json")
+    with (Path(args.anchor_dir) / "image_data.json").open() as fh:
+        on_coco = {int(m["image_id"]) for m in json.load(fh) if m.get("coco_id")}
+
+    log(f"loading VG objects.json ({(VG_ROOT / 'objects.json').stat().st_size / 1e6:.0f} MB)")
+    with (VG_ROOT / "objects.json").open() as fh:
+        records = json.load(fh)
+
+    n_images: dict[str, int] = defaultdict(int)
+    n_off: dict[str, int] = defaultdict(int)
+    for rec in records:
+        iid = int(rec["image_id"])
+        seen = set()
+        for obj in rec.get("objects") or []:
+            names = obj.get("names") or []
+            if names and str(names[0]).strip().lower():
+                seen.add(str(names[0]).strip().lower())
+        for name in seen:
+            n_images[name] += 1
+            if iid not in on_coco:
+                n_off[name] += 1
+    log(f"  {len(n_images)} distinct primary names")
+
+    shipped = {n for v in pc.SCALE_VG_NAMES.values() for n in v}
+    for v in pc.SCALE_VG_AMBIGUOUS.values():
+        shipped |= set(v)
+    targets = {c: {c, *pc.SCALE_VG_NAMES.get(c, ())} for c in pc.SCALE_CLASSES}
+
+    cands = near_misses(n_images, targets, shipped, args.max_edits, args.min_len, args.min_images)
+
+    print("\n" + "=" * 78)
+    print("NEAR-MISS SPELLINGS -- names to measure, not names to fold")
+    print(f"within {args.max_edits} edits of a class name or a shipped alias, >= {args.min_images} images")
+    print("=" * 78)
+    total = off_total = 0
+    for cls, names in cands.items():
+        if not names:
+            continue
+        imgs = sum(n_images[n] for n in names)
+        off = sum(n_off[n] for n in names)
+        total += imgs
+        off_total += off
+        print(f"\n{cls}  ({len(names)} candidates, {imgs} images, {off} off-COCO)")
+        for n in sorted(names, key=lambda n: -n_images[n])[:12]:
+            print(f"    {n:<28}{n_images[n]:>7} imgs{n_off[n]:>8} off-COCO")
+    print(f"\n{sum(len(v) for v in cands.values())} candidates over {total} images, {off_total} of them off-COCO")
+    print("That off-COCO count is the ceiling on what this residue can be worth: on the")
+    print("COCO half the labels are replaced wholesale, so a missed spelling costs nothing there.")
+
+    if args.out:
+        Path(args.out).write_text(json.dumps(cands, indent=1) + "\n")
+        log(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/meta/test_pile_name_misspellings.py
+++ b/tests_lib/meta/test_pile_name_misspellings.py
@@ -1,0 +1,128 @@
+"""The spellings a head-noun family cannot reach, and the guards on that search (#3663).
+
+`vg_name_families.py` finds candidates by head noun, which cannot reach a
+misspelling: `umberella` shares no token with `umbrella`. `name_misspellings.py`
+closes that hole with an edit-distance search, and the whole risk in a search
+like this is that it returns the dictionary. Two guards keep it honest, and both
+are here because the measurement showed what happens without them:
+
+* a **length floor**, because one edit from a four-letter class name is most of
+  English -- `cup` would reach `cap`, `cut`, `can`, `cop`;
+* **the shipped tables are excluded**, so the output is only what the curation
+  actually dropped, which is the number #3663 asks for.
+
+The result the search produced is that no candidate clears the evidence cuts:
+the real misspellings carry 3-5 images each, and everything else is a different
+common word (`pole` at 14,372 images is one edit from `phone`).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+
+@pytest.fixture(scope="module")
+def misspell():
+    """``name_misspellings``, imported for its pure halves.
+
+    It calls ``pc.setup_env()`` at import like its neighbours, which is fine
+    here: the functions under test read nothing but their arguments.
+    """
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import name_misspellings
+
+    return name_misspellings
+
+
+class TestEditDistance:
+    def test_it_counts_the_edits(self, misspell):
+        # Every misspelling this search was built for is ONE edit from the class
+        # name -- umb-e-rella, umbre-a-lla, bicy[c]le -- which is why a cap of 2
+        # is generous rather than tight, and why the noise it lets in (`pole` is
+        # two from `phone`, on 14,372 images) is what the evidence cuts must
+        # reject. I first asserted 2 for `umberella` here; the function was right
+        # and the test was wrong, which is the reason to spell the edits out.
+        assert misspell.edit_distance("umbrella", "umberella") == 1
+        assert misspell.edit_distance("umbrella", "umbrealla") == 1
+        assert misspell.edit_distance("bicycle", "bicyle") == 1
+        assert misspell.edit_distance("phone", "pole") == 2
+
+    def test_identical_strings_are_zero(self, misspell):
+        assert misspell.edit_distance("clock", "clock") == 0
+
+    def test_it_stops_once_the_cap_is_passed(self, misspell):
+        """The cap is what makes a scan over 100k names cheap; it must not lie below it."""
+        assert misspell.edit_distance("umbrella", "fire hydrant", cap=2) > 2
+        assert misspell.edit_distance("cup", "cap", cap=2) == 1
+
+
+class TestNearMisses:
+    VOCAB = {
+        "umbrella": 900,
+        "umberella": 4,
+        "unbrella": 3,
+        "parasol": 60,
+        "umbrellas": 120,
+        "elephant": 500,
+        "rare typo": 1,
+    }
+
+    def test_it_finds_the_misspellings_a_family_cannot(self, misspell):
+        out = misspell.near_misses(
+            self.VOCAB, {"umbrella": {"umbrella"}}, shipped=set(), max_edits=2, min_len=5, min_images=3
+        )
+
+        assert "umberella" in out["umbrella"]
+        assert "unbrella" in out["umbrella"]
+
+    def test_the_class_name_is_not_its_own_candidate(self, misspell):
+        out = misspell.near_misses(
+            self.VOCAB, {"umbrella": {"umbrella"}}, shipped=set(), max_edits=2, min_len=5, min_images=3
+        )
+
+        assert "umbrella" not in out["umbrella"]
+
+    def test_a_shipped_name_is_not_a_finding(self, misspell):
+        """The output has to be what curation dropped, not what it kept."""
+        out = misspell.near_misses(
+            self.VOCAB, {"umbrella": {"umbrella"}}, shipped={"umbrellas"}, max_edits=2, min_len=5, min_images=3
+        )
+
+        assert "umbrellas" not in out["umbrella"]
+
+    def test_a_name_below_the_image_floor_is_dropped(self, misspell):
+        """A one-image name cannot be evidence of anything, so it is not a candidate."""
+        out = misspell.near_misses(
+            self.VOCAB, {"umbrella": {"umbrella"}}, shipped=set(), max_edits=2, min_len=5, min_images=3
+        )
+
+        assert "rare typo" not in out["umbrella"]
+
+    def test_a_short_target_contributes_nothing(self, misspell):
+        """At four characters an edit is too cheap: `cup` would reach half of English."""
+        vocab = {"cap": 100, "cut": 100, "cop": 100}
+
+        out = misspell.near_misses(vocab, {"cup": {"cup"}}, shipped=set(), max_edits=2, min_len=5, min_images=3)
+
+        assert out["cup"] == []
+
+    def test_it_searches_from_the_aliases_too(self, misspell):
+        """`hyrdant` is close to the alias `hydrant`, not to `fire hydrant`."""
+        vocab = {"hyrdant": 3, "hydrant": 600}
+
+        out = misspell.near_misses(
+            vocab,
+            {"fire hydrant": {"fire hydrant", "hydrant"}},
+            shipped={"hydrant"},
+            max_edits=2,
+            min_len=5,
+            min_images=3,
+        )
+
+        assert out["fire hydrant"] == ["hyrdant"]


### PR DESCRIPTION
Closes #3663.

The issue says the hand curation that cut #3618's candidate list down from the head-noun families dropped spellings that would have mattered — `umbrella.`, `umbrella's`, `umberella`, `unbrella`, `umbrell` — and that the size of that residue is unmeasured. It is measured now, and nothing survives.

## The obvious run does not test it

Re-deriving candidates from `vg_name_families.py --min-images 3` and scoring them gives 0 new alias names and one new ambiguous name (`cake knife`). That number is meaningless here: **a head-noun family cannot contain a misspelling.** `umberella` shares no token with `umbrella`, so no family will ever hold it — the `umbrella` family reached `umbrella's` and none of the four misspellings. That run also *repairs fewer* images than the shipped tables, because it loses everything the fold-in search contributes (`bike`, `magazine`, `duck`).

## The measurement that does

`name_misspellings.py` enumerates VG primary names within a small edit distance of a class name or a shipped alias and emits them as a `--candidates` file, so `name_evidence.py` scores them with the same three cuts as everything else. It reaches exactly the spellings the issue names:

```
umbrella (13):  umbella, umberella, umbrealla, umbrela, umbrella's, unbrella, ...
bicycle  (8):   bicycle., bicyle, bicycler, cycle, cycles, icicle, icicles, unicycle
fire hydrant:   hyrdant, fire hydrants
```

**1,018 candidates over 267,852 images, 138,261 of them off-COCO → 0 alias names, 0 ambiguous names.**

Two populations, neither able to clear a bar that means anything:

- **the real misspellings are tiny** — `hyrdant` has 3 images, the `umbrella` misspellings 3–5 each, and `--min-sole 5` exists because below that a rate is not a rate;
- **the rest are different words** — one edit from `phone` is `pole` (14,372 images), `shoe` (5,820), `photo`, `plane`, `hole`, `stone`, `cone`. Every one scored `neither` at 0–4% precision, which is the search working.

So the 138,261 off-COCO images the candidates touch is a ceiling that collapses on contact: it is `pole` and `shoe`, not `umberella`.

## Guards, both tested

A **length floor** (one edit from `cup` is `cap`, `cut`, `can`, `cop`) and **excluding the shipped tables**, so the output is only what curation actually dropped. Without either, the search returns the dictionary.

## Plan changes

- **#3663** comes off the pre-pass blocker list, having moved no supply.
- **#3655** comes off it too, for a different reason recorded on that issue: it moves the *negative* pool, which the pass does not annotate. Its stated cost is also a use the datasheet already refuses (*"Is class X harder than class Y?" — not currently supported*), and its stated benefit is nearly inert against a pool that is 18× over-subscribed.
- **#3605** keeps its pointer and gains the number that settles its open option: folding the withheld spellings into the pass would add **9,963 images, about 4× the queue**, so `bike` stays a name-evidence question.

`umbrealla` and friends join codespell's ignore list beside the misspellings already there (`bouy`, `dalmation`, `goup`) — they are test data.

## Testing

9 tests over the edit distance and both guards, including the case where the search must start from an *alias* (`hyrdant` is close to `hydrant`, not to `fire hydrant`).

Full `./run-tests.sh` on the GRID (job 625870): **RUN PASSED**, 11,043 passed / 6 skipped / 2 xpassed, all gates green.
