### PR TITLE
Plan: #3686 was never a blocker, and its premise is pre-#3670

### DIFF
--- a/docs/plans/vg-scale-exhaustive-annotation.md
+++ b/docs/plans/vg-scale-exhaustive-annotation.md
@@ -107,7 +107,13 @@ cannot be regenerated, so a rebuild *after* the pass throws some of them away.
 Land or dismiss all of them, rebuild once, then freeze the roster — in that
 order.
 
-Two have already left the list on measurement rather than on work. **#3663** is
+Three have already left the list on measurement rather than on work. **#3686**
+was never a blocker: I filed it here as overlapping the pass, and it does not —
+the pass annotates off-COCO *positives* and that issue hunts false negatives in
+the *pool*. Its own premise is also pre-#3670: the shipped pool is now
+9,900/9,900 COCO-answerable with zero measured contamination, so the stratum it
+searches is empty. `vg_scale_deep`, whose 6,264 unprovable negatives are the
+only VG-silence population left in the pile, is where that instrument now points. **#3663** is
 refuted: the misspellings it named are in VG and reachable by an edit-distance
 search, they were scored by the same three cuts, and **none clears them** — the
 real ones carry 3–5 images each. **#3655** moves the *negative* pool, which the
@@ -155,7 +161,6 @@ now covers all 25 classes, so #3618's "before the next rebuild" warning is spent
 
 <!-- item-sep -->
 
-- [ ] #3686 — the text-sort false-negative hunt covers the stratum this pass answers outright (do one, not both)
 
 <!-- item-sep -->
 


### PR DESCRIPTION
I filed #3686 on the pre-pass list as *"covers the stratum this pass answers outright — do one, not both"*. That is wrong: the pass annotates off-COCO **positives**, and #3686 hunts false negatives in the **negative pool**. Disjoint populations, nothing to sequence.

Its own premise is also overtaken. It opens with *"the negative pool rests on VG's silence for a bit over half its number"*, which was true when filed. Since #3670 the pool is drawn entirely from the COCO-scored half — tonight's verify reports `9900/9900 negatives answerable, 0 hold a class of C` — so a text sort over it would rank 9,900 images whose labels are already known. Same emptiness as #3675.

The instrument keeps a target, and a bigger one: `vg_scale_deep` retains the pre-#3670 draw, and **6,264 of its 11,700 negatives rest on VG's silence** with nothing able to check them. Re-scope recorded on the issue.

## Testing

`./run-tests.sh` on the GRID (job 626009): **RUN PASSED**, markdown-only narrowing, 1,091 passed.