### PR TITLE
Region voting: let a Shift-drag start below/above the image

### DIFF
--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -488,6 +488,16 @@ region you want to vote good on.  After release the rectangle shows
 Then **press `→`** (or click **Good**) to submit a good vote with
 the region attached.
 
+**You can start the drag outside the image.**  A region that runs
+right to an edge is awkward to start from inside the picture, so a
+drag begun anywhere in the centre column - the empty space beside
+the image, or the band below it holding the image controls, the
+Good / Bad buttons and the metadata tray - anchors the rectangle at
+the point of the image nearest to where you pressed.  Buttons and
+sliders are the exception: a drag started on one still presses it,
+so the controls keep working normally (including while the Marquee
+toggle is on).
+
 The rectangle is stored in *normalised image coordinates* - it
 stays anchored to the same pixels of the image even if you zoom in,
 pan, or rotate before voting.  A click without dragging (a

--- a/docs/user/USER_GUIDE.md
+++ b/docs/user/USER_GUIDE.md
@@ -491,12 +491,16 @@ the region attached.
 **You can start the drag outside the image.**  A region that runs
 right to an edge is awkward to start from inside the picture, so a
 drag begun anywhere in the centre column - the empty space beside
-the image, or the band below it holding the image controls, the
-Good / Bad buttons and the metadata tray - anchors the rectangle at
-the point of the image nearest to where you pressed.  Buttons and
-sliders are the exception: a drag started on one still presses it,
-so the controls keep working normally (including while the Marquee
-toggle is on).
+the image, or the band just below it holding the image controls and
+the Good / Bad buttons - anchors the rectangle at the point of the
+image nearest to where you pressed.
+
+Two things are deliberately left out.  Buttons and sliders still
+press: a drag started on one does what it always did, so the
+controls keep working normally (including while the Marquee toggle
+is on).  And the **metadata tray** at the very bottom is not part
+of the draw area at all, so you can still select and drag across a
+filename or an MD5 there.
 
 The rectangle is stored in *normalised image coordinates* - it
 stays anchored to the same pixels of the image even if you zoom in,

--- a/frontend/src/app/components/center-panel/center-panel.component.html
+++ b/frontend/src/app/components/center-panel/center-panel.component.html
@@ -1,4 +1,9 @@
-<div class="center-panel" [class.empty]="!media()">
+<div
+  class="center-panel"
+  [class.empty]="!media()"
+  [class.region-draw]="regionDrawActive"
+  (mousedown)="onPanelMouseDown($event)"
+>
   @if (!media()) {
     <p class="placeholder-text">Select a media item to view</p>
   } @else {

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -28,6 +28,16 @@
     color: var(--text-placeholder);
     font-size: var(--font-xl);
   }
+
+  // A Shift-drag (or the sticky Marquee toggle) can anchor a region box from
+  // anywhere in this column, not just from the image canvas - see
+  // `ImageViewerComponent.tryStartOffCanvasDraw`. The crosshair is the only
+  // affordance saying so; without it the reachable area below the image is
+  // invisible. Interactive controls keep their own cursor, matching the fact
+  // that a drag begun on one still does what it always did.
+  &.region-draw {
+    cursor: crosshair;
+  }
 }
 
 .placeholder-text {
@@ -136,6 +146,11 @@
 
 .ivc-zoom-slider {
   width: 100px;
+  // Every other control down here carries its own `cursor: pointer`, and a rule
+  // matching an element directly beats a value inherited from an ancestor - so
+  // the `.center-panel.region-draw` crosshair leaves them alone for free. The
+  // slider had no cursor of its own and would have inherited it.
+  cursor: pointer;
 }
 
 .ivc-zoom-label {

--- a/frontend/src/app/components/center-panel/center-panel.component.scss
+++ b/frontend/src/app/components/center-panel/center-panel.component.scss
@@ -37,6 +37,13 @@
   // that a drag begun on one still does what it always did.
   &.region-draw {
     cursor: crosshair;
+
+    // The tray is out of the draw zone, so it must not advertise itself as in
+    // it. `auto` hands the cursor back to the UA, which means the I-beam over
+    // the selectable metadata text - the gesture that still works down here.
+    .metadata-tray {
+      cursor: auto;
+    }
   }
 }
 

--- a/frontend/src/app/components/center-panel/center-panel.component.ts
+++ b/frontend/src/app/components/center-panel/center-panel.component.ts
@@ -415,6 +415,24 @@ export class CenterPanelComponent implements OnDestroy {
       });
   }
 
+  /** True while a Shift-drag (or the sticky Marquee toggle) would draw a region.
+   *  Drives the panel-wide crosshair, which is the only affordance saying the
+   *  gesture reaches past the image into the space below it. */
+  get regionDrawActive(): boolean {
+    return this.mediaType === 'image' && (this.imageViewer()?.regionDrawActive ?? false);
+  }
+
+  /** Off-canvas region-draw start: a Shift-drag begun on the toolbar strip, the
+   *  vote row, the metadata tray or the gaps between them anchors a box at the
+   *  nearest point on the image, exactly as one begun in the letterbox column
+   *  beside it always has. The viewer decides whether to claim the event and
+   *  ignores anything begun on an interactive control, so every click down here
+   *  keeps its current behaviour. */
+  onPanelMouseDown(event: MouseEvent): void {
+    if (this.mediaType !== 'image') return;
+    this.imageViewer()?.tryStartOffCanvasDraw(event);
+  }
+
   onRegionBoxChange(box: RegionBox | null): void {
     this.currentRegionBox = box;
     // Clearing the box also clears any pending bad-vote confirmation;

--- a/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/center-panel.zoneless.spec.ts
@@ -551,4 +551,54 @@ describe('CenterPanelComponent', () => {
       expect(component.marqueeAriaLabel).toBe('Marquee: draw region');
     });
   });
+
+  // The panel owns the vertical band below the image (toolbar, vote row,
+  // metadata tray), so it is the only place a mousedown there can be caught and
+  // handed to the viewer. It stays a pure delegation: the viewer decides whether
+  // to claim the event.
+  describe('off-canvas region-draw delegation', () => {
+    const imageMedia: Media = { ...mockMedia, media_type: 'image', filename: 'pic.png' };
+
+    function stubViewer(): { calls: MouseEvent[] } {
+      const calls: MouseEvent[] = [];
+      (component as unknown as { imageViewer: () => unknown }).imageViewer = () => ({
+        tryStartOffCanvasDraw: (e: MouseEvent) => calls.push(e),
+        regionDrawActive: true,
+      });
+      return { calls };
+    }
+
+    function mousedown(): MouseEvent {
+      return { button: 0, clientX: 10, clientY: 10, target: document.createElement('div') } as unknown as MouseEvent;
+    }
+
+    it('forwards a panel mousedown to the image viewer', () => {
+      fixture.componentRef.setInput('media', imageMedia);
+      const { calls } = stubViewer();
+      component.onPanelMouseDown(mousedown());
+      expect(calls.length).toBe(1);
+    });
+
+    it('does not forward for non-image media', () => {
+      fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'audio' });
+      const { calls } = stubViewer();
+      component.onPanelMouseDown(mousedown());
+      expect(calls.length).toBe(0);
+    });
+
+    it('reports regionDrawActive only for images, for the panel-wide crosshair', () => {
+      fixture.componentRef.setInput('media', imageMedia);
+      stubViewer();
+      expect(component.regionDrawActive).toBe(true);
+      fixture.componentRef.setInput('media', { ...mockMedia, media_type: 'audio' });
+      expect(component.regionDrawActive).toBe(false);
+    });
+
+    it('is inert when there is no image viewer mounted', () => {
+      fixture.componentRef.setInput('media', imageMedia);
+      (component as unknown as { imageViewer: () => unknown }).imageViewer = () => undefined;
+      expect(component.regionDrawActive).toBe(false);
+      expect(() => component.onPanelMouseDown(mousedown())).not.toThrow();
+    });
+  });
 });

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -14,6 +14,12 @@ type DragMode =
 
 const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a stray click
 
+// Controls that keep their own click semantics when a region draw is started from
+// outside the canvas (see `tryStartOffCanvasDraw`). Without this, turning the
+// sticky Marquee toggle on would make the Good/Bad buttons and the zoom slider
+// unusable, because every mousedown on them would anchor a box instead.
+const OFF_CANVAS_DRAW_EXCLUDED = 'button, input, select, textarea, a, label, [role="button"], [contenteditable]';
+
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-image-viewer',
@@ -276,22 +282,8 @@ export class ImageViewerComponent implements OnDestroy {
   onMouseDown(event: MouseEvent): void {
     if (event.button !== 0) return;
 
-    if (this.regionDrawActive && this.renderedW() > 0 && this.renderedH() > 0) {
-      // Drag from anywhere on the canvas (Shift-held or marquee mode) starts a fresh
-      // box. If an older box existed, discard it before recording the new anchor.
-      const local = this.screenToImageNormalized(event);
-      if (!local) return;
-      const x = clamp01(local.x);
-      const y = clamp01(local.y);
-      if (this.pendingBadConfirm()) this.armedConfirmCanceled.emit();
-      // Remember the prior box so we can restore it on a zero-area release;
-      // a stray Shift-click on empty space must not throw away real work.
-      this.drag = { kind: 'draw', anchor: { x, y }, previousBox: this.regionBox() };
-      this.regionBox.set([x, y, x, y]);
-      event.preventDefault();
-      this.setupWindowMouseListeners();
-      return;
-    }
+    // Drag from anywhere on the canvas (Shift-held or marquee mode) starts a fresh box.
+    if (this.beginDraw(event)) return;
 
     // Default: pan-when-zoomed.
     const max = this.getMaxPan();
@@ -305,6 +297,58 @@ export class ImageViewerComponent implements OnDestroy {
     };
     event.preventDefault();
     this.setupWindowMouseListeners();
+  }
+
+  /** Start a region draw from a point OUTSIDE the image canvas.
+   *
+   *  The horizontal case has always worked by accident of layout: the image is
+   *  ``object-fit: contain`` inside a full-width ``.image-wrap``, so for a tall
+   *  image the letterbox columns beside it are still *inside* the wrap and hit
+   *  `onMouseDown` above; `screenToImageNormalized` returns ``x < 0`` and
+   *  `clamp01` snaps the anchor to the nearest edge. Vertically there is no such
+   *  slack - the wrap is exactly as tall as the media area, and below it sit the
+   *  toolbar, the vote buttons and the metadata tray as SIBLINGS under
+   *  ``.center-panel``, so a mousedown there never reached this component at all
+   *  (it just started a native text selection over the buttons).
+   *
+   *  This is the same gesture, delegated from the panel. Nothing downstream needs
+   *  to change: the anchor is clamped exactly as the sideways case is, and the
+   *  move/up listeners were already on ``window``, so dragging out of the canvas
+   *  has always worked once a drag was under way. Only the *start* was gated.
+   *
+   *  Interactive controls are deliberately excluded - a click on the Good/Bad
+   *  buttons, the zoom slider or the metadata toggle keeps doing exactly what it
+   *  does today, including while the sticky Marquee toggle is on. */
+  tryStartOffCanvasDraw(event: MouseEvent): void {
+    if (event.button !== 0 || !this.regionDrawActive) return;
+    const target = event.target as HTMLElement | null;
+    const wrap = this.wrapRef()?.nativeElement;
+    // Inside the canvas the wrap's own handler owns the gesture; this delegated
+    // one sees the bubbled event afterwards and must not start a second draw.
+    if (!wrap || !target || wrap.contains(target)) return;
+    if (target.closest?.(OFF_CANVAS_DRAW_EXCLUDED)) return;
+    this.beginDraw(event);
+  }
+
+  /** Anchor a fresh draw at `event`, clamped to the image. Returns false (leaving
+   *  the caller to fall through to its own default) when region-draw isn't active
+   *  or the image isn't laid out yet. */
+  private beginDraw(event: MouseEvent): boolean {
+    if (!this.regionDrawActive || this.renderedW() <= 0 || this.renderedH() <= 0) return false;
+    const local = this.screenToImageNormalized(event);
+    if (!local) return false;
+    const x = clamp01(local.x);
+    const y = clamp01(local.y);
+    if (this.pendingBadConfirm()) this.armedConfirmCanceled.emit();
+    // Remember the prior box so we can restore it on a zero-area release;
+    // a stray Shift-click on empty space must not throw away real work.
+    this.drag = { kind: 'draw', anchor: { x, y }, previousBox: this.regionBox() };
+    this.regionBox.set([x, y, x, y]);
+    // Also what stops the drag from painting a native text selection across the
+    // buttons and labels it passes over.
+    event.preventDefault();
+    this.setupWindowMouseListeners();
+    return true;
   }
 
   onRegionBodyMouseDown(event: MouseEvent): void {

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.component.ts
@@ -14,11 +14,18 @@ type DragMode =
 
 const MIN_BOX_SIZE = 0.01; // 1% of the image; below this we treat a draw as a stray click
 
-// Controls that keep their own click semantics when a region draw is started from
-// outside the canvas (see `tryStartOffCanvasDraw`). Without this, turning the
-// sticky Marquee toggle on would make the Good/Bad buttons and the zoom slider
-// unusable, because every mousedown on them would anchor a box instead.
-const OFF_CANVAS_DRAW_EXCLUDED = 'button, input, select, textarea, a, label, [role="button"], [contenteditable]';
+// What a region draw started from outside the canvas does NOT claim (see
+// `tryStartOffCanvasDraw`). Two different reasons:
+//
+//   - Interactive controls keep their own click semantics. Without this, turning
+//     the sticky Marquee toggle on would make the Good/Bad buttons and the zoom
+//     slider unusable, because every mousedown on them would anchor a box.
+//   - `.metadata-tray` is excluded wholesale, controls and prose alike. It sits at
+//     the very bottom of the panel, far enough from the image that a drag begun
+//     there reads as "select this text", not as "box that corner"; and selecting a
+//     filename or an MD5 by dragging across it is a thing people actually do.
+const OFF_CANVAS_DRAW_EXCLUDED =
+  'button, input, select, textarea, a, label, [role="button"], [contenteditable], .metadata-tray';
 
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
@@ -613,6 +613,144 @@ describe('ImageViewerComponent', () => {
     });
   });
 
+  // The sideways half of this gesture has always worked, because the letterbox
+  // columns beside a tall image are still inside `.image-wrap`. Below the image
+  // there is no such slack: the toolbar, vote row and metadata tray are siblings
+  // under `.center-panel`, so the panel delegates their mousedowns here.
+  describe('off-canvas draw start (tryStartOffCanvasDraw)', () => {
+    // The wrap is 100x100 at the viewport origin; anything the panel forwards
+    // is by construction outside it, so `contains` is always false here.
+    function setupWrap(component: ImageViewerComponent) {
+      component.renderedW.set(100);
+      component.renderedH.set(100);
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
+        nativeElement: {
+          contains: () => false,
+          getBoundingClientRect: () => ({
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+            right: 100,
+            bottom: 100,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>);
+    }
+
+    function eventAt(x: number, y: number, target: HTMLElement, prevented: { value: boolean }): MouseEvent {
+      return {
+        button: 0,
+        clientX: x,
+        clientY: y,
+        target,
+        preventDefault: () => {
+          prevented.value = true;
+        },
+      } as unknown as MouseEvent;
+    }
+
+    let prevented: { value: boolean };
+    let plainTarget: HTMLElement;
+
+    beforeEach(() => {
+      setupWrap(component);
+      prevented = { value: false };
+      plainTarget = document.createElement('div');
+    });
+
+    it('anchors at the nearest point on the image for a drag started BELOW it', () => {
+      component.shiftHeld.set(true);
+      // 40px below the wrap's bottom edge, a third of the way across.
+      component.tryStartOffCanvasDraw(eventAt(30, 140, plainTarget, prevented));
+
+      expect(component.regionBox()).not.toBeNull();
+      expect(component.regionBox()![0]).toBeCloseTo(0.3, 5);
+      expect(component.regionBox()![1]).toBeCloseTo(1, 5);
+    });
+
+    it('anchors at the nearest point for a drag started ABOVE it', () => {
+      component.shiftHeld.set(true);
+      component.tryStartOffCanvasDraw(eventAt(70, -25, plainTarget, prevented));
+
+      expect(component.regionBox()![0]).toBeCloseTo(0.7, 5);
+      expect(component.regionBox()![1]).toBeCloseTo(0, 5);
+    });
+
+    it('preventDefaults so the drag paints no native text selection', () => {
+      component.shiftHeld.set(true);
+      component.tryStartOffCanvasDraw(eventAt(30, 140, plainTarget, prevented));
+      expect(prevented.value).toBe(true);
+    });
+
+    it('works from the sticky Marquee toggle too, with no Shift held', () => {
+      component.marqueeMode.set(true);
+      component.tryStartOffCanvasDraw(eventAt(50, 160, plainTarget, prevented));
+      expect(component.regionBox()).not.toBeNull();
+    });
+
+    it('does nothing when neither Shift nor marquee mode is active', () => {
+      component.tryStartOffCanvasDraw(eventAt(30, 140, plainTarget, prevented));
+      expect(component.regionBox()).toBeNull();
+      expect(prevented.value).toBe(false);
+    });
+
+    // Every click on a control below the image keeps doing exactly what it did
+    // before — including while the sticky Marquee toggle is on, when there is no
+    // modifier to distinguish "draw" from "press the Good button".
+    it('leaves interactive controls alone', () => {
+      component.marqueeMode.set(true);
+      const button = document.createElement('button');
+      component.tryStartOffCanvasDraw(eventAt(30, 140, button, prevented));
+      expect(component.regionBox()).toBeNull();
+      expect(prevented.value).toBe(false);
+    });
+
+    it('leaves a control alone when the mousedown lands on a child of it', () => {
+      component.marqueeMode.set(true);
+      const button = document.createElement('button');
+      const icon = document.createElement('span');
+      button.appendChild(icon);
+      component.tryStartOffCanvasDraw(eventAt(30, 140, icon, prevented));
+      expect(component.regionBox()).toBeNull();
+    });
+
+    it('ignores an event that bubbled up from inside the canvas', () => {
+      component.shiftHeld.set(true);
+      (component as unknown as { wrapRef: () => ElementRef<HTMLDivElement> }).wrapRef = () => ({
+        nativeElement: {
+          contains: () => true,
+          getBoundingClientRect: () => ({
+            left: 0, top: 0, width: 100, height: 100, right: 100, bottom: 100, x: 0, y: 0, toJSON: () => ({}),
+          }),
+        } as unknown as HTMLDivElement,
+      } as ElementRef<HTMLDivElement>);
+
+      component.tryStartOffCanvasDraw(eventAt(30, 30, plainTarget, prevented));
+      // The wrap's own handler already owns this one; starting a second draw
+      // here would overwrite `previousBox` with the anchor it just set.
+      expect(component.regionBox()).toBeNull();
+    });
+
+    it('ignores a non-primary button', () => {
+      component.shiftHeld.set(true);
+      const ev = { ...eventAt(30, 140, plainTarget, prevented), button: 2 } as unknown as MouseEvent;
+      component.tryStartOffCanvasDraw(ev);
+      expect(component.regionBox()).toBeNull();
+    });
+
+    it('restores the prior box on a zero-area off-canvas click', () => {
+      component.regionBox.set([0.1, 0.1, 0.6, 0.6]);
+      component.shiftHeld.set(true);
+      component.tryStartOffCanvasDraw(eventAt(30, 140, plainTarget, prevented));
+      window.dispatchEvent(new MouseEvent('mouseup'));
+      expect(component.regionBox()).toEqual([0.1, 0.1, 0.6, 0.6]);
+    });
+  });
+
   describe('best-match highlight overlay', () => {
     it('starts off and flips on toggle', () => {
       expect(component.highlightMode()).toBe(false);

--- a/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
+++ b/frontend/src/app/components/center-panel/image-viewer/image-viewer.zoneless.spec.ts
@@ -709,6 +709,21 @@ describe('ImageViewerComponent', () => {
       expect(prevented.value).toBe(false);
     });
 
+    // The tray is the bottom of the panel, far from the image and full of text
+    // people select by dragging; it is out of the draw zone entirely, prose and
+    // controls alike.
+    it('leaves the whole metadata tray alone, not just its controls', () => {
+      component.marqueeMode.set(true);
+      const tray = document.createElement('div');
+      tray.className = 'metadata-tray';
+      const value = document.createElement('span');
+      value.className = 'metadata-value';
+      tray.appendChild(value);
+      component.tryStartOffCanvasDraw(eventAt(30, 190, value, prevented));
+      expect(component.regionBox()).toBeNull();
+      expect(prevented.value).toBe(false);
+    });
+
     it('leaves a control alone when the mousedown lands on a child of it', () => {
       component.marqueeMode.set(true);
       const button = document.createElement('button');


### PR DESCRIPTION
## What

Starting a region box to the **left or right** of a tall image has always worked. Starting one **below or above** it did not — the drag just painted a native text selection across the Good/Bad buttons. This makes the second axis behave like the first.

## Why it only worked in one dimension

Not a coordinate-math gap — an event-reach gap.

The `<img>` is `object-fit: contain` inside a full-width `.image-wrap`. For a tall image the letterbox columns either side are still **inside** the wrap, so a mousedown there hits its `(mousedown)`; `screenToImageNormalized` returns `x < 0` and `clamp01` snaps the anchor to the nearest point on the image. There is no code implementing "nearest point on the image" — it falls out of the clamp.

Vertically there is no such slack. The wrap is exactly as tall as the media area, and the toolbar, vote row and metadata tray sit below it as **siblings** under `.center-panel`. A mousedown there never reached the viewer at all.

Everything downstream was already ready: the move/up listeners are on `window`, so dragging *out* of the canvas has always worked once a drag was under way, and the anchor clamp is the same one the sideways case uses. Only the *start* was gated by which element the mousedown landed on.

## How

`.center-panel` delegates its mousedowns to the viewer, which claims the ones it wants:

- **`ImageViewerComponent.tryStartOffCanvasDraw`** anchors a draw from a point outside the canvas. The existing draw-start body is extracted into a shared private `beginDraw`, so both paths clamp and `preventDefault` identically — that `preventDefault` is also what stops the drag painting a text selection.
- Events that **bubbled up from inside the wrap** are ignored; the wrap's own handler already owns those, and starting a second draw would overwrite the `previousBox` that the zero-area-click restore depends on.
- **`.center-panel.region-draw` shows a crosshair**, the only affordance saying the gesture reaches past the image. Controls carry their own `cursor`, and a rule matching an element directly beats an inherited value, so they are unaffected for free; the zoom slider had none and gets one.

## What the draw zone deliberately excludes

- **Interactive controls.** A click on Good/Bad, the zoom slider, the metadata toggle or a copy button keeps doing exactly what it did before — including while the sticky Marquee toggle is on, when there is no modifier to tell "draw" from "press the button" apart.
- **The metadata tray, wholesale** — prose and controls alike. It is the bottom ~100px of the column, far enough from the image that a drag begun there reads as "select this text" rather than "box that corner", and dragging across a filename or an MD5 to select it is a thing people actually do. The crosshair is dropped over the tray to match (`cursor: auto`, i.e. the I-beam over its text), so the affordance does not promise a draw the tray will not perform.

That leaves an ~82px band below the image (toolbar strip + vote row + the panel's own padding) on a 900px viewport, plus the full letterbox column beside the image.

## Cost

One event binding on a div that already exists. No new elements, no layout or size change, nothing added to the render path, no per-frame work, no change to the displayed image size.

## Verification

Full `./run-tests.sh` green (11065 passed). Beyond the 16 new unit specs, the behaviour was checked in **real Chromium** against the running app, since jsdom cannot exercise sibling-to-panel bubbling, `closest()` on real targets, or cursor inheritance.

First pass — 16/16:
- a Shift-drag started in the band below the image draws a box, anchored at exactly 100% of the image height (clamped to the bottom edge);
- the drag selects no text on its way past the buttons;
- a Shift-drag started **on** the Bad button draws nothing;
- Good and Bad still post votes, and Bad-with-a-box still arms the discard-confirm unchanged;
- with Marquee on and no modifier: the toolbar strip draws, and the Bad button and zoom slider still work;
- computed cursors: panel `crosshair`, empty vote row `crosshair`, Good button `pointer`, zoom slider `pointer`.

Tray-exclusion pass — 9/9:
- a Shift-drag started in the expanded tray draws nothing;
- dragging across a metadata value still selects it (`"shapes_0011.png"`), with Marquee on as well as off;
- the vote-row band directly above the tray still draws;
- computed cursors: tray and its values `auto` (not `crosshair`), toggle `pointer`, band still `crosshair`.

No screenshot reshoot: cursors are not captured and no framed surface moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZEw1P2vsyASEPaQ1xqQX9