### PR TITLE
Build the review set for the pass: one dataset, 25 detectors (#3720)

### DIFF
--- a/scripts/experiments/pile/make_pass25.py
+++ b/scripts/experiments/pile/make_pass25.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Build the review set for the exhaustive pass: one dataset, 25 detectors (#3720).
+
+The pass owes an answer for every `(image, class)` pair on the off-COCO
+positives — 3,397 images, 25 classes. **It is run as 25 per-class passes, not as
+one multi-class naming pass**, on the owner's ruling: holding one class in mind
+while scanning is much easier than recognising twenty-five at once, and the app
+is already built for exactly that shape. The cost framing that argued otherwise
+(~85,000 votes) was wrong, because a per-class pass is mostly bulk in a ranked
+review rather than 3,397 deliberate acts.
+
+That ruling makes the recording problem disappear too: a per-class pass records
+exactly the pairs it asked about, so "absent" can never be read back for a class
+the reviewer was never shown — the hazard #3727 had to guard against under the
+compact per-image shape.
+
+**One dataset, twenty-five detectors.** The images are imported once and every
+detector scores the same set. Importing per class would embed the same 3,397
+images twenty-five times (#3669), and there is nowhere for the class's rule to
+live in a shared folder's *dataset* name — but a detector's name is chosen by
+the reviewer when they start a pass, so that is where the rule goes. Each
+detector is named from `pile_config.SCALE_CLASS_RULES`, which is the wording the
+reviewer sees while voting and the only place a definition survives (#3612).
+
+**Controls are mixed in and are not distinguishable.** A fixed number of
+COCO-anchored positives per class join the set; COCO answers exhaustively for
+them, so every pass scores itself against a key the reviewer cannot see, at no
+extra review cost. Files are named by image id alone, exactly as
+`make_audit_slate.py` does it. The key is written beside the folder and is
+**not** given to the app.
+
+Usage::
+
+    python make_pass25.py                      # build the folder and the key
+    python make_pass25.py --api http://host:port --create   # import + 25 detectors
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from pathlib import Path
+
+import pile_config as pc
+
+#: Known positives per class among the controls. Twelve is enough to see a
+#: reviewer missing a quarter of a class, and keeps the controls under a tenth
+#: of the set -- the reviewer pays for every control image like any other.
+CONTROLS_PER_CLASS = 12
+
+#: Fixed so the control set is the same for whoever rebuilds it, and so a
+#: second build can be diffed against the first rather than re-argued.
+CONTROL_SEED = 3720
+
+
+def log(msg: str) -> None:
+    print(f"[pass25] {msg}", flush=True)
+
+
+def draw_controls(
+    medias: dict[int, dict],
+    held_by: dict[int, list[str]],
+    per_class: int = CONTROLS_PER_CLASS,
+    seed: int = CONTROL_SEED,
+) -> dict[int, list[str]]:
+    """``{image_id: the classes COCO says it holds}`` for the control images.
+
+    Drawn from the cell's **COCO-scored** positives, which is what makes them a
+    key: COCO answered for all eighty of its classes at once, so a control is a
+    known positive for its own class *and* a known negative for the other
+    twenty-four. One control therefore scores every pass it appears in, not just
+    the one it was drawn for.
+
+    Images already in the queue cannot be drawn: the queue is off-COCO by
+    construction and these are anchored, so the two sets are disjoint and this
+    is an assertion rather than a filter.
+    """
+    rng = random.Random(seed)
+    by_class: dict[str, list[int]] = {c: [] for c in pc.SCALE_CLASSES}
+    for iid, media in sorted(medias.items()):
+        if not media.get("coco_scored") or not media.get("categories"):
+            continue
+        if iid not in held_by:
+            continue
+        for cell in media["categories"]:
+            cls = cell.split("@", 1)[0]
+            if cls in by_class:
+                by_class[cls].append(iid)
+    chosen: dict[int, list[str]] = {}
+    for cls in pc.SCALE_CLASSES:
+        pool = sorted(set(by_class[cls]) - set(chosen))
+        for iid in rng.sample(pool, min(per_class, len(pool))):
+            chosen[iid] = list(held_by[iid])
+    return chosen
+
+
+def link_images(paths: dict[int, str], out_dir: Path) -> int:
+    """Symlink each image into *out_dir* under its image id, and count them.
+
+    Named by id alone, with nothing in the filename saying whether a row is a
+    control -- that is the whole point of the controls, and a reviewer who could
+    tell them apart would score differently on them.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for old in out_dir.glob("*.jpg"):
+        old.unlink()
+    n = 0
+    for iid, src in sorted(paths.items()):
+        dest = out_dir / f"{iid}.jpg"
+        dest.symlink_to(src)
+        n += 1
+    return n
+
+
+def detector_name(cls: str) -> str:
+    """The string the reviewer sees while voting: the class's written rule.
+
+    `SCALE_CLASS_RULES` carries the wording a class was reviewed under, and it
+    is the only place a definition travels with the work (#3612 -- `book` split
+    over magazines because the rule lived in a manifest). A class with no rule
+    falls back to its bare name and is reported, because an unruled class is a
+    ruling somebody owes (#3673) rather than a class without a boundary.
+    """
+    rule = pc.SCALE_CLASS_RULES.get(cls)
+    return getattr(rule, "name", "") or cls
+
+
+def api(base: str, path: str, payload: dict | None = None, method: str = "GET") -> dict:
+    url = base.rstrip("/") + path
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(  # noqa: S310 - our own app on the cluster
+        url, data=data, method=method, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as fh:  # noqa: S310
+            body = fh.read().decode()
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"{method} {path} -> {exc.code}: {exc.read().decode()[:400]}") from exc
+    return json.loads(body) if body.strip() else {}
+
+
+def main() -> int:
+    pc.setup_env()
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    base = pc.PILE.parent / "vgscale-3156"
+    ap.add_argument("--queue", default=str(base / "annotation_queue.jsonl"))
+    ap.add_argument("--cell", default=str(pc.EMBEDDINGS / "vg_scale__siglip.pkl"))
+    ap.add_argument("--out", default=str(base / "pass25"))
+    ap.add_argument("--per-class", type=int, default=CONTROLS_PER_CLASS)
+    ap.add_argument("--api", default="", help="app base URL, e.g. http://rack7n06:11850")
+    ap.add_argument("--create", action="store_true", help="import the dataset and create the 25 detectors")
+    ap.add_argument("--dataset-name", default="vg_scale off-COCO positives")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "calibration"))
+    sys.path.insert(0, str(Path(__file__).resolve().parent / "pilebuild"))
+    from _cells_io import load_medias  # noqa: PLC0415
+
+    from pilebuild.audit import coco_held_by  # noqa: PLC0415
+
+    rows = [json.loads(line) for line in Path(args.queue).read_text().splitlines() if line.strip()]
+    log(f"{len(rows)} queue rows from {Path(args.queue).name}")
+
+    medias = load_medias(Path(args.cell))
+    held_by = coco_held_by()
+    controls = draw_controls(medias, held_by, args.per_class)
+    log(f"{len(controls)} controls drawn ({args.per_class}/class, COCO-answered)")
+
+    queue_ids = {int(r["image_id"]) for r in rows}
+    overlap = queue_ids & set(controls)
+    if overlap:
+        raise SystemExit(f"{len(overlap)} controls are also queue rows; the two sets must be disjoint")
+
+    paths = {int(r["image_id"]): r["path"] for r in rows}
+    for iid in controls:
+        paths[iid] = medias[iid]["origin_name"]
+
+    out = Path(args.out)
+    n = link_images(paths, out / "images")
+    key = {
+        "dataset_name": args.dataset_name,
+        "queue": sorted(queue_ids),
+        "controls": {str(i): v for i, v in sorted(controls.items())},
+        "per_class": args.per_class,
+        "seed": CONTROL_SEED,
+    }
+    (out / "controls.json").write_text(json.dumps(key, indent=1) + "\n")
+    log(f"{n} images linked into {out / 'images'}; key at {out / 'controls.json'}")
+
+    unruled = [c for c in pc.SCALE_CLASSES if not pc.SCALE_CLASS_RULES.get(c)]
+    if unruled:
+        log(f"NOTE: no written rule for {', '.join(unruled)} -- the detector falls back to the bare name (#3673)")
+
+    per_class_controls = Counter(c for v in controls.values() for c in v if c in set(pc.SCALE_CLASSES))
+    thin = [c for c in pc.SCALE_CLASSES if per_class_controls[c] < args.per_class]
+    if thin:
+        log(f"NOTE: fewer than {args.per_class} known positives among the controls for: {', '.join(thin)}")
+
+    if not args.create:
+        log("built, nothing sent to the app. Re-run with --api URL --create to import.")
+        return 0
+    if not args.api:
+        raise SystemExit("--create needs --api")
+
+    log(f"importing {n} images as {args.dataset_name!r} ...")
+    api(
+        args.api,
+        "/api/dataset/import/server_folder",
+        {
+            "path": str(out / "images"),
+            "media_type": "image",
+            "recursive": "false",
+            "dig_archives": "false",
+            "dataset_name": args.dataset_name,
+        },
+        method="POST",
+    )
+    log("  import submitted; poll /api/dataset/status")
+
+    made = 0
+    for cls in pc.SCALE_CLASSES:
+        name = detector_name(cls)
+        api(
+            args.api,
+            "/api/detectors",
+            {
+                "name": name,
+                "media_type": "image",
+                "text_query": cls,
+                "embedder_type": "semantic",
+                "examples": [{"type": "text", "value": cls}],
+            },
+            method="POST",
+        )
+        made += 1
+    log(f"{made} detectors created, one per class, each named for its rule")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_lib/meta/test_pile_pass25.py
+++ b/tests_lib/meta/test_pile_pass25.py
@@ -1,0 +1,120 @@
+"""The review set for the exhaustive pass: controls, and the name a reviewer sees (#3720).
+
+The pass runs as 25 per-class passes over one dataset, on the owner's ruling
+that holding one class in mind beats recognising twenty-five at once. Two things
+in that build decide whether the result can be trusted afterwards:
+
+* **the controls**, which are COCO-answered images mixed in so every pass scores
+  itself. They have to be drawn from the anchored half (COCO answered for all
+  eighty classes at once, so one control scores every pass it appears in), be
+  disjoint from the queue, and be reproducible;
+* **the detector name**, because it is the only string the app shows while
+  voting, so it is the only place a class's rule can live where the reviewer
+  meets it (#3612 -- `book` split over magazines because the rule lived in a
+  manifest instead).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+
+@pytest.fixture(scope="module")
+def pass25():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import make_pass25
+
+    return make_pass25
+
+
+@pytest.fixture(scope="module")
+def pc():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pile_config
+
+    return pile_config
+
+
+def _anchored(cls: str, iid: int, scored: bool = True) -> dict:
+    return {"id": iid, "categories": [f"{cls}@small"], "coco_scored": scored, "origin_name": f"/vg/{iid}.jpg"}
+
+
+class TestDrawControls:
+    def test_it_draws_the_asked_for_number_per_class(self, pass25, pc):
+        cls = pc.SCALE_CLASSES[0]
+        medias = {i: _anchored(cls, i) for i in range(100)}
+        held = {i: [cls] for i in range(100)}
+
+        chosen = pass25.draw_controls(medias, held, per_class=12)
+
+        assert len(chosen) == 12
+        assert all(v == [cls] for v in chosen.values())
+
+    def test_only_coco_scored_images_can_be_controls(self, pass25, pc):
+        """A control is a key, and only COCO answers for all 25 classes at once."""
+        cls = pc.SCALE_CLASSES[0]
+        medias = {i: _anchored(cls, i, scored=False) for i in range(50)}
+        held = {i: [cls] for i in range(50)}
+
+        assert pass25.draw_controls(medias, held, per_class=12) == {}
+
+    def test_an_image_coco_cannot_answer_for_is_not_drawn(self, pass25, pc):
+        """Anchored by the stamp but absent from the join is no answer at all."""
+        cls = pc.SCALE_CLASSES[0]
+        medias = {i: _anchored(cls, i) for i in range(50)}
+
+        assert pass25.draw_controls(medias, {}, per_class=12) == {}
+
+    def test_the_draw_is_a_function_of_the_seed(self, pass25, pc):
+        cls = pc.SCALE_CLASSES[0]
+        medias = {i: _anchored(cls, i) for i in range(200)}
+        held = {i: [cls] for i in range(200)}
+
+        first = pass25.draw_controls(medias, held, per_class=12, seed=7)
+        again = pass25.draw_controls(medias, held, per_class=12, seed=7)
+        other = pass25.draw_controls(medias, held, per_class=12, seed=8)
+
+        assert first == again
+        assert set(first) != set(other)
+
+    def test_one_image_is_never_drawn_twice(self, pass25, pc):
+        """An image positive for two classes must not be counted as two controls."""
+        a, b = pc.SCALE_CLASSES[0], pc.SCALE_CLASSES[1]
+        medias = {i: {"id": i, "categories": [f"{a}@small", f"{b}@large"], "coco_scored": True} for i in range(30)}
+        held = {i: [a, b] for i in range(30)}
+
+        chosen = pass25.draw_controls(medias, held, per_class=12)
+
+        assert len(chosen) == len(set(chosen))
+
+    def test_it_carries_every_class_coco_says_is_present(self, pass25, pc):
+        """The key is the whole answer, not just the class the image was drawn for."""
+        a, b = pc.SCALE_CLASSES[0], pc.SCALE_CLASSES[1]
+        medias = {1: _anchored(a, 1)}
+
+        chosen = pass25.draw_controls(medias, {1: [a, b]}, per_class=1)
+
+        assert chosen[1] == [a, b]
+
+
+class TestDetectorName:
+    def test_a_ruled_class_shows_its_rule(self, pass25, pc):
+        """The rule is what the reviewer reads while voting, so it is the name."""
+        ruled = next(c for c in pc.SCALE_CLASSES if pc.SCALE_CLASS_RULES.get(c))
+
+        assert pass25.detector_name(ruled) == pc.SCALE_CLASS_RULES[ruled].name
+
+    def test_an_unruled_class_falls_back_to_its_bare_name(self, pass25):
+        """`dog` has no written rule; that is a ruling owed (#3673), not a crash."""
+        assert pass25.detector_name("nonesuch") == "nonesuch"
+
+    def test_every_class_yields_a_non_empty_name(self, pass25, pc):
+        for cls in pc.SCALE_CLASSES:
+            assert pass25.detector_name(cls).strip()


### PR DESCRIPTION
The pass runs as **25 per-class passes in the existing app**, on your ruling — no new UI. Holding one class in mind beats recognising twenty-five at once, and the app is already built for that shape. My earlier cost framing (~85,000 votes) was wrong: a per-class pass is mostly bulk in a ranked review, not 3,397 deliberate acts.

That ruling also dissolves the recording hazard #3727 had to guard against — a per-class pass records exactly the pairs it asked about, so "absent" can never be read back for a class the reviewer was never shown.

## What is on the dashboard now

| | |
|---|---|
| dataset | **vg_scale off-COCO positives** — 3,697 images |
| detectors | **25**, one per class, each named for its rule from `SCALE_CLASS_RULES` |

**One dataset, not 25.** Importing per class would embed the same images twenty-five times (#3669). The class's rule lives in the **detector** name — the string the app shows while voting, chosen deliberately when a pass starts — which is also the answer to the objection that had blocked #3669's fix 2, where a shared folder had nowhere to put it.

**Controls are mixed in and indistinguishable.** 12 COCO-anchored positives per class, 300 images, 8% of the set. COCO answered for all eighty classes at once on those, so one control is a known positive for its own class *and* a known negative for the other twenty-four — it scores every pass it appears in. Files are named by image id alone, as `make_audit_slate.py` does it; the key is written beside the folder and **not** given to the app.

## One thing owed

`dog` has no written rule, so its detector falls back to the bare class name and the build says so. That is a ruling somebody owes (#3673), not a class without a boundary — the other 24 carry theirs.

## Testing

9 tests over the two things that decide whether the result can be trusted: the control draw (anchored-only, seed-stable, never double-counted, carries the whole answer) and the detector name (rule when there is one, bare name when there is not).

Full `./run-tests.sh` on the GRID (job 629963): **RUN PASSED**, 11,064 passed / 6 skipped / 2 xpassed.