### PR TITLE
Re-bank the pass25 verdicts before retiring their detectors

### DIFF
--- a/scripts/experiments/pile/human_record/LABELSETS__pass25__bench.json
+++ b/scripts/experiments/pile/human_record/LABELSETS__pass25__bench.json
@@ -1875,7 +1875,7 @@
  ],
  "class": "bench",
  "detector_name": "bench not chairs",
- "exported": "2026-09-08",
+ "exported": "2026-09-09",
  "good": [
   {
    "cid": null,

--- a/scripts/experiments/pile/human_record/LABELSETS__pass25__bicycle.json
+++ b/scripts/experiments/pile/human_record/LABELSETS__pass25__bicycle.json
@@ -9528,11 +9528,24 @@
    "region_box": null,
    "score": -1.0,
    "time": -1.0
+  },
+  {
+   "cid": null,
+   "filename": "2318011.jpg",
+   "id": "c0f28cc0f925432f",
+   "label": "bad",
+   "md5": "560adfd04c96afc57383523c19c2ce5f",
+   "media_type": "image",
+   "name": "2318011.jpg",
+   "origin_name": "2318011.jpg",
+   "region_box": null,
+   "score": -1.0,
+   "time": -1.0
   }
  ],
  "class": "bicycle",
  "detector_name": "bicycle incl trikes not motorcycles",
- "exported": "2026-09-08",
+ "exported": "2026-09-09",
  "good": [
   {
    "cid": null,
@@ -13180,6 +13193,19 @@
     0.7739127314170379,
     1.0
    ],
+   "score": -1.0,
+   "time": -1.0
+  },
+  {
+   "cid": null,
+   "filename": "2389554.jpg",
+   "id": "bcd970e54f0cb003",
+   "label": "good",
+   "md5": "0074e2577ec056f31f226df03351d76f",
+   "media_type": "image",
+   "name": "2389554.jpg",
+   "origin_name": "2389554.jpg",
+   "region_box": null,
    "score": -1.0,
    "time": -1.0
   }


### PR DESCRIPTION
Re-bank the pass25 verdicts before retiring their detectors

The dashboard carries 50 detectors -- 25 from the one-dataset pass and 25 for
the new slates -- and the old ones are now unusable: the slates exclude every
image already answered, so an old detector's labels have ZERO overlap with its
own slate and the panel renders entirely dead thumbnails.

Retiring them means deleting them, since the registry offers DELETE and no
rename. Checking first was not a formality: `bicycle` had moved from 203/733 to
204/734 between the export and now, because the reviewer kept working. Two
verdicts, and deleting on the strength of the older copy would have lost them
with nothing to say they had ever existed.

So the rule that matters is the ordering, not the backup: re-export, diff
against the committed copy, and only then delete. A detector holding the only
copy of a person's judgement is not a cache.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012yKKtCnzocPQy6yZGQyzTZ