### PR TITLE
Serve dynamic field options for settings importers and exporters

### DIFF
--- a/docs/EXTENDING-plugins.md
+++ b/docs/EXTENDING-plugins.md
@@ -929,8 +929,10 @@ API contract: every plugin family that renders a field form has an options
 route of the same shape — `POST /api/dataset/import/<name>/options`
 (dataset importers), `POST /api/label-importers/field-options/<name>`,
 `POST /api/datasource-import/<name>/options`,
-`POST /api/seed-import/<name>/options`, and
-`POST /api/exporters/field-options/<name>` (results exporters). With body
+`POST /api/seed-import/<name>/options`,
+`POST /api/exporters/field-options/<name>` (results exporters),
+`POST /api/settings-importers/field-options/<name>`, and
+`POST /api/settings-exporters/field-options/<name>`. With body
 `{"field_key": "...", "values": {...}}` each returns
 `{"options": [{"value": "...", "label": "..."}, ...]}` — both the plain-
 string and `(value, label)` shapes are coerced to `{value, label}` before
@@ -1903,11 +1905,23 @@ SETTINGS_IMPORTER = S3SettingsImporter()
 |-----------|---------|-------------|
 | `icon` | `"⚙️"` | Emoji shown in the UI |
 
+### Dynamic select options
+
+Dynamic select options work exactly as for dataset importers: declare a
+field with `dynamic_options=True` and implement
+`get_field_options(field_key, current_values)`
+(see [Dynamic field options](#dynamic-field-options)). The Import Settings
+modal pre-fetches them the same way every other plugin-field form does, so
+an options list that is only knowable at runtime (remote profiles, buckets,
+saved configurations) fills in there too.
+
 ### How it gets invoked
 
 1. `GET /api/settings-importers` returns available importers.
 2. `POST /api/settings-importers/import/<name>` invokes `run()` and applies
    the returned settings.
+3. `POST /api/settings-importers/field-options/<name>` serves dynamic field
+   options.
 
 ---
 
@@ -1983,6 +1997,12 @@ SETTINGS_EXPORTER = S3SettingsExporter()
 |-----------|---------|-------------|
 | `icon` | `"📤"` | Emoji shown in the UI |
 
+### Dynamic select options
+
+Same as for the settings importer above: `dynamic_options=True` plus
+`get_field_options(field_key, current_values)`, honoured by the Export
+Settings modal.
+
 ### How it gets invoked
 
 1. `GET /api/settings-exporters` returns available exporters.
@@ -1996,7 +2016,10 @@ SETTINGS_EXPORTER = S3SettingsExporter()
 
    Note the asymmetry with the settings-*importer* sibling, which does
    keep the name in the path
-   (`POST /api/settings-importers/import/<importer_name>`).
+   (`POST /api/settings-importers/import/<importer_name>`). The
+   field-options route below keeps the name in the path on both sides.
+3. `POST /api/settings-exporters/field-options/<name>` serves dynamic field
+   options.
 
 ---
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -305,6 +305,26 @@ GET /api/settings-importers
 
 → JSON array of settings importer objects.
 
+### Dynamic field options (settings importers)
+
+```
+POST /api/settings-importers/field-options/{importer_name}
+```
+
+**Body:** `{"field_key": "...", "values": {...}}` (`values` is a snapshot of
+the form's current field values)
+
+Returns the dropdown options for a `dynamic_options` field on a settings
+importer, for an importer whose option list is only knowable at runtime.
+Used by the Import Settings modal.
+
+→ `{"options": [{"value": "...", "label": "..."}, ...]}` (same shape as the
+results-exporter and label-importer routes above).
+
+Errors: 400 (unknown/non-dynamic field key), 404 (unknown importer),
+501 (importer does not implement `get_field_options`),
+502 (remote service backing dynamic options failed).
+
 ### Run settings import
 
 ```
@@ -322,6 +342,16 @@ GET /api/settings-exporters
 ```
 
 → JSON array of settings exporter objects.
+
+### Dynamic field options (settings exporters)
+
+```
+POST /api/settings-exporters/field-options/{exporter_name}
+```
+
+Same contract as the settings-importer route above, for the Export Settings
+modal's field form. Note that the exporter is named in the **path** here even
+though `POST /api/settings-exporters/export` names it in the body.
 
 ### Run settings export
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -13862,6 +13862,70 @@
         ]
       }
     },
+    "/api/settings-exporters/field-options/{exporter_name}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "exporter_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Mirror of the settings-importer route above, for the Export Settings\nmodal's field form.",
+        "operationId": "settings_exporter_field_options",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImporterFieldOptionsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImporterFieldOptionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Unknown or non-dynamic field key."
+          },
+          "404": {
+            "description": "Unknown exporter name."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "500": {
+            "description": "get_field_options did not return a list."
+          },
+          "501": {
+            "description": "Exporter does not implement get_field_options."
+          },
+          "502": {
+            "description": "Remote service backing dynamic options raised an error."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return dropdown options for a dynamic-options field on a settings exporter.",
+        "tags": [
+          "settings_io"
+        ]
+      }
+    },
     "/api/settings-importers": {
       "get": {
         "operationId": "get_settings_importers",
@@ -13884,6 +13948,70 @@
           }
         },
         "summary": "Return a list of all registered settings importers.",
+        "tags": [
+          "settings_io"
+        ]
+      }
+    },
+    "/api/settings-importers/field-options/{importer_name}": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "importer_name",
+          "required": true,
+          "schema": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "description": "Same contract as the other plugin families' options routes (see\n``POST /api/label-importers/field-options/<name>``): the importer's\n``get_field_options(field_key, current_values)`` is called with the\nsupplied snapshot of current form values, and plugin errors (network\nfailure, auth error, ...) surface as a 502 with the original message\nso the Import Settings modal can display them inline.",
+        "operationId": "settings_importer_field_options",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImporterFieldOptionsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImporterFieldOptionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "description": "Unknown or non-dynamic field key."
+          },
+          "404": {
+            "description": "Unknown importer name."
+          },
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_CONTENT"
+          },
+          "500": {
+            "description": "get_field_options did not return a list."
+          },
+          "501": {
+            "description": "Importer does not implement get_field_options."
+          },
+          "502": {
+            "description": "Remote service backing dynamic options raised an error."
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return dropdown options for a dynamic-options field on a settings importer.",
         "tags": [
           "settings_io"
         ]

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.html
@@ -51,16 +51,45 @@
                 [(ngModel)]="formValues[field.key]"
                 [placeholder]="field.placeholder || field.description || field.label || field.key"
               />
+            } @else if (field.field_type === 'select' && field.allow_free_text) {
+              <input
+                [id]="'sef-' + field.key"
+                type="text"
+                class="form-input"
+                [attr.list]="'sef-' + field.key + '-list'"
+                [(ngModel)]="formValues[field.key]"
+                [disabled]="!!fieldOptions.loading()[field.key]"
+                [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                (ngModelChange)="onFormFieldChanged(field.key)"
+              />
+              <datalist [id]="'sef-' + field.key + '-list'">
+                @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                  <option [value]="opt.value">{{ opt.label }}</option>
+                }
+              </datalist>
+              @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+              }
             } @else if (field.field_type === 'select') {
               <select
                 [id]="'sef-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
+                (ngModelChange)="onFormFieldChanged(field.key)"
+                [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
               >
-                @for (opt of field.options || []; track opt) {
-                  <option [value]="opt">{{ opt }}</option>
+                @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
+                  <option value="">Loading…</option>
+                } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
+                  <option value="">No options available</option>
+                }
+                @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                  <option [value]="opt.value">{{ opt.label }}</option>
                 }
               </select>
+              @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+              }
             } @else if (field.field_type === 'number') {
               <input
                 [id]="'sef-' + field.key"

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.spec.ts
@@ -48,6 +48,16 @@ describe('SettingsExporterModalComponent', () => {
     await settleResource();
   }
 
+  /** `flushInit` with a caller-supplied exporter list, then a real click on the
+   *  first picker card. The bound event is what schedules change detection under
+   *  zoneless, so the form view actually renders for DOM assertions. */
+  async function openFirstExporter(exporters: unknown[]): Promise<void> {
+    TestBed.tick();
+    httpMock.expectOne('/api/settings-exporters').flush(exporters);
+    await settleResource();
+    (fixture.nativeElement.querySelector('.picker-card') as HTMLButtonElement).click();
+  }
+
   it('should create and render exporter cards', async () => {
     await flushInit();
     expect(component).toBeTruthy();
@@ -102,5 +112,40 @@ describe('SettingsExporterModalComponent', () => {
     const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
     expect(err).toBeTruthy();
     expect(err.textContent).toContain('cannot write');
+  });
+
+  // Issue #3802 (export side): selecting an exporter must pre-fetch every
+  // `dynamic_options` field so the plugin's `get_field_options()` runs.
+  it('pre-fetches options for a dynamic_options field on exporter select', async () => {
+    const dynamicExporter = {
+      name: 'dyn',
+      fields: [{ key: 'bucket', field_type: 'select', dynamic_options: true, required: true }],
+    } as any;
+    await openFirstExporter([dynamicExporter]);
+
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/settings-exporters/field-options/dyn'))
+      .flush({ options: [{ value: 'b1', label: 'Bucket One' }] });
+    await settleZoneless(fixture);
+
+    expect(component.formValues['bucket']).toBe('b1');
+    const options = fixture.nativeElement.querySelectorAll('select option');
+    expect([...options].map((o: any) => o.textContent.trim())).toContain('Bucket One');
+  });
+
+  it('surfaces a field-options failure inline next to the field', async () => {
+    const dynamicExporter = {
+      name: 'dyn',
+      fields: [{ key: 'bucket', field_type: 'select', dynamic_options: true }],
+    } as any;
+    await openFirstExporter([dynamicExporter]);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/settings-exporters/field-options/dyn'))
+      .flush({ message: 'bucket listing failed' }, { status: 502, statusText: 'Bad Gateway' });
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('bucket listing failed');
   });
 });

--- a/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-exporter-modal/settings-exporter-modal.component.ts
@@ -10,6 +10,7 @@ import { ImporterField } from '../../../models/api.models';
 import type { SettingsExporterEntry } from '../../../generated/api-client/models/settings-exporter-entry';
 import type { RunSettingsExportResponse } from '../../../generated/api-client/models/run-settings-export-response';
 import { apiErrorMessage } from '../../../utils/api-error';
+import { DynamicFieldOptions } from '../../../utils/dynamic-field-options';
 
 type ModalView = 'picker' | 'form';
 
@@ -52,6 +53,11 @@ export class SettingsExporterModalComponent implements OnDestroy {
       (this.exportersResource.error() ? 'Failed to load settings exporters' : ''),
   );
   readonly successMessage = signal('');
+  /** Option lists for the selected exporter's ``dynamic_options`` fields;
+   *  the export-side twin of the settings-importer gap fixed in #3802. */
+  readonly fieldOptions = new DynamicFieldOptions((key, values) =>
+    this.settingsIoApi.getExporterFieldOptions(this.selectedExporter!.name, key, values),
+  );
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   get modalTitle(): string {
@@ -73,6 +79,7 @@ export class SettingsExporterModalComponent implements OnDestroy {
     this.formValues = {};
     this.exportError.set('');
     this.successMessage.set('');
+    this.fieldOptions.reset();
     const fields = (exporter.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -86,6 +93,7 @@ export class SettingsExporterModalComponent implements OnDestroy {
         this.formValues[field.key] = field.options![0];
       }
     }
+    this.fieldOptions.refreshAll(fields, this.formValues);
     // If the exporter has no fields, submit immediately
     if (fields.length === 0) {
       this.view = 'form';
@@ -95,11 +103,19 @@ export class SettingsExporterModalComponent implements OnDestroy {
     }
   }
 
+  /** Re-fetch the options of every field that depends on the one just
+   *  edited, so a ``depends_on`` chain stays consistent. */
+  onFormFieldChanged(changedKey: string): void {
+    if (!this.selectedExporter?.fields) return;
+    this.fieldOptions.refreshDependentsOf(changedKey, this.selectedExporterFields, this.formValues);
+  }
+
   back(): void {
     this.view = 'picker';
     this.selectedExporter = null;
     this.exportError.set('');
     this.successMessage.set('');
+    this.fieldOptions.reset();
   }
 
   submit(): void {

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.html
@@ -59,16 +59,45 @@
                 [accept]="field.accept || ''"
                 (change)="onFileSelected($event, field.key)"
               />
+            } @else if (field.field_type === 'select' && field.allow_free_text) {
+              <input
+                [id]="'sif-' + field.key"
+                type="text"
+                class="form-input"
+                [attr.list]="'sif-' + field.key + '-list'"
+                [(ngModel)]="formValues[field.key]"
+                [disabled]="!!fieldOptions.loading()[field.key]"
+                [placeholder]="fieldOptions.loading()[field.key] ? 'Loading…' : (field.placeholder || field.description || field.label || field.key)"
+                (ngModelChange)="onFormFieldChanged(field.key)"
+              />
+              <datalist [id]="'sif-' + field.key + '-list'">
+                @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                  <option [value]="opt.value">{{ opt.label }}</option>
+                }
+              </datalist>
+              @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+              }
             } @else if (field.field_type === 'select') {
               <select
                 [id]="'sif-' + field.key"
                 class="form-select"
                 [(ngModel)]="formValues[field.key]"
+                (ngModelChange)="onFormFieldChanged(field.key)"
+                [disabled]="!!fieldOptions.loading()[field.key] || (!!field.dynamic_options && fieldOptions.optionsFor(field).length === 0)"
               >
-                @for (opt of field.options || []; track opt) {
-                  <option [value]="opt">{{ opt }}</option>
+                @if (field.dynamic_options && fieldOptions.loading()[field.key]) {
+                  <option value="">Loading…</option>
+                } @else if (field.dynamic_options && fieldOptions.optionsFor(field).length === 0 && !fieldOptions.error()[field.key]) {
+                  <option value="">No options available</option>
+                }
+                @for (opt of fieldOptions.optionsFor(field); track opt.value) {
+                  <option [value]="opt.value">{{ opt.label }}</option>
                 }
               </select>
+              @if (field.dynamic_options && fieldOptions.error()[field.key]) {
+                <p class="error-text">{{ fieldOptions.error()[field.key] }}</p>
+              }
             } @else if (field.field_type === 'number') {
               <input
                 [id]="'sif-' + field.key"

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.spec.ts
@@ -46,6 +46,17 @@ describe('SettingsImporterModalComponent', () => {
     await settleResource();
   }
 
+  /** `flushInit` with a caller-supplied importer list, then a real click on the
+   *  first picker card. Going through the bound event (rather than calling
+   *  `selectImporter()` directly) is what schedules change detection under
+   *  zoneless, so the form view actually renders for DOM assertions. */
+  async function openFirstImporter(importers: unknown[]): Promise<void> {
+    TestBed.tick();
+    httpMock.expectOne('/api/settings-importers').flush(importers);
+    await settleResource();
+    (fixture.nativeElement.querySelector('.picker-card') as HTMLButtonElement).click();
+  }
+
   it('should create and render importer cards', async () => {
     await flushInit();
     expect(component).toBeTruthy();
@@ -100,5 +111,66 @@ describe('SettingsImporterModalComponent', () => {
     const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
     expect(err).toBeTruthy();
     expect(err.textContent).toContain('bad file');
+  });
+
+  // Issue #3802: selecting an importer must pre-fetch every `dynamic_options`
+  // field, which is the round-trip that calls the plugin's
+  // `get_field_options()`. Before the fix no request was ever issued.
+  it('pre-fetches options for a dynamic_options field on importer select', async () => {
+    const dynamicImporter = {
+      name: 'dyn',
+      fields: [{ key: 'profile', field_type: 'select', dynamic_options: true, required: true }],
+    } as any;
+    await openFirstImporter([dynamicImporter]);
+
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/settings-importers/field-options/dyn'))
+      .flush({ options: [{ value: 'p1', label: 'Profile One' }] });
+    await settleZoneless(fixture);
+
+    expect(component.fieldOptions.optionsFor(dynamicImporter.fields[0])).toEqual([
+      { value: 'p1', label: 'Profile One' },
+    ]);
+    // A required strict select auto-selects the first fetched option.
+    expect(component.formValues['profile']).toBe('p1');
+
+    const options = fixture.nativeElement.querySelectorAll('select option');
+    expect([...options].map((o: any) => o.textContent.trim())).toContain('Profile One');
+  });
+
+  it('sends the current form values so depends_on chains resolve', async () => {
+    const dynamicImporter = {
+      name: 'dyn',
+      fields: [
+        { key: 'kind', field_type: 'select', options: ['audio', 'image'] },
+        { key: 'profile', field_type: 'select', dynamic_options: true, depends_on: ['kind'] },
+      ],
+    } as any;
+    await openFirstImporter([dynamicImporter]);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/settings-importers/field-options/dyn'))
+      .flush({ options: [] });
+
+    component.formValues['kind'] = 'image';
+    component.onFormFieldChanged('kind');
+    const req = httpMock.expectOne((r) => r.url.endsWith('/api/settings-importers/field-options/dyn'));
+    expect(req.request.body).toEqual({ field_key: 'profile', values: { kind: 'image', profile: '' } });
+    req.flush({ options: [] });
+  });
+
+  it('surfaces a field-options failure inline next to the field', async () => {
+    const dynamicImporter = {
+      name: 'dyn',
+      fields: [{ key: 'profile', field_type: 'select', dynamic_options: true }],
+    } as any;
+    await openFirstImporter([dynamicImporter]);
+    httpMock
+      .expectOne((req) => req.url.endsWith('/api/settings-importers/field-options/dyn'))
+      .flush({ message: 'remote listing failed' }, { status: 502, statusText: 'Bad Gateway' });
+    await settleZoneless(fixture);
+
+    const err = fixture.nativeElement.querySelector('.error-text') as HTMLElement;
+    expect(err).toBeTruthy();
+    expect(err.textContent).toContain('remote listing failed');
   });
 });

--- a/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
+++ b/frontend/src/app/components/modals/settings-importer-modal/settings-importer-modal.component.ts
@@ -9,6 +9,7 @@ import { SettingsIoApiService } from '../../../services/settings-io-api.service'
 import { ImporterField } from '../../../models/api.models';
 import type { SettingsImporterEntry } from '../../../generated/api-client/models/settings-importer-entry';
 import { apiErrorMessage } from '../../../utils/api-error';
+import { DynamicFieldOptions } from '../../../utils/dynamic-field-options';
 
 type ModalView = 'picker' | 'form';
 
@@ -53,6 +54,14 @@ export class SettingsImporterModalComponent implements OnDestroy {
       (this.importersResource.error() ? 'Failed to load settings importers' : ''),
   );
   readonly successMessage = signal('');
+  /** Option lists for the selected importer's ``dynamic_options`` fields.
+   *  Without this the select rendered only the options frozen into the
+   *  plugin definition, so a settings importer that computes its options at
+   *  runtime had an empty dropdown and its ``get_field_options()`` was never
+   *  called (issue #3802). */
+  readonly fieldOptions = new DynamicFieldOptions((key, values) =>
+    this.settingsIoApi.getImporterFieldOptions(this.selectedImporter!.name, key, values),
+  );
   private closeTimer: ReturnType<typeof setTimeout> | null = null;
 
   get modalTitle(): string {
@@ -76,6 +85,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
     this.selectedFileFieldKey = null;
     this.importError.set('');
     this.successMessage.set('');
+    this.fieldOptions.reset();
     const fields = (importer.fields ?? []) as ImporterField[];
     for (const field of fields) {
       if (field.default) {
@@ -89,7 +99,15 @@ export class SettingsImporterModalComponent implements OnDestroy {
         this.formValues[field.key] = field.options![0];
       }
     }
+    this.fieldOptions.refreshAll(fields, this.formValues);
     this.view = 'form';
+  }
+
+  /** Re-fetch the options of every field that depends on the one just
+   *  edited, so a ``depends_on`` chain stays consistent. */
+  onFormFieldChanged(changedKey: string): void {
+    if (!this.selectedImporter?.fields) return;
+    this.fieldOptions.refreshDependentsOf(changedKey, this.selectedImporterFields, this.formValues);
   }
 
   back(): void {
@@ -97,6 +115,7 @@ export class SettingsImporterModalComponent implements OnDestroy {
     this.selectedImporter = null;
     this.importError.set('');
     this.successMessage.set('');
+    this.fieldOptions.reset();
   }
 
   onFileSelected(event: Event, fieldName: string): void {

--- a/frontend/src/app/services/settings-io-api.service.ts
+++ b/frontend/src/app/services/settings-io-api.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { ApiConfiguration } from '../generated/api-client/api-configuration';
+import type { FieldOptions } from '../generated/api-client/models/field-options';
 import type { SettingsImporterEntry } from '../generated/api-client/models/settings-importer-entry';
 import type { SettingsExporterEntry } from '../generated/api-client/models/settings-exporter-entry';
 import type { RunSettingsExportRequest } from '../generated/api-client/models/run-settings-export-request';
@@ -11,6 +12,8 @@ import type { RunSettingsExportResponse } from '../generated/api-client/models/r
 import { getSettingsImporters } from '../generated/api-client/fn/settings-io/get-settings-importers';
 import { getSettingsExporters } from '../generated/api-client/fn/settings-io/get-settings-exporters';
 import { runSettingsExport } from '../generated/api-client/fn/settings-io/run-settings-export';
+import { settingsImporterFieldOptions } from '../generated/api-client/fn/settings-io/settings-importer-field-options';
+import { settingsExporterFieldOptions } from '../generated/api-client/fn/settings-io/settings-exporter-field-options';
 
 /** Response shape for the plugin-field import route. The body shape is
  *  plugin-dependent and not described in the OpenAPI spec (the spec
@@ -54,8 +57,34 @@ export class SettingsIoApiService {
     return this.http.post<SettingsImportResponse>(url, params);
   }
 
+  /** Current option list for one of *importerName*'s ``dynamic_options``
+   *  select fields, given a snapshot of the form's current values. */
+  getImporterFieldOptions(
+    importerName: string,
+    fieldKey: string,
+    values: Record<string, string>,
+  ): Observable<{ options: FieldOptions[] }> {
+    return settingsImporterFieldOptions(this.http, this.config.rootUrl, {
+      importer_name: importerName,
+      body: { field_key: fieldKey, values },
+    }).pipe(map((r) => ({ options: r.body.options ?? [] })));
+  }
+
   listExporters(): Observable<SettingsExporterEntry[]> {
     return getSettingsExporters(this.http, this.config.rootUrl).pipe(map((r) => r.body));
+  }
+
+  /** Current option list for one of *exporterName*'s ``dynamic_options``
+   *  select fields, given a snapshot of the form's current values. */
+  getExporterFieldOptions(
+    exporterName: string,
+    fieldKey: string,
+    values: Record<string, string>,
+  ): Observable<{ options: FieldOptions[] }> {
+    return settingsExporterFieldOptions(this.http, this.config.rootUrl, {
+      exporter_name: exporterName,
+      body: { field_key: fieldKey, values },
+    }).pipe(map((r) => ({ options: r.body.options ?? [] })));
   }
 
   runExport(

--- a/tests/io/test_settings_io.py
+++ b/tests/io/test_settings_io.py
@@ -7,6 +7,7 @@ Covers:
 - Built-in plugins: local_json_file, server_json_file (both import and export)
 - POST /api/settings-importers/import/<name> endpoint
 - POST /api/settings-exporters/export endpoint
+- POST /api/settings-{importers,exporters}/field-options/<name> endpoints
 """
 
 from __future__ import annotations
@@ -456,3 +457,138 @@ class TestSettingsExportEndpoint:
             json={"exporter_name": "server_json_file", "field_values": {}},
         )
         assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /api/settings-importers/field-options/<name>
+# POST /api/settings-exporters/field-options/<name>
+#
+# Issue #3802: the settings import/export modals were the only plugin-field
+# forms without an options route, so a ``dynamic_options`` select there never
+# reached ``get_field_options()`` and rendered empty.
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsImporterFieldOptionsEndpoint:
+    URL = "/api/settings-importers/field-options/server_json_file"
+
+    @staticmethod
+    def _importer():
+        from vtsearch.settings_io.importers import get_settings_importer
+
+        return get_settings_importer("server_json_file")
+
+    @classmethod
+    def _filepath_field(cls):
+        return next(f for f in cls._importer().fields if f.key == "filepath")
+
+    def test_unknown_field_400(self, client):
+        res = client.post(self.URL, json={"field_key": "nope", "values": {}})
+        assert res.status_code == 400
+
+    def test_non_dynamic_field_400(self, client):
+        res = client.post(self.URL, json={"field_key": "filepath", "values": {}})
+        assert res.status_code == 400
+        assert "not dynamic" in res.get_json()["message"]
+
+    def test_unknown_importer_404(self, client):
+        res = client.post(
+            "/api/settings-importers/field-options/nonexistent",
+            json={"field_key": "x", "values": {}},
+        )
+        assert res.status_code == 404
+
+    def test_unimplemented_dynamic_options_501(self, client, monkeypatch):
+        monkeypatch.setattr(self._filepath_field(), "dynamic_options", True)
+        res = client.post(self.URL, json={"field_key": "filepath", "values": {}})
+        assert res.status_code == 501
+
+    def test_options_normalised_to_value_label(self, client, monkeypatch):
+        imp = self._importer()
+        field_key = "filepath"
+        monkeypatch.setattr(self._filepath_field(), "dynamic_options", True)
+        monkeypatch.setattr(imp, "get_field_options", lambda key, values: ["plain", ("id1", "Label 1")])
+        res = client.post(self.URL, json={"field_key": field_key, "values": {}})
+        assert res.status_code == 200
+        assert res.get_json()["options"] == [
+            {"value": "plain", "label": "plain"},
+            {"value": "id1", "label": "Label 1"},
+        ]
+
+    def test_current_values_reach_the_plugin(self, client, monkeypatch):
+        """The ``values`` snapshot is what makes ``depends_on`` chains work."""
+        imp = self._importer()
+        field_key = "filepath"
+        seen: dict = {}
+        monkeypatch.setattr(self._filepath_field(), "dynamic_options", True)
+
+        def _capture(key, values):
+            seen["key"] = key
+            seen["values"] = values
+            return ["a"]
+
+        monkeypatch.setattr(imp, "get_field_options", _capture)
+        res = client.post(self.URL, json={"field_key": field_key, "values": {"media_type": "audio"}})
+        assert res.status_code == 200
+        assert seen == {"key": field_key, "values": {"media_type": "audio"}}
+
+    def test_plugin_error_maps_to_502(self, client, monkeypatch):
+        imp = self._importer()
+        field_key = "filepath"
+        monkeypatch.setattr(self._filepath_field(), "dynamic_options", True)
+
+        def _boom(key, values):
+            raise RuntimeError("service auth failed")
+
+        monkeypatch.setattr(imp, "get_field_options", _boom)
+        res = client.post(self.URL, json={"field_key": field_key, "values": {}})
+        assert res.status_code == 502
+        assert "service auth failed" in res.get_json()["message"]
+
+
+class TestSettingsExporterFieldOptionsEndpoint:
+    URL = "/api/settings-exporters/field-options/server_json_file"
+
+    @staticmethod
+    def _exporter():
+        from vtsearch.settings_io.exporters import get_settings_exporter
+
+        return get_settings_exporter("server_json_file")
+
+    @classmethod
+    def _filepath_field(cls):
+        return next(f for f in cls._exporter().fields if f.key == "filepath")
+
+    def test_non_dynamic_field_400(self, client):
+        res = client.post(self.URL, json={"field_key": "filepath", "values": {}})
+        assert res.status_code == 400
+        assert "not dynamic" in res.get_json()["message"]
+
+    def test_unknown_exporter_404(self, client):
+        res = client.post(
+            "/api/settings-exporters/field-options/nonexistent",
+            json={"field_key": "x", "values": {}},
+        )
+        assert res.status_code == 404
+
+    def test_options_normalised_to_value_label(self, client, monkeypatch):
+        exp = self._exporter()
+        field_key = "filepath"
+        monkeypatch.setattr(self._filepath_field(), "dynamic_options", True)
+        monkeypatch.setattr(exp, "get_field_options", lambda key, values: [("b1", "Bucket One")])
+        res = client.post(self.URL, json={"field_key": field_key, "values": {}})
+        assert res.status_code == 200
+        assert res.get_json()["options"] == [{"value": "b1", "label": "Bucket One"}]
+
+    def test_plugin_error_maps_to_502(self, client, monkeypatch):
+        exp = self._exporter()
+        field_key = "filepath"
+        monkeypatch.setattr(self._filepath_field(), "dynamic_options", True)
+
+        def _boom(key, values):
+            raise RuntimeError("bucket listing failed")
+
+        monkeypatch.setattr(exp, "get_field_options", _boom)
+        res = client.post(self.URL, json={"field_key": field_key, "values": {}})
+        assert res.status_code == 502
+        assert "bucket listing failed" in res.get_json()["message"]

--- a/vtsearch/routes/settings/io.py
+++ b/vtsearch/routes/settings/io.py
@@ -8,6 +8,10 @@ Endpoints
 GET  /api/settings-importers
     List all registered settings importers with their metadata and fields.
 
+POST /api/settings-importers/field-options/<importer_name>
+    Resolve one ``dynamic_options`` select field's option list by calling
+    the importer's ``get_field_options(field_key, current_values)``.
+
 POST /api/settings-importers/import/<importer_name>
     Run the named settings importer and apply the imported settings.
     The request body shape depends on the importer plugin and isn't
@@ -19,6 +23,10 @@ POST /api/settings-importers/import/<importer_name>
 
 GET  /api/settings-exporters
     List all registered settings exporters with their metadata and fields.
+
+POST /api/settings-exporters/field-options/<exporter_name>
+    Resolve one ``dynamic_options`` select field's option list by calling
+    the exporter's ``get_field_options(field_key, current_values)``.
 
 POST /api/settings-exporters/export
     Run the named settings exporter on the current per-user settings.
@@ -39,9 +47,14 @@ from vtsearch.errors import error_response
 from vtsearch import settings
 from vtsearch.routes._plugins import (
     get_plugin_or_404,
+    plugin_field_options,
     run_plugin_or_error,
     validate_exporter_field_values,
     validate_plugin_args,
+)
+from vtsearch.schemas.datasets import (
+    ImporterFieldOptionsRequestSchema,
+    ImporterFieldOptionsResponseSchema,
 )
 from vtsearch.schemas.settings_io import (
     RunSettingsExportRequestSchema,
@@ -74,6 +87,39 @@ def get_settings_importers():
     from vtsearch.settings import filter_visible_plugins
 
     return [imp.to_dict() for imp in filter_visible_plugins("settings_importers", list_settings_importers())]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/settings-importers/field-options/<importer_name>
+# ---------------------------------------------------------------------------
+
+
+@settings_io_bp.route("/api/settings-importers/field-options/<importer_name>", methods=["POST"])
+@settings_io_bp.arguments(ImporterFieldOptionsRequestSchema)
+@settings_io_bp.response(200, ImporterFieldOptionsResponseSchema)
+@settings_io_bp.alt_response(400, description="Unknown or non-dynamic field key.")
+@settings_io_bp.alt_response(404, description="Unknown importer name.")
+@settings_io_bp.alt_response(500, description="get_field_options did not return a list.")
+@settings_io_bp.alt_response(501, description="Importer does not implement get_field_options.")
+@settings_io_bp.alt_response(502, description="Remote service backing dynamic options raised an error.")
+def settings_importer_field_options(body: dict, importer_name: str):
+    """Return dropdown options for a dynamic-options field on a settings importer.
+
+    Same contract as the other plugin families' options routes (see
+    ``POST /api/label-importers/field-options/<name>``): the importer's
+    ``get_field_options(field_key, current_values)`` is called with the
+    supplied snapshot of current form values, and plugin errors (network
+    failure, auth error, ...) surface as a 502 with the original message
+    so the Import Settings modal can display them inline.
+    """
+    importer, err = get_plugin_or_404(
+        get_settings_importer, list_settings_importers, importer_name, "settings importer"
+    )
+    if err:
+        return err
+    assert importer is not None  # narrowed by err check
+
+    return plugin_field_options(importer, body)
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +183,35 @@ def get_settings_exporters():
     from vtsearch.settings import filter_visible_plugins
 
     return [exp.to_dict() for exp in filter_visible_plugins("settings_exporters", list_settings_exporters())]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/settings-exporters/field-options/<exporter_name>
+# ---------------------------------------------------------------------------
+
+
+@settings_io_bp.route("/api/settings-exporters/field-options/<exporter_name>", methods=["POST"])
+@settings_io_bp.arguments(ImporterFieldOptionsRequestSchema)
+@settings_io_bp.response(200, ImporterFieldOptionsResponseSchema)
+@settings_io_bp.alt_response(400, description="Unknown or non-dynamic field key.")
+@settings_io_bp.alt_response(404, description="Unknown exporter name.")
+@settings_io_bp.alt_response(500, description="get_field_options did not return a list.")
+@settings_io_bp.alt_response(501, description="Exporter does not implement get_field_options.")
+@settings_io_bp.alt_response(502, description="Remote service backing dynamic options raised an error.")
+def settings_exporter_field_options(body: dict, exporter_name: str):
+    """Return dropdown options for a dynamic-options field on a settings exporter.
+
+    Mirror of the settings-importer route above, for the Export Settings
+    modal's field form.
+    """
+    exporter, err = get_plugin_or_404(
+        get_settings_exporter, list_settings_exporters, exporter_name, "settings exporter"
+    )
+    if err:
+        return err
+    assert exporter is not None  # narrowed by err check
+
+    return plugin_field_options(exporter, body)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3802

## The bug

A `SettingsImporter` could declare a `"select"` field with `dynamic_options=True`, but `get_field_options()` was never called for it — the dropdown rendered empty with no way to populate it.

The cause is a missing route. Every other plugin family that renders a field form has an options endpoint (`POST /api/dataset/import/<name>/options`, `/api/label-importers/field-options/<name>`, `/api/datasource-import/<name>/options`, `/api/seed-import/<name>/options`, `/api/exporters/field-options/<name>`) — settings importers and settings exporters had none, and their two modals never attempted the fetch. `docs/EXTENDING-plugins.md` already claimed "every plugin family that renders a field form has an options route of the same shape", so the docs were describing a contract these two surfaces didn't honour.

Same class of gap as #3360, which fixed it for the Settings › Auto-Find exporter tab.

## The fix

**Backend** — two new routes in `vtsearch/routes/settings/io.py`:

```
POST /api/settings-importers/field-options/<importer_name>
POST /api/settings-exporters/field-options/<exporter_name>
```

Both delegate to the shared `plugin_field_options` helper, so the contract is identical to every other family with nothing re-derived: `{"field_key", "values"}` in, `{"options": [{"value", "label"}]}` out, plain-string and `(value, label)` options coerced alike, and 400 (unknown / non-dynamic field) / 404 (unknown plugin) / 501 (hook not implemented) / 502 (plugin raised — message surfaced verbatim for inline display).

**Frontend** — both modals now use the shared `DynamicFieldOptions` helper, which gives them the same behaviour the other forms already had: pre-fetch on plugin select, `depends_on` re-fetch with the dependent value cleared first, `Loading…` / `No options available` / inline error states, free-text combobox rendering when `allow_free_text` is set, and the stale-response token guard.

**Scope note:** the issue names the importer only. The exporter modal is the identical gap in the same pair of surfaces sharing one service, so fixing one and leaving the other would just produce the twin issue a week later; it is included deliberately.

## Also updated

- `docs/api/io.md` — both routes documented alongside the existing ones.
- `docs/EXTENDING-plugins.md` — added to the "every family has an options route" list, plus a **Dynamic select options** subsection in each of the settings-importer and settings-exporter guides.
- `frontend/openapi.json` — regenerated (the new routes are in the spec, so the generated TS client exposes them).

## Tests

- `tests/io/test_settings_io.py`: two new classes covering both routes — 400 unknown / 400 non-dynamic / 404 unknown plugin / 501 unimplemented / 502 plugin error, `(value, label)` normalisation, and that the `values` snapshot actually reaches the plugin (what makes `depends_on` work).
- Both modal specs: pre-fetch on select, the `depends_on` re-fetch body, and inline rendering of a 502. These open the form by **clicking the picker card** rather than calling `selectImporter()` directly — `view` is a plain property, so only the bound event schedules change detection under zoneless, and calling the method directly leaves the form unrendered.

`./run-tests.sh`: 11111 passed, 6 skipped; pyright, pip-audit, vulture whitelist, frontend build and the 2387-test Vitest suite all green.

**One pre-existing failure not fixed here:** the `npm audit` lane, on the 7 moderate Angular advisories against the pinned 21.2.19. It is red on `dev` for every branch and is already tracked as #3795, which records that the bump cannot be resolved in a Claude Code on the web container — `npm audit fix` is confirmed a no-op here again. It touches no file in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBCVMBwLjGZAi4wiXpAvhD

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBCVMBwLjGZAi4wiXpAvhD)_