### PR TITLE
PROPOSAL (do not merge yet): a rebox designates an instance, and the set is kept (#3726)

### DIFF
--- a/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
+++ b/scripts/experiments/pile/pilebuild/loaders/vg_scale.py
@@ -365,6 +365,7 @@ def apply_corrections(
     box_dims: dict[int, tuple[int, int]],
     exhaustive: set[int],
     classes: tuple[str, ...] | None = None,
+    designated: dict[tuple[int, str], list[list[float]]] | None = None,
 ) -> set[tuple[int, str]]:
     """Fold human verdicts into *labels*, and return the pairs that cannot be banded.
 
@@ -377,6 +378,12 @@ def apply_corrections(
     could see that, because the BAND is derived from the same corrupted box, so
     the cell name and its boxes stayed consistent with each other all the way
     into the study.
+
+    **A drawn box designates rather than replaces** when *designated* is given
+    (#3726). The reviewer's box is recorded there and kept at the head of the
+    class's box list; the instances VG already had are kept behind it, where the
+    old behaviour dropped them. Passing ``None`` keeps the pre-#3726 semantics,
+    which is what every caller that only wants the labels still does.
 
     A pair a reviewer ruled "present" without drawing a box cannot be banded: a
     band is a claim about size, and no size was measured. It leaves every cell of
@@ -422,7 +429,28 @@ def apply_corrections(
         if verdict.get("present"):
             boxes = correction_boxes_px(verdict, *box_dims[iid])
             if boxes:
-                labels[iid][name] = boxes
+                # A reviewer's box does TWO things, and the build used to hear
+                # only one of them (#3726). It annotates an instance, and it
+                # *designates* which instance this cell is about -- Sam's own
+                # description of what he was doing: "there was a different,
+                # more-prominent example elsewhere in the image".
+                #
+                # Replacing the set hears the designation and throws the
+                # annotation away: 26 of 470 boxed corrections collapsed a
+                # multi-instance set, `book` 713617 from 14 boxes to 1. Merging
+                # without designating hears the annotation and loses the choice:
+                # `band_for` would union the drawn box with the others, the image
+                # would not move to the band the reviewer picked, and a scattered
+                # set would take it out of every band -- overturning #3616.
+                #
+                # So both are recorded. The set keeps every instance; the
+                # designation is carried beside it and is what bands the cell.
+                if designated is not None:
+                    designated[(iid, name)] = boxes
+                    existing = labels[iid].get(name) or []
+                    labels[iid][name] = boxes + [b for b in existing if b not in boxes]
+                else:
+                    labels[iid][name] = boxes
             else:
                 labels[iid].pop(name, None)
                 unbanded.add((iid, name))
@@ -476,8 +504,14 @@ def band_candidates(
     box_dims: dict[int, tuple[int, int]],
     unbanded: set[tuple[int, str]],
     classes: tuple[str, ...] | None = None,
+    designated: dict[tuple[int, str], list[list[float]]] | None = None,
 ) -> tuple[dict[str, dict[str, list[int]]], dict[tuple[int, str], list[list[float]]], list[int]]:
     """Sort every image into ``(class, band)`` supply, or into the clean pool.
+
+    Returns ``(supply, boxes_for, clean)``. *designated* carries a reviewer's
+    chosen box per ``(image, class)`` (#3726): it decides the **band**, while
+    ``boxes_for`` still carries every instance, so the cell knows what the class
+    has in the image and the band still says which one was picked.
 
     Returns ``(supply, boxes_for, clean)``. An image with no instance of any
     class in C joins ``clean`` -- unless its ``(image, class)`` pair is in
@@ -506,7 +540,12 @@ def band_candidates(
                 clean.append(iid)
             continue
         for name, bs in by_name.items():
-            band = band_for(bs, W, H)
+            # The band is a claim about the object this cell is about, so a
+            # reviewer's designation decides it and the other instances do not
+            # drag it (#3726). Without a designation this is exactly the old
+            # behaviour: the union over everything the class has here.
+            picked = (designated or {}).get((iid, name))
+            band = band_for(picked or bs, W, H)
             if band not in pc.BOX_BANDS:  # scattered, or bigger than a region
                 continue
             supply[name][band].append(iid)
@@ -888,7 +927,8 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
     # and is what lets `contested` be counted against the real pixel space, and
     # only on the images that actually pay it.
     folded, contested = canonicalise(labels, pc.SCALE_VG_NAMES, box_dims, pc.SCALE_FOLD_MODE)
-    unbanded = apply_corrections(labels, corrections, box_dims, exhaustive)
+    designated: dict[tuple[int, str], list[list[float]]] = {}
+    unbanded = apply_corrections(labels, corrections, box_dims, exhaustive, designated=designated)
     suppressed = lift_ambiguous(labels, pc.SCALE_VG_AMBIGUOUS, exhaustive)
     unbanded |= suppressed
     log(
@@ -940,7 +980,7 @@ def load(dataset: str, medias: dict[int, dict], embedder_name: str) -> None:
         )
         log("    run `coco_folds.py --classes <c>` and record the result in pile_config.SCALE_VG_NAMES_AUDITED (#3605)")
 
-    supply, boxes_for, clean = band_candidates(labels, box_dims, unbanded)
+    supply, boxes_for, clean = band_candidates(labels, box_dims, unbanded, designated=designated)
 
     roster = {}
     if pc.ROSTER.exists():

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -156,6 +156,96 @@ class TestApplyCorrections:
         assert "bus" not in labels[7]
 
 
+class TestReboxDesignates:
+    """A reviewer's box designates an instance; the set is kept (#3726).
+
+    The box does two things at once, and the build used to hear one of them.
+    Sam's description of what he was doing: *"there was a different,
+    more-prominent example elsewhere in the image"* -- so the box is usually a
+    **different instance**, not a correction of the drawn one.
+
+    Replacing the set hears the designation and throws the annotation away: 26 of
+    470 boxed corrections collapsed a multi-instance set, `book` 713617 from 14
+    boxes to 1. Merging without designating hears the annotation and loses the
+    choice, because `band_for` would union the drawn box with the others and the
+    image would not move to the band the reviewer picked -- overturning #3616.
+    """
+
+    def test_the_other_instances_survive_a_rebox(self, vgs):
+        drawn = [0.5, 0.5, 0.6, 0.6]
+        others = [[10.0, 10.0, 20.0, 20.0], [30.0, 30.0, 44.0, 44.0]]
+        labels = {7: {"bowl": [list(b) for b in others]}}
+        designated: dict[tuple[int, str], list[list[float]]] = {}
+
+        vgs.apply_corrections(
+            labels, {(7, "bowl"): _verdict(True, [drawn])}, {7: (100, 100)}, set(), designated=designated
+        )
+
+        assert [[50.0, 50.0, 60.0, 60.0], *others] == labels[7]["bowl"], "the reviewer's box leads, the rest remain"
+        assert designated[(7, "bowl")] == [[50.0, 50.0, 60.0, 60.0]]
+
+    def test_without_the_dict_the_old_behaviour_is_exact(self, vgs):
+        """Every caller that only wants labels keeps the pre-#3726 semantics."""
+        labels = {7: {"bowl": [[10.0, 10.0, 20.0, 20.0]]}}
+
+        vgs.apply_corrections(labels, {(7, "bowl"): _verdict(True, [[0.5, 0.5, 0.6, 0.6]])}, {7: (100, 100)}, set())
+
+        assert labels[7]["bowl"] == [[50.0, 50.0, 60.0, 60.0]]
+
+    def test_a_designation_that_repeats_an_instance_is_not_stored_twice(self, vgs):
+        same = [[50.0, 50.0, 60.0, 60.0]]
+        labels = {7: {"bowl": [list(b) for b in same]}}
+
+        vgs.apply_corrections(
+            labels, {(7, "bowl"): _verdict(True, [[0.5, 0.5, 0.6, 0.6]])}, {7: (100, 100)}, set(), designated={}
+        )
+
+        assert labels[7]["bowl"] == same
+
+    def test_the_band_follows_the_designated_box_not_the_union(self, vgs, pc):
+        """#3616's ruling, kept: the image moves to the band the reviewer picked.
+
+        The union over a small box and a large one lands in a different band from
+        the small box alone -- which is exactly the case that made this a choice
+        rather than a merge.
+        """
+        small = [0.0, 0.0, 5.0, 5.0]  # 25/10_000 -- inside `small`
+        large = [0.0, 0.0, 70.0, 70.0]  # 0.49 of the frame: inside `large`, and the union stays bandable
+        labels = {7: {"bowl": [small, large]}}
+
+        _supply, _boxes, _clean = vgs.band_candidates(
+            labels, {7: (100, 100)}, set(), classes=("bowl",), designated={(7, "bowl"): [small]}
+        )
+        by_union = vgs.band_for([small, large], 100, 100)
+        by_designation = vgs.band_for([small], 100, 100)
+
+        assert by_union != by_designation, "the fixture must actually separate the two readings"
+        assert 7 in _supply["bowl"][by_designation]
+        assert 7 not in _supply["bowl"].get(by_union, [])
+
+    def test_the_cell_still_carries_every_instance(self, vgs):
+        """The band is a view; the boxes are the record (the 2026-09-07 decision)."""
+        small = [0.0, 0.0, 5.0, 5.0]
+        large = [0.0, 0.0, 70.0, 70.0]  # 0.49 of the frame: inside `large`, and the union stays bandable
+        labels = {7: {"bowl": [small, large]}}
+
+        _supply, boxes_for, _clean = vgs.band_candidates(
+            labels, {7: (100, 100)}, set(), classes=("bowl",), designated={(7, "bowl"): [small]}
+        )
+
+        (cell,) = [k for k in boxes_for if k[0] == 7]
+        assert boxes_for[cell] == [small, large]
+
+    def test_an_undesignated_class_bands_by_the_union_as_before(self, vgs):
+        small = [0.0, 0.0, 5.0, 5.0]
+        large = [0.0, 0.0, 70.0, 70.0]  # 0.49 of the frame: inside `large`, and the union stays bandable
+        labels = {7: {"bowl": [small, large]}}
+
+        supply, _boxes, _clean = vgs.band_candidates(labels, {7: (100, 100)}, set(), classes=("bowl",), designated={})
+
+        assert 7 in supply["bowl"][vgs.band_for([small, large], 100, 100)]
+
+
 class TestAnchorToCoco:
     """COCO's exhaustive labels replace VG's, except where the copies disagree."""
 


### PR DESCRIPTION
> **Do not merge until you have ruled on #3726.** This implements *one* of that issue's three readings — the one I recommended — and if the ruling goes another way the branch is discarded rather than amended. Opened so the option is ready rather than to ask for it.

A reviewer's box does **two things at once**, and the build hears one of them. Your own description of what you were doing (#3616): *"there was a different, more-prominent example elsewhere in the image"* — so the box usually names a **different instance** rather than correcting the drawn one. It annotates an instance, and it *designates* which instance the cell is about.

| reading | hears | loses |
|---|---|---|
| replace the set (today) | the designation | the annotation — 26 of 470 boxed corrections collapse a multi-instance set, `book` 713617 from 14 boxes to 1, 118 boxes in all |
| merge without designating | the annotation | the choice — `band_for` unions the drawn box with the others, the image does not move to the band the reviewer picked, and a scattered set leaves every band, overturning #3616 |
| **designate and keep (this PR)** | both | — |

`apply_corrections` keeps every instance with the reviewer's box at the head and reports the designation beside the labels; `band_candidates` bands from the designation where there is one, and from the union where there is not. **Both parameters default to `None`**, so every caller that only wants labels keeps the pre-#3726 semantics exactly — which is why the existing 116 tests pass untouched.

## Measured: this changes membership by nothing

`replay_selection.py` reports **30 positives moving over 12 cells on `dev`, and 30 over 12 on this branch.** The bands are identical, because the designated box is the same box the old code banded from. What changes is that the cell now carries the class's other instances instead of dropping them — the band decision of 2026-09-07 (*"the band is a view over every instance"*) finally holding on the images a human has actually looked at.

## The one consequence to weigh

Those instances reach `regions`, so a region-voting arm sees more true boxes on 26 reviewed images than it did today. More correct, and still a change to what an eval arm trains on — so it belongs to the same rebuild rather than arriving on its own.

## Testing

6 new tests, including the fixture that separates the two readings (a small box and a large one whose union lands in a different band) and the proof that omitting the new parameter reproduces the old behaviour byte for byte.

Full `./run-tests.sh` on the GRID (job 626220): **RUN PASSED**, 11,049 passed / 6 skipped / 2 xpassed, all gates green.
