### PR TITLE
Keep a partially pre-embedded import under one embedder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,35 @@ not list every commit. Use `git log` for the full history.
 
 ### Fixed
 
+- **A dataset imported with some of its vectors already computed no longer
+  fails every Browse, Train and text sort afterwards** (issue #3798). An
+  importer plugin that ships pre-computed vectors for part of a dataset
+  (`content_vectors` / `custom_metadata_map`, with no embedder name) and leaves
+  the rest for VTSearch to embed produced a dataset that was one embedding
+  space in fact and two by name: the items VTSearch embedded were keyed under
+  the embedder it resolved, the shipped vectors stayed nameless. The first
+  request for that embedder's matrix then raised
+  `media N has no embedding for embedder '<name>'` on every shipped item. This
+  happened whenever the import named no embedder - the CLI never does, and the
+  GUI need not - and became visible with the mixed-space guard added on
+  2026-09-04, which stopped reading a nameless vector as "the same space" on
+  the strength of the first media alone. The embed step now stamps the
+  embedder it resolved onto the nameless vectors whenever it embeds alongside
+  them (or the dataset already carries that embedder's name), so the dataset
+  leaves the import keyed under one name. A vector whose width contradicts
+  that embedder's declared dimension is rejected at import, naming both widths,
+  instead of surfacing later as a missing vector. A fully pre-computed nameless
+  import with nothing left to embed is unchanged.
+
+- **An import whose embedder produced nothing now says so.** Items the embedder
+  returned no vector for were dropped at the end of the load with one log line
+  and a progress message that the next stage overwrote within seconds, so a
+  dataset that silently shrank looked like a healthy one. The embed step now
+  logs which embedder declined and for how many items (and when a bulk
+  embedder returns the wrong number of vectors, or no embedder is registered
+  for the media type at all), and the drop raises a warning toast that stays
+  until dismissed.
+
 - **Startup no longer stalls for minutes on a cold NFS install** (issue #3715).
   `transformers` builds `importlib.metadata.packages_distributions()` when it is
   imported, and the stdlib version of that stats every file recorded by every

--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -761,9 +761,12 @@ Two related checks you will hit:
   embedder's declared `embedding_dim`.  Declaring `siglip2_l` while shipping
   768-dim rows is a self-contradiction, and it is rejected at import.
 - **Nameless vectors.** A vector supplied with no embedder name is stored under
-  a sentinel key and re-keyed to the embedder the load actually picked.  That
-  re-keying asserts the vector lives in that embedder's space, so it is
-  width-checked too — supply the name yourself if you know it.
+  a sentinel key and re-keyed to the embedder the load actually picked — the
+  user's pick, or, when nothing was picked and the framework had items of
+  yours to embed, the media-type default it resolved.  That re-keying asserts
+  the vector lives in that embedder's space, so it is width-checked too —
+  supply the name yourself if you know it.  A fully pre-computed nameless
+  import with nothing left to embed keeps the sentinel and is never re-keyed.
 
 When building dicts directly, the importer should also override
 `build_origin()` to return an empty origin (since the default

--- a/tests_lib/datasets/test_multi_embedder_loader.py
+++ b/tests_lib/datasets/test_multi_embedder_loader.py
@@ -165,8 +165,11 @@ class TestRequestedEmbedderStamping:
             np.testing.assert_array_equal(media_embedding(m, "siglip"), vecs[i])
 
     def test_blank_name_left_blank_when_no_pick(self):
-        # No explicit pick → the blank sentinel key is left untouched (the
+        # No explicit pick, nothing to embed and no media already keyed under
+        # the resolved embedder → the blank sentinel key is left untouched (the
         # nameless vector still resolves as the primary via media_embedding).
+        # When a no-pick load *does* embed something, the resolved embedder is
+        # stamped instead - see tests_lib/datasets/test_partial_precomputed_import.py.
         emb = _fake_embedder("audio_default", dim=4)
         rng = np.random.default_rng(2)
         vecs = {i: rng.standard_normal(4).astype(np.float32) for i in range(1, 4)}

--- a/tests_lib/datasets/test_partial_precomputed_import.py
+++ b/tests_lib/datasets/test_partial_precomputed_import.py
@@ -1,0 +1,302 @@
+"""A dataset that arrives partly embedded must leave the embed stage single-space.
+
+Issue #3798.  A third-party importer ships vectors for *some* of its items
+(``content_vectors`` / ``custom_metadata_map``, which the folder loader stores
+under the blank :data:`UNKNOWN_EMBEDDER_KEY` sentinel because the importer did
+not name the embedder) and leaves the rest for the framework to embed.  When the
+load names no embedder - the CLI never does, and the GUI need not - the stage
+resolved the media-type default, embedded the missing items under that name,
+and left the pre-computed vectors under the sentinel.  The dataset was then two
+"spaces" by name while being one space in fact, and the first thing to ask the
+matrix layer for the routed embedder (Browse, Train, text sort) raised::
+
+    media 7 has no embedding for embedder 'custom-embedder' (embedding=None)
+
+These tests mock the importer's output shape directly - the medias dict as the
+folder loader / a ``fetch_record`` importer hands it to the embed stage - with
+some items carrying a vector and some not, and a fake embedder standing in for
+the plugin's.
+"""
+
+from __future__ import annotations
+
+import logging
+import unittest.mock as mock
+
+import numpy as np
+import pytest
+
+from vtscore.concurrency.progress import LoadingTasksTracker
+from vtscore.datasets.stages.embedding import _embed_missing_stage, embed_missing
+from vtscore.datasets.stages.finalize import _drop_none_embeddings_stage
+from vtscore.embedding.matrix import _stack_embeddings, _uniform_primary_embedder, get_embedding_matrix
+from vtscore.embedding.media_vectors import UNKNOWN_EMBEDDER_KEY, init_embeddings, media_embedding
+from vtscore.embedding.precomputed import MismatchedVectorError
+from vtscore.state.core import DatasetContext
+
+DIM = 4
+EMBEDDER = "custom_embedder"
+
+
+def _fake_embedder(name: str = EMBEDDER, dim: int = DIM, *, fail_ids: frozenset[int] = frozenset()):
+    """A MagicMock embedder whose bulk pass returns ``None`` for *fail_ids*."""
+    emb = mock.MagicMock()
+    emb.name = name
+    emb.media_type_id = "audio"
+    emb._model = True
+    emb.supports_text = True
+    emb.supports_patch_regions = False
+    emb.supports_geometric_verification = False
+    emb.embedding_dim = None
+
+    def _bulk(medias):
+        return [None if m["id"] in fail_ids else np.full(dim, float(m["id"]), dtype=np.float32) for m in medias]
+
+    emb.embed_media_bulk.side_effect = _bulk
+    return emb
+
+
+def _media(mid: int, vec: np.ndarray | None) -> dict:
+    """One media dict in the shape the folder loader emits for an importer.
+
+    ``init_embeddings("", vec)`` is exactly what ``_build_folder_media_data``
+    does with a ``content_vectors`` hit: the vector lands under the blank
+    sentinel key because the importer named no embedder.
+    """
+    return {
+        "id": mid,
+        "media_type": "audio",
+        "filename": f"{mid}.wav",
+        "md5": f"md5-{mid}",
+        "embedder": "",
+        "embeddings": init_embeddings("", vec),
+        "media_path": f"/tmp/{mid}.wav",
+    }
+
+
+def _partial_medias(rng: np.random.Generator, *, pre: tuple[int, ...], missing: tuple[int, ...]) -> tuple[dict, dict]:
+    """Medias where *pre* carry a pre-computed vector and *missing* carry none."""
+    vecs = {i: rng.standard_normal(DIM).astype(np.float32) for i in pre}
+    medias = {i: _media(i, vecs[i]) for i in pre}
+    medias.update({i: _media(i, None) for i in missing})
+    return dict(sorted(medias.items())), vecs
+
+
+class _registered:
+    """Register *emb* in the process embedder registry for the block."""
+
+    def __init__(self, emb) -> None:
+        self._emb = emb
+
+    def __enter__(self):
+        from vtscore.media import _embedder_registry, register_embedder
+
+        self._registry = _embedder_registry
+        self._prev = _embedder_registry.get(self._emb.name)
+        register_embedder(self._emb)
+        return self._emb
+
+    def __exit__(self, *exc):
+        if self._prev is None:
+            self._registry.pop(self._emb.name, None)
+        else:
+            self._registry[self._emb.name] = self._prev
+        return False
+
+
+def _tracker():
+    return LoadingTasksTracker().create_task("test_partial_import", "test")
+
+
+class TestPartialImportNoPick:
+    """No embedder named for the load (CLI, or a GUI import with no pick)."""
+
+    def test_precomputed_vectors_are_keyed_under_the_resolved_embedder(self):
+        emb = _fake_embedder()
+        medias, vecs = _partial_medias(np.random.default_rng(3798), pre=(1, 3), missing=(2,))
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias, "")
+
+        # Only the item with no vector was embedded; the shipped vectors were kept.
+        assert emb.embed_media_bulk.call_count == 1
+        assert [m["id"] for m in emb.embed_media_bulk.call_args.args[0]] == [2]
+        for i in (1, 3):
+            np.testing.assert_array_equal(medias[i]["embeddings"][EMBEDDER], vecs[i])
+
+        # ...and every media now lives under the one embedder that produced the
+        # load, so nothing downstream can find a media "missing" that space.
+        for m in medias.values():
+            assert m["embedder"] == EMBEDDER
+            assert set(m["embeddings"]) == {EMBEDDER}
+            assert media_embedding(m, EMBEDDER) is not None
+        assert _uniform_primary_embedder(medias) == EMBEDDER
+
+    def test_matrix_for_the_resolved_embedder_builds(self):
+        """The exact call Browse / Train / text sort make after the import."""
+        emb = _fake_embedder()
+        medias, _ = _partial_medias(np.random.default_rng(1), pre=(1, 3), missing=(2,))
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias, "")
+
+        matrix = _stack_embeddings(sorted(medias), medias, EMBEDDER)
+        assert matrix.shape == (3, DIM)
+
+    def test_pipeline_stage_then_routed_matrix(self):
+        """End to end through the load-pipeline stages and the routing table.
+
+        ``_embed_missing_stage`` is what the GUI import runs; ``routed_embedder``
+        plus ``get_embedding_matrix`` is what Browse asks for first.  Before the
+        fix the second call raised ``media 2 has no embedding for embedder``.
+        """
+        emb = _fake_embedder()
+        ctx = DatasetContext("test_partial_import_ctx")
+        medias, _ = _partial_medias(np.random.default_rng(2), pre=(2, 3), missing=(1,))
+        ctx.medias.update(medias)
+
+        # Registered so the routing table's capability lookup resolves the
+        # fake; patched so the media-type default resolves to it as well.
+        with _registered(emb), mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            _embed_missing_stage(ctx, _tracker(), [""])
+            _drop_none_embeddings_stage(ctx, _tracker())
+            routed = ctx.routed_embedder("score")
+            assert routed == EMBEDDER
+            ids, matrix = get_embedding_matrix(ctx, routed)
+
+        assert ids == [1, 2, 3]
+        assert matrix.shape == (3, DIM)
+
+    def test_already_mixed_dataset_is_healed_on_reload(self):
+        """A dataset saved in the broken shape loads clean once the fix exists.
+
+        Nothing is missing, but some media already carry the resolved embedder's
+        name, so the nameless ones must be its vectors too.
+        """
+        emb = _fake_embedder()
+        rng = np.random.default_rng(4)
+        nameless = rng.standard_normal(DIM).astype(np.float32)
+        named = rng.standard_normal(DIM).astype(np.float32)
+        medias = {
+            1: _media(1, nameless),
+            2: {**_media(2, None), "embedder": EMBEDDER, "embeddings": {EMBEDDER: named}},
+        }
+
+        with mock.patch("vtscore.media.get_embedder", return_value=emb):
+            embed_missing(medias, "")
+
+        assert emb.embed_media_bulk.call_count == 0
+        assert set(medias[1]["embeddings"]) == {EMBEDDER}
+        assert medias[1]["embedder"] == EMBEDDER
+        np.testing.assert_array_equal(medias[1]["embeddings"][EMBEDDER], nameless)
+        assert _uniform_primary_embedder(medias) == EMBEDDER
+
+    def test_fully_precomputed_nameless_dataset_is_left_alone(self):
+        """No pick, nothing to embed, no named vectors: the sentinel stays.
+
+        A manifest of vectors from a model VTSearch has never heard of is a
+        supported import; stamping the media-type default onto it would assert
+        a space nothing asked for.
+        """
+        emb = _fake_embedder()
+        medias, vecs = _partial_medias(np.random.default_rng(5), pre=(1, 2), missing=())
+
+        with mock.patch("vtscore.media.embedders_for_type", return_value=[emb]):
+            embed_missing(medias, "")
+
+        assert emb.embed_media_bulk.call_count == 0
+        for i, m in medias.items():
+            assert set(m["embeddings"]) == {UNKNOWN_EMBEDDER_KEY}
+            assert not m.get("embedder")
+            np.testing.assert_array_equal(media_embedding(m), vecs[i])
+
+    def test_wrong_width_precomputed_vector_is_rejected_at_import(self):
+        """The stamp asserts the shipped vectors are the resolved embedder's.
+
+        When the embedder declares a width and a shipped vector disagrees, the
+        load fails here naming both widths - not at sort time, as a bare
+        "has no embedding" for a media that visibly has one.
+        """
+        emb = _fake_embedder()
+        emb.embedding_dim = DIM
+        medias, _ = _partial_medias(np.random.default_rng(6), pre=(1,), missing=(2,))
+        medias[1]["embeddings"][UNKNOWN_EMBEDDER_KEY] = np.ones(DIM + 3, dtype=np.float32)
+
+        with (
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+            mock.patch("vtscore.media.get_embedder", return_value=emb),
+            pytest.raises(MismatchedVectorError) as exc,
+        ):
+            embed_missing(medias, "")
+
+        msg = str(exc.value)
+        assert "1.wav" in msg
+        assert str(DIM + 3) in msg and str(DIM) in msg
+        assert EMBEDDER in msg
+
+
+class TestPartialImportExplicitPick:
+    def test_pick_still_stamps_and_embeds_the_rest(self):
+        """The named-pick path (GUI import with a pick) is unchanged."""
+        emb = _fake_embedder()
+        medias, vecs = _partial_medias(np.random.default_rng(7), pre=(1,), missing=(2, 3))
+
+        with (
+            mock.patch("vtscore.media.get_embedder", return_value=emb),
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+        ):
+            embed_missing(medias, EMBEDDER)
+
+        assert [m["id"] for m in emb.embed_media_bulk.call_args.args[0]] == [2, 3]
+        np.testing.assert_array_equal(medias[1]["embeddings"][EMBEDDER], vecs[1])
+        for m in medias.values():
+            assert set(m["embeddings"]) == {EMBEDDER}
+        assert _stack_embeddings(sorted(medias), medias, EMBEDDER).shape == (3, DIM)
+
+
+class TestEmbedFailuresAreLoud:
+    """An embedder that produces nothing must say so in the log, not just drop rows."""
+
+    def test_items_the_embedder_returns_none_for_are_named(self, caplog):
+        emb = _fake_embedder(fail_ids=frozenset({2, 3}))
+        medias, _ = _partial_medias(np.random.default_rng(8), pre=(), missing=(1, 2, 3))
+
+        with (
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+            caplog.at_level(logging.WARNING, logger="vtscore.datasets.stages.embedding"),
+        ):
+            embed_missing(medias, "")
+
+        assert media_embedding(medias[1]) is not None
+        assert media_embedding(medias[2]) is None
+        assert media_embedding(medias[3]) is None
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("2 of 3" in w and EMBEDDER in w for w in warnings), warnings
+
+    def test_short_result_list_is_named_and_nothing_is_misattributed(self, caplog):
+        emb = _fake_embedder()
+        emb.embed_media_bulk.side_effect = lambda medias: [np.ones(DIM, dtype=np.float32)]
+        medias, _ = _partial_medias(np.random.default_rng(9), pre=(), missing=(1, 2))
+
+        with (
+            mock.patch("vtscore.media.embedders_for_type", return_value=[emb]),
+            caplog.at_level(logging.WARNING, logger="vtscore.datasets.stages.embedding"),
+        ):
+            embed_missing(medias, "")
+
+        # A wrong-length answer cannot be paired with the inputs, so no vector
+        # is attached to the wrong media; the mismatch is reported instead.
+        assert all(media_embedding(m) is None for m in medias.values())
+        assert any("1 vector(s) for 2 item(s)" in r.getMessage() for r in caplog.records)
+
+    def test_no_embedder_for_the_media_type_is_named(self, caplog):
+        medias, _ = _partial_medias(np.random.default_rng(10), pre=(), missing=(1, 2))
+
+        with (
+            mock.patch("vtscore.media.embedders_for_type", return_value=[]),
+            caplog.at_level(logging.WARNING, logger="vtscore.datasets.stages.embedding"),
+        ):
+            embed_missing(medias, "")
+
+        assert all(media_embedding(m) is None for m in medias.values())
+        assert any("no embedder" in r.getMessage().lower() and "audio" in r.getMessage() for r in caplog.records)

--- a/vtscore/CHANGELOG.md
+++ b/vtscore/CHANGELOG.md
@@ -376,6 +376,32 @@ instead, since every commit on `dev` is effectively a new app release.)
 
 ### Fixed
 
+- **`embed_missing()` leaves a partially pre-embedded import keyed under one
+  embedder name** (issue #3798). Nameless pre-computed vectors (an importer's
+  `content_vectors` / `custom_metadata_map` entries, or an `.npz` manifest
+  without `embedder_name`) sit under the blank `UNKNOWN_EMBEDDER_KEY` sentinel,
+  and the stage re-keyed them to the load's embedder only when the caller
+  *named* one. A no-pick load - `vtscore.cli` always, `load_pipeline` when the
+  request carried no `embedder` - resolved the media-type default, embedded the
+  vector-less items under it, and left the shipped vectors nameless: two names
+  for one space, and `get_embedding_matrix(ctx, ctx.routed_embedder(...))`
+  raised `has no embedding for embedder` on every shipped media once #3650
+  stopped collapsing that request to the primary path on the first media's
+  say-so. The resolved embedder is now stamped whenever leaving the sentinel
+  would split the dataset - at least one nameless vector alongside at least one
+  media that is about to be, or already is, keyed under that embedder - with
+  the same width check the named path applies (`MismatchedVectorError` naming
+  both widths). A dataset that is nameless throughout with nothing to embed is
+  left exactly as it arrived, so a manifest of vectors from an unregistered
+  model still loads slot-less. Named-pick loads are unchanged.
+
+  Two silences in the same stage are now log `WARNING`s: an
+  `embed_media_bulk` that returns `None` for some inputs (naming the embedder
+  and the count), or a list of the wrong length (nothing is attached, since
+  `zip` would have paired vectors with the wrong media), and a media type with
+  no registered embedder at all. `_drop_none_embeddings_stage` additionally
+  publishes a warning `notify()` so the shrink reaches the user.
+
 - **A matrix built for one embedding space can no longer be filled with
   another space's vectors** (issue #3650). `scoreable_snapshot()`,
   `get_embedding_matrix()` and `get_embedding_matrix_for_snap()` decide whether

--- a/vtscore/cli.py
+++ b/vtscore/cli.py
@@ -893,9 +893,9 @@ def _embed_loaded_medias(medias: dict[int, dict[str, Any]]) -> dict[int, dict[st
 
     Importers never call an embedder - that is the contract on
     :class:`~vtscore.datasets.importers.base.core.DataSourceImporter`.  They emit
-    media dicts with ``embedding=None`` and the framework's
+    media dicts with no vector (``embeddings={}``) and the framework's
     :func:`~vtscore.datasets.stages.embedding.embed_missing` stage embeds
-    everything still at ``None`` once the importer returns.  The GUI's
+    everything still without a vector once the importer returns.  The GUI's
     ``load_pipeline`` runs that stage; the CLI ran *none* of the post-import
     stages and let the vectors appear incidentally at scoring time, inside
     ``route_and_embed``'s per-detector-group embed pass.

--- a/vtscore/converters/runner.py
+++ b/vtscore/converters/runner.py
@@ -4,7 +4,7 @@ This module provides :func:`run_converters_on_folder`, a reusable utility
 that any dataset importer can call to scan a directory for source media
 files, convert them via one or more :class:`MediaConverter` instances,
 and append them to an existing medias dict.  The converter outputs are
-left with ``embedding=None``; the framework
+left with no vector (``embeddings={}``); the framework
 :func:`vtscore.datasets.stages.embedding.embed_missing` stage fills them
 in after the importer returns.
 """
@@ -122,7 +122,7 @@ def _build_converted_media_dict(
 ) -> dict[str, Any]:
     """Build the media dict for one converter output.
 
-    ``embedding`` is left at ``None``; the framework
+    ``embeddings`` is left empty; the framework
     :func:`~vtscore.datasets.stages.embedding.embed_missing` stage embeds
     converter outputs via ``media_bytes`` / ``media_string`` after the
     importer returns.
@@ -237,7 +237,7 @@ def _emit_converted_outputs(
     to hand one shared origin dict to all N outputs of a source, leaving lazy
     replay and label re-resolution unable to tell page 3 from page 7.
 
-    Outputs leave with ``embedding=None``; the framework embed stage
+    Outputs leave with no vector (``embeddings={}``); the framework embed stage
     embeds them from ``media_bytes`` / ``media_string``.
 
     When *lazy_source* is given (reference / *thin* mode) each output keeps
@@ -404,7 +404,7 @@ def apply_converter_to_demo(
     After conversion, *medias* contains the converted outputs (target type)
     instead of the original source-type medias.  Each converted media's
     origin records the demo dataset and the converter used.  Outputs
-    leave with ``embedding=None``; the framework embed stage fills them
+    leave with no vector (``embeddings={}``); the framework embed stage fills them
     in.
 
     :param embedder_name: **Accepted and ignored.**  Conversion changes the

--- a/vtscore/datasets/importers/base/core.py
+++ b/vtscore/datasets/importers/base/core.py
@@ -37,16 +37,24 @@ class ImporterBase(PluginBase):
     Embedding contract
     ------------------
     Importers do **not** call any embedder.  Emit media dicts with
-    ``embedding=None`` (and ``embedder=""``); the framework
+    ``embeddings={}`` (and ``embedder=""``); the framework
     :func:`~vtscore.datasets.stages.embedding.embed_missing` stage runs
-    after the importer returns and bulk-embeds every item still at
-    ``None`` using the user's selected embedder (or the default for the
+    after the importer returns and bulk-embeds every item still without a
+    vector using the user's selected embedder (or the default for the
     media type).  Items where the embedder returns ``None`` get dropped
-    by the next stage.
+    by the next stage.  (There is no singular ``media["embedding"]`` field:
+    ``media["embeddings"]`` - a ``{embedder_name: vector}`` dict - is the
+    only per-media vector store.)
 
     If your importer ships pre-computed vectors (e.g. an NPZ archive),
     use :attr:`content_vectors` or :attr:`custom_metadata_map` (below)
-    so the framework treats them as already-embedded and skips them.
+    so the framework treats them as already-embedded and skips them.  A
+    partially pre-embedded import is fine: the items you leave without a
+    vector are embedded by the framework, and the vectors you shipped are
+    re-keyed under that same embedder so the dataset stays one space by
+    name (issue #3798) - which also means they must *be* that embedder's
+    vectors; a width that disagrees with its declared ``embedding_dim``
+    is rejected at import.
 
     Custom metadata
     ---------------

--- a/vtscore/datasets/importers/base/dataset_importer.py
+++ b/vtscore/datasets/importers/base/dataset_importer.py
@@ -361,9 +361,10 @@ class DatasetImporter(ImporterBase):
         """Convert a single *record* into a media dict.
 
         The returned dict should contain the standard media fields
-        (``type``, ``filename``, ``embedding``, ``md5``, ``media_bytes`` /
-        ``media_path``, etc.).  ``id`` is assigned by the framework and may
-        be omitted.  ``origin`` and ``origin_name`` may also be omitted;
+        (``type``, ``filename``, ``embeddings`` (``{}`` to let the framework
+        embed, or ``{"<embedder>": vec}`` with ``embedder="<embedder>"`` for a
+        vector you already have), ``md5``, ``media_bytes`` / ``media_path``,
+        etc.).  ``id`` is assigned by the framework and may be omitted.  ``origin`` and ``origin_name`` may also be omitted;
         :meth:`run` falls back to :meth:`build_origin` and the filename.
 
         Return ``None`` to skip the record (e.g. unsupported media type).

--- a/vtscore/datasets/stages/embedding.py
+++ b/vtscore/datasets/stages/embedding.py
@@ -97,21 +97,90 @@ def _resolve_embedder(
     return emb
 
 
-def _stamp_requested_embedder(medias: dict[int, dict[str, Any]], embedder_name: str) -> None:
-    """Stamp the requested *embedder_name* onto pre-embedded media whose name is blank.
+def _would_leave_mixed(medias: dict[int, dict[str, Any]], embedder_name: str) -> bool:
+    """Whether leaving nameless vectors un-stamped would split *medias* by name.
 
-    An npz/sidecar importer that ships a pre-computed vector but not its
-    producing embedder stores it under the blank sentinel key
-    (:data:`UNKNOWN_EMBEDDER_KEY`) with no recorded ``media["embedder"]``.  When
-    the caller named an embedder for this load, that nameless vector *is* that
-    embedder's vector — the archive just didn't carry the name — so re-key it
+    The no-pick load path (the CLI never names an embedder; a GUI import need
+    not) resolves *embedder_name* itself and embeds every item with no vector
+    under it.  A partially pre-embedded import - an importer that shipped
+    ``content_vectors`` for some files and left the rest to the framework -
+    then holds two kinds of media: the framework-embedded ones keyed under
+    *embedder_name*, and the shipped ones under the blank sentinel with no
+    recorded ``embedder``.  One space in fact, two by name; and the first
+    request for the routed embedder's matrix (Browse, Train, text sort) raises
+    ``has no embedding for embedder`` on every shipped media (issue #3798).
+
+    ``True`` when *medias* holds at least one nameless vector **and** at least
+    one media that is (or is about to be) keyed under *embedder_name*: an item
+    with no vector at all, which this load will embed, or one already carrying
+    *embedder_name*'s vector (the same dataset reloaded from a pickle written
+    in the split shape).  ``False`` for a dataset that is nameless throughout
+    with nothing to embed - a manifest of vectors from a model this process
+    does not know is a supported import, and stamping the media-type default
+    onto it would assert a space nobody asked for.
+    """
+    has_nameless = False
+    has_named_or_missing = False
+    for m in medias.values():
+        embs = m.get(EMBEDDINGS_KEY)
+        if not m.get("embedder") and isinstance(embs, dict) and UNKNOWN_EMBEDDER_KEY in embs:
+            has_nameless = True
+        elif media_embedding(m) is None or media_embedding(m, embedder_name) is not None:
+            has_named_or_missing = True
+        if has_nameless and has_named_or_missing:
+            return True
+    return False
+
+
+def _stamp_load_embedder(medias: dict[int, dict[str, Any]], requested: str, resolved: str) -> None:
+    """Stamp the load's embedder onto nameless pre-computed vectors when it applies.
+
+    A pre-embedded media whose producing embedder the archive didn't record
+    (npz/sidecar/``content_vectors`` import → vector under the blank sentinel
+    key) is stamped with *resolved* - the embedder this load runs - so the
+    vector resolves under that name rather than being re-embedded or leaving
+    the dataset split by name.  Always when the caller *requested* a pick (the
+    pre-existing contract; *resolved* is that pick whenever it exists, else
+    the default it fell back to, which is the embedder that embeds the rest);
+    when no pick was named, only if leaving the sentinel in place would split
+    the dataset (issue #3798, :func:`_would_leave_mixed`).
+    """
+    if requested or _would_leave_mixed(medias, resolved):
+        _stamp_requested_embedder(medias, resolved)
+
+
+def _warn_no_embedder(medias: dict[int, dict[str, Any]], media_type: str) -> None:
+    """Log that no embedder resolved for *media_type* and how many items it costs.
+
+    Returning silently here is how an import "silently" shrinks: nothing
+    embeds, and the finalize stage drops every vector-less item with one
+    generic line that names neither the media type nor the reason.
+    """
+    logging.getLogger(__name__).warning(
+        "No embedder is registered for media_type=%r; %d item(s) left unembedded "
+        "(they will be dropped at the end of the load)",
+        media_type,
+        sum(1 for m in medias.values() if media_embedding(m) is None),
+    )
+
+
+def _stamp_requested_embedder(medias: dict[int, dict[str, Any]], embedder_name: str) -> None:
+    """Stamp *embedder_name* onto pre-embedded media whose embedder name is blank.
+
+    An npz/sidecar/``content_vectors`` importer that ships a pre-computed
+    vector but not its producing embedder stores it under the blank sentinel
+    key (:data:`UNKNOWN_EMBEDDER_KEY`) with no recorded ``media["embedder"]``.
+    When the load resolved an embedder - the caller's pick, or the one
+    :func:`embed_missing` resolved for a load that would otherwise be split by
+    name (see :func:`_would_leave_mixed`) - that nameless vector *is* that
+    embedder's vector, the archive just didn't carry the name, so re-key it
     under *embedder_name* and record the primary.  This lets
     ``media_embedding(m, embedder_name)`` resolve, so the named-missing check
     below won't needlessly re-embed the media and downstream binding won't fall
     back to the media-type default (a dimension mismatch when the pick differs).
 
     Only media whose embedder name is blank are touched; an importer-set name is
-    never overwritten.  A no-op when *embedder_name* is blank (no pick to stamp).
+    never overwritten.  A no-op when *embedder_name* is blank (nothing to stamp).
 
     **The stamp is checked, not assumed.**  Re-keying is an assertion that the
     nameless vector belongs to *embedder_name*'s space, and a manifest whose
@@ -225,13 +294,40 @@ def _run_embed_pass(
     if vectors is None:
         return
     embedder_id = emb.name
+    # A wrong-length answer cannot be paired with its inputs: ``zip`` would
+    # silently truncate and attach vectors to the wrong media, so attach none
+    # and say so.  The contract is one entry per input, ``None`` for a failure.
+    if len(vectors) != total:
+        logging.getLogger(__name__).warning(
+            "Embedder %r returned %d vector(s) for %d item(s) (media_type=%s); attaching none. "
+            "embed_media_bulk must return one entry per input media, None where an item could not be embedded.",
+            embedder_id,
+            len(vectors),
+            total,
+            media_type,
+        )
+        return
+    n_failed = 0
     for (mid, _), vec in zip(missing, vectors):
         if vec is None:
+            n_failed += 1
             continue
         media = medias.get(mid)
         if media is None:
             continue
         set_media_embedding(media, embedder_id, vec)
+    if n_failed:
+        # Items the embedder could not embed stay at ``None`` and are dropped
+        # by the finalize stage; that drop is announced there, but this is the
+        # only place that knows *which embedder* declined and how often.
+        logging.getLogger(__name__).warning(
+            "Embedder %r produced no vector for %d of %d item(s) (media_type=%s); "
+            "they will be dropped at the end of the load",
+            embedder_id,
+            n_failed,
+            total,
+            media_type,
+        )
 
 
 def _run_backfill_pass(
@@ -291,6 +387,13 @@ def embed_missing(
     Patch-region tensors are also attached here for embedders that
     report ``supports_patch_regions``.
 
+    A partially pre-embedded import (some items shipped with a nameless
+    vector, the rest left for the framework) leaves this function keyed under
+    **one** embedder name throughout: the resolved embedder is stamped onto the
+    nameless vectors whenever leaving them un-stamped would split the dataset
+    by name (issue #3798; see :func:`_would_leave_mixed`).  A fully nameless
+    dataset with nothing to embed is left as it arrived.
+
     Multi-embedder note: "missing" and the patch / structural back-fills are
     keyed to *this* embedder's per-media vector (``media["embeddings"][name]``,
     via :func:`media_embedding`).  So a second bound embedder run over an
@@ -307,14 +410,10 @@ def embed_missing(
 
     emb = _resolve_embedder(medias, embedder_name, media_type)
     if emb is None:
+        _warn_no_embedder(medias, media_type)
         return
 
-    # A pre-embedded media whose producing embedder the archive didn't record
-    # (npz/sidecar import → vector under the blank sentinel key) carries the
-    # caller's named embedder when one was given: stamp that name so the vector
-    # resolves under it rather than being re-embedded or leaving downstream
-    # binding to fall back to the media-type default (dimension mismatch).
-    _stamp_requested_embedder(medias, embedder_name)
+    _stamp_load_embedder(medias, embedder_name, emb.name)
 
     # Which items still need *this* embedder's vector.
     missing = _missing_for_embedder(medias, emb, embedder_name)

--- a/vtscore/datasets/stages/finalize.py
+++ b/vtscore/datasets/stages/finalize.py
@@ -46,9 +46,24 @@ def _drop_none_embeddings_stage(ctx: DatasetContext, tracker) -> None:
 
     import logging  # noqa: PLC0415
 
+    from vtscore.concurrency.notifications import notify  # noqa: PLC0415
+
     logging.getLogger(__name__).warning(
         "Dropped %d media item(s) with embedding=None (importer or re-embed step failed)",
         len(none_ids),
+    )
+    # The tracker message below is overwritten by the next stage within
+    # seconds, so a load that silently shrank was indistinguishable from one
+    # that didn't (issue #3798).  A warning toast stays until dismissed.
+    notify(
+        f"Dropped {len(none_ids)} item(s) whose embedding failed",
+        level="warning",
+        detail=(
+            f"{len(none_ids)} of {len(none_ids) + len(ctx.medias)} imported item(s) had no vector after the "
+            "embed step (the embedder returned nothing for them, or none is registered for their media type). "
+            "See the server log for which embedder declined."
+        ),
+        source="Dataset import",
     )
     tracker.update(
         "loading",


### PR DESCRIPTION
Closes #3798

## What was wrong

An importer plugin that ships pre-computed vectors for **some** of its items (`content_vectors` / `custom_metadata_map`, no embedder name) and leaves the rest for the framework produced a dataset that was one embedding space in fact and two by name. The folder loader stores a nameless shipped vector under the blank `UNKNOWN_EMBEDDER_KEY` sentinel; `embed_missing()` re-keyed those to the load's embedder **only when the caller named one**. On a no-pick load (the CLI never names an embedder, and a GUI import need not) it resolved the media-type default, embedded the vector-less items under that name, and left the shipped vectors nameless.

The first request for the routed embedder's matrix (Browse, Train, text sort) then raised, on every shipped item:

```
media 2 has no embedding for embedder 'custom_embedder' (embedding=None); scoring/sorting require every media to have a vector. This usually means an importer or re-embed step silently failed.
```

It became visible with #3650 (2026-09-04), which stopped collapsing a routed request to the primary path on the first media's say-so and now requires *every* media to agree. Before that, the same split dataset "worked" by reading each media's sole vector regardless of name, which is consistent with the reporter's "fine on the Aug 25 build, broken now".

## What changed

- **`embed_missing()`** stamps the embedder it resolved onto the nameless vectors whenever leaving the sentinel would split the dataset: at least one nameless vector alongside at least one media that is about to be embedded under that name, or that already carries it (so a dataset saved in the split shape heals on reload). The width check the named path already applied carries over (`MismatchedVectorError` naming both widths, at import rather than as a "missing" vector at sort time). A dataset that is nameless throughout with nothing to embed is left as it arrived, so a manifest of vectors from an unregistered model still loads slot-less. Named-pick loads are unchanged.
- **The stage is no longer silent when it produces nothing.** An `embed_media_bulk` that returns `None` for some inputs, or a list of the wrong length (nothing is attached, since `zip` would have paired vectors with the wrong media), and a media type with no registered embedder each log a `WARNING` naming the embedder, the media type and the count. `_drop_none_embeddings_stage` additionally publishes a warning toast, because its tracker message was overwritten by the next stage within seconds.
- **Tests** (`tests_lib/datasets/test_partial_precomputed_import.py`) mock a dataset that comes back with some vectors but not all, as the issue asked for: through `embed_missing`, through the pipeline stages plus the routing table's matrix request (the reproduction raises the exact error above without the fix), the reload-heal case, the fully-nameless case, the width-mismatch case, the named-pick case, and the three new warnings.
- Docstrings in the importer base, converter runner and CLI that still described the retired singular `embedding` field now name `embeddings`; `docs/EXTENDING-plugins.md` states when a nameless vector is re-keyed. Changelog entries in both `CHANGELOG.md` and `vtscore/CHANGELOG.md`.

## Test results

Full `./run-tests.sh`: 11100 Python tests passed, pyright, pip-audit, vulture whitelist, frontend build and Vitest all OK. The one red gate is **`npm audit`**, which is red on `dev` as well: seven moderate Angular advisories (GHSA-p297-fm68-3q8c, GHSA-hh8m-fm6v-7cvg) published against `@angular/*` ≤ 21.2.19. The fix is `@angular/*@21.2.23` / `@angular/{build,cli}@21.2.24`, but that adds 2.21 kB to the initial bundle (522.21 kB against the 520 kB budget), and raising the budget needs the owner's approval per CLAUDE.md, so it is not folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QEbBkJJr1rMGk5U8qP122

---
_Generated by [Claude Code](https://claude.ai/code/session_016QEbBkJJr1rMGk5U8qP122)_