### PR TITLE
bird: bring the guide's one-liner up to the dead-bird ruling

### DIFF
--- a/scripts/experiments/pile/ANNOTATION-GUIDE.md
+++ b/scripts/experiments/pile/ANNOTATION-GUIDE.md
@@ -98,9 +98,12 @@ The full wording is in `SCALE_CLASS_RULES`; these are the discriminations.
 - **Clock** — a device whose job is showing the time and which stands, hangs or
   is mounted. **Not a wristwatch**, not a departure board, not a clock drawn on
   a screen.
-- **Bird** — any live bird of any species. **Not a cooked one**: in VG,
-  `chicken` (428 images, 10%) and `turkey` (53, 12%) are usually food, and
-  `crane` (308, 2%) is a machine.
+- **Bird** — any **whole** bird of any species, **alive or dead**: prey in
+  another bird's beak, one lying dead, and a taxidermy mount, which is the
+  animal itself rather than a figurine of one (#3789). **Death is not the test,
+  food is** — a bird **prepared as food**, cooked or plucked or butchered, is
+  not one, because in VG `chicken` (428 images, 10%) and `turkey` (53, 12%) are
+  usually food. `crane` (308, 2%) is a machine.
 - **Boat** — anything built to travel on water. On a trailer still counts. Not a
   surfboard, which is COCO's own class.
 - **Umbrella** — one central pole carrying a round canopy: hand-held, parasol,


### PR DESCRIPTION
#3789 ruled that a whole dead bird is a Bird — prey in another bird's beak, one lying dead, a taxidermy mount — and that the exclusion is **food rather than death**. #3791 applied that to `SCALE_CLASS_RULES["bird"]`, which is the wording the slate maker reads and the reviewer sees as the detector name.

It left the second copy behind. `scripts/experiments/pile/ANNOTATION-GUIDE.md` — the reviewer's document for the twelve shipped `vg_scale` classes — still said:

> **Bird** — any live bird of any species. **Not a cooked one**

which is the exact wording the ruling overturned, in the file a reviewer reads before voting the pass. So #3789's own closing condition ("a ruling plus a wording change to the `bird` entry") was only half applied.

The guide's header already says which way this drift gets fixed: *"If the two ever disagree, `pile_config` is the one the slate maker reads — fix this file."* So the one-liner now carries the ruling, including the two cases the ruling decided and the old wording got wrong (prey, taxidermy) and the `prepared as food` clause that replaced `cooked`. The `chicken` (428 images, 10%) / `turkey` (53, 12%) / `crane` (308, 2%) measurements the food exclusion actually rests on are unchanged — they were never about death.

Still free to apply, for the same reason #3791 was: the bird pass has not started (0 of 645), so no verdict was cast under either wording.

Nothing else carries a copy — `grep -i "cooked\|taxiderm\|prey"` over the tree finds only `pile_config.py` and this one bullet, and the #3588 candidates' guide has no bird rule.

`./run-tests.sh` passes. The change is markdown-only, so the bare run narrowed itself to the `docs` gate (every cheap gate, plus the tests that read a repo doc): `RUN PASSED (markdown-only; this is the full gate for a markdown-only change)`, 1126 passed / 5 skipped.

Closes #3789

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H9zRHYGyH3zppbWN1Vq2J

---
_Generated by [Claude Code](https://claude.ai/code/session_014H9zRHYGyH3zppbWN1Vq2J)_