### PR TITLE
Triage two vulture pre-release findings

### DIFF
--- a/.vulture-whitelist.py
+++ b/.vulture-whitelist.py
@@ -272,6 +272,7 @@ converged_training  # noqa: F821 - pins training hyperparameters to convergence
 degenerate_gmm  # noqa: F821 - forces the GMM to degenerate
 restore_resolvers  # noqa: F821 - re-binds the resolver globals via monkeypatch so teardown restores them
 clean_paths  # noqa: F821 - saves/restores sys.path and sys.meta_path around setup_env
+restore_stdlib  # noqa: F821 - re-installs the stdlib packages_distributions via monkeypatch for the test
 
 # ---------------------------------------------------------------------------
 # Mock function signatures that must match a real API but whose body

--- a/tests_lib/cli/test_load_embed_stage.py
+++ b/tests_lib/cli/test_load_embed_stage.py
@@ -66,9 +66,8 @@ class _StubImporter:
 
     name = "stub"
 
-    def __init__(self, medias: list[dict[str, Any]], chunk_size: int = 0) -> None:
+    def __init__(self, medias: list[dict[str, Any]]) -> None:
         self._medias = medias
-        self._chunk_size = chunk_size
 
     def validate_cli_field_values(self, field_values: dict[str, Any]) -> None:
         return None


### PR DESCRIPTION
The pre-release `vulture-audit.py` scan raised three hits ahead of the `dev → main` release. Two files needed changes:

- `tests_lib/core/test_import_metadata_seed.py`'s `restore_stdlib` is a pytest fixture requested for its `monkeypatch` side effect, so both usages read as 100 %-confidence dead parameters. Whitelisted alongside the other side-effect fixtures (`restore_pil_limit`, `restore_provider`, …).
- `tests_lib/cli/test_load_embed_stage.py`'s `_StubImporter.__init__` took an unused `chunk_size` and stored it as `self._chunk_size`; nothing reads it (the real chunk size flows in through `run_chunked_cli`'s own parameter), and no caller passes it either. Drop both.

Vulture is clean after this, and the `--check-whitelist` gate stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QhoG5H5P1s3dusd4cNVPs

---
_Generated by [Claude Code](https://claude.ai/code/session_014QhoG5H5P1s3dusd4cNVPs)_