### PR TITLE
bench: seating built into a vehicle is a component, not an instance

### DIFF
--- a/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
+++ b/docs/experiments/2026-09-03-vg-scale-classes/ANNOTATION_GUIDE.md
@@ -799,9 +799,28 @@ ledge, a low wall, a kerb or a platform (`wall` 16, `concrete` 6, `platform` 5,
 `rail`/`railing` 10). The test is intent of manufacture, not affordance.
 
 Together these narrow the class by roughly 3% of COCO's bench boxes, which the
-supply absorbs. A rowboat's **thwart** — the crosswise plank built to sit on —
-**counts**: it is seating, and it was built as seating, so it passes both tests
-even though it is part of a boat.
+supply absorbs.
+
+> **SUPERSEDED 2026-09-08.** This section used to rule that a rowboat's
+> **thwart** *counts* — "it is seating, and it was built as seating, so it
+> passes both tests even though it is part of a boat". It no longer does.
+> **Seating built into a vehicle is not a Bench**: a thwart, a boat's built-in
+> hull seating, a bus's bench seat. A bench standing *loose* on a deck or in a
+> bus still is one, exactly as a car seat out of the car is a Chair.
+>
+> The old ruling saw the tension and accepted it. It was overturned because it
+> contradicts the `Chair` ruling two sections below — "fixed seating that is
+> part of a vehicle is not a Chair", which names boats — and one principle
+> across both classes beats two that disagree. Note the asymmetry in evidence:
+> the `Chair` ruling has a rate test behind it, and this one does not. Run the
+> same test on `bench` and it is confounded rather than confirming (boat 1.42x
+> base, but car 1.43x and train 1.40x, because benches and vehicles share
+> outdoor scenes and a platform bench *is* a Bench). What COCO does with
+> built-in boat seating is unmeasured; this rests on consistency.
+>
+> Benches already voted under the old rule are re-reviewed as their own pass
+> (#3755), not mid-run. The live wording is
+> `pile_config.SCALE_CLASS_RULES["bench"]`.
 
 ### `chair incl stools not couches`
 

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -1809,6 +1809,19 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
     # The cost is real and worth naming: a swan boat's passenger bench is
     # unambiguously built as seating for two or more, and it is now Bad. The line
     # is "part of a vehicle", not "not really seating".
+    #
+    # **This ruling rests on consistency, NOT on a measurement**, and that is a
+    # weaker footing than `chair`'s. The annotation guide settled `chair` with a
+    # rate test -- every vehicle class holds a chair BELOW COCO's base rate
+    # (airplane 0.14x, train 0.17x, bus 0.20x, boat 0.56x), which reads as
+    # annotators treating a vehicle interior as containing none. Run for `bench`
+    # the same test says the opposite -- boat 1.42x, train 1.40x, car 1.43x --
+    # and it is confounded rather than contradicting: benches and vehicles share
+    # outdoor scenes, so a waterfront bench behind a moored boat and a station
+    # bench beside a train both count. The guide itself rules a platform bench a
+    # Bench. Neither that test nor a box-containment test separates "in the
+    # vehicle" from "near it" for this class, so what COCO does with built-in
+    # boat seating is UNMEASURED. Rendered cases show genuine ones exist.
     "bench": ClassRule(
         name="bench not chairs",
         test=(

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -1797,15 +1797,30 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
     # The guide first named `chair` (53 boxes) as this class's confusion. It is
     # third: `seat` (64) and `table` (58) both outrank it, and each turns on a
     # question COCO's annotators do not ask.
+    # `bench` and `chair` share one principle about vehicles, and until 2026-09-08
+    # they contradicted each other: `chair` ruled a car seat out ("a component is
+    # not an instance"; "A PART INHERITS THE RULING OF ITS WHOLE") while `bench`
+    # ruled a rowboat's thwart IN. The reviewer found it mid-pass. `chair`'s
+    # principle wins because it generalises -- one line covers cars, motorcycles,
+    # buses and boats for both classes -- and because the alternative forces
+    # `chair` to admit bus seats, which it refuses for a practical reason rather
+    # than a principled one.
+    #
+    # The cost is real and worth naming: a swan boat's passenger bench is
+    # unambiguously built as seating for two or more, and it is now Bad. The line
+    # is "part of a vehicle", not "not really seating".
     "bench": ClassRule(
         name="bench not chairs",
         test=(
             "Good: any backed or backless seat BUILT AS SEATING for two or more -- park, "
-            "bus-stop and station benches, church pews, picnic-table benches, and a "
-            "rowboat's thwart. Bad: a single chair, a sofa, a judge's bench (that is a "
-            "table; the seating is the chairs behind it), and a concrete planter wall or "
-            "ledge people merely sit on. Two tests: seating or surface, and built as "
-            "seating or merely sittable."
+            "bus-stop and station benches, church pews, picnic-table benches. Bad: a "
+            "single chair, a sofa, a judge's bench (that is a table; the seating is the "
+            "chairs behind it), a concrete planter wall or ledge people merely sit on, "
+            "and SEATING BUILT INTO A VEHICLE -- a rowboat's thwart, a boat's built-in "
+            "hull seating, a bus's bench seat. A bench standing loose on a deck or in a "
+            "bus IS one, exactly as a car seat out of the car is a Chair. Three tests: "
+            "seating or surface, built as seating or merely sittable, and free-standing "
+            "or part of a vehicle."
         ),
     ),
     "chair": ClassRule(


### PR DESCRIPTION
`bench` and `chair` contradicted each other about seating that is part of a
vehicle, and the reviewer found it mid-pass while labelling benches.

`chair` ruled a car seat **out** — *"a component is not an instance"*, and in as
many words *"A PART INHERITS THE RULING OF ITS WHOLE"* — backed by a rate table.
`bench` ruled a rowboat's thwart **in**, also in as many words. Both were
shipped, so a reviewer reading the two rules got opposite answers to one
question.

Settled in favour of `chair`'s principle: **seating built into a vehicle is not a
Bench.** It wins because it generalises — one line now covers cars, motorcycles,
buses and boats for both classes — and because the alternative forces `chair` to
admit bus seats, which it refuses for a practical reason rather than a
principled one.

### What changed

- `SCALE_CLASS_RULES["bench"]`: the thwart dropped from Good; `SEATING BUILT
  INTO A VEHICLE` added to Bad, with the free-standing case spelled out (a bench
  loose on a deck or in a bus still counts, exactly as a car seat out of the car
  is a Chair). Two tests became three.
- A comment beside the rule records the conflict and **the cost**: a swan boat's
  passenger bench is unambiguously built as seating for two or more, and it is
  now Bad. The line is "part of a vehicle", not "not really seating".
- The same comment records that **this ruling rests on consistency, not on a
  measurement.** The guide's usual co-occurrence rate test is confounded here:
  `boat` is 1.42x base, but `car` is 1.43x and `train` 1.40x against a 4.7%
  base, because benches and vehicles share outdoor scenes. The test cannot
  separate the hypotheses and should not be cited as if it had.
- `ANNOTATION_GUIDE.md`'s thwart passage marked `SUPERSEDED 2026-09-08` rather
  than deleted, so a reviewer who labelled under the old rule can see why their
  verdicts disagree with the new one.

### What this does not do

Some `bench` votes in the run now in progress were cast under the old rule and
were correct as cast. Re-deciding a class boundary mid-pass is how a review ends
up answering two questions under one name, so the re-review is deliberately
**not** done here: filed as #3755, to run as its own small slate of the boaty
and busy benches, and to land with the next rebuild since it moves membership.

Refs #3720. Related: #3673, #3612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yKKtCnzocPQy6yZGQyzTZ
