### PR TITLE
Retire the 21 planter positives the recheck rejected (#3778)

### DIFF
--- a/scripts/experiments/pile/apply_recheck.py
+++ b/scripts/experiments/pile/apply_recheck.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Apply a recheck pass's verdicts to `corrections.json` (#3778).
+
+A ruling changes what a class *is*, and every row cast under the old wording
+then means something the table no longer says. The planter ruling (#3784) is the
+first one to have done that to rows already on disk: `vase` claimed "flower pots,
+planters" and said in as many words that a potted plant's pot is a vase, so 31
+`vase` rows and 49 `bowl` rows were cast under a definition that is now
+withdrawn. `make_class_recheck.py` put all 80 back in front of the reviewer as an
+image-level question -- *does this photo contain one under the new rule?* -- and
+this is the other end of that: 21 of them came back Bad, and a Bad here is a
+positive that has to leave the class.
+
+**A recheck re-answers an existing row and never writes a new one.** The slate
+was built from the present rows of `corrections.json` itself, so every verdict in
+it has a row to land on. An image with no row is therefore not a new correction
+to add, it is evidence that the slate and the file have drifted apart -- so it
+refuses rather than inventing membership from a question nobody asked about this
+image.
+
+**The rule in force is checked, not assumed.** The labelset records the rule
+whose name the reviewer was voting under (#3612: that name is the only wording a
+reviewer ever sees). If `SCALE_CLASS_RULES` has moved on since, these verdicts
+answer a superseded question and applying them would silently apply the old
+ruling under the new one's name. That is the failure this whole issue was: a
+correction row records no rule version, so a ruling quietly changes what old rows
+mean. Here it is at least checkable, so it is checked.
+
+**Why `present: false` and no boxes.** The question was asked of the image, not
+of a box, deliberately (an image may hold a planter *and* a real bowl, in which
+case the photo is still a positive and only its box is wrong -- a smaller and
+separate question). `apply_corrections` answers a boxless `present: false` by
+popping the class from the image's labels, so the image leaves every cell of that
+class, keeps its pinned seat only if it is still eligible (it is not), and is
+backfilled by rank. It also becomes a *provable negative* for that class, which
+is the half a rejection usually cannot buy: a human looked at this photo and said
+there is none.
+
+The verdicts are read from the committed copies under
+:data:`verdict_store.STORE` rather than from the live app or from scratch. A
+labelset on scratch is purgeable and the app's copy is the thing #3729 is about;
+the committed one is the record, and its diff is a diff of answers.
+
+Usage::
+
+    python apply_recheck.py --dry-run      # what would change
+    python apply_recheck.py                # write it
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+import pile_config as pc
+import verdict_store
+from pilebuild.corrections import write_json_locked
+
+#: The ``source`` of a row retired because a ruling moved the class boundary
+#: under it. Distinct from `human_reject+adjudicated` (the reviewer rejected the
+#: box and an adjudicator named the object) because nothing was wrong with these
+#: rows when they were cast: the reviewer was right, the definition moved. An
+#: audit that cannot tell those apart reads a ruling as a pile of annotator
+#: errors.
+SOURCE_RECHECK = "human_recheck"
+
+
+def log(msg: str) -> None:
+    print(f"[recheck] {msg}", flush=True)
+
+
+def load_labelsets(classes: tuple[str, ...], store: Path | None = None) -> dict[str, dict]:
+    """The committed recheck labelset for each class in *classes*."""
+    store = store or verdict_store.STORE
+    out = {}
+    for cls in classes:
+        path = store / f"LABELSETS__recheck__{cls}.json"
+        if not path.exists():
+            raise SystemExit(f"no committed recheck labelset for {cls!r} at {path}")
+        out[cls] = json.loads(path.read_text())
+    return out
+
+
+def plan(
+    labelsets: dict[str, dict],
+    rows: list[dict],
+    rules: dict[str, str],
+) -> tuple[list[dict], Counter, list[str]]:
+    """``(rows, stats, problems)`` -- the corrections file this pass implies.
+
+    Pure, so the guards below are testable without a pile: *rows* is the
+    corrections file as read, *rules* maps a class to the name of the rule
+    currently in force, and the returned rows are the same rows with the Bad
+    verdicts' entries retired.
+
+    Every problem is a refusal rather than a skip. Each one means the pass and
+    the file disagree about what was reviewed, and there is no reading of that
+    which a silent partial apply improves.
+    """
+    by_key = {(int(r["image_id"]), r["class"]): r for r in rows}
+    stats: Counter = Counter()
+    problems: list[str] = []
+    retire: dict[tuple[int, str], str] = {}
+
+    for cls, ls in sorted(labelsets.items()):
+        if ls.get("kind") != "recheck":
+            problems.append(f"{cls}: labelset kind is {ls.get('kind')!r}, not 'recheck'")
+            continue
+        if ls.get("class") != cls:
+            problems.append(f"{cls}: labelset says class {ls.get('class')!r}")
+            continue
+        in_force = rules.get(cls)
+        if ls.get("rule") != in_force:
+            problems.append(
+                f"{cls}: voted under rule {ls.get('rule')!r}, but {in_force!r} is in force -- "
+                f"these verdicts answer a superseded question"
+            )
+            continue
+
+        good = {_image_id(v) for v in ls.get("good", [])}
+        bad = {_image_id(v) for v in ls.get("bad", [])}
+        for iid in sorted(good & bad):
+            problems.append(f"{cls}: image {iid} is in both good and bad")
+        for iid in sorted(good | bad):
+            row = by_key.get((iid, cls))
+            if row is None:
+                problems.append(f"{cls}: image {iid} has no row to re-answer (the slate and the file have drifted)")
+            elif iid in good and not row.get("present"):
+                problems.append(f"{cls}: image {iid} was re-confirmed present, but its row already says absent")
+        for iid in sorted(bad):
+            retire[(iid, cls)] = in_force or cls
+        stats[f"{cls}: re-confirmed"] += len(good)
+        stats[f"{cls}: retired"] += len(bad)
+
+    if problems:
+        return rows, stats, problems
+
+    out = []
+    for r in rows:
+        key = (int(r["image_id"]), r["class"])
+        if key not in retire:
+            out.append(r)
+            continue
+        if not r.get("present"):
+            stats["already retired"] += 1
+            out.append(r)
+            continue
+        stats["rows changed"] += 1
+        out.append(
+            {
+                "image_id": key[0],
+                "class": key[1],
+                "present": False,
+                "boxes": [],
+                "source": SOURCE_RECHECK,
+                "note": (
+                    f"re-asked at image level under {retire[key]!r} after the planter ruling (#3778, #3784) "
+                    f"and the reviewer said this photo holds none"
+                ),
+            }
+        )
+    return out, stats, []
+
+
+def _image_id(verdict: dict) -> int:
+    """The VG image id a recheck verdict is about.
+
+    `make_class_recheck.py` builds each dataset out of ``<image_id>.jpg``
+    symlinks, so the filename *is* the id. Read from ``filename`` rather than
+    ``name`` because the app rewrites the latter on a collision.
+    """
+    return int(Path(verdict["filename"]).stem)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--classes", default="bowl,vase", help="classes whose recheck labelset to apply")
+    ap.add_argument("--corrections", default=os.environ.get("VTS_CORRECTIONS", str(pc.PILE / "corrections.json")))
+    ap.add_argument("--dry-run", action="store_true", help="report the change and write nothing")
+    args = ap.parse_args()
+
+    classes = tuple(c.strip() for c in args.classes.split(",") if c.strip())
+    path = Path(args.corrections)
+    rows = json.loads(path.read_text())
+    rules = {c: getattr(pc.SCALE_CLASS_RULES.get(c), "name", "") for c in classes}
+
+    log(f"{len(rows)} rows in {path}")
+    new_rows, stats, problems = plan(load_labelsets(classes), rows, rules)
+    for k, v in sorted(stats.items()):
+        log(f"  {k:<28}{v:>5}")
+
+    if problems:
+        print("\nREFUSING to write: the pass and the file disagree about what was reviewed\n")
+        for p in problems:
+            print(f"    {p}")
+        return 2
+
+    changed = [r for r in new_rows if r.get("source") == SOURCE_RECHECK]
+    for r in sorted(changed, key=lambda r: (r["class"], r["image_id"])):
+        log(f"  retired {r['class']:<6} {r['image_id']}")
+    if not stats["rows changed"]:
+        log("nothing to do: every retirement is already applied")
+        return 0
+    if args.dry_run:
+        log(f"--dry-run: {stats['rows changed']} rows would change, nothing written")
+        return 0
+
+    # Locked and atomic: `corrections.json` is shared by every session on this
+    # pile and is last-writer-wins with no history (#3729).
+    write_json_locked(path, new_rows)
+    log(f"wrote {len(new_rows)} rows ({stats['rows changed']} changed) to {path}")
+    log("run `python verdict_store.py export` to update the committed copy")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/human_record/MANIFEST.json
+++ b/scripts/experiments/pile/human_record/MANIFEST.json
@@ -336,9 +336,9 @@
     "why": "app labelset exports -- the clicks themselves, which `ingest_slate.py` turns into verdicts -- plus the verdict files parked here by hand, one of which is hardcoded in `verdicts_to_corrections.py`'s default"
   },
   "PILE__corrections.json": {
-    "bytes": 191185,
+    "bytes": 190949,
     "rel": "corrections.json",
-    "sha256": "4f785cadc3d533a211f944f6168f80dbef6ce66eb1f18cf10887cce8a9f84fbb",
+    "sha256": "9b1c22f7d90d17ccfc1d9d9fec64daa1b7fd6d939e80ab000fb3ba04e7ab6f0a",
     "source": "{PILE}/corrections.json",
     "tier": "human",
     "why": "the verdicts the build actually reads; reproducible only from the recovered two-campaign recipe in `verdicts_to_corrections.py`, and only while `{WORK3588}` survives"

--- a/scripts/experiments/pile/human_record/PILE__corrections.json
+++ b/scripts/experiments/pile/human_record/PILE__corrections.json
@@ -121,19 +121,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.8240534521158129,
-        0.6737193763919822,
-        0.8841870824053452,
-        0.7516703786191536
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 918,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -181,19 +174,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.7079621380846325,
-        0.8608017817371938,
-        0.7806236080178174,
-        0.965478841870824
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 1187,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -671,19 +657,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.7691249248957104,
-        0.7730673980956483,
-        0.8401423571668032,
-        0.8121545119812885
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 3253,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -822,19 +801,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.4398663697104677,
-        0.4888641425389755,
-        0.48162583518930957,
-        0.5723830734966593
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 3593,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -882,19 +854,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.007214765100671103,
-        0.37986577181208053,
-        0.3313758389261745,
-        0.6899328859060403
-      ]
-    ],
+    "boxes": [],
     "class": "bowl",
     "image_id": 4012,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'bowl incl plates not planters or wrappers' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -949,19 +914,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.4615812917594655,
-        0.6904231625835189,
-        0.6185968819599109,
-        0.9387527839643652
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 4225,
-    "present": true,
-    "source": "human_rebox"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "boxes": [],
@@ -1031,19 +989,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.34544647828507796,
-        0.7216035634743875,
-        0.3905554008908686,
-        0.8830734966592427
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 4618,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -1210,49 +1161,28 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.7188195991091314,
-        0.6447661469933185,
-        0.8324053452115813,
-        0.8474387527839644
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 285878,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.027944095116777763,
-        0.5906290088029543,
-        0.0901118572866878,
-        0.6852412259773629
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 286001,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.25131042072661475,
-        0.6191536748329621,
-        0.44665989525334077,
-        0.8919821826280624
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 286045,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -1420,19 +1350,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.5126268008769488,
-        0.6403118040089086,
-        0.6076991839504454,
-        0.7538975501113586
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 713657,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -2450,19 +2373,12 @@
     "source": "claude_triage"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.1974075723830735,
-        0.534521158129176,
-        0.32497104677060135,
-        0.734966592427617
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2320748,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -4524,19 +4440,12 @@
     "source": "human_rebox"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.780063481055706,
-        0.4910913140311804,
-        0.9034247762826241,
-        0.6458797327394209
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2348728,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -4706,19 +4615,12 @@
     "source": "human_rebox"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.2410913140311804,
-        0.2505567928730512,
-        0.3129175946547884,
-        0.2962138084632517
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2350725,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -5909,19 +5811,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.7606161899630169,
-        0.253458837371151,
-        0.8954176675300946,
-        0.4267750228145366
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2370044,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "boxes": [],
@@ -5954,19 +5849,12 @@
     "source": "human_confirmed"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.13291314031180396,
-        0.4042316258351893,
-        0.640988864142539,
-        0.6770601336302895
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2370389,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -6418,19 +6306,12 @@
     "source": "human_confirmed"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.34855233853006684,
-        0.6837416481069042,
-        0.4658500371195249,
-        0.7839643652561247
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2375571,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",
@@ -8307,19 +8188,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.6782526789653129,
-        0.04477607815487594,
-        0.7322613660158308,
-        0.14743342807093293
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2396901,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "boxes": [],
@@ -8351,19 +8225,12 @@
     "source": "claude_triage"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.15339643652561244,
-        0.4866369710467706,
-        0.2168708240534521,
-        0.623608017817372
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2397454,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "boxes": [],
@@ -9191,19 +9058,12 @@
     "source": "human_confirmed"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.7263294657791727,
-        0.09213370135790411,
-        0.7902087377445148,
-        0.17696925417166684
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2405305,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "boxes": [],
@@ -10076,19 +9936,12 @@
     "source": "human_review"
   },
   {
-    "box_space": "normalised",
-    "boxes": [
-      [
-        0.2978841870824053,
-        0.532293986636971,
-        0.3688752783964365,
-        0.6135857461024499
-      ]
-    ],
+    "boxes": [],
     "class": "vase",
     "image_id": 2417159,
-    "present": true,
-    "source": "human_review"
+    "note": "re-asked at image level under 'vase not planters' after the planter ruling (#3778, #3784) and the reviewer said this photo holds none",
+    "present": false,
+    "source": "human_recheck"
   },
   {
     "box_space": "normalised",

--- a/tests_lib/meta/test_pile_apply_recheck.py
+++ b/tests_lib/meta/test_pile_apply_recheck.py
@@ -1,0 +1,150 @@
+"""Applying a recheck pass to `corrections.json` (#3778).
+
+A recheck exists because a ruling moved a class boundary under rows that were
+already cast. The planter ruling (#3784) did that to 80 of them, and 21 came
+back Bad -- so this pass is the first thing in the pile that *retires* a human
+positive at scale, against a file where 865 of 872 rows say `present: true`.
+
+The properties worth holding it to are all about what it refuses. A recheck
+re-answers rows that already exist, so a verdict with no row means the slate and
+the file have drifted and the safe reading is not "add it". And the verdicts are
+answers to a *named rule* -- the only wording the reviewer ever saw (#3612) -- so
+applying them under a different one would apply the old ruling in the new one's
+name, which is the exact confusion this issue was filed about.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+RULE = "vase not planters"
+
+
+@pytest.fixture(scope="module")
+def ar():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import apply_recheck
+
+    return apply_recheck
+
+
+def _verdict(iid: int) -> dict:
+    return {"filename": f"{iid}.jpg", "label": "good", "md5": "x"}
+
+
+def _labelset(cls: str = "vase", good: list[int] | None = None, bad: list[int] | None = None, rule: str = RULE) -> dict:
+    return {
+        "class": cls,
+        "kind": "recheck",
+        "rule": rule,
+        "question": "does this photo contain one under the revised rule?",
+        "good": [_verdict(i) for i in good or []],
+        "bad": [_verdict(i) for i in bad or []],
+    }
+
+
+def _row(iid: int, cls: str = "vase", present: bool = True) -> dict:
+    box = [[0.1, 0.1, 0.2, 0.2]] if present else []
+    return {
+        "image_id": iid,
+        "class": cls,
+        "present": present,
+        "boxes": box,
+        "box_space": "normalised",
+        "source": "human_review",
+    }
+
+
+class TestPlan:
+    def test_a_bad_verdict_retires_the_row(self, ar):
+        rows, stats, problems = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": RULE})
+
+        assert problems == []
+        assert stats["rows changed"] == 1
+        (row,) = rows
+        assert row["present"] is False
+        assert row["source"] == ar.SOURCE_RECHECK
+
+    def test_a_retired_row_carries_no_box(self, ar):
+        """`apply_corrections` pops the class on a boxless absent; a box would band it."""
+        rows, _, _ = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": RULE})
+
+        assert rows[0]["boxes"] == []
+
+    def test_a_retired_row_says_why(self, ar):
+        """A ruling is not an annotator error, and an audit has to be able to tell."""
+        rows, _, _ = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": RULE})
+
+        assert RULE in rows[0]["note"] and "3778" in rows[0]["note"]
+
+    def test_a_good_verdict_leaves_its_row_exactly_as_it_was(self, ar):
+        """Re-confirmation changes nothing: the row and its box were right all along."""
+        before = _row(7)
+        rows, stats, problems = ar.plan({"vase": _labelset(good=[7])}, [before], {"vase": RULE})
+
+        assert problems == [] and rows == [before]
+        assert stats["vase: re-confirmed"] == 1 and not stats["rows changed"]
+
+    def test_it_touches_no_other_class(self, ar):
+        """`corrections.json` is shared by every build of this family (#3588)."""
+        other = _row(7, "bowl")
+        rows, _, problems = ar.plan({"vase": _labelset(bad=[7])}, [_row(7), other], {"vase": RULE})
+
+        assert problems == []
+        assert other in rows
+        assert [r for r in rows if r["class"] == "vase"][0]["present"] is False
+
+    def test_applying_twice_changes_nothing(self, ar):
+        once, _, _ = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": RULE})
+        twice, stats, problems = ar.plan({"vase": _labelset(bad=[7])}, once, {"vase": RULE})
+
+        assert problems == [] and twice == once
+        assert stats["already retired"] == 1 and not stats["rows changed"]
+
+    def test_the_row_count_never_moves(self, ar):
+        rows, _, _ = ar.plan({"vase": _labelset(good=[1, 2], bad=[3])}, [_row(i) for i in (1, 2, 3)], {"vase": RULE})
+
+        assert len(rows) == 3
+
+
+class TestRefusals:
+    """Each of these means the pass and the file disagree about what was reviewed."""
+
+    def test_a_superseded_rule_is_refused(self, ar):
+        """The verdicts answer the question the reviewer was shown, and no other."""
+        rows, _, problems = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": "vase incl pots and planters"})
+
+        assert len(problems) == 1 and "superseded" in problems[0]
+        assert rows == [_row(7)], "a refusal writes nothing"
+
+    def test_a_verdict_with_no_row_is_refused(self, ar):
+        """A recheck re-answers existing rows; a new one would invent membership."""
+        _, _, problems = ar.plan({"vase": _labelset(bad=[7])}, [], {"vase": RULE})
+
+        assert len(problems) == 1 and "no row to re-answer" in problems[0]
+
+    def test_one_image_answered_both_ways_is_refused(self, ar):
+        _, _, problems = ar.plan({"vase": _labelset(good=[7], bad=[7])}, [_row(7)], {"vase": RULE})
+
+        assert any("both good and bad" in p for p in problems)
+
+    def test_a_re_confirmation_of_an_absent_row_is_refused(self, ar):
+        """Somebody else already retired it: two passes disagree and neither wins here."""
+        _, _, problems = ar.plan({"vase": _labelset(good=[7])}, [_row(7, present=False)], {"vase": RULE})
+
+        assert any("already says absent" in p for p in problems)
+
+    def test_a_labelset_of_another_kind_is_refused(self, ar):
+        """A slate asks "is this box one?" -- a different question with the same shape."""
+        ls = _labelset(bad=[7])
+        ls["kind"] = "slate"
+
+        _, _, problems = ar.plan({"vase": ls}, [_row(7)], {"vase": RULE})
+
+        assert any("not 'recheck'" in p for p in problems)

--- a/tests_lib/meta/test_pile_vg_scale.py
+++ b/tests_lib/meta/test_pile_vg_scale.py
@@ -958,6 +958,85 @@ class TestConfirmationKeepsItsSeat:
         assert unlucky[0] in chosen
 
 
+class TestRetirementLeavesTheCell:
+    """The `present: false` path, end to end (#3778).
+
+    865 of the live file's 872 rows say `present: true`, so the half of
+    :func:`apply_corrections` that *retires* a positive had never been exercised
+    by anything but a unit test -- and the planter ruling (#3784) retires 21 rows
+    at once, 20 of them `vase` positives sitting in designated cells with the
+    roster pinning them there. Three passes have to agree for that to work, and
+    the failure mode if they do not is the quiet one: a cell that still looks
+    perfect while holding an image its own rule now excludes.
+    """
+
+    def _banded(self, pc, cls: str, band: str, ids: list[int]):
+        """*ids*, each holding one box of *cls* squarely inside *band*."""
+        lo, hi = pc.BOX_BANDS[band]
+        side = (((lo + hi) / 2) * 10000) ** 0.5
+        labels = {i: {cls: [[0.0, 0.0, side, side]]} for i in ids}
+        return labels, {i: (100, 100) for i in ids}
+
+    def test_a_retired_positive_loses_its_pinned_seat_and_is_backfilled(self, vgs, pc):
+        """The roster pins the membership a review was carried out against.
+
+        It must not pin an image the review has since removed: `designate_cells`
+        keeps a pin only while it is still *eligible*, and a retired positive is
+        not in the supply at all. Were it otherwise, a ruling could never take
+        anything out of a cell it had already been reviewed into.
+        """
+        cls, band = pc.SCALE_CLASSES[0], next(iter(pc.BOX_BANDS))
+        cell = pc.scale_cell(cls, band)
+        ids = list(range(1000, 1000 + pc.SCALE_N_POS + 5))
+        labels, box_dims = self._banded(pc, cls, band, ids)
+        retired = ids[0]
+        corrections = {(retired, cls): _verdict(False)}
+        roster = {"cells": {cell: ids[: pc.SCALE_N_POS]}}
+
+        unbanded = vgs.apply_corrections(labels, corrections, box_dims, set())
+        supply, _, _ = vgs.band_candidates(labels, box_dims, unbanded)
+        chosen = vgs.designate_cells(supply, corrections, roster)
+
+        assert labels[retired] == {}, "the class is popped from the image"
+        assert retired not in supply[cls][band]
+        assert retired not in chosen[cell], "a pin is not a licence to keep a retired positive"
+        assert len(chosen[cell]) == pc.SCALE_N_POS, "the seat is backfilled, not left empty"
+
+    def test_a_retired_positive_becomes_a_usable_negative(self, vgs, pc):
+        """What a rejection usually cannot buy: a human said this photo holds none.
+
+        It is the difference between `present: false` and a boxless
+        `present: true`, which lands in ``unbanded`` and is neither.
+        """
+        cls, band = pc.SCALE_CLASSES[0], next(iter(pc.BOX_BANDS))
+        labels, box_dims = self._banded(pc, cls, band, [7])
+        exhaustive: set[int] = set()
+
+        unbanded = vgs.apply_corrections(labels, {(7, cls): _verdict(False)}, box_dims, exhaustive)
+        _, _, clean = vgs.band_candidates(labels, box_dims, unbanded)
+
+        assert clean == [7] and unbanded == set()
+        assert exhaustive == {7}, "somebody looked, so absence here is a fact"
+
+    def test_it_retires_only_the_class_the_reviewer_was_asked_about(self, vgs, pc):
+        """The planter recheck ran per class over images that can hold both.
+
+        `bowl` and `vase` share images in this very pass -- `make_class_recheck`
+        symlinks one file into both datasets -- so a retirement that popped the
+        image rather than the class would delete a positive nobody rejected.
+        """
+        kept, retired_cls = pc.SCALE_CLASSES[0], pc.SCALE_CLASSES[1]
+        band = next(iter(pc.BOX_BANDS))
+        labels, box_dims = self._banded(pc, kept, band, [7])
+        labels[7][retired_cls] = [[0.0, 0.0, 4.0, 4.0]]
+
+        vgs.apply_corrections(labels, {(7, retired_cls): _verdict(False)}, box_dims, set())
+        supply, _, clean = vgs.band_candidates(labels, box_dims, set())
+
+        assert list(labels[7]) == [kept]
+        assert supply[kept][band] == [7] and clean == []
+
+
 class TestDisqualifiedNegatives:
     def test_a_rostered_negative_that_is_no_longer_clean_is_recorded(self, vgs):
         roster = {"negatives": [1, 2, 3], "spares": [4]}


### PR DESCRIPTION
Retire the 21 planter positives the recheck rejected (#3778)

The planter ruling shipped in #3784 and changed what a `vase` and a `bowl`
ARE, which left 80 rows in `corrections.json` cast under a definition that is
now withdrawn. `make_class_recheck.py` put all 80 back in front of the reviewer
as an image-level question -- *does this photo contain one under the new rule?*
-- and 21 came back Bad. This is the other end of that pass: those 21 rows
become `present: false`, so the images leave the class they can no longer be
positives for.

`apply_recheck.py` does it, and what it refuses is the point:

* **a verdict with no row is a refusal, not an insert.** The slate was built
  from the present rows of `corrections.json` itself, so every verdict in it has
  a row to land on; one that does not means the slate and the file have drifted,
  and inventing membership from a question nobody asked about that image is the
  wrong reading of it;
* **the rule in force is checked against the one the reviewer voted under.** The
  labelset records it, because that name is the only wording a reviewer ever
  sees (#3612). If `SCALE_CLASS_RULES` has moved on since, these verdicts answer
  a superseded question -- which is this issue's own failure mode pointed at
  itself, and the one thing here that *is* mechanically checkable;
* a re-confirmation of a row that already says absent, one image answered both
  ways, and a labelset of another `kind` are each a refusal too. A partial apply
  improves none of them.

A retired row carries its own `source` (`human_recheck`) rather than
`human_reject+adjudicated`: nothing was wrong with these rows when they were
cast. The reviewer was right and the definition moved, and an audit that cannot
tell those apart reads a ruling as a pile of annotator errors.

### The `present: false` path had never really run

865 of the live file's 872 rows say `present: true`, so the half of
`apply_corrections` that RETIRES a positive was exercised only by unit tests --
and this lands 21 of them at once, 20 of them `vase` positives sitting in
designated cells with the roster pinning them there.
`TestRetirementLeavesTheCell` walks the three passes that have to agree:

* a retired positive loses its **pinned** seat (a pin is kept only while the
  image is still eligible, and it is not in the supply at all) and the seat is
  backfilled by rank rather than left empty;
* it becomes a **usable negative** -- what a rejection usually cannot buy, since
  a human looked at the photo and said there is none. That is the difference
  between `present: false` and a boxless `present: true`, which lands in
  `unbanded` and is neither;
* it retires **the class, not the image**. `bowl` and `vase` share images in
  this very pass -- `make_class_recheck` symlinks one file into both datasets --
  so popping the image would delete a positive nobody rejected.

### Measured, not assumed

`replay_selection.py` against the live pile, after the write: **21 positives
dropped and 21 added over 4 cells** -- `vase@medium` 15, `vase@small` 4,
`vase@large` 1, `bowl@large` 1 -- and **0 negatives moved**. That is the
retirement list cell for cell with nothing else touched. The retired images are
now eligible for the negative pool and do not enter it at this rebuild, because
the pool is roster-pinned and already full.

It moves membership, so it lands with the next rebuild. `corrections.json` on
the pile is written under the existing lock and a pre-change copy is at
`/exp/sgreenberg/backups/corrections-pre-3778-20260912-1708.json`; the committed
copy is re-exported by `verdict_store.py`.

Refs #3778, #3784, #3720.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1xA9ArRkoQscwxTenJE5
