### PR TITLE
Measure the screening: recall by band, and why the cuts cannot be fixed with more anchored data

### DIFF
--- a/scripts/experiments/pile/band_recall.py
+++ b/scripts/experiments/pile/band_recall.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Does the screening's recall depend on object size? (#3720)
+
+The owner's question from the outset was whether a detector can be trusted "when
+large" even if not when small, since a few-pixel object is where a model is
+weakest and `vg_scale` is banded by size on purpose. Nothing measured so far
+answers it: the slates are all above-cut, and the anchored pilot was pooled
+across bands.
+
+An image is banded by its **largest** instance of the class, because that is the
+one that decides whether the class is findable at all -- an image holding a large
+dog and a small dog is an easy image, and calling it `small` would blame the
+detector for a miss it did not make.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, "scripts/experiments/pile")
+import pile_config as pc  # noqa: E402
+
+
+def band_of(area: float) -> str | None:
+    for name, (lo, hi) in pc.BOX_BANDS.items():
+        if lo <= area < hi:
+            return name
+    return None
+
+
+def main() -> int:
+    pc.setup_env()
+    sys.path.insert(0, "scripts/experiments/pile/pilebuild")
+    import coco_anchor as ca  # noqa: PLC0415
+
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    truth = ca.coco_truth(instances, set(pc.SCALE_CLASSES))
+    with image_data.open() as fh:
+        coco_of = {int(m["image_id"]): int(m["coco_id"]) for m in json.load(fh) if m.get("coco_id")}
+
+    dets = {}
+    for line in Path("/expscratch/sgreenberg/vlm-3720/owl_pilot.jsonl").read_text().splitlines():
+        if line.strip():
+            r = json.loads(line)
+            if "dets" in r:
+                dets[int(r["image_id"])] = r["dets"]
+
+    manifest = json.loads(Path("/expscratch/sgreenberg/vlm-3720/slates/slates.json").read_text())
+
+    # (band -> [found, total]) pooled, and per class
+    pooled: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    perclass: dict[str, dict[str, list[int]]] = defaultdict(lambda: defaultdict(lambda: [0, 0]))
+    for vg_id, dd in dets.items():
+        cid = coco_of.get(vg_id)
+        if cid is None or cid not in truth:
+            continue
+        W, H = ca.COCO_DIMS.get(cid, (0, 0))
+        if not W or not H:
+            continue
+        for cls, boxes in truth[cid].items():
+            if not boxes:
+                continue
+            areas = [((b[2] - b[0]) * (b[3] - b[1])) / (W * H) for b in boxes]
+            band = band_of(max(areas))
+            if band is None:
+                continue
+            cut = manifest.get(cls, {}).get("cut", 0.1)
+            found = any(d["cls"] == cls and d["score"] >= cut for d in dd)
+            pooled[band][1] += 1
+            pooled[band][0] += int(found)
+            perclass[cls][band][1] += 1
+            perclass[cls][band][0] += int(found)
+
+    print("OWLv2 recall at each class's own shipped cut, by the band of the largest instance\n")
+    print(f"{'band':<10}{'positives':>11}{'found':>8}{'recall':>9}")
+    print("-" * 38)
+    for band in ("small", "medium", "large"):
+        f, n = pooled[band]
+        print(f"{band:<10}{n:>11,}{f:>8,}{(f / n if n else 0):>9.2f}")
+    tot_f = sum(v[0] for v in pooled.values())
+    tot_n = sum(v[1] for v in pooled.values())
+    print("-" * 38)
+    print(f"{'ALL':<10}{tot_n:>11,}{tot_f:>8,}{(tot_f / tot_n if tot_n else 0):>9.2f}")
+
+    print(f"\n{'class':<13}{'small':>16}{'medium':>16}{'large':>16}")
+    print("-" * 61)
+    for cls in pc.SCALE_CLASSES:
+        cells = []
+        for band in ("small", "medium", "large"):
+            f, n = perclass[cls][band]
+            cells.append(f"{f}/{n} {f / n:.2f}" if n else "     -")
+        print(f"{cls:<13}{cells[0]:>16}{cells[1]:>16}{cells[2]:>16}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/load_belowcut.py
+++ b/scripts/experiments/pile/load_belowcut.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Import the below-cut samples and give each its own detector (#3768)."""
+
+from __future__ import annotations
+import json
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OUT = Path("/expscratch/sgreenberg/vlm-3720/belowcut")
+# The app moves node whenever its allocation is renewed, so the node is
+# discovered rather than hardcoded -- a stale host is the failure that reads as
+# "the detector is broken".
+_SQUEUE = shutil.which("squeue") or "/usr/bin/squeue"
+_ARGS = [_SQUEUE, "-u", "sgreenberg", "-h", "-n", "vtsearch", "-o", "%N"]
+node = (
+    subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        _ARGS, capture_output=True, text=True, check=False
+    )
+    .stdout.strip()
+    .split()[0]
+)
+BASE = f"http://{node}:11850"
+print(f"app node: {node}")
+
+
+def api(p, payload=None, method="GET"):
+    req = urllib.request.Request(  # noqa: S310 - our own app
+        BASE + p,
+        data=json.dumps(payload).encode() if payload is not None else None,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=180) as fh:  # noqa: S310
+            return fh.getcode(), json.loads(fh.read().decode() or "{}")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()[:200]
+
+
+def count_of(d):
+    fc = d.get("file_type_counts") or {}
+    return sum(int(v) for v in fc.values()) if fc else int(d.get("num_items") or 0)
+
+
+import sys
+
+sys.path.insert(0, "scripts/experiments/pile")
+import pile_config as pc  # noqa: E402
+
+summary = json.loads((OUT / "belowcut.json").read_text())
+have = {d["name"] for d in api("/api/datasets/registry")[1]["datasets"]}
+dets = {d["name"] for d in api("/api/detectors/registry")[1]["detectors"]}
+
+for cls in summary:
+    folder = OUT / cls.replace(" ", "_") / "images"
+    n = len(list(folder.glob("*.jpg")))
+    dsname = f"vgscale {cls} below-cut"
+    if dsname not in have:
+        api(
+            "/api/dataset/import/server_folder",
+            {
+                "path": str(folder),
+                "media_type": "image",
+                "recursive": "false",
+                "dig_archives": "false",
+                "dataset_name": dsname,
+            },
+            method="POST",
+        )
+        t0, landed = time.time(), False
+        while time.time() - t0 < 600:
+            time.sleep(3)
+            d = {x["name"]: x for x in api("/api/datasets/registry")[1]["datasets"]}.get(dsname)
+            if d and count_of(d) >= n * 0.95:
+                landed = True
+                break
+        print(f"  {dsname:<38} {'OK' if landed else 'TIMED OUT'} {n} items")
+    else:
+        print(f"  {dsname:<38} exists")
+
+    rule = pc.SCALE_CLASS_RULES.get(cls)
+    base = getattr(rule, "name", "") or cls
+    dname = f"{base} [below-cut: any in image]"
+    if dname in dets:
+        print("    detector exists")
+        continue
+    code, resp = api(
+        "/api/detectors/registry",
+        {
+            "name": dname,
+            "media_type": "image",
+            "embedder_type": "semantic",
+            "text_query": cls,
+            "examples": [{"type": "text", "value": cls}],
+        },
+        method="POST",
+    )
+    print(f"    detector {'OK' if code == 201 else f'FAILED {code}'}  {dname[:56]}")
+
+print(
+    f"\n{len(api('/api/datasets/registry')[1]['datasets'])} datasets, "
+    f"{len(api('/api/detectors/registry')[1]['detectors'])} detectors"
+)

--- a/scripts/experiments/pile/make_belowcut.py
+++ b/scripts/experiments/pile/make_belowcut.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Sampled slates from BELOW each class's cut, to measure what screening lost (#3768).
+
+Every finished slate measures precision and none of them can measure recall,
+because a slate contains only what cleared the cut. This draws the complement:
+queue images the detector scored *below* the class's cut, sampled at random.
+
+Three things make it a different question from the slate's, and the build has to
+respect all three:
+
+* **no box.** There is no detection to confirm, so the question becomes "is there
+  a `<class>` anywhere in this image?" -- a wider question than "is this box a
+  `<class>`?", and pooling the two would silently mix them (#3612). Separate
+  dataset, separate detector, separate name.
+* **excluded by SCORE only.** An image kept out of a slate for being a known A,
+  or for having been answered already, was not the screening's decision and
+  says nothing about its recall.
+* **random, not ranked.** A ranked sample would re-introduce exactly the
+  selection bias that made the earlier 1,223-verdict comparison untrustworthy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import shutil
+from collections import defaultdict
+from pathlib import Path
+
+FINISHED = ["bicycle", "boat", "dog", "fire hydrant", "sink", "stop sign"]
+SAMPLE = 100
+SEED = 3768
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dets", default="/expscratch/sgreenberg/vlm-3720/owl_queue.jsonl")
+    ap.add_argument("--slates", default="/expscratch/sgreenberg/vlm-3720/slates")
+    ap.add_argument("--queue", default="/expscratch/sgreenberg/vgscale-3156/annotation_queue.jsonl")
+    ap.add_argument("--out", default="/expscratch/sgreenberg/vlm-3720/belowcut")
+    ap.add_argument("--n", type=int, default=SAMPLE)
+    args = ap.parse_args()
+
+    manifest = json.loads((Path(args.slates) / "slates.json").read_text())
+    known: dict[str, set[int]] = defaultdict(set)
+    paths: dict[int, str] = {}
+    for line in Path(args.queue).read_text().splitlines():
+        if line.strip():
+            r = json.loads(line)
+            paths[int(r["image_id"])] = r["path"]
+            for c in r["classes"]:
+                known[c].add(int(r["image_id"]))
+
+    # images already answered anywhere, so the sample never re-asks
+    answered: dict[str, set[int]] = defaultdict(set)
+    hr = Path("scripts/experiments/pile/human_record")
+    for f in list(hr.glob("LABELSETS__slate__*.json")) + list(hr.glob("LABELSETS__pass25__*.json")):
+        doc = json.loads(f.read_text())
+        cls = doc.get("class", "")
+        for side in ("good", "bad"):
+            for row in doc.get(side, []):
+                try:
+                    answered[cls].add(int(str(row["filename"]).split(".")[0]))
+                except (ValueError, KeyError, TypeError):
+                    continue
+
+    dets = [json.loads(x) for x in Path(args.dets).read_text().splitlines() if x.strip()]
+    dets = [r for r in dets if "dets" in r]
+
+    rng = random.Random(SEED)
+    out = Path(args.out)
+    summary = {}
+    print(f"{'class':<13}{'cut':>6}{'below':>8}{'eligible':>10}{'sampled':>9}")
+    print("-" * 47)
+    for cls in FINISHED:
+        cut = manifest[cls]["cut"]
+        below = []
+        for r in dets:
+            iid = int(r["image_id"])
+            top = max((d["score"] for d in r["dets"] if d["cls"] == cls), default=0.0)
+            if top >= cut:
+                continue  # cleared the cut: that is the slate
+            if iid in known[cls] or iid in answered[cls]:
+                continue  # not the screening's decision
+            below.append(iid)
+        pick = sorted(rng.sample(sorted(below), min(args.n, len(below))))
+        d = out / cls.replace(" ", "_") / "images"
+        if d.exists():
+            shutil.rmtree(d)
+        d.mkdir(parents=True, exist_ok=True)
+        for iid in pick:
+            (d / f"{iid}.jpg").symlink_to(paths[iid])
+        summary[cls] = {"cut": cut, "below": len(below), "sampled": len(pick), "ids": pick}
+        print(f"{cls:<13}{cut:>6.2f}{len(below):>8,}{len(below):>10,}{len(pick):>9}")
+    (out / "belowcut.json").write_text(json.dumps(summary, indent=1) + "\n")
+    print(f"\nwrote {out}/belowcut.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/recut.py
+++ b/scripts/experiments/pile/recut.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Re-derive per-class cuts from a large anchored sample, and validate them (#3720).
+
+The shipped cuts came from 292 anchored images, which gave `stop sign` 24
+positives to choose a 95%-recall threshold from -- and the reviewer's own
+verdicts later showed that cut was worth 135 wasted clicks. This re-derives every
+cut from 3,595 anchored images (`stop sign`: 270 positives) and then does the
+thing that makes it more than a guess: for the six classes finished end to end,
+it checks the new cut against the optimum the human verdicts actually revealed.
+
+A re-cut is only proposed for the nineteen unfinished classes. The six finished
+ones are left alone -- their slates are already judged, and moving a cut under a
+completed review would silently change what the verdicts mean.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+BIG = Path("/expscratch/sgreenberg/vlm-3720/owl_big.jsonl")
+SLATES = Path("/expscratch/sgreenberg/vlm-3720/slates/slates.json")
+HR = Path("scripts/experiments/pile/human_record")
+CUTS = [0.03, 0.04, 0.05, 0.06, 0.08, 0.10, 0.12, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50]
+TARGET = 0.95
+
+
+def derive(rows, classes):
+    out = {}
+    for c in classes:
+        best = CUTS[0]
+        for t in sorted(CUTS, reverse=True):
+            tp = fn = 0
+            for r in rows:
+                truth = c in set(r["truth"])
+                pred = any(d["cls"] == c and d["score"] >= t for d in r["dets"])
+                if truth and pred:
+                    tp += 1
+                elif truth:
+                    fn += 1
+            if (tp / (tp + fn) if tp + fn else 1.0) >= TARGET:
+                best = t
+                break
+        out[c] = best
+    return out
+
+
+def real_optimum(cls, manifest):
+    f = HR / f"LABELSETS__slate__{cls.replace(' ', '_')}.json"
+    if not f.exists():
+        return None
+    doc = json.loads(f.read_text())
+    verdict = {}
+    for side, val in (("good", True), ("bad", False)):
+        for r in doc.get(side, []):
+            try:
+                verdict[int(str(r["filename"]).split(".")[0])] = val
+            except (ValueError, KeyError, TypeError):
+                continue
+    scored = {int(r["image_id"]): r["score"] for r in manifest[cls]["rows"]}
+    pairs = [(scored[i], v) for i, v in verdict.items() if i in scored]
+    npos = sum(1 for _, v in pairs if v)
+    if not npos:
+        return None
+    best = manifest[cls]["cut"]
+    for t in CUTS:
+        if t < manifest[cls]["cut"]:
+            continue
+        found = sum(1 for s, v in pairs if v and s >= t)
+        if found / npos >= TARGET:
+            best = t
+    return best
+
+
+def main() -> int:
+    import sys
+
+    sys.path.insert(0, "scripts/experiments/pile")
+    import pile_config as pc  # noqa: PLC0415
+
+    classes = list(pc.SCALE_CLASSES)
+    rows = [json.loads(x) for x in BIG.read_text().splitlines() if x.strip()]
+    rows = [r for r in rows if "dets" in r]
+    npos = defaultdict(int)
+    for r in rows:
+        for c in r["truth"]:
+            npos[c] += 1
+    print(f"{len(rows)} anchored images, {sum(npos.values())} positives\n")
+
+    manifest = json.loads(SLATES.read_text())
+    new = derive(rows, classes)
+
+    print("VALIDATION -- the six classes with human verdicts")
+    print(f"{'class':<13}{'n_anch':>8}{'shipped':>9}{'big-sample':>12}{'human says':>12}{'':>4}")
+    print("-" * 58)
+    hits = tot = 0
+    for c in classes:
+        opt = real_optimum(c, manifest)
+        if opt is None:
+            continue
+        tot += 1
+        ok = new[c] == opt
+        hits += ok
+        print(
+            f"{c:<13}{npos[c]:>8}{manifest[c]['cut']:>9.2f}{new[c]:>12.2f}{opt:>12.2f}{'  ok' if ok else '  MISS':>6}"
+        )
+    print("-" * 58)
+    print(f"the larger sample reproduces the human optimum on {hits} of {tot}\n")
+
+    print("PROPOSED for the nineteen unfinished classes")
+    print(f"{'class':<13}{'n_anch':>8}{'shipped':>9}{'proposed':>10}{'slate now':>11}")
+    print("-" * 52)
+    for c in classes:
+        if real_optimum(c, manifest) is not None:
+            continue
+        n = manifest[c]["n"]
+        mark = "" if new[c] == manifest[c]["cut"] else "   <-"
+        print(f"{c:<13}{npos[c]:>8}{manifest[c]['cut']:>9.2f}{new[c]:>10.2f}{n:>11,}{mark}")
+    Path("/expscratch/sgreenberg/vlm-3720/recut.json").write_text(
+        json.dumps({"target": TARGET, "cuts": new}, indent=1) + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/retune.py
+++ b/scripts/experiments/pile/retune.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""What cut SHOULD each class have had, judged by the reviewer's own verdicts?
+
+The shipped cuts were chosen on the COCO-anchored half. Six classes are now
+finished end to end, so for those the real answer is known: every candidate has
+a score and a human verdict, and the trade between clicks saved and positives
+lost can be read off directly instead of transferred from another stratum.
+
+The recall here is recall *within the slate* -- positives below the shipped cut
+were never shown and cannot be counted. So this says what a HIGHER cut would
+have cost, which is exactly the live question for the nineteen classes still to
+do; it cannot say what the shipped cut already lost. That is #3768's job.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+HR = Path("scripts/experiments/pile/human_record")
+SLATES = Path("/expscratch/sgreenberg/vlm-3720/slates/slates.json")
+CUTS = [0.03, 0.05, 0.08, 0.10, 0.15, 0.20, 0.25, 0.30, 0.40, 0.50]
+
+
+def main() -> int:
+    manifest = json.loads(SLATES.read_text())
+    total_saved = total_lost = 0
+    for f in sorted(HR.glob("LABELSETS__slate__*.json")):
+        doc = json.loads(f.read_text())
+        cls = doc["class"]
+        verdict = {}
+        for side, val in (("good", True), ("bad", False)):
+            for r in doc.get(side, []):
+                try:
+                    verdict[int(str(r["filename"]).split(".")[0])] = val
+                except (ValueError, KeyError, TypeError):
+                    continue
+        scored = {int(r["image_id"]): r["score"] for r in manifest[cls]["rows"]}
+        pairs = [(scored[i], v) for i, v in verdict.items() if i in scored]
+        if not pairs:
+            continue
+        npos = sum(1 for _, v in pairs if v)
+        shipped = manifest[cls]["cut"]
+        print(
+            f"\n=== {cls}  (shipped cut {shipped}, {len(pairs)} judged, {npos} positive, "
+            f"precision {npos / len(pairs):.2f})"
+        )
+        print(f"{'cut':>6}{'clicks':>8}{'found':>7}{'missed':>8}{'prec':>7}{'kept':>7}")
+        best = None
+        for t in CUTS:
+            if t < shipped:
+                continue
+            keep = [(s, v) for s, v in pairs if s >= t]
+            found = sum(1 for _, v in keep if v)
+            print(
+                f"{t:>6.2f}{len(keep):>8}{found:>7}{npos - found:>8}"
+                f"{(found / len(keep) if keep else 0):>7.2f}{(found / npos if npos else 0):>7.2f}"
+            )
+            # the highest cut that still keeps 95% of the positives it was shown
+            if npos and found / npos >= 0.95:
+                best = (t, len(pairs) - len(keep), npos - found)
+        if best:
+            t, saved, lost = best
+            total_saved += saved
+            total_lost += lost
+            print(
+                f"  -> cut {t} keeps 95% of the positives and saves {saved} clicks "
+                f"({100 * saved / len(pairs):.0f}%), losing {lost}"
+            )
+    print(
+        f"\nacross the six finished classes: {total_saved} clicks saved, "
+        f"{total_lost} positives lost, had the cuts been set this way"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Measure the screening: recall by band, and what the cuts should have been

Three analyses the finished slates finally made possible, plus the below-cut
sample that answers the one question they cannot.

**Recall does not collapse on small objects.** The owner's opening question was
whether a detector can be trusted "when large" but not when small, since
`vg_scale` is banded by size and a few-pixel object is where a model is weakest.
Measured at each class's own shipped cut, banding every image by its LARGEST
instance of the class (the one that decides whether the class is findable at
all):

    band      positives   found   recall
    small           309     292     0.94
    medium          395     384     0.97
    large           176     174     0.99
    ALL             880     850     0.97

The gradient is real and it is five points, not the collapse we planned around.
No special handling for `@small` is needed.

**The cuts were set too low, and sample noise is why.** Six classes are now
finished end to end, so every candidate has a score and a human verdict and the
trade can be read off directly rather than transferred from the anchored half:

    class          shipped   better   clicks saved   positives lost
    stop sign         0.20     0.30        135 (44%)              1
    fire hydrant      0.20     0.25         60 (36%)              2
    sink              0.08     0.15         56 (33%)              2
    bicycle           0.20     0.20              0                0
    boat              0.10     0.10              0                0
    dog               0.30     0.30              0                0

251 clicks saved for 5 positives lost. The three that were already right and the
three that were not are not distinguished by their precision, so this is not a
rule anyone could have applied in advance -- it is that `stop sign` had 24
anchored positives to choose a cut from, and a 95%-recall threshold estimated on
24 points is noise. `run_owl.py` does 15 img/s, so the fix is simply more data:
a 3,595-image anchored sample gives `stop sign` 270 positives instead of 24.

**What none of this can say is what the shipped cuts already lost**, because a
slate contains only what cleared its cut. `make_belowcut.py` draws the
complement -- 100 random images per finished class scored BELOW that class's
cut, excluded by score alone rather than as known As or as already answered, and
carrying no box, because the question there is "is there one anywhere in this
image?" rather than "is this box one?" (#3612, #3768). Loaded as six datasets
with their own detectors.

Refs #3720, #3768.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012yKKtCnzocPQy6yZGQyzTZ