### PR TITLE
Slate import: say which device it will embed on, and what that costs (#3669)

### DIFF
--- a/scripts/experiments/pile/import_slates.py
+++ b/scripts/experiments/pile/import_slates.py
@@ -17,6 +17,14 @@ HTTP hop to authenticate, and the memory cost is one dataset at a time -- but
 it does mean this must not run while the app is up on the same data dir, since
 both would write the registry. Stop the app first.
 
+**Every image is embedded again, and the pile already holds its vector** (#3669).
+The importer takes a folder and computes; there is no reuse path, so a slate
+drawn from the pile pays ~1.2 s/image on CPU for numbers that exist on disk.
+This now prints the device it resolved and what that implies for the slate in
+front of it, because the failure was silent: `auto` becomes CUDA or CPU
+depending on which partition the job landed on, and a twelve-minute import of
+200 images looks exactly like a slow one.
+
 Usage::
 
     python import_slates.py --slates /expscratch/$USER/classes-3588/slates
@@ -55,6 +63,27 @@ def main() -> int:
 
     index = json.loads((Path(args.slates) / "slates.json").read_text())
     log(f"{len(index)} slates under {args.slates}")
+    total_images = sum(int(e.get("n") or 0) for e in index)
+
+    # WHICH DEVICE, before anything is embedded, and before --dry-run returns --
+    # planning the run is exactly what a dry run is for (#3669). The embedder
+    # resolves `auto` against whatever host it lands on, so the same command is
+    # minutes on a GPU node and hours on a CPU one, and nothing said so: the
+    # #3588 pass paid ~12 minutes for well under a minute of GPU work, and a
+    # slate import sent to the wrong partition looked exactly like a slow one.
+    #
+    # `app` lives at the repo root; this script runs from scripts/experiments/pile.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+    from vtscore.config import resolve_device  # noqa: PLC0415
+
+    device = resolve_device()
+    # 1.2 s/image measured on CPU (#3669: 200 images, 238 s). The GPU figure is
+    # an order-of-magnitude placeholder and is labelled as one rather than
+    # quoted: nobody has timed this import on a GPU.
+    rate, sure = (1.2, "measured") if device == "cpu" else (0.05, "guessed")
+    log(f"embedding device: {device} -- {total_images} images, roughly {total_images * rate / 60:.0f} min ({sure})")
+    if device == "cpu":
+        log("  every one of those vectors is already in the pile; a CPU import is hours (#3669)")
 
     if args.dry_run:
         for e in index:
@@ -67,8 +96,6 @@ def main() -> int:
     os.environ.setdefault("VTSEARCH_MODELS_DIR", str(pc.PILE / "models"))
     os.environ.setdefault("HF_HOME", str(pc.PILE / "models"))
 
-    # `app` lives at the repo root; this script runs from scripts/experiments/pile.
-    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
     import app  # noqa: F401, PLC0415  -- wires the registries
 
     from vtscore.datasets import registry as ds_registry  # noqa: PLC0415


### PR DESCRIPTION
Takes fix (1) of #3669 — the cheapest of its three, and the one that makes the other two decidable.

The embedder resolves `auto` against whatever host the job lands on, so the same command is minutes on a GPU node and hours on a CPU one, and nothing said which had happened. The #3588 pass paid ~12 minutes for well under a minute of GPU work, and an import sent to the wrong partition looked exactly like a slow one.

```
[import] 13 slates under /expscratch/$USER/classes-3588/slates
[import] embedding device: cpu -- 3900 images, roughly 78 min (measured)
[import]   every one of those vectors is already in the pile; a CPU import is hours (#3669)
```

Printed **before `--dry-run` returns**, because planning the run is what a dry run is for. The CPU rate is #3669's own measurement (200 images, 238 s); the GPU rate is an order-of-magnitude placeholder and the line prints `guessed` rather than `measured` when it uses it, since nobody has timed this import on a GPU. Changes no behaviour.

## Why not (2) or (3)

Both are on the issue in full; briefly:

**(2), "N detectors against one dataset", moves the class's rule off the string the reviewer sees.** This script's contract is that the dataset and detector share the name from `SCALE_CLASS_RULES`, because that name "is the only string the app shows while voting". The #3588 pass ran three rules over one folder; one dataset cannot carry three names. Trading that for ~8 minutes of CPU is the `book`-split failure (#3612) bought back. It needs a decision about where the rule lives when a folder is shared, not a refactor.

**(3), a precomputed-vector import path, is the one that matters for the pass** — 3,391 images at the measured rate is ~68 minutes to recompute vectors `vg_scale__siglip.pkl` already holds, and it removes the "did the app and the pile embed this the same way?" question by construction. It is app-tier, it needs the app running to verify, and it wants doing deliberately rather than unattended at 00:30.

## Testing

Full `./run-tests.sh` on the GRID (job 625949): **RUN PASSED**, 11,043 passed / 6 skipped / 2 xpassed, all gates green. Smoke-tested against the live #3588 slates, output above.
