### PR TITLE
Clear the npm audit gate: Angular 21.2.23/24 lockfile refresh (#3795)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,22 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-json
+        # These files are JSONC, not JSON.  Angular, TypeScript, pyright and
+        # VS Code all document comment support in their own config files, and
+        # this repo depends on it: the bundle-budget rationale lives in an
+        # angular.json comment precisely because the Angular schema rejects
+        # extra keys (08c17ca7).  The hook parses with a strict json.load, so
+        # it rejects all eight of them.  That stayed invisible because
+        # pre-commit only passes STAGED files -- editing one of these is rare,
+        # and when it happens the hook blocks the commit outright with
+        # "Failed to json decode" (#3795).  The hook is kept for real .json.
+        exclude: |
+          (?x)^(
+            frontend/\.vscode/.*\.json|
+            frontend/angular\.json|
+            frontend/tsconfig(\.\w+)?\.json|
+            pyrightconfig\.json
+          )$
       - id: check-merge-conflict
       - id: check-added-large-files
         # 4 MB, not the default 500 KB.  This hook exists to keep datasets and

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -51,7 +51,7 @@
           "configurations": {
             "production": {
               "budgets": [
-                // initial: 520kB. The app is zoneless (zone.js dropped from the
+                // initial: 525kB. The app is zoneless (zone.js dropped from the
                 // production polyfills), which took the measured eager bundle to
                 // ~488kB. The eager path is framework-dominated (Angular
                 // core+router+forms+http+CDK), not app bloat: routes are lazy,
@@ -67,9 +67,23 @@
                 // limit sits just above the real size with a small headroom.
                 // Do not raise without first auditing the eager path for genuine
                 // bloat.
+                //
+                // Raised 520kB -> 525kB on 2026-09-12 (#3795) to take the
+                // Angular 21.2.19 -> 21.2.23 security patch (GHSA-p297-fm68-3q8c
+                // HttpTransferCache bypass, GHSA-hh8m-fm6v-7cvg sanitization
+                // bypass) that the npm audit gate needs. Audited as instructed
+                // above: that change is a package-lock.json refresh and touches
+                // no app file, so the growth is framework-only, not app bloat.
+                // Measured on one machine, same build, only the lockfile
+                // swapped: 519.04kB at 21.2.19 -> 522.21kB at 21.2.23, +3.17kB.
+                // The old 520kB left 0.96kB of headroom and the patch alone
+                // consumed it; 525kB restores a comparable margin (2.79kB) so
+                // the next patch release does not re-red the gate by itself.
+                // The audit instruction above still governs any raise driven by
+                // APP code, which this one was not.
                 {
                   "type": "initial",
-                  "maximumWarning": "520kB",
+                  "maximumWarning": "525kB",
                   "maximumError": "1MB"
                 },
                 {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -253,13 +253,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2102.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.19.tgz",
-      "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
+      "version": "0.2102.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.24.tgz",
+      "integrity": "sha512-U/d5l/1rfrNSlbGjMTunyzwxh+2vJce3y0r0tIx/NOFZbnYhq+gx+e33mR6oxI4yk/1Jks67ltvstrJuBbVbYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.19",
+        "@angular-devkit/core": "21.2.24",
         "rxjs": "7.8.2"
       },
       "bin": {
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.19.tgz",
-      "integrity": "sha512-dtpJMQBz5nhkcIogPmXP/aT2Ak8m/wLRPOSTI/g4vSJSuGiI53PgtWq4/wfQga6E6wdM2XWsblAE89d8w5heQQ==",
+      "version": "21.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.24.tgz",
+      "integrity": "sha512-QLYLd6OcfQS5qWTlzG1/d8lFTcJDFcsY6sOaGVtrruYiDxrbeM2iJttoIoKzvbNPROFyo3fANVQJOVhytpXWPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -300,13 +300,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.19.tgz",
-      "integrity": "sha512-AG3Fzh9wJCmKBfxUQOUWaEHMj5Gq2O+Msf1z52aDSxbVhs5/iSQcXGPv/DLdAXu7d4xmQhLouNe9Glaq2omDyw==",
+      "version": "21.2.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.24.tgz",
+      "integrity": "sha512-mLOme2vfbLrHFmMyM6ybPuGCnCvPiemXWdHnptY2Q7Hzum72DabfgtTNsrMcI2F5zrQV2DDQunNjC5cXqtq4/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.19",
+        "@angular-devkit/core": "21.2.24",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
         "ora": "9.3.0",
@@ -319,14 +319,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.19.tgz",
-      "integrity": "sha512-emy9mqrTXAwhZzcvx8MaHyz+cUR06PVGxnqy91+bpDxPP9S5x67sPoOkY9y/ETFFhRpB5ULlUxyq0eN/pi6QOg==",
+      "version": "21.2.24",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-21.2.24.tgz",
+      "integrity": "sha512-NurM2W7Q/lCGonkYgSNNxGrh9AYH3LksekYRVxl0KxVKa8Z5x6oMYlLfyI4Lv9Q4C1/x1SXv3xNxgYu/nIW4vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2102.19",
+        "@angular-devkit/architect": "0.2102.24",
         "@babel/core": "7.29.7",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -349,7 +349,7 @@
         "semver": "7.7.4",
         "source-map-support": "0.5.21",
         "tinyglobby": "0.2.15",
-        "undici": "7.28.0",
+        "undici": "7.29.1",
         "vite": "7.3.6",
         "watchpack": "2.5.1"
       },
@@ -369,7 +369,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-server": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
-        "@angular/ssr": "^21.2.19",
+        "@angular/ssr": "^21.2.24",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^21.0.0",
@@ -435,19 +435,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.19.tgz",
-      "integrity": "sha512-i78NzvoNonAY17QgzSmqrYnXHmEfraLv4wZ/o/m3efxuz61ZJ+5X/PsCeAhbwBvQfRrPRQaJV2tK9vGjHa+U6w==",
+      "version": "21.2.24",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.24.tgz",
+      "integrity": "sha512-lx8baI3gssBv+xuwEf5wvAoBi7XSIB1RRuAmSnuAO2E4CAlJmU4eiVhKxd/haXvONH6peYxFGH2N6mSrkkHfIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2102.19",
-        "@angular-devkit/core": "21.2.19",
-        "@angular-devkit/schematics": "21.2.19",
+        "@angular-devkit/architect": "0.2102.24",
+        "@angular-devkit/core": "21.2.24",
+        "@angular-devkit/schematics": "21.2.24",
         "@inquirer/prompts": "7.10.1",
         "@listr2/prompt-adapter-inquirer": "3.0.5",
-        "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "21.2.19",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "@schematics/angular": "21.2.24",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.48.1",
         "ini": "6.0.0",
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.19.tgz",
-      "integrity": "sha512-Rvo/VXI0kUmfQT7+OeAjv526OJlf/WrLnJq1Tz84Jkyv9bs9SOMTCT6m4+boo8gxVNdrcxvGU3Q0o2jZzKceSg==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.23.tgz",
+      "integrity": "sha512-IVhHD4w/+v/S7YAIyF3v20u3zpOj7Y8EuL9xxPyfyxlfz5zPpJFJ/GaZb0Y5sMANCFLVwQj3VcQNWgYtd7W2yA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -481,14 +481,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.19",
+        "@angular/core": "21.2.23",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.19.tgz",
-      "integrity": "sha512-vuF5i1t14ftJiHXVVLgDYLWkT99QuajphcUHy1VZaMX3FiqSGXRV62g+R2RMxL0OJ5C1ai8xTHKPx9n1lQFyFg==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.23.tgz",
+      "integrity": "sha512-7HUdsXQKGPqKiRhwsbMGVqtMEVGT4qf5NKpLDmY4kLMeJhjRKchY/4cljEqUERvvXUid6GTWK+/tSJdIcFNnEw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.19.tgz",
-      "integrity": "sha512-QxWqUvhTWgyYPPkfpupOUIEa3Y5cbzMilaFgRNpkvFy6teARw5Izsd7RxUbj3Tp3xJOi1MtumNmkxLxmv3iv7A==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.23.tgz",
+      "integrity": "sha512-/dtKObY5fvBuNMxLFe9jtnsMwaDV2zm+5sKP2EIWtDO0N18WlZSOFCTL6Tkz3LHE/4y+TjW46POu/rz0q/Cw6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -521,7 +521,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.19",
+        "@angular/compiler": "21.2.23",
         "typescript": ">=5.9 <6.1"
       },
       "peerDependenciesMeta": {
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.19.tgz",
-      "integrity": "sha512-PVoXD1kBexOJLkFzKx2zBY/0oZJXGru0eGn2hu0q5n3vkZlYsR1yRolfGenK1gZE48Qibiw/ttg/X/pAIPEZGg==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.23.tgz",
+      "integrity": "sha512-O8i8ntukAhg3nM9y9A/o1eXVFnFk5/VltA2gQrDuWTpIPLyWmyZW+Zb65UBJI14tGOTt99Y3l3teIuF36mLBgQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -542,7 +542,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.19",
+        "@angular/compiler": "21.2.23",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.19.tgz",
-      "integrity": "sha512-tEw8cz2UU6VSB+ReJN86k87nRdLRXGi+8SZhoRl2dFu2iReIO3S6kJAVTH7Y9kdrokqTPhWG+KNEzWgqhdjXOg==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.23.tgz",
+      "integrity": "sha512-l0PyfoCO6MflgQwL4spawbiTqzSrlOWUn1BUcbGuBU33lbgTBrR9dogfT8sQ54ZO/6gcWkToxi0WbvugSfzQtQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -568,16 +568,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.19",
-        "@angular/core": "21.2.19",
-        "@angular/platform-browser": "21.2.19",
+        "@angular/common": "21.2.23",
+        "@angular/core": "21.2.23",
+        "@angular/platform-browser": "21.2.23",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.19.tgz",
-      "integrity": "sha512-YMguYVhdkV8tr9MvbN+VpMjbdmsYq6g12M9WPvAYM51BkL2iREbWeoXDGmfCw9G0it6+0pMdgrSPFFUFuOqpAQ==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.23.tgz",
+      "integrity": "sha512-3/yTsYroz6xjH1sqxJwOcBdLEGU4QLouu5z1ja/JN7jrPUfRHj2YBfVS+ayWLEnMt9CfuyjZxoVPXHtWuZ3Gog==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -586,9 +586,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "21.2.19",
-        "@angular/common": "21.2.19",
-        "@angular/core": "21.2.19"
+        "@angular/animations": "21.2.23",
+        "@angular/common": "21.2.23",
+        "@angular/core": "21.2.23"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.19.tgz",
-      "integrity": "sha512-cKO/aq1xEMvgS29jFUc/Y3KsgEzHnwOw6sEL+UQZkZTmGD5YrYv8Yvj05GDMEUYbvDxBd5DixVVEbH38lyQKqA==",
+      "version": "21.2.23",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.23.tgz",
+      "integrity": "sha512-cNwTd1XvCXsFZqvn4WFPv7VUci7PJzlK9Ex/git3oEyS9318sJjX7sw2IeTpvwIg01BZtF1xBvWgMTHgcXvzIA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -608,9 +608,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.19",
-        "@angular/core": "21.2.19",
-        "@angular/platform-browser": "21.2.19",
+        "@angular/common": "21.2.23",
+        "@angular/core": "21.2.23",
+        "@angular/platform-browser": "21.2.23",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2141,13 +2141,13 @@
       ]
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -3720,14 +3720,14 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "21.2.19",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.19.tgz",
-      "integrity": "sha512-eL+UU9eizoadhDB4YEctRmmo0A5iwrSmGzeuEa6akrq8nLGVWM8zO91HTJutkPqGQjelF+UOiOShsQSZAU9SIQ==",
+      "version": "21.2.24",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.24.tgz",
+      "integrity": "sha512-eGBr4Yhg/A8Lt8QGtWxmXAyKboX8QBwbDG1hSyApQfHAh9iNFbV7mgWSmk0qPWvRJM38s0t3EEkEg79QZ98dWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.19",
-        "@angular-devkit/schematics": "21.2.19",
+        "@angular-devkit/core": "21.2.24",
+        "@angular-devkit/schematics": "21.2.24",
         "jsonc-parser": "3.3.1"
       },
       "engines": {


### PR DESCRIPTION
Fixes #3795.

`./run-tests.sh` failed its `npm audit` lane on `dev` for **every** branch. Two moderate advisories land against the pinned 21.2.19 tree:

- **GHSA-p297-fm68-3q8c** — information leak via `HttpTransferCache` bypass when using `withRequestsMadeViaParent`
- **GHSA-hh8m-fm6v-7cvg** — sanitization bypass via directive host bindings

They fan out to the 7 reported findings across `common`/`forms`/`platform-browser`/`router` and `compiler`/`compiler-cli`/`core`.

`frontend/package.json` already allows the fix (`^21.2.17`, `^21.2.16`), so the bump itself is **a lockfile refresh only — no range changed**.

Three commits, because clearing the audit gate uncovered two things sitting behind it.

---

## 1. The lockfile refresh

### Why the obvious commands did not work

The issue could not get past this in the web container and read it as environment-specific. It is not — it is a property of the dependency graph:

**The Angular framework packages peer-depend on each other at an EXACT version**, not a range — `@angular/common@21.2.19` requires `@angular/core@21.2.19`. They form a clique that can only move as one atomic set.

| attempt | result |
|---|---|
| `npm update --package-lock-only @angular/...` (all ten) | moved `@angular/cli` alone; framework stayed at 21.2.19 |
| `npm install --package-lock-only @angular/...@21.2.23` (all nine at once) | `ERESOLVE` — npm anchors the peer graph on the versions **already recorded in the lockfile**, so it still saw `forms@21.2.19` demanding `common@21.2.19` |

The issue diagnosed that second failure as the peer graph being read off the *installed* copies in `node_modules`. It reproduces with **no `node_modules` present at all** — the lockfile alone is enough to pin it, which is why the same command also failed here on an ordinary npm environment.

**What works:** drop the ten `node_modules/@angular/*` entries from the lockfile and let `npm install --package-lock-only` refill them. With no stale entries to anchor on, the whole set resolves in one step.

### Scope of the diff

Deliberately surgical. The only non-`@angular` movement is Angular's own toolchain — `@angular-devkit/*` and `@schematics/angular` 21.2.19 → 21.2.24 — plus `@modelcontextprotocol/sdk`, which `@angular/cli` pulls in.

The alternative (delete the lockfile, regenerate) reaches the *same* Angular versions but rewrites far more. Both were built and compared:

| | Angular result | diff lines | non-Angular bumps |
|---|---|---|---|
| full regeneration | identical | 1229 | 123 |
| **surgical (this PR)** | identical | **134** | **5** |

Final: framework `21.2.23`, `@angular/build` / `@angular/cli` `21.2.24`, `@angular/cdk` unchanged at `21.2.14` (already its 21.2.x tip).

---

## 2. The bundle budget: 520kB → 525kB

With the audit gate green, the **frontend build gate went red in its place** — the patch costs 3.17kB of framework code and `dev` had under 1kB of headroom.

Measured on one cpu node, same build, only `package-lock.json` swapped between runs:

| lockfile | initial bundle | vs 520kB budget |
|---|---|---|
| `dev` (Angular 21.2.19) | **519.04 kB** | 0.96 kB under |
| this branch (21.2.23) | **522.21 kB** | **2.21 kB over** |

`angular.json` says not to raise the budget without first auditing the eager path for genuine bloat, and `CLAUDE.md` / `docs/FRONTEND.md` require **the user's explicit approval**.

- **The audit is the diff**: commit 1 changes `package-lock.json` and nothing else, so no app code entered the eager path — the whole +3.17kB is framework.
- **Approval**: given 2026-09-12 on the two measurements above.
- **525kB, not the minimum 523kB**: `dev`'s headroom was already 0.96kB and this single patch consumed it. 2.79kB restores a comparable margin so the next Angular patch does not re-red the gate on its own. It is also the value the budget held before (540 → 525 → 520).

The standing "audit before raising" instruction is kept in `angular.json`, now scoped to raises driven by app code, with this measurement recorded next to the number.

---

## 3. `check-json` vs the repo's eight JSONC files

Committing commit 2 was **impossible with hooks enabled**:

```
frontend/angular.json: Failed to json decode (Expecting value: line 54 column 17)
```

Not new, and not specific to `angular.json`. Eight tracked files fail a strict parse today, all legitimately JSONC:

```
frontend/.vscode/{extensions,launch,tasks}.json
frontend/angular.json
frontend/tsconfig{,.app,.spec}.json
pyrightconfig.json
```

Angular, TypeScript, pyright and VS Code all document comment support in their config files, and this repo actively **depends** on it — 08c17ca7 moved the bundle-budget rationale *into* a JSONC comment precisely because the Angular schema rejects extra keys. The files are right; the hook is wrong.

It stayed invisible because pre-commit only passes **staged** files: the hook is a no-op until somebody edits one of the eight, and then it blocks them outright. (Which suggests prior edits to these files went in under `--no-verify`.) The exclude keeps `check-json` doing its real job on actual `.json` files.

---

## Verification

GRID, `rack2n10`, against the pushed head — the lockfile A/B was job 642479, the gates job 642481:

- `npm ci` from the new lockfile — clean install, **`found 0 vulnerabilities`**
- `npm ls --depth=0` confirms the *installed* tree is really 21.2.23/21.2.24, not just the lockfile text
- `./run-tests.sh frontend` — **`Frontend build OK`**, **`npm audit: OK`**, Vitest
- `./run-tests.sh` — the full suite, so this is confirmed green everywhere and not only on the frontend lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH8JkPckirmtQM4S91sVnq
