### PR TITLE
Rule the planter out of both vase and bowl

### DIFF
--- a/scripts/experiments/pile/check_pair_scale.py
+++ b/scripts/experiments/pile/check_pair_scale.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Do anchored VG<->COCO pairs actually share the same pixel dimensions? (#3720)
+
+`anchor_to_coco` gates a pairing on ASPECT-RATIO drift (MAX_ASPECT_DRIFT = 0.01),
+which is scale-invariant by construction: a 500x375 image and a 1000x750 one pass
+it. That is fine for anything comparing shapes, and wrong for anything that maps
+a COCO BOX onto the VG image, because the box arrives in COCO's pixel frame.
+
+Rendering COCO vase boxes onto their VG images turned up boxes running past the
+image edge, so this measures how often the two frames disagree, and by how much.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path("/exp/scale26/datasets/external/vtsearch-demos/visual_genome")
+SAMPLE = 4000
+
+
+def main() -> int:
+    sys.path.insert(0, "scripts/experiments/pile")
+    import pile_config as pc  # noqa: PLC0415
+
+    pc.setup_env()
+    import coco_anchor as ca  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
+
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    ca.coco_truth(instances, set(pc.SCALE_CLASSES))  # populates COCO_DIMS
+    with image_data.open() as fh:
+        pairs = [(int(m["image_id"]), int(m["coco_id"])) for m in json.load(fh) if m.get("coco_id")]
+    rng = random.Random(3720)
+    pairs = rng.sample(pairs, min(SAMPLE, len(pairs)))
+    print(f"checking {len(pairs)} anchored pairs")
+
+    same = diff = missing = 0
+    ratios = []
+    tally = Counter()
+    for vg_id, cid in pairs:
+        dims = ca.COCO_DIMS.get(cid)
+        src = next(
+            (ROOT / s / f"{vg_id}.jpg" for s in ("VG_100K", "VG_100K_2") if (ROOT / s / f"{vg_id}.jpg").exists()), None
+        )
+        if not dims or src is None:
+            missing += 1
+            continue
+        try:
+            with Image.open(src) as im:  # header only, no decode
+                vw, vh = im.size
+        except Exception:  # noqa: BLE001
+            missing += 1
+            continue
+        cw, ch = dims
+        if (cw, ch) == (vw, vh):
+            same += 1
+            tally["identical"] += 1
+            continue
+        diff += 1
+        r = (cw / vw + ch / vh) / 2
+        ratios.append(r)
+        tally["COCO larger" if r > 1.02 else "VG larger" if r < 0.98 else "off by <2%"] += 1
+
+    tot = same + diff
+    print(f"\n{tot} pairs compared ({missing} unreadable)")
+    print(f"  identical dimensions : {same:,}  ({100 * same / tot:.1f}%)")
+    print(f"  different dimensions : {diff:,}  ({100 * diff / tot:.1f}%)")
+    for k, n in tally.most_common():
+        print(f"     {k:<16}{n:>7}")
+    if ratios:
+        ratios.sort()
+        med = ratios[len(ratios) // 2]
+        print(f"\n  median COCO/VG scale where they differ: {med:.3f}")
+        print(f"  10th/90th percentile: {ratios[len(ratios) // 10]:.3f} / {ratios[9 * len(ratios) // 10]:.3f}")
+    print(
+        "\nreading: a COCO box mapped onto a VG image is only valid where the "
+        "dimensions\nmatch. Aspect-ratio gating cannot catch a pure rescale."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/coco_vase_crops.py
+++ b/scripts/experiments/pile/coco_vase_crops.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Render COCO `vase` instances so we can see whether COCO counts a flower pot.
+
+The empty-planter question cannot be answered from the rule text -- `bowl`
+refuses it ("made to hold food"), `potted plant` needs a plant, and `vase`'s
+inclusion of planters is the very line under review. COCO annotated these
+images, so what COCO drew a `vase` box around is the evidence.
+
+Deliberately drawn from images COCO gives NO `potted plant`, so anything
+plant-pot-shaped here is a pot COCO chose to call a vase rather than one it
+declined to annotate.
+"""
+
+import json
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "scripts/experiments/pile")
+import pile_config as pc  # noqa: E402
+
+pc.setup_env()
+import coco_anchor as ca  # noqa: E402
+
+OUT = Path("/expscratch/sgreenberg/vlm-3720/coco_vase_crops")
+OUT.mkdir(parents=True, exist_ok=True)
+image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+truth = ca.coco_truth(instances, {"vase", "potted plant"})
+
+# coco_id -> a VG path we can actually open
+vg_of = {}
+with image_data.open() as fh:
+    for m in json.load(fh):
+        if m.get("coco_id"):
+            vg_of[int(m["coco_id"])] = m
+cands = []
+for cid, d in truth.items():
+    v, pp = d.get("vase") or [], d.get("potted plant") or []
+    if v and not pp and cid in vg_of:
+        cands.append((cid, v))
+print(f"{len(cands):,} COCO images with a vase and no potted plant")
+
+rng = random.Random(3778)
+from PIL import Image  # noqa: E402
+
+sys.path.insert(0, str(Path("scripts/experiments/pile").resolve()))
+from make_positive_slate import draw_with_inset  # noqa: E402
+
+picked = rng.sample(cands, 8)
+for cid, boxes in picked:
+    m = vg_of[cid]
+    iid = int(m["image_id"])
+    # image_data carries ids, not paths; VG splits its images over two folders
+    root = Path("/exp/scale26/datasets/external/vtsearch-demos/visual_genome")
+    src = next((root / d / f"{iid}.jpg" for d in ("VG_100K", "VG_100K_2") if (root / d / f"{iid}.jpg").exists()), None)
+    if src is None:
+        continue
+    with Image.open(src) as im:
+        W, H = im.size
+    b = max(boxes, key=lambda x: (x[2] - x[0]) * (x[3] - x[1]))
+    nb = (b[0] / W, b[1] / H, b[2] / W, b[3] / H)
+    dest = OUT / f"coco{cid}.jpg"
+    try:
+        draw_with_inset(src, nb, dest)
+        print(f"  wrote {dest.name}  box {tuple(round(v, 2) for v in nb)}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {cid}: {exc}")

--- a/scripts/experiments/pile/coco_vase_what.py
+++ b/scripts/experiments/pile/coco_vase_what.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""What does COCO actually call a `vase`? (#3778)
+
+The empty-planter question is not answerable from the rule text, and three
+eyeballed crops are not an answer either. This crops every COCO `vase` box in
+images COCO gives NO `potted plant` -- so nothing here is a pot COCO declined to
+annotate -- and asks an open-vocabulary detector which of a handful of words the
+crop best matches.
+
+It measures what the objects LOOK like, not what COCO meant, so it can only
+support a reading rather than prove one. But if COCO's vase set were largely
+flower pots, that would show, and it is the difference between a ruling with
+evidence and a ruling with a hunch.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+QUERIES = [
+    "a photo of a vase",
+    "a photo of a flower pot",
+    "a photo of a potted plant",
+    "a photo of a jug or pitcher",
+    "a photo of a bowl",
+    "a photo of a cup",
+]
+SHORT = ["vase", "flower pot", "potted plant", "pitcher", "bowl", "cup"]
+ROOT = Path("/exp/scale26/datasets/external/vtsearch-demos/visual_genome")
+
+
+def main() -> int:
+    sys.path.insert(0, "scripts/experiments/pile")
+    import pile_config as pc  # noqa: PLC0415
+
+    pc.setup_env()
+    import coco_anchor as ca  # noqa: PLC0415
+    import torch  # noqa: PLC0415
+    from PIL import Image  # noqa: PLC0415
+    from transformers import Owlv2ForObjectDetection, Owlv2Processor  # noqa: PLC0415
+
+    image_data, instances = ca.ensure_sources(pc.PILE / "coco_anchor", fetch=False)
+    truth = ca.coco_truth(instances, {"vase", "potted plant"})
+    vg_of = {}
+    with image_data.open() as fh:
+        for m in json.load(fh):
+            if m.get("coco_id"):
+                vg_of[int(m["coco_id"])] = int(m["image_id"])
+
+    jobs = []
+    for cid, d in truth.items():
+        v, pp = d.get("vase") or [], d.get("potted plant") or []
+        if not v or pp or cid not in vg_of:
+            continue
+        iid = vg_of[cid]
+        src = next(
+            (ROOT / s / f"{iid}.jpg" for s in ("VG_100K", "VG_100K_2") if (ROOT / s / f"{iid}.jpg").exists()), None
+        )
+        if src:
+            jobs.append((cid, src, v))
+    print(f"[what] {len(jobs)} COCO vase images with no potted plant", flush=True)
+
+    m = "google/owlv2-base-patch16-ensemble"
+    proc = Owlv2Processor.from_pretrained(m)
+    model = Owlv2ForObjectDetection.from_pretrained(m).to("cuda").eval()
+
+    tally, skipped, rows = Counter(), 0, []
+    for n, (cid, src, boxes) in enumerate(jobs, 1):
+        try:
+            im = Image.open(src).convert("RGB")
+        except Exception:  # noqa: BLE001
+            skipped += 1
+            continue
+        W, H = im.size
+        b = max(boxes, key=lambda x: (x[2] - x[0]) * (x[3] - x[1]))
+        # COCO boxes arrive in COCO's pixel frame, and 88% of anchored pairs are
+        # a uniform rescale of it (median 1.28x). Aspect gating cannot see a pure
+        # rescale, so the box must be carried across by the DIMENSION RATIO --
+        # dividing by the VG size instead is a silent 28% error.
+        cw, ch = ca.COCO_DIMS.get(cid, (0, 0))
+        if not cw or not ch:
+            skipped += 1
+            continue
+        sx, sy = W / cw, H / ch
+        b = [b[0] * sx, b[1] * sy, b[2] * sx, b[3] * sy]
+        if b[2] > W + 2 or b[3] > H + 2 or b[0] < -2 or b[1] < -2:
+            skipped += 1
+            continue
+        pad = 0.15 * max(b[2] - b[0], b[3] - b[1])
+        crop = im.crop((max(0, b[0] - pad), max(0, b[1] - pad), min(W, b[2] + pad), min(H, b[3] + pad)))
+        if crop.width < 8 or crop.height < 8:
+            skipped += 1
+            continue
+        inputs = proc(text=[QUERIES], images=[crop], return_tensors="pt").to("cuda")
+        with torch.inference_mode():
+            o = model(**inputs)
+        res = proc.post_process_grounded_object_detection(
+            outputs=o, target_sizes=torch.tensor([[crop.height, crop.width]], device="cuda"), threshold=0.02
+        )[0]
+        if not len(res["scores"]):
+            tally["no detection"] += 1
+            continue
+        k = SHORT[int(res["labels"][int(res["scores"].argmax())])]
+        tally[k] += 1
+        rows.append({"coco_id": cid, "top": k})
+        if n % 100 == 0:
+            print(f"[what] {n}/{len(jobs)}", flush=True)
+
+    Path("/expscratch/sgreenberg/vlm-3720/coco_vase_what2.json").write_text(
+        json.dumps({"tally": dict(tally), "skipped": skipped, "rows": rows}, indent=1) + "\n"
+    )
+    total = sum(tally.values())
+    print(f"\nwhat COCO's `vase` boxes look like ({total} crops, {skipped} skipped as mis-scaled or tiny):")
+    for k, c in tally.most_common():
+        print(f"   {k:<14}{c:>6}  {100 * c / total:5.1f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -1742,7 +1742,7 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
     # first name -- "incl plates and dishes" -- said nothing about it. Renamed
     # mid-slate once that showed up.
     "bowl": ClassRule(
-        name="bowl incl plates and food containers not wrappers",
+        name="bowl incl plates not planters or wrappers",
         test=(
             "Good: bowls, plates (a paper plate is a plate), saucers, dishes, serving "
             "pots, baskets that hold food, disposable food containers, and a dog's water "
@@ -1751,7 +1751,7 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
             "of apples is not a bowl, nor is a shopping cart, a grocery store, or a car "
             "boot with the shopping in it. It has to be MADE to hold food. "
             "Bad: flat wrappers and sleeves, cups and mugs (`cup`), sink basins (`sink`), "
-            "toilet bowls, feed troughs, planters (`vase`), ashtrays and carafes. "
+            "toilet bowls, feed troughs, planters (out of C, not `vase`), ashtrays and carafes. "
             "Judge the vessel, not the food -- which answers WHAT TO BOX. Contents "
             "answer WHICH CLASS when the vessel alone is ambiguous: full of soup is a "
             "Bowl whatever its shape; empty, the ladder decides (Bowl 0.66 h/w, Cup 1.26). "
@@ -1778,15 +1778,44 @@ SCALE_CLASS_RULES: dict[str, ClassRule] = {
             "`jar` (120) and `jug` (28) fold in and barely have one."
         ),
     ),
+    # Until 2026-09-09 `vase` claimed "flower pots, planters" and "a potted
+    # plant's pot is a vase", and `bowl` pointed planters AT `vase`. The reviewer
+    # rejected planters through the whole finished vase slate and reported the
+    # line as "a little weak", judging on proportions and ornateness instead --
+    # which is the shape of a rule nobody can apply twice the same way.
+    #
+    # COCO disagrees with the old wording in two independent ways. `potted plant`
+    # is a class of its own: 69% of its images carry no `vase` at all, and only
+    # 82 of 2,500 potted plants reach IoU>0.5 with a vase box. And of 445 COCO
+    # `vase` crops taken from images with NO potted plant, 82.0% look like a vase
+    # and 4.1% like a flower pot or potted plant. (The first pass of that
+    # measurement normalised COCO's boxes by the VG file's dimensions and read
+    # 47.4%/3.6%; 88% of anchored pairs are a uniform ~1.28x rescale of each
+    # other, which aspect-ratio gating cannot see -- the trap `anchor_to_coco`
+    # documents and this analysis walked into anyway.)
+    #
+    # So a planter is not a vase, and `bowl` already refused it on its own
+    # principle -- "it has to be MADE to hold food" -- which a planter fails
+    # whatever its shape. Both doors shut, and `potted plant` is not in C, so the
+    # object is out of C. The plant is not the operative fact; being made to hold
+    # one is, which is why an EMPTY planter is out too.
+    #
+    # Sized before ruling: 167 of the 278 vase rejects score `potted plant` or
+    # `flower pot` above `vase`, against 18 of the 116 accepts. Applying the old
+    # wording literally would have roughly doubled vase's positives, so this
+    # keeps the 394 verdicts as cast rather than voiding them.
     "vase": ClassRule(
-        name="vase incl pots and planters",
+        name="vase not planters",
         test=(
-            "Good: only a vessel MADE as one -- vases, flower pots, planters, urns, "
-            "pottery. Against an ornamental BOWL, use the box: a vase is TALLER THAN "
+            "Good: only a vessel MADE as one -- vases, urns, decorative pottery. "
+            "Against an ornamental BOWL, use the box: a vase is TALLER THAN "
             "WIDE (median h/w 1.58, 84% of boxes) and a bowl is wider than tall (0.66, "
             "13%); the middle halves do not overlap. Size does not help -- bowl's median "
             "box is the larger. "
-            "A potted plant's pot is a vase; vote the vessel, not the plant. "
+            "A VESSEL MADE TO HOLD A GROWING PLANT is neither a vase nor a bowl -- a "
+            "flower pot, planter or window box is out of C entirely, whether or not a "
+            "plant is in it, because the plant is not what decides it. If you cannot "
+            "tell a planter from a vase and it is empty, use the shape test above. "
             "Bad: a cooking pot on a stove, a plain bowl, and any BORROWED vessel however "
             "it is used -- a jar of cut flowers is a `bottle`, a glass of them a `cup`. "
             "A pitcher or jug of them is a `bottle`: COCO split them (pitcher to cup 30, "


### PR DESCRIPTION
Rule the planter out of both `vase` and `bowl`

`vase` claimed "flower pots, planters" as Good and said "a potted plant's pot is
a vase"; `bowl` pointed planters AT `vase`. The reviewer rejected planters
through the whole finished vase slate and reported the line as weak, judging on
proportions and ornateness -- which is the shape of a rule nobody can apply twice
the same way.

Three independent things agree against the old wording:

* **`bowl` already refused it on its own principle.** "It has to be MADE to hold
  food", which a planter fails whatever its shape -- the same test that rules out
  a 5-gallon bucket of apples.
* **`potted plant` is a COCO class of its own**, and 69% of its images carry no
  `vase` at all; only 82 of 2,500 potted plants reach IoU>0.5 with a vase box.
* **COCO's `vase` is not full of pots.** Of 760 COCO vase crops from images with
  no potted plant, 82.0% look like a vase and 4.1% like a flower pot or potted
  plant.

So the object is out of *C* entirely, and the plant is not what decides it --
being MADE to hold one is, which is why an empty planter is out too. That was the
reviewer's question and it is the part the earlier draft got wrong: an empty pot
is not a `potted plant`, but it is not a bowl either.

Sized before ruling: 167 of the 278 vase rejects score `potted plant` or
`flower pot` above `vase`, against 18 of the 116 accepts. The old wording applied
literally would have roughly doubled vase's positives, so this ruling keeps the
394 verdicts as cast instead of voiding them. `bowl` has not started, which is
why this lands now -- 592 images were about to be judged the other way.

**A correction to my own measurement.** The first pass read 47.4% vase / 3.6%
pot, with 41% of crops discarded as unusable. It normalised COCO's boxes by the
VG file's dimensions. 88% of anchored pairs are a uniform ~1.28x rescale of each
other -- aspect-ratio gating is scale-invariant by construction and cannot see
it -- so every crop was 28% oversized and offset. `anchor_to_coco` documents this
exact trap in its docstring and handles it correctly; nothing in the pipeline is
affected, and only this analysis was wrong. Rescaled, 0 of 760 crops are
unusable and the reading is stronger, not weaker.

`check_pair_scale.py` measures the rescale so the next join does not have to
rediscover it. Refs #3778, #3720.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012yKKtCnzocPQy6yZGQyzTZ