### PR TITLE
replay_selection: say how many cells the table left out

### DIFF
--- a/scripts/experiments/pile/replay_selection.py
+++ b/scripts/experiments/pile/replay_selection.py
@@ -116,10 +116,21 @@ def _compare(
     print(f"positives: {add_total} would be added, {drop_total} would be dropped, over {len(per_cell)} cells")
     print(f"negatives: {neg_add} would be added, {neg_drop} would be dropped (pool of {len(want_neg)})")
     if per_cell:
-        worst = sorted(per_cell.items(), key=lambda kv: -(kv[1]["added"] + kv[1]["dropped"]))[:8]
+        # Say what was left out. This table shows the worst few cells, and a
+        # reader who sums it gets a number that disagrees with the header two
+        # lines above -- which is exactly how "26 positives over 8 cells" was
+        # reported from a run whose header said 30 over 12. The total is right
+        # and the table is a sample; only the silence about that was wrong.
+        shown = 8
+        worst = sorted(per_cell.items(), key=lambda kv: -(kv[1]["added"] + kv[1]["dropped"]))[:shown]
         print(f"  {'cell':<24}{'added':>8}{'dropped':>9}")
         for cell, row in worst:
             print(f"  {cell:<24}{row['added']:>8}{row['dropped']:>9}")
+        if len(per_cell) > shown:
+            print(
+                f"  ... and {len(per_cell) - shown} more cell(s) not shown; "
+                f"the {add_total}/{drop_total} above the table is the total, not the sum of these rows"
+            )
     return {
         "positives_added": add_total,
         "positives_dropped": drop_total,


### PR DESCRIPTION
The per-cell table shows the worst 8 and said nothing about the rest, so a reader who sums its rows gets a number that disagrees with the header two lines above.

Not hypothetical: **I reported "26 positives over 8 cells" from a run whose header said 30 over 12**, and it reached an issue comment and a handoff before the header was read properly. The total was right and the table was a sample; only the silence about that was wrong.

```
... and 28 more cell(s) not shown; the 2455/2455 above the table is the total,
not the sum of these rows
```

Same shape as #3736, where a task log printed a denominator the array no longer had. The peer session and I were each caught by one of these overnight, from opposite ends — mine by summing a truncated table, theirs by counting per-cell totals that a 30-in/30-out swap leaves identical.

For the record on that second one: this script is **not** vulnerable to it. It compares by set difference (`len(want - have)`, `len(have - want)`), so a swap that preserves every count still shows up. That is now stated in the commit rather than left to be rediscovered.

## Testing

Full `./run-tests.sh` on the GRID (job 629276): **RUN PASSED**, 11,055 passed / 6 skipped / 2 xpassed. Verified against the live pile: the note fires on the 36-cell unpinned table and stays silent on the 0-cell pinned one.