### PR TITLE
Eager-path audit: drop FormsModule, 522.21kB -> 483.71kB (#3811)

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -726,6 +726,21 @@ written into `angular.json` next to the number. `./run-tests.sh` treats **any**
 `anyComponentStyle` budget. Fix the bloat — split the component, extract shared
 styles, delete dead rules. Raising a budget needs the user's explicit approval.
 
+What actually sits in the eager bundle is mostly **framework**: 317 kB of
+Angular against 121 kB of app code when it was last audited (#3811). That is
+why the budget carries visible headroom — Angular's own patch releases move the
+number a few kB at a time, and when the margin was under 1 kB a routine
+security bump turned the build gate red for every branch (#3795). Treat the
+headroom as reserved for the framework, not as room for app code.
+
+The corollary is that the budget cannot catch an app-code regression on its own
+any more, so one specific trap is covered by a test:
+**do not import `FormsModule` into anything on the eager path.** `vt-login` and
+`vt-dialog-host` each render a single uncontrolled text field and used to pull
+all ~37 kB of `@angular/forms` for it; both now use plain `[value]` + `(input)`.
+`TestEagerBundleComposition` in `tests/core/test_frontend.py` walks the built
+bundle's *static* imports from `main.js` and fails if the package reappears.
+
 ### Other primitives
 
 `components/icon/` maps names (and backend-supplied emoji) to sanitised inline

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -51,36 +51,36 @@
           "configurations": {
             "production": {
               "budgets": [
-                // initial: 525kB. The app is zoneless (zone.js dropped from the
-                // production polyfills), which took the measured eager bundle to
-                // ~488kB. The eager path is framework-dominated (Angular
-                // core+router+forms+http+CDK), not app bloat: routes are lazy,
-                // the heavy modals are @defer'd, and `marked` lives only in a
-                // deferred chunk. The shared `vt-modal` adds CDK a11y's focus
-                // trap (`CdkTrapFocus`) for keyboard/screen-reader focus
-                // management across all ~24 dialogs; because the modal is eager,
-                // that ~7kB lands in the initial bundle, taking it to ~507kB.
-                // Measured 515.63kB as of the eager-path audit that split
-                // `DashboardSortService` out of `DashboardColumnsService` (the
-                // eager context pulldowns were dragging `ManagedColumns` and the
-                // Dashboard column metadata onto first paint, ~6.5kB). The warn
-                // limit sits just above the real size with a small headroom.
-                // Do not raise without first auditing the eager path for genuine
-                // bloat.
+                // initial: 525kB. The app is zoneless (zone.js dropped from
+                // the production polyfills). The eager path is
+                // framework-dominated, not app bloat: routes are lazy, the
+                // heavy modals are @defer'd, and `marked` lives only in a
+                // deferred chunk. Measured 2026-09-12 (#3811) the eager split
+                // is 317.54kB framework to 121.47kB app code.
                 //
-                // Raised 520kB -> 525kB on 2026-09-12 (#3795) to take the
-                // Angular 21.2.19 -> 21.2.23 security patch (GHSA-p297-fm68-3q8c
-                // HttpTransferCache bypass, GHSA-hh8m-fm6v-7cvg sanitization
-                // bypass) that the npm audit gate needs. Audited as instructed
-                // above: that change is a package-lock.json refresh and touches
-                // no app file, so the growth is framework-only, not app bloat.
-                // Measured on one machine, same build, only the lockfile
-                // swapped: 519.04kB at 21.2.19 -> 522.21kB at 21.2.23, +3.17kB.
-                // The old 520kB left 0.96kB of headroom and the patch alone
-                // consumed it; 525kB restores a comparable margin (2.79kB) so
-                // the next patch release does not re-red the gate by itself.
-                // The audit instruction above still governs any raise driven by
-                // APP code, which this one was not.
+                // Measured initial total: 483.71kB (#3811). The ~41kB of
+                // headroom is deliberate and is NOT spare capacity for app
+                // code. Angular's own patch releases move this number ~3kB at
+                // a time, and when the margin was last under 1kB a routine
+                // security bump (21.2.19 -> 21.2.23, #3795) turned the build
+                // gate red for every branch, for reasons nothing to do with
+                // the change under test.
+                //
+                // #3811 reclaimed 38.50kB by dropping FormsModule from the
+                // only two components on the eager path that pulled it
+                // (`vt-login`, `vt-dialog-host`) -- one uncontrolled text
+                // field each, now plain `[value]` + `(input)`. A test guards
+                // that, because the budget no longer can: see
+                // TestEagerBundleComposition in tests/core/test_frontend.py.
+                //
+                // Still eager on purpose: @angular/cdk a11y (~9kB), reached
+                // via `vt-modal` inside the always-rendered `vt-dialog-host`.
+                // Dropping it would cost the focus trap on all ~24 dialogs,
+                // and deferring the dialog host would put a chunk fetch in
+                // front of every confirm()/prompt().
+                //
+                // Do not raise without first auditing the eager path for
+                // genuine bloat.
                 {
                   "type": "initial",
                   "maximumWarning": "525kB",

--- a/frontend/src/app/components/dialog-host/dialog-host.component.html
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.html
@@ -3,8 +3,8 @@
   @if (dialog.dialogShowInput()) {
     <input
       class="form-input"
-      [ngModel]="dialog.dialogInputValue()"
-      (ngModelChange)="dialog.dialogInputValue.set($event)"
+      [value]="dialog.dialogInputValue()"
+      (input)="dialog.dialogInputValue.set($any($event.target).value)"
       (keydown.enter)="onButtonClick('__input__')"
       [attr.aria-label]="dialog.dialogTitle()"
       autofocus

--- a/frontend/src/app/components/dialog-host/dialog-host.component.ts
+++ b/frontend/src/app/components/dialog-host/dialog-host.component.ts
@@ -1,15 +1,19 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
-import { FormsModule } from '@angular/forms';
 import { ModalComponent } from '../modal/modal.component';
 import { IconComponent } from '../icon/icon.component';
 import { VtDialogService } from '../../services/dialog.service';
 
+// Deliberately does NOT import FormsModule.  This host is rendered
+// unconditionally by AppComponent, so it sits on the EAGER path: importing it
+// here pulled all of @angular/forms (~37kB) into the initial bundle for the
+// single prompt() text field.  `[value]` + `(input)` is equivalent here; see
+// the bundle-budget note in angular.json and #3811.
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-dialog-host',
   standalone: true,
-  imports: [FormsModule, ModalComponent, IconComponent],
+  imports: [ModalComponent, IconComponent],
   templateUrl: './dialog-host.component.html',
   styleUrl: './dialog-host.component.scss',
 })

--- a/frontend/src/app/components/login/login.component.html
+++ b/frontend/src/app/components/login/login.component.html
@@ -3,13 +3,14 @@
     <img src="logo.png" alt="VTSearch logo" class="login-logo">
     <h1>VTSearch</h1>
     <p class="login-subtitle">Enter your name to get started</p>
-    <form (ngSubmit)="submit()" class="login-form">
+    <form (submit)="$event.preventDefault(); submit()" class="login-form">
       <label for="login-username" class="sr-only">Username</label>
       <input
         id="login-username"
         class="form-input"
         type="text"
-        [(ngModel)]="username"
+        [value]="username"
+        (input)="username = $any($event.target).value"
         name="username"
         placeholder="Username"
         title="Enter your username to log in"

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -1,14 +1,18 @@
 import { ChangeDetectionStrategy, Component, inject, output, signal } from '@angular/core';
 
-import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
 import { apiErrorMessage } from '../../utils/api-error';
 
+// Deliberately does NOT import FormsModule.  This component and
+// `vt-dialog-host` are the only two on the EAGER path, so importing it here
+// pulls all of @angular/forms (~37kB) into the initial bundle for one text
+// field.  The plain `[value]` + `(input)` pair below is equivalent for a
+// single uncontrolled input; use it rather than `ngModel` if you add a field.
+// See the bundle-budget note in angular.json and #3811.
 @Component({
   changeDetection: ChangeDetectionStrategy.OnPush,
   selector: 'vt-login',
   standalone: true,
-  imports: [FormsModule],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })

--- a/tests/core/test_frontend.py
+++ b/tests/core/test_frontend.py
@@ -10,6 +10,9 @@ Covers:
 
 from __future__ import annotations
 
+import pathlib
+import re
+
 import pytest
 
 # Tests below hit the Angular SPA shell or its bundle artefacts
@@ -212,6 +215,67 @@ class TestFrontendContentIntegrity:
         text = resp.data.decode("utf-8")
         # Angular global styles contain layout and panel classes
         assert "panel" in text or "grid" in text or "--bg-body" in text
+
+
+class TestEagerBundleComposition:
+    """Guards on what is allowed into the INITIAL (eager) bundle.
+
+    The eager path is framework-dominated and deliberately carries headroom
+    for Angular's own patch releases; the rationale lives next to
+    `maximumWarning` in frontend/angular.json.  The budget alone cannot police
+    this: #3811 reclaimed ~38kB, so a re-added FormsModule would still fit
+    under the number while silently spending the margin that exists so a
+    framework bump does not turn the gate red for everyone (#3795).
+    """
+
+    @staticmethod
+    def _eager_bundle_text() -> str:
+        """`main.js` plus every chunk it imports STATICALLY, concatenated.
+
+        `from"./chunk-X.js"` is a static import and keeps that chunk on the
+        eager path.  `import("./chunk-Y.js")` is the `@defer` / lazy-route
+        boundary and is deliberately NOT followed: following it would walk the
+        whole app and make every assertion here vacuous.
+        """
+        static_dir = pathlib.Path("static")
+        static_import = re.compile(r'from"\./(chunk-[A-Z0-9]+\.js)"')
+        seen: set[str] = set()
+        queue = ["main.js"]
+        parts: list[str] = []
+        while queue:
+            name = queue.pop()
+            if name in seen:
+                continue
+            path = static_dir / name
+            if not path.exists():
+                continue
+            seen.add(name)
+            text = path.read_text(encoding="utf-8")
+            parts.append(text)
+            queue.extend(static_import.findall(text))
+        return "".join(parts)
+
+    def test_eager_bundle_resolves(self):
+        """Fail loudly if the walk above stops matching the build output."""
+        text = self._eager_bundle_text()
+        assert len(text) > 100_000, (
+            "Could not resolve the eager bundle from static/main.js. The build "
+            "output's import syntax probably changed, which would make the "
+            "FormsModule guard below silently vacuous -- fix the regex."
+        )
+
+    def test_forms_module_is_not_eager(self):
+        # `ngNoForm` comes from NgForm's selector (`form:not([ngNoForm])`) and
+        # appears nowhere outside @angular/forms, so it is a precise marker for
+        # the package landing in the initial bundle.
+        assert "ngNoForm" not in self._eager_bundle_text(), (
+            "@angular/forms (~37kB) is back in the EAGER bundle.\n"
+            "Something on the eager path imports FormsModule -- most likely a new\n"
+            "`ngModel` in vt-login or vt-dialog-host, the two eager components that\n"
+            "used to pull it (#3811). A single uncontrolled input does not need it:\n"
+            "use `[value]` + `(input)` instead. If the import is genuinely required,\n"
+            "re-audit the budget in frontend/angular.json rather than deleting this."
+        )
 
 
 class TestVersionEndpoint:


### PR DESCRIPTION
Fixes #3811.

The issue was scoped around clawing back the ~3 kB that an Angular patch release costs. The audit found **38.50 kB**, in one place.

| | initial bundle | headroom under the 525 kB budget |
|---|---|---|
| `dev` | 522.21 kB | 2.79 kB |
| this PR | **483.71 kB** | **41.29 kB** |

Measured on one cpu node, production build, nothing else changed between runs.

## What the audit found

Attributing every eager byte back to its source module (esbuild metafile, walking **only** static `import-statement` edges from `src/main.ts`, so `@defer` and lazy routes are correctly excluded) gives:

| | before | after |
|---|---|---|
| framework (npm) | 354.50 kB | 317.54 kB |
| app code | 121.58 kB | 121.47 kB |

So the eager path is ~74% framework, and the app's own contribution was **already lean** — the last audit had done its job. The weight was one npm package that had no business being eager:

```
src/main.ts
  -> src/app/app.component.ts
  -> src/app/components/dialog-host/dialog-host.component.ts
  -> @angular/forms          36.96 kB
```

`vt-dialog-host` is rendered unconditionally by `AppComponent`, and `vt-login` sits on the same eager path. Between them they imported `FormsModule` for **two uncontrolled text fields** — the login username box and the `prompt()` input.

Both now use plain `[value]` + `(input)`; the login form swaps `(ngSubmit)` for native `(submit)` with an explicit `preventDefault()`. **Nothing is deferred**, so no interaction pays a lazy-chunk fetch — the bytes leave the eager graph outright rather than moving to another chunk. Verified after the change: `@angular/forms — eager? no`.

The login form had no other dependency on `NgForm`: no `#f="ngForm"` reference, and no `required`/`pattern`/`type=email`, so the `novalidate` that `NgForm` silently adds had nothing to suppress. Both components' existing specs already drove the inputs through native `input`/`submit` events, so they cover the new implementation unchanged.

## Left eager on purpose

`@angular/cdk` a11y (~9 kB), reached via `vt-modal` inside the always-rendered `vt-dialog-host`. Dropping it costs the focus trap on all ~24 dialogs; deferring the dialog host puts a chunk fetch in front of every `confirm()`/`prompt()`. Neither is worth 9 kB when there is now 41 kB of headroom, so the trade is written into `angular.json` instead of being rediscovered next time.

## The budget can no longer police this

That is the uncomfortable half of the result: with 41 kB of slack, a re-added `FormsModule` would fit **silently**, spending exactly the margin that exists so a framework bump does not turn the gate red for everyone (#3795). Per the issue, the reclaimed bytes stay as headroom rather than becoming a lower number — so the specific trap gets a test instead.

`TestEagerBundleComposition` resolves the eager chunk set from the build output: `main.js` plus everything reachable through `from"./chunk-X.js"`, **never** following `import("./chunk-Y.js")` — that second form *is* the `@defer`/lazy-route boundary, and following it would walk the whole app and make the assertion vacuous. It then asserts `ngNoForm` is absent; that string is from `NgForm`'s own selector (`form:not([ngNoForm])`) and appears in exactly one chunk of the build, so it is a precise marker.

**The guard was verified to fail, not assumed to work.** With the first commit reverted and the bundle rebuilt at 522.21 kB it fails; with the fix it passes:

```
PHASE A (FormsModule eager, 522.21 kB):  1 failed, 1 passed   <- correct
PHASE B (fix in place,      483.71 kB):  2 passed             <- correct
```

A second test asserts the walk still resolves a plausibly-sized bundle, so if the build output's import syntax ever changes, that surfaces as a failure rather than a guard that silently matches nothing.

## Verification

GRID, full `./run-tests.sh`: **11115 passed**, 6 skipped, build OK, `npm audit` OK, Vitest OK.

(The 2 `xpassed` are the pre-existing pair in `tests_lib/cli/test_tqdm_progress.py`, marked *"partialmethod identity is unstable across attribute accesses"* — self-describing run-to-run flakiness in tqdm code, unrelated to anything here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DH8JkPckirmtQM4S91sVnq
