### PR TITLE
Record the rule a correction row was answered under (#3814)

### DIFF
--- a/scripts/experiments/pile/README.md
+++ b/scripts/experiments/pile/README.md
@@ -364,6 +364,50 @@ labels with a perfectly healthy media count. It now stamps a digest of the
 parent's labels, `--verify` compares that against the live parent, and a run
 that rebuilds `vg_scale` pulls the derived dataset in with it.
 
+## A row records the rule it was answered under
+
+The class rule *is* the question: it is the detector name a reviewer reads while
+voting (#3612), and files are named by image id alone. So when a ruling changes a
+rule, every row cast under the old wording silently starts meaning something
+else. That is not hypothetical — it cost the 80-image planter recheck. `vase`
+claimed "flower pots, planters" until #3784 withdrew the line, and nothing on the
+31 `vase` rows or the 49 `bowl` rows said which wording they were cast under, so
+all 80 had to go back in front of a human (#3778) to find the **21** that had
+actually moved.
+
+A row therefore carries two more optional fields (#3814): `rule`, the name the
+reviewer saw, and `rule_digest`, a hash of that rule's full `test` — because a
+rule can be rewritten in the body while the name stands still (#3756 did that to
+`bench`). Recording both is what separates "the reviewer read different words"
+from "the wording behind identical words moved".
+
+Three properties, and the third is the one that makes the field worth anything:
+
+- **The stamp is taken from what the reviewer was shown, never from the table.**
+  `ingest_slate.py` reads it off the slate's `detector` column; `apply_recheck.py`
+  takes it from the labelset it has just verified; `verdicts_to_corrections.py`
+  *carries* it and never re-derives one. That script reads August verdict files
+  and runs today — stamping them from `SCALE_CLASS_RULES` would write a wording
+  their reviewers never saw, which looks like a fix and is the bug.
+- **A recheck stamps both directions.** A Bad retires the row and carries the
+  rule that retired it; a **Good** changes no label and establishes the one thing
+  nothing else can — that a human looked under the rule now in force. 59 of the
+  80 planter images came back that way.
+- **Absence means unknown, and is never read as current.** The 872 rows written
+  before the field cannot be back-filled from anything, and treating them as
+  answered would be the original failure rather than a rounding of it.
+
+Asking the question is `rule_drift.py`, which sorts every row into `current` /
+`edited` / `superseded` / `unknown` and will print the superseded ids as a recheck
+slate. Every build additionally names the **superseded** count as it loads the
+file — and says nothing about `unknown`, which starts at 872, nobody can act on
+mid-run, and would train everyone to skip the line that matters.
+
+```bash
+python rule_drift.py                            # the table
+python rule_drift.py --state superseded --ids   # the slate a ruling implies
+```
+
 ## A rebox can change the band, and that is a correction
 
 An image sits in `class@band` because of the box it arrived with, so a reviewer

--- a/scripts/experiments/pile/apply_recheck.py
+++ b/scripts/experiments/pile/apply_recheck.py
@@ -26,6 +26,19 @@ ruling under the new one's name. That is the failure this whole issue was: a
 correction row records no rule version, so a ruling quietly changes what old rows
 mean. Here it is at least checkable, so it is checked.
 
+**And now it is recorded, on every row this pass re-answers** (#3814). The check
+above proves which rule these verdicts answer; writing it onto the row is what
+keeps the next person from having to prove it again. Both directions get the
+stamp, because both are answers: a Bad retires the row and carries the rule that
+retired it, and a **Good** changes nothing about the label while establishing the
+one thing nothing else can -- that a human looked at this photo under the rule now
+in force. 59 of the 80 planter images came back that way and the file had no way
+to say so, which is precisely why all 80 had to be asked rather than 31.
+
+That is also the only back-fill this design permits, and it is not really one:
+the evidence is the labelset sitting beside the file, not a guess about what
+somebody was shown. Rows nobody re-answered stay `unknown` and must.
+
 **Why `present: false` and no boxes.** The question was asked of the image, not
 of a box, deliberately (an image may hold a planter *and* a real bowl, in which
 case the photo is still a positive and only its box is wrong -- a smaller and
@@ -88,22 +101,30 @@ def plan(
     labelsets: dict[str, dict],
     rows: list[dict],
     rules: dict[str, str],
+    rule_digests: dict[str, str] | None = None,
 ) -> tuple[list[dict], Counter, list[str]]:
     """``(rows, stats, problems)`` -- the corrections file this pass implies.
 
     Pure, so the guards below are testable without a pile: *rows* is the
     corrections file as read, *rules* maps a class to the name of the rule
-    currently in force, and the returned rows are the same rows with the Bad
-    verdicts' entries retired.
+    currently in force, *rule_digests* to that rule's
+    :func:`pile_config.rule_digest` (omit it to check the name alone, which is
+    all a labelset written before #3814 can be held to), and the returned rows
+    are the same rows with the Bad
+    verdicts' entries retired and **every** re-answered row stamped with the rule
+    it was re-answered under.
 
     Every problem is a refusal rather than a skip. Each one means the pass and
     the file disagree about what was reviewed, and there is no reading of that
     which a silent partial apply improves.
     """
+    rule_digests = rule_digests or {}
     by_key = {(int(r["image_id"]), r["class"]): r for r in rows}
     stats: Counter = Counter()
     problems: list[str] = []
     retire: dict[tuple[int, str], str] = {}
+    # Every pair this pass re-answered, Good or Bad, and the stamp it earns.
+    stamp: dict[tuple[int, str], dict[str, str]] = {}
 
     for cls, ls in sorted(labelsets.items()):
         if ls.get("kind") != "recheck":
@@ -119,6 +140,21 @@ def plan(
                 f"these verdicts answer a superseded question"
             )
             continue
+        # The same refusal one notch finer, for a labelset that records the
+        # rule's DIGEST as well as its name (`bank_verdicts.py` writes both since
+        # #3814). A rule can be rewritten in the body while the name stands still
+        # -- #3756 changed `bench`'s Bad list and kept its name -- and a reviewer
+        # who voted before that edit answered about a different boundary under
+        # identical words. Weaker than a rename and refused the same way, because
+        # the alternative is deciding on the reviewer's behalf which edits were
+        # cosmetic.
+        voted_digest = ls.get("rule_digest")
+        if voted_digest and voted_digest != rule_digests.get(cls):
+            problems.append(
+                f"{cls}: voted under rule {in_force!r} as written at {voted_digest}, but its wording has been "
+                f"EDITED since (now {rule_digests.get(cls)}) -- the name is unchanged, the test is not"
+            )
+            continue
 
         good = {_image_id(v) for v in ls.get("good", [])}
         bad = {_image_id(v) for v in ls.get("bad", [])}
@@ -130,6 +166,13 @@ def plan(
                 problems.append(f"{cls}: image {iid} has no row to re-answer (the slate and the file have drifted)")
             elif iid in good and not row.get("present"):
                 problems.append(f"{cls}: image {iid} was re-confirmed present, but its row already says absent")
+            # The rule the LABELSET carries, which the checks above have just
+            # established is the one in force. The digest rides along only when
+            # the labelset recorded one: a labelset that names a rule without
+            # pinning its wording cannot vouch for the body, and taking the
+            # body's digest from the table anyway would assert exactly what was
+            # not checked.
+            stamp[(iid, cls)] = {"rule": in_force or cls, **({"rule_digest": voted_digest} if voted_digest else {})}
         for iid in sorted(bad):
             retire[(iid, cls)] = in_force or cls
         stats[f"{cls}: re-confirmed"] += len(good)
@@ -141,18 +184,33 @@ def plan(
     out = []
     for r in rows:
         key = (int(r["image_id"]), r["class"])
+        fields = stamp.get(key, {})
         if key not in retire:
-            out.append(r)
+            # A re-confirmation changes no answer and is not nothing: a human
+            # looked at this photo under the rule now in force and said it still
+            # holds one, which is the only thing that can move a row out of
+            # `unknown` without inventing history (#3814). 59 of the 80 planter
+            # images came back this way and the file could not say so.
+            stamped, moved = _stamped(r, fields)
+            stats["rows stamped"] += int(moved)
+            out.append(stamped)
             continue
         if not r.get("present"):
+            # Retired by an earlier run of this same pass, under this same rule.
+            # The stamp is recoverable and true, so a re-run backfills it -- the
+            # one back-fill #3814 permits, because the evidence is the labelset
+            # sitting right here rather than a guess about what someone saw.
+            stamped, moved = _stamped(r, fields)
             stats["already retired"] += 1
-            out.append(r)
+            stats["rows stamped"] += int(moved)
+            out.append(stamped)
             continue
         stats["rows changed"] += 1
         out.append(
             {
                 "image_id": key[0],
                 "class": key[1],
+                **fields,
                 "present": False,
                 "boxes": [],
                 "source": SOURCE_RECHECK,
@@ -163,6 +221,18 @@ def plan(
             }
         )
     return out, stats, []
+
+
+def _stamped(row: dict, fields: dict[str, str]) -> tuple[dict, bool]:
+    """``(row, moved)`` -- *row* carrying *fields*, and whether that changed it.
+
+    Returning the original object when nothing moves is what keeps a second run
+    a no-op all the way down to object identity, which is what the idempotence
+    test actually asserts.
+    """
+    if not fields or all(row.get(k) == v for k, v in fields.items()):
+        return row, False
+    return {**row, **fields}, True
 
 
 def _image_id(verdict: dict) -> int:
@@ -185,10 +255,15 @@ def main() -> int:
     classes = tuple(c.strip() for c in args.classes.split(",") if c.strip())
     path = Path(args.corrections)
     rows = json.loads(path.read_text())
-    rules = {c: getattr(pc.SCALE_CLASS_RULES.get(c), "name", "") for c in classes}
+    # `review_name`, not `SCALE_CLASS_RULES[c].name`: an unruled class's rule IS
+    # its bare name, and that is what a slate's detector carries and what
+    # `bank_verdicts.py` reads back out of it. Reading the table directly gave
+    # such a class `""`, which no labelset can ever match.
+    rules = {c: pc.review_name(c) for c in classes}
+    digests = {c: pc.rule_digest(c) for c in classes}
 
     log(f"{len(rows)} rows in {path}")
-    new_rows, stats, problems = plan(load_labelsets(classes), rows, rules)
+    new_rows, stats, problems = plan(load_labelsets(classes), rows, rules, digests)
     for k, v in sorted(stats.items()):
         log(f"  {k:<28}{v:>5}")
 
@@ -201,17 +276,18 @@ def main() -> int:
     changed = [r for r in new_rows if r.get("source") == SOURCE_RECHECK]
     for r in sorted(changed, key=lambda r: (r["class"], r["image_id"])):
         log(f"  retired {r['class']:<6} {r['image_id']}")
-    if not stats["rows changed"]:
-        log("nothing to do: every retirement is already applied")
+    if not (stats["rows changed"] or stats["rows stamped"]):
+        log("nothing to do: every retirement is already applied and every re-answered row already carries its rule")
         return 0
+    moved = f"{stats['rows changed']} retired, {stats['rows stamped']} stamped with their rule"
     if args.dry_run:
-        log(f"--dry-run: {stats['rows changed']} rows would change, nothing written")
+        log(f"--dry-run: {moved}, nothing written")
         return 0
 
     # Locked and atomic: `corrections.json` is shared by every session on this
     # pile and is last-writer-wins with no history (#3729).
     write_json_locked(path, new_rows)
-    log(f"wrote {len(new_rows)} rows ({stats['rows changed']} changed) to {path}")
+    log(f"wrote {len(new_rows)} rows ({moved}) to {path}")
     log("run `python verdict_store.py export` to update the committed copy")
     return 0
 

--- a/scripts/experiments/pile/bank_verdicts.py
+++ b/scripts/experiments/pile/bank_verdicts.py
@@ -5,6 +5,14 @@ rename removed from every detector name -- so both kinds collapsed onto one
 filename and the later write clobbered the earlier. The question a detector asks
 is the thing that actually distinguishes them, so it is what the filename
 follows, and a collision is now an error rather than a silent overwrite.
+
+**The labelset records the rule's digest beside its name** (#3814), when and only
+when the detector's name still matches the rule in force. The name is what the
+reviewer read; the digest covers the ``test`` behind it, which can be rewritten
+without the name moving (#3756 did that to `bench`). `apply_recheck.py` refuses a
+pass whose digest has moved and stamps the surviving rows with it, so the pair is
+what lets a later reader tell "voted under this rule" from "voted under a rule
+spelt this way".
 """
 
 import json
@@ -14,6 +22,9 @@ import subprocess
 import sys
 import urllib.parse
 import urllib.request
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import pile_config as pc  # noqa: E402
 
 _SQUEUE = shutil.which("squeue") or "/usr/bin/squeue"
 _ARGS = [_SQUEUE, "-u", "sgreenberg", "-h", "-n", "vtsearch", "-o", "%N"]
@@ -67,11 +78,18 @@ for d in sorted(get("/api/detectors/registry")["detectors"], key=lambda x: x["na
         fail = True
         continue
     written[p] = name
+    # Only when the detector still names the rule in force. A detector left over
+    # from before a ruling names the OLD rule, and there is nothing on the
+    # cluster that can reconstruct the body that rule used to have -- so the
+    # labelset records the name it really asked and stays silent about the
+    # wording, which is the weaker claim and the true one.
+    digest = {"rule_digest": pc.rule_digest(cls)} if rule == pc.review_name(cls) else {}
     p.write_text(
         json.dumps(
             {
                 "detector_name": name,
                 "rule": rule,
+                **digest,
                 "class": cls,
                 "kind": kind,
                 "question": QUESTION[kind],

--- a/scripts/experiments/pile/ingest_slate.py
+++ b/scripts/experiments/pile/ingest_slate.py
@@ -12,6 +12,15 @@ disagreements, and review *coverage* falls out for free — without it, "no bus
 here" is indistinguishable from "nobody looked", and every rate computed
 afterwards is biased by an unknown amount.
 
+**Each verdict records the rule it was cast under, read off the slate** (#3814).
+A class rule moves -- three rulings landed in September on classes with verdicts
+already banked -- and a row that says only what the reviewer answered starts
+meaning something else the moment one does. The wording is taken from the
+manifest's ``detector`` column, which is what the reviewer actually read while
+voting (#3612), and never from the rule table, which says what is in force today.
+See :func:`rule_stamp_for`; `verdicts_to_corrections.py` carries the stamp onto
+the correction row, and `rule_drift.py` is what asks the question afterwards.
+
 **The rate comes from the random stratum alone.** The boundary stratum is chosen
 to find errors, so its error rate is not the pool's error rate and averaging the
 two together produces a number that means nothing. Both are reported, labelled,
@@ -48,6 +57,27 @@ def log(msg: str) -> None:
 #: boxed re-issue supersedes the bare thumbnail: it is the same question asked
 #: in a form the reviewer could actually answer (`make_positive_slate.py`).
 STRATUM_RANK = {"positive": 0, "boundary": 0, "random": 0, "positive_boxed": 1}
+
+
+def rule_stamp_for(detector: str, cls: str) -> dict[str, str]:
+    """The rule this verdict was cast under, read from the SLATE (#3814).
+
+    Read from the slate's ``detector`` rather than from ``SCALE_CLASS_RULES``,
+    even though the table is right there, because the two are not the same claim
+    and only one of them is true. The detector name is what the reviewer had in
+    front of them while voting (#3612); the table is what is in force *now*, and
+    an export ingested after a ruling would otherwise be stamped with a wording
+    its reviewer never saw -- writing down the exact confusion the stamp exists
+    to prevent.
+
+    The digest rides along only when the two agree, because a digest covers the
+    rule's ``test`` and nothing in a detector name can reconstruct the body of a
+    rule that has since been rewritten. A name with no digest is an honest
+    smaller claim; a digest guessed from today's table would not be.
+    """
+    observed = pc.rule_of_review_name(detector)
+    in_force = pc.rule_stamp(cls)
+    return in_force if observed == in_force["rule"] else {"rule": observed}
 
 
 def load_manifests(roots: list[Path]) -> tuple[dict[tuple[int, str, str], dict], dict[str, str]]:
@@ -200,6 +230,7 @@ def main() -> int:
                 {
                     "image_id": iid,
                     "class": c,
+                    **rule_stamp_for(det, c),
                     "stratum": row["stratum"],
                     "human": "present" if el.get("label") == "good" else "absent",
                     "reference": row["reference"],
@@ -245,6 +276,16 @@ def main() -> int:
     if conflicts:
         log(f"  WARNING {conflicts} images carry BOTH a Good and a Bad vote -- kept the boxed one")
     verdicts = sorted(merged.values(), key=lambda v: (v["class"], v["image_id"]))
+
+    # Named, not silently carried: a slate whose detector no longer matches the
+    # class rule is a review of a superseded question, and the verdicts are
+    # stamped with what it actually asked (#3814). They are still ingested --
+    # the reviewer's answer to the old question is a fact, and `rule_drift.py`
+    # is what turns it into a recheck slate -- but "this pass predates a ruling"
+    # is the sort of thing worth reading before the rates below.
+    superseded = sorted({(v["class"], v["rule"]) for v in verdicts if v["rule"] != pc.review_name(v["class"])})
+    for cls, was in superseded:
+        log(f"  NOTE {cls}: voted under {was!r}, now {pc.review_name(cls)!r} -- stamped as cast, not as current")
 
     # Per stratum, per direction. Never pooled across strata.
     by: dict[tuple[str, str], int] = defaultdict(int)

--- a/scripts/experiments/pile/pile_config.py
+++ b/scripts/experiments/pile/pile_config.py
@@ -26,6 +26,7 @@ mis-specification has burned three studies (#2877, #2897, #2905), so
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 from typing import NamedTuple
@@ -2183,6 +2184,70 @@ def review_name(cls: str, suffix: str = "") -> str:
     """
     rule = SCALE_CLASS_RULES.get(cls)
     return f"{rule.name if rule else cls}{f' {suffix}' if suffix else ''}"
+
+
+#: The pass suffixes :func:`review_name` appends. Listed so the join can be
+#: undone: a slate's ``detector`` column is the only place a *past* review's rule
+#: name survives, and reading it back is what lets a verdict be stamped with the
+#: wording its reviewer saw rather than the wording in force today.
+REVIEW_SUFFIXES = ("positives", "audit", "reviewed")
+
+
+def rule_of_review_name(detector: str) -> str:
+    """The rule name inside a slate's ``detector``, with the pass suffix removed.
+
+    The inverse of :func:`review_name`, and it has to be an inverse rather than a
+    guess: a detector name is *evidence about the past*. ``make_class_recheck.py``
+    additionally appends a ``" -- ..."`` tail naming the question, which
+    ``bank_verdicts.py`` already strips the same way.
+
+    ``tests_lib/meta/test_pile_rule_version.py`` pins the round trip over every
+    class and every suffix, so a new suffix that is not listed above fails there
+    rather than silently reading as part of the rule.
+    """
+    name = detector.split(" -- ")[0]
+    for suffix in REVIEW_SUFFIXES:
+        if name.endswith(f" {suffix}"):
+            return name[: -len(suffix) - 1]
+    return name
+
+
+def rule_digest(cls: str) -> str:
+    """A short hash of *cls*'s rule **as written** -- the name and the test together.
+
+    The name answers "was the reviewer shown different words?". It does not
+    answer "did the rule move?", because a rule can be edited in the body while
+    the name stands still: #3756 rewrote `bench`'s Bad list and kept its name.
+    Both questions are worth asking and only one of them is readable in a diff,
+    so both are recorded -- the name because it is the wording a reviewer saw and
+    a human can check it at a glance, the digest because it is the only thing
+    that can see an edit the name hides.
+
+    Twelve hex characters, which is a hash to compare rather than a hash to
+    defend: the adversary here is a forgotten edit, not a forger.
+    """
+    rule = SCALE_CLASS_RULES.get(cls)
+    payload = f"{rule.name if rule else cls}\n{rule.test if rule else ''}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:12]
+
+
+def rule_stamp(cls: str) -> dict[str, str]:
+    """The two fields a row records about the rule it was answered under (#3814).
+
+    Merge into a verdict or a correction row at the moment the answer is
+    *given*, never at the moment a file is regenerated: a row cast in August and
+    re-derived in September must carry August's rule, or the stamp asserts the
+    one thing it exists to disprove. Every writer here therefore takes its name
+    from what the reviewer was shown -- the slate's ``detector`` column, or a
+    labelset's recorded ``rule`` -- and falls back to this only when the two
+    already agree.
+
+    **Absence means unknown and must never be read as current.** The 872 rows
+    predating this field cannot be back-filled honestly: nothing on disk says
+    which wording they were cast under, which is the whole of #3814. See
+    :func:`pilebuild.corrections.rule_state`.
+    """
+    return {"rule": review_name(cls), "rule_digest": rule_digest(cls)}
 
 
 def scale_vg_wanted() -> set[str]:

--- a/scripts/experiments/pile/pilebuild/corrections.py
+++ b/scripts/experiments/pile/pilebuild/corrections.py
@@ -1,6 +1,10 @@
 """Human verdicts on ``(image, class)`` pairs, and the one box-space crossing.
 
-Everything in this module exists to make **one** conversion happen exactly once.
+Two things about a verdict have to survive the trip to disk, and this module owns
+both. They are the two halves of the same sentence: *what* a reviewer answered,
+and *which question* they were shown.
+
+The box space is the first, and it is made to happen exactly once.
 A correction's boxes arrive normalised (they come from the app's ``region_box``);
 every other box in the scale build is in pixels. Converting here, on the way in,
 is what keeps the rest of the loader in a single space -- and #3281 is what the
@@ -8,6 +12,17 @@ other arrangement costs: a normalised box merged unconverted is normalised a
 second time by the region write, which divides it by ~500 and parks it on the
 frame origin, with the band derived from the same corrupted box so that nothing
 downstream can see the disagreement.
+
+The **rule** is the second (#3814). A class rule is not a constant: three rulings
+landed in September on classes with rows already on disk, and a row that records
+only its answer starts meaning something else the moment one does. Since the
+``rule`` / ``rule_digest`` fields exist, a row carries the wording it was cast
+under, and :func:`rule_state` is where that is compared against the wording in
+force. Its one law is that **an absent stamp means unknown**: the 872 rows
+written before the field cannot be back-filled from anything -- nothing on disk
+ever said which wording they answered, which is why re-asking a human all 80
+planter images was the only way to find out (#3778) -- so reading them as current
+would be the failure itself rather than a rounding of it.
 """
 
 from __future__ import annotations
@@ -15,9 +30,27 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+from collections.abc import Iterable
 from pathlib import Path
 
 import pile_config as pc
+
+#: The row's rule is the one in force: nothing has moved under it.
+RULE_CURRENT = "current"
+#: The name matches but the *wording behind it* has been edited since (#3756
+#: rewrote `bench`'s Bad list and kept its name). The reviewer read the same
+#: words off the detector; what a near-miss resolves to may have changed.
+RULE_EDITED = "edited"
+#: The row names a rule that is no longer in force. These answer a superseded
+#: question, and they are the only state anybody can act on: they are exactly
+#: the rows a recheck slate should be built from.
+RULE_SUPERSEDED = "superseded"
+#: The row records no rule at all. **Not** a synonym for `current`: it is the
+#: state #3814 exists to make visible, and the 872 rows that predate the field
+#: are all in it. Nothing can back-fill them -- the wording they were cast under
+#: was never written down, which is why the planter recheck had to ask a human
+#: all 80 images again (#3778).
+RULE_UNKNOWN = "unknown"
 
 
 def dropped_rows(old: list[dict], new: list[dict]) -> dict[str, int]:
@@ -82,6 +115,17 @@ def load_corrections() -> dict[tuple[int, str], dict]:
     app's ``region_box``. The space is validated on the way in and converted to
     pixels once, by :func:`correction_boxes_px`, so that everything downstream
     of this function is in one space. See ``pile_config.CORRECTION_BOX_SPACE``.
+
+    **It names, but does not refuse, rows whose rule has been ruled away.** A
+    superseded row is not malformed -- the reviewer answered honestly, and the
+    definition moved afterwards -- so refusing would stop every build over a debt
+    that only a human re-review can settle. Reporting it here rather than only
+    from a tool that is asked is deliberate, and it is the counting that makes it
+    bearable: `unknown` is **excluded**, because 872 unstamped rows is a constant
+    nobody can act on and a line printed every run is a line everybody learns to
+    skip. What is left starts at zero and becomes non-zero exactly when a ruling
+    lands on stamped rows, which is the moment worth interrupting somebody for.
+    `rule_drift.py` is where the full four-state breakdown lives.
     """
     path = Path(os.environ.get("VTS_CORRECTIONS", pc.PILE / "corrections.json"))
     if not path.exists():
@@ -91,6 +135,14 @@ def load_corrections() -> dict[tuple[int, str], dict]:
     for r in rows:
         assert_correction_box_space(r, path)
         out[(int(r["image_id"]), r["class"])] = r
+    stale = superseded_rows(rows)
+    if stale:
+        classes = sorted({r["class"] for r in stale})
+        print(
+            f"[corrections] {len(stale)} of {len(rows)} rows answer a rule that has since been ruled away "
+            f"({', '.join(classes)}) -- `python rule_drift.py --state superseded --ids` names them (#3814)",
+            flush=True,
+        )
     return out
 
 
@@ -117,6 +169,66 @@ def assert_correction_box_space(row: dict, path: Path) -> None:
             )
         if float(b[2]) <= float(b[0]) or float(b[3]) <= float(b[1]):
             raise SystemExit(f"{where}: box {b} is degenerate (x1 <= x0 or y1 <= y0)")
+
+
+def rule_state(row: dict, in_force: dict[str, str] | None = None) -> str:
+    """Where *row*'s recorded rule stands against the one now in force (#3814).
+
+    One of :data:`RULE_CURRENT`, :data:`RULE_EDITED`, :data:`RULE_SUPERSEDED` or
+    :data:`RULE_UNKNOWN`. *in_force* is the class's :func:`pile_config.rule_stamp`,
+    passed in so the states are testable against a rule table this repository
+    does not have to actually hold.
+
+    **A row with no `rule` reads as unknown, never as current.** That asymmetry
+    is the entire point: reading an unstamped row as current is precisely the
+    silent re-interpretation #3814 was filed about, and it would make the 872
+    legacy rows look answered.
+
+    A row carrying a matching *name* and no digest reads as `current`. The name
+    is what the reviewer was shown, so the row's claim is satisfied; the digest
+    is the stricter, optional check, and its absence means the `edited` question
+    cannot be asked of that row rather than that the answer is no.
+    """
+    recorded = row.get("rule")
+    if not recorded:
+        return RULE_UNKNOWN
+    stamp = in_force if in_force is not None else pc.rule_stamp(row["class"])
+    if recorded != stamp.get("rule"):
+        return RULE_SUPERSEDED
+    digest = row.get("rule_digest")
+    if digest and digest != stamp.get("rule_digest"):
+        return RULE_EDITED
+    return RULE_CURRENT
+
+
+def rule_states(rows: Iterable[dict], stamps: dict[str, dict[str, str]] | None = None) -> list[tuple[dict, str]]:
+    """``[(row, state)]`` for every row, resolving each class's rule once.
+
+    The lookup is hoisted because :func:`pile_config.rule_digest` hashes the
+    rule's whole ``test`` -- a few hundred words for `truck` -- and a correction
+    file holds hundreds of rows per class.
+    """
+    stamps = {} if stamps is None else dict(stamps)
+    out = []
+    for row in rows:
+        cls = row["class"]
+        if cls not in stamps:
+            stamps[cls] = pc.rule_stamp(cls)
+        out.append((row, rule_state(row, stamps[cls])))
+    return out
+
+
+def superseded_rows(rows: Iterable[dict], stamps: dict[str, dict[str, str]] | None = None) -> list[dict]:
+    """The rows whose recorded rule has since been ruled away.
+
+    The one state a build can usefully name, and the reason the build's report is
+    not simply "rows that are not current": `unknown` is a large constant that
+    decays only as new rows are cast, and a number nobody can act on is a number
+    everybody learns to skip. This one is **zero until a ruling actually lands on
+    stamped rows**, which is exactly the event worth interrupting a run for. The
+    full four-state breakdown belongs to `rule_drift.py`, which is asked.
+    """
+    return [row for row, state in rule_states(rows, stamps) if state == RULE_SUPERSEDED]
 
 
 def correction_boxes_px(row: dict, W: int, H: int) -> list[list[float]]:

--- a/scripts/experiments/pile/rule_drift.py
+++ b/scripts/experiments/pile/rule_drift.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Which correction rows predate the ruling now in force? (#3814)
+
+A row in `corrections.json` records what a reviewer answered. Since #3814 it also
+records *which question they were shown* -- the rule name on the detector they
+were voting (#3612), and a digest of that rule's full ``test``. This is the other
+end of that: the question "which rows were cast under a rule that has since
+moved?" asked as a query instead of as an 80-image review.
+
+The 80-image review is not hypothetical. `vase` claimed "flower pots, planters"
+until #3784 withdrew the line, and nothing on the 31 `vase` rows or the 49 `bowl`
+rows said which wording they were cast under -- so the only way to find out was
+to put all 80 back in front of a human (#3778), of which 21 had moved and 59 had
+not. Re-asking is right when the answer is unknown; what this ends is the answer
+being *unknowable*.
+
+Four states, and the distinction between the last two is the whole point:
+
+``current``      the row's rule is the one in force, wording included
+``edited``       the name matches; the ``test`` behind it has been rewritten
+                 since (#3756 changed `bench`'s Bad list and kept its name)
+``superseded``   the row names a rule that has been ruled away -- **this is the
+                 actionable state**, and the set a recheck slate is built from
+``unknown``      the row carries no rule at all
+
+**`unknown` is not a defect and cannot be repaired here.** The 872 rows written
+before the field have nothing on disk saying what wording they answered, and
+back-filling them with today's rule would assert the exact thing #3814 was filed
+about. They shrink as passes land -- a recheck that re-confirms a row stamps it,
+which is the one honest way out (`apply_recheck.py`) -- and until then the right
+reading of the number is "this much of the file is not queryable", not "this much
+of the file is wrong".
+
+Usage::
+
+    python rule_drift.py                                  # the table
+    python rule_drift.py --state superseded --ids         # the recheck slate
+    python rule_drift.py --class vase --state unknown     # one class
+    python rule_drift.py --json                           # for another script
+    python rule_drift.py --corrections scripts/experiments/pile/human_record/PILE__corrections.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pile_config as pc
+from pilebuild.corrections import (
+    RULE_CURRENT,
+    RULE_EDITED,
+    RULE_SUPERSEDED,
+    RULE_UNKNOWN,
+    rule_states,
+)
+
+#: Worst first: the order a reader should spend attention in, and the column
+#: order of the table. `superseded` leads because it is the only state anybody
+#: can act on today.
+STATES = (RULE_SUPERSEDED, RULE_EDITED, RULE_UNKNOWN, RULE_CURRENT)
+
+
+def log(msg: str) -> None:
+    print(f"[rule-drift] {msg}", flush=True)
+
+
+def report(rows: list[dict]) -> tuple[dict[str, Counter], list[tuple[dict, str]]]:
+    """``({class: Counter(state)}, [(row, state)])`` over *rows*."""
+    states = rule_states(rows)
+    per_class: dict[str, Counter] = defaultdict(Counter)
+    for row, state in states:
+        per_class[row["class"]][state] += 1
+    return per_class, states
+
+
+def print_table(per_class: dict[str, Counter]) -> None:
+    names = {cls: pc.review_name(cls) for cls in per_class}
+    wide = max([len(n) for n in names.values()] + [len("rule in force")])
+    hdr = f"{'class':<14}" + "".join(f"{s:>13}" for s in STATES) + "   " + "rule in force"
+    print(hdr)
+    print("-" * (len(hdr) - len("rule in force") + wide))
+    totals: Counter = Counter()
+    for cls in sorted(per_class):
+        counts = per_class[cls]
+        totals.update(counts)
+        # A zero prints as blank: the eye should land on the states that have
+        # rows in them, and every class has zeros in most columns.
+        cells = "".join(f"{counts.get(s, 0) or '':>13}" for s in STATES)
+        print(f"{cls:<14}{cells}   {names[cls]}")
+    print("-" * (len(hdr) - len("rule in force") + wide))
+    print(f"{'ALL':<14}" + "".join(f"{totals.get(s, 0):>13}" for s in STATES))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--corrections", default=os.environ.get("VTS_CORRECTIONS", str(pc.PILE / "corrections.json")))
+    ap.add_argument("--class", dest="klass", default="", help="one class (default: all)")
+    ap.add_argument("--state", default="", help=f"one of {', '.join(STATES)} (default: all)")
+    ap.add_argument("--ids", action="store_true", help="print `class image_id` lines instead of the table")
+    ap.add_argument("--json", action="store_true", help="print the rows and their states as JSON")
+    args = ap.parse_args()
+
+    if args.state and args.state not in STATES:
+        raise SystemExit(f"unknown --state {args.state!r}; known: {', '.join(STATES)}")
+
+    path = Path(args.corrections)
+    if not path.exists():
+        raise SystemExit(
+            f"no corrections file at {path} (pass --corrections, or the committed copy under human_record)"
+        )
+    rows = json.loads(path.read_text())
+    if args.klass:
+        rows = [r for r in rows if r["class"] == args.klass]
+    per_class, states = report(rows)
+    selected = [(r, s) for r, s in states if not args.state or s == args.state]
+
+    if args.json:
+        print(json.dumps([{**r, "rule_state": s} for r, s in selected], indent=1))
+        return 0
+    if args.ids:
+        for r, _ in sorted(selected, key=lambda rs: (rs[0]["class"], int(rs[0]["image_id"]))):
+            print(f"{r['class']} {r['image_id']}")
+        return 0
+
+    log(f"{len(rows)} rows in {path}")
+    print()
+    print_table(per_class)
+
+    # Named individually, because the recheck they imply is a per-rule pass: the
+    # question to re-ask is not "is this row stale" but "does this photo hold one
+    # under the NEW wording", which is asked of every row a given ruling moved
+    # at once (`make_class_recheck.py`).
+    superseded: dict[tuple[str, str], int] = Counter()
+    for row, state in states:
+        if state == RULE_SUPERSEDED:
+            superseded[(row["class"], row["rule"])] += 1
+    if superseded:
+        print(f"\n=== {sum(superseded.values())} rows answer a rule that has been ruled away ===")
+        print("   Each line is a recheck slate: re-ask the class question of those images")
+        print("   under the wording now in force, then `apply_recheck.py`.\n")
+        print("   %-14s %-7s %-34s %s" % ("class", "rows", "voted under", "in force"))
+        for (cls, was), n in sorted(superseded.items()):
+            print("   %-14s %-7d %-34s %s" % (cls, n, was, pc.review_name(cls)))
+        print(f"\n   ids: python {Path(__file__).name} --state superseded --ids")
+
+    unknown = sum(c.get(RULE_UNKNOWN, 0) for c in per_class.values())
+    if unknown:
+        print(
+            f"\n{unknown} rows record no rule. Not repairable and not a defect: the wording they were"
+            f"\ncast under was never written down (#3814). They leave this column only by being"
+            f"\nre-answered -- a recheck that re-confirms a row stamps it -- never by back-fill."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiments/pile/verdicts_to_corrections.py
+++ b/scripts/experiments/pile/verdicts_to_corrections.py
@@ -24,6 +24,14 @@ Three sources feed one file, and they are *not* interchangeable:
 * **triage flags** -- a model pass over the ranked negatives, which finds
   contaminated negatives efficiently but draws no boxes.
 
+**A human row carries the rule it was answered under; a triage row does not**
+(#3814). The stamp is *carried* from the verdict, never re-derived here -- this
+script reads August verdict files and would otherwise write September's rule onto
+them, which is the silent re-interpretation the field exists to prevent. Triage
+rows get none on purpose: no reviewer read a rule, so there is no wording to
+record, and `unknown` is the true answer rather than a gap to fill. Rows merged
+from another campaign pass through exactly as that campaign wrote them.
+
 **Boxes are written NORMALISED, and say so.** A drawn box arrives as the app's
 `region_box`, which is already in [0, 1], while VG's and COCO's are in pixels.
 The builder normalises every box it merges, so an undeclared correction box was
@@ -106,6 +114,20 @@ def log(msg: str) -> None:
 
 def _cell_band(cell: str) -> str:
     return cell.rsplit("@", 1)[1] if "@" in cell else ""
+
+
+def _rule(verdict: dict) -> dict[str, str]:
+    """The verdict's own rule stamp, CARRIED and never re-derived (#3814).
+
+    This script runs long after the votes it reads: the live file is the union of
+    two campaigns whose verdict files are dated August, and a regeneration today
+    would stamp September's rule onto every one of them. So the stamp travels
+    with the verdict from `ingest_slate.py`, which took it from the slate the
+    reviewer was actually shown, and a verdict that carries none produces a row
+    that carries none -- unknown, which is the honest answer and the only one
+    available for the rows that predate the field.
+    """
+    return {k: verdict[k] for k in ("rule", "rule_digest") if verdict.get(k)}
 
 
 def _box_band(box: list[float]) -> str:
@@ -212,6 +234,7 @@ def main() -> int:
                 out[key] = {
                     "image_id": key[0],
                     "class": key[1],
+                    **_rule(v),
                     "present": True,
                     "boxes": [box] if box else [],
                     "box_space": pc.CORRECTION_BOX_SPACE,
@@ -226,6 +249,7 @@ def main() -> int:
                     out[key] = {
                         "image_id": key[0],
                         "class": key[1],
+                        **_rule(v),
                         "present": True,
                         "boxes": [box],
                         "box_space": pc.CORRECTION_BOX_SPACE,
@@ -256,6 +280,7 @@ def main() -> int:
                     out[key] = {
                         "image_id": key[0],
                         "class": key[1],
+                        **_rule(v),
                         "present": True,
                         "boxes": [],
                         "box_space": pc.CORRECTION_BOX_SPACE,
@@ -277,6 +302,7 @@ def main() -> int:
                 out[key] = {
                     "image_id": key[0],
                     "class": key[1],
+                    **_rule(v),
                     "present": False,
                     "boxes": [],
                     "source": "human_reject+adjudicated_definition",
@@ -289,6 +315,7 @@ def main() -> int:
                 out[key] = {
                     "image_id": key[0],
                     "class": key[1],
+                    **_rule(v),
                     "present": False,
                     "boxes": [],
                     "source": "human_reject+adjudicated",

--- a/tests_lib/meta/test_pile_apply_recheck.py
+++ b/tests_lib/meta/test_pile_apply_recheck.py
@@ -38,11 +38,18 @@ def _verdict(iid: int) -> dict:
     return {"filename": f"{iid}.jpg", "label": "good", "md5": "x"}
 
 
-def _labelset(cls: str = "vase", good: list[int] | None = None, bad: list[int] | None = None, rule: str = RULE) -> dict:
+def _labelset(
+    cls: str = "vase",
+    good: list[int] | None = None,
+    bad: list[int] | None = None,
+    rule: str = RULE,
+    digest: str | None = None,
+) -> dict:
     return {
         "class": cls,
         "kind": "recheck",
         "rule": rule,
+        **({"rule_digest": digest} if digest else {}),
         "question": "does this photo contain one under the revised rule?",
         "good": [_verdict(i) for i in good or []],
         "bad": [_verdict(i) for i in bad or []],
@@ -83,12 +90,18 @@ class TestPlan:
 
         assert RULE in rows[0]["note"] and "3778" in rows[0]["note"]
 
-    def test_a_good_verdict_leaves_its_row_exactly_as_it_was(self, ar):
-        """Re-confirmation changes nothing: the row and its box were right all along."""
+    def test_a_good_verdict_leaves_its_ANSWER_exactly_as_it_was(self, ar):
+        """Re-confirmation changes no label: the row and its box were right all along.
+
+        It does add the one thing the row could not otherwise carry -- which rule
+        a human answered it under (#3814) -- so `rows == [before]` is no longer
+        the property. Everything that was on the row still is, unchanged.
+        """
         before = _row(7)
         rows, stats, problems = ar.plan({"vase": _labelset(good=[7])}, [before], {"vase": RULE})
 
-        assert problems == [] and rows == [before]
+        assert problems == []
+        assert {k: v for k, v in rows[0].items() if k != "rule"} == before
         assert stats["vase: re-confirmed"] == 1 and not stats["rows changed"]
 
     def test_it_touches_no_other_class(self, ar):
@@ -111,6 +124,70 @@ class TestPlan:
         rows, _, _ = ar.plan({"vase": _labelset(good=[1, 2], bad=[3])}, [_row(i) for i in (1, 2, 3)], {"vase": RULE})
 
         assert len(rows) == 3
+
+
+class TestTheRuleStamp:
+    """A recheck is the one pass that can say which rule a row was answered under.
+
+    It has just proved the labelset's rule is the one in force, so writing that
+    onto the rows it touched costs nothing and ends the question for them. The
+    Good half matters more than the Bad: 59 of the 80 planter images came back
+    re-confirmed, and nothing in the file could say so (#3778, #3814).
+    """
+
+    DIGEST = "0123456789ab"
+
+    def test_a_retired_row_carries_the_rule_that_retired_it(self, ar):
+        rows, _, _ = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": RULE})
+
+        assert rows[0]["rule"] == RULE
+
+    def test_a_re_confirmed_row_carries_the_rule_it_was_re_confirmed_under(self, ar):
+        rows, stats, _ = ar.plan({"vase": _labelset(good=[7])}, [_row(7)], {"vase": RULE})
+
+        assert rows[0]["rule"] == RULE
+        assert stats["rows stamped"] == 1
+
+    def test_the_digest_is_recorded_when_the_labelset_pinned_one(self, ar):
+        ls = _labelset(good=[7], digest=self.DIGEST)
+        rows, _, problems = ar.plan({"vase": ls}, [_row(7)], {"vase": RULE}, {"vase": self.DIGEST})
+
+        assert problems == []
+        assert rows[0]["rule_digest"] == self.DIGEST
+
+    def test_no_digest_is_INVENTED_for_a_labelset_that_pinned_none(self, ar):
+        """A name is the weaker claim and the true one; the table's digest was never checked."""
+        rows, _, _ = ar.plan({"vase": _labelset(good=[7])}, [_row(7)], {"vase": RULE}, {"vase": self.DIGEST})
+
+        assert rows[0]["rule"] == RULE
+        assert "rule_digest" not in rows[0]
+
+    def test_a_row_nobody_re_answered_is_left_unstamped(self, ar):
+        """The law: only an actual answer moves a row out of `unknown`."""
+        other = _row(8)
+        rows, _, _ = ar.plan({"vase": _labelset(good=[7])}, [_row(7), other], {"vase": RULE})
+
+        assert other in rows
+
+    def test_an_already_retired_row_is_back_filled_on_a_re_run(self, ar):
+        """The 21 rows this pass retired before the field existed.
+
+        The one back-fill the design permits, and it is not really one: the
+        evidence is the labelset beside the file, not a guess about what someone
+        was shown.
+        """
+        retired = {**_row(7, present=False), "source": ar.SOURCE_RECHECK}
+        rows, stats, _ = ar.plan({"vase": _labelset(bad=[7])}, [retired], {"vase": RULE})
+
+        assert rows[0]["rule"] == RULE
+        assert stats["already retired"] == 1 and stats["rows stamped"] == 1
+
+    def test_stamping_is_idempotent(self, ar):
+        once, _, _ = ar.plan({"vase": _labelset(good=[7], bad=[8])}, [_row(7), _row(8)], {"vase": RULE})
+        twice, stats, problems = ar.plan({"vase": _labelset(good=[7], bad=[8])}, once, {"vase": RULE})
+
+        assert problems == [] and twice == once
+        assert not stats["rows stamped"] and not stats["rows changed"]
 
 
 class TestRefusals:
@@ -139,6 +216,26 @@ class TestRefusals:
         _, _, problems = ar.plan({"vase": _labelset(good=[7])}, [_row(7, present=False)], {"vase": RULE})
 
         assert any("already says absent" in p for p in problems)
+
+    def test_a_labelset_whose_rule_was_EDITED_under_its_own_name_is_refused(self, ar):
+        """The finer half of the same check: #3756 rewrote `bench`'s Bad list in place.
+
+        The reviewer read identical words off the detector and was answering
+        about a different boundary. Weaker than a rename and refused the same
+        way, because the alternative is deciding for them which edits were
+        cosmetic.
+        """
+        ls = _labelset(bad=[7], digest="0123456789ab")
+        rows, _, problems = ar.plan({"vase": ls}, [_row(7)], {"vase": RULE}, {"vase": "ffffffffffff"})
+
+        assert len(problems) == 1 and "EDITED" in problems[0]
+        assert rows == [_row(7)], "a refusal writes nothing"
+
+    def test_an_unpinned_labelset_is_NOT_refused_by_the_digest_check(self, ar):
+        """Every labelset banked before #3814 records a name and no digest."""
+        _, _, problems = ar.plan({"vase": _labelset(bad=[7])}, [_row(7)], {"vase": RULE}, {"vase": "ffffffffffff"})
+
+        assert problems == []
 
     def test_a_labelset_of_another_kind_is_refused(self, ar):
         """A slate asks "is this box one?" -- a different question with the same shape."""

--- a/tests_lib/meta/test_pile_class_rules.py
+++ b/tests_lib/meta/test_pile_class_rules.py
@@ -96,7 +96,10 @@ def test_no_two_passes_of_one_class_share_a_detector(pc):
     seen: dict[str, str] = {}
     classes = set(pc.SCALE_CLASSES) | set(pc.SCALE_CLASS_RULES)
     for cls in sorted(classes):
-        for suffix in ("", "positives", "audit", "reviewed"):
+        # `REVIEW_SUFFIXES` rather than a copy of the list: `rule_of_review_name`
+        # undoes this join to read a past review's rule off its detector (#3814),
+        # so a suffix known to one and not the other is a silent misparse.
+        for suffix in ("", *pc.REVIEW_SUFFIXES):
             name = pc.review_name(cls, suffix)
             assert name not in seen, f"{cls}/{suffix!r} collides with {seen[name]}"
             seen[name] = f"{cls}/{suffix!r}"

--- a/tests_lib/meta/test_pile_rule_version.py
+++ b/tests_lib/meta/test_pile_rule_version.py
@@ -1,0 +1,397 @@
+"""A verdict records the rule it was answered under, and can be asked about (#3814).
+
+A correction row used to say only *what* a reviewer answered. The class rule is
+the question -- it is the detector name they read while voting (#3612) -- so a
+ruling that moves a class boundary silently changed what every row cast under the
+old wording meant. It cost the 80-image planter recheck (#3778): nothing on the
+31 `vase` rows or the 49 `bowl` rows said which wording they answered, so all 80
+had to go back in front of a human to find the 21 that had actually moved.
+
+Two fields fix it and one law protects them. `rule` is the name the reviewer saw;
+`rule_digest` covers the wording behind that name, which can be rewritten while
+the name stands still (#3756 did that to `bench`). The law is that **absence
+means unknown**: the 872 rows that predate the fields can never be back-filled,
+and a reader that treats them as current has re-created the bug.
+
+These pin both halves -- the stamp each writer produces (and, more importantly,
+the stamp it refuses to invent) and the four states a reader can distinguish.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PILE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "experiments" / "pile"
+
+_CLASS = "vase"
+_RULE = "vase not planters"
+
+
+@pytest.fixture(scope="module")
+def pc():
+    if str(_PILE_DIR) not in sys.path:
+        sys.path.insert(0, str(_PILE_DIR))
+    import pile_config
+
+    return pile_config
+
+
+@pytest.fixture(scope="module")
+def corr(pc):
+    from pilebuild import corrections
+
+    return corrections
+
+
+@pytest.fixture(scope="module")
+def ingest(pc):
+    """``ingest_slate``, imported without letting it build a pile directory.
+
+    The module calls ``pc.setup_env()`` at import, which mkdirs under
+    ``VTS_PILE`` -- ``/expscratch/$USER/vts-cache`` by default, which exists on
+    the cluster and nowhere else. The sibling script tests pay for that with a
+    subprocess and a ``VTS_PILE`` override; there is nothing to isolate here,
+    because :func:`ingest_slate.rule_stamp_for` reads the rule table and touches
+    no path at all.
+    """
+    real, pc.setup_env = pc.setup_env, lambda *a, **k: None
+    try:
+        import ingest_slate
+    finally:
+        pc.setup_env = real
+    return ingest_slate
+
+
+def _stamp(rule: str = _RULE, digest: str | None = None) -> dict[str, str]:
+    return {"rule": rule, **({"rule_digest": digest} if digest else {})}
+
+
+def _row(cls: str = _CLASS, **extra) -> dict:
+    return {"image_id": 7, "class": cls, "present": True, "boxes": [], "source": "human_review", **extra}
+
+
+class TestTheStamp:
+    """What a writer records about the rule, and what it declines to record."""
+
+    def test_the_name_is_what_the_reviewer_would_have_seen(self, pc):
+        assert pc.rule_stamp(_CLASS)["rule"] == pc.review_name(_CLASS) == _RULE
+
+    def test_an_unruled_class_stamps_its_bare_name(self, pc):
+        """`review_name`'s fallback, so every class is stampable, not just the ruled ones."""
+        assert "cat" not in pc.SCALE_CLASS_RULES
+        assert pc.rule_stamp("cat")["rule"] == "cat"
+
+    def test_the_digest_moves_when_the_TEST_is_rewritten_under_an_unchanged_name(self, pc, monkeypatch):
+        """The whole reason a name is not enough: #3756 edited `bench`'s Bad list in place."""
+        before = pc.rule_digest("bench")
+        rule = pc.SCALE_CLASS_RULES["bench"]
+        monkeypatch.setitem(pc.SCALE_CLASS_RULES, "bench", rule._replace(test=rule.test + " Bad: a church pew."))
+
+        assert pc.rule_stamp("bench")["rule"] == rule.name, "the name has not moved"
+        assert pc.rule_digest("bench") != before, "but the wording behind it has"
+
+    def test_the_digest_moves_when_the_name_is_rewritten(self, pc, monkeypatch):
+        before = pc.rule_digest(_CLASS)
+        rule = pc.SCALE_CLASS_RULES[_CLASS]
+        monkeypatch.setitem(pc.SCALE_CLASS_RULES, _CLASS, rule._replace(name="vase incl planters"))
+
+        assert pc.rule_digest(_CLASS) != before
+
+    def test_the_digest_is_stable_across_calls(self, pc):
+        """A stamp written twice must compare equal, or every row reads as edited."""
+        assert pc.rule_digest(_CLASS) == pc.rule_digest(_CLASS)
+
+    def test_two_classes_do_not_share_a_digest(self, pc):
+        digests = {cls: pc.rule_digest(cls) for cls in pc.SCALE_CLASSES}
+        assert len(set(digests.values())) == len(digests)
+
+
+class TestReadingADetectorName:
+    """The slate's detector is the only surviving record of a PAST review's rule."""
+
+    def test_it_inverts_review_name_for_every_class_and_every_pass(self, pc):
+        classes = set(pc.SCALE_CLASSES) | set(pc.SCALE_CLASS_RULES) | {"cat"}
+        for cls in sorted(classes):
+            for suffix in ("", *pc.REVIEW_SUFFIXES):
+                detector = pc.review_name(cls, suffix)
+                assert pc.rule_of_review_name(detector) == pc.review_name(cls), f"{cls}/{suffix!r}"
+
+    def test_no_rule_name_ends_IN_a_pass_suffix(self, pc):
+        """What makes the inverse well defined rather than a lucky parse."""
+        for cls, rule in pc.SCALE_CLASS_RULES.items():
+            for suffix in pc.REVIEW_SUFFIXES:
+                assert not rule.name.endswith(f" {suffix}"), f"{cls}: {rule.name!r} ends in a pass suffix"
+
+    def test_it_drops_the_recheck_tail(self, pc):
+        """`make_class_recheck.py` appends the question; `bank_verdicts.py` strips it the same way."""
+        assert pc.rule_of_review_name(f"{_RULE} -- recheck: is there one in this image?") == _RULE
+
+    def test_a_rule_that_has_been_ruled_away_still_reads_back(self, pc):
+        """The case that matters: a detector naming a rule the table no longer holds."""
+        assert pc.rule_of_review_name("vase incl pots and planters positives") == "vase incl pots and planters"
+
+
+class TestWhatIngestStamps:
+    """`ingest_slate.py` takes the rule from the SLATE, never from today's table."""
+
+    def test_a_current_detector_gets_the_name_and_the_digest(self, pc, ingest):
+        assert ingest.rule_stamp_for(_RULE, _CLASS) == pc.rule_stamp(_CLASS)
+
+    def test_a_suffixed_detector_is_still_recognised(self, pc, ingest):
+        assert ingest.rule_stamp_for(f"{_RULE} positives", _CLASS) == pc.rule_stamp(_CLASS)
+
+    def test_a_superseded_detector_records_what_it_ASKED(self, ingest):
+        stamp = ingest.rule_stamp_for("vase incl pots and planters", _CLASS)
+
+        assert stamp["rule"] == "vase incl pots and planters"
+
+    def test_a_superseded_detector_records_NO_digest(self, ingest):
+        """A digest covers a `test` body, and no detector name can reconstruct a withdrawn one.
+
+        Taking it from the table anyway would stamp today's wording onto a vote
+        cast under yesterday's -- the exact substitution the field exists to
+        prevent, made harder to see by looking precise.
+        """
+        assert "rule_digest" not in ingest.rule_stamp_for("vase incl pots and planters", _CLASS)
+
+
+class TestRuleState:
+    """The four states a reader can tell apart."""
+
+    def test_a_matching_name_and_digest_is_current(self, corr, pc):
+        row = _row(**pc.rule_stamp(_CLASS))
+
+        assert corr.rule_state(row, pc.rule_stamp(_CLASS)) == corr.RULE_CURRENT
+
+    def test_a_moved_name_is_superseded(self, corr, pc):
+        row = _row(**_stamp("vase incl pots and planters"))
+
+        assert corr.rule_state(row, pc.rule_stamp(_CLASS)) == corr.RULE_SUPERSEDED
+
+    def test_a_matching_name_with_a_moved_digest_is_edited(self, corr, pc):
+        row = _row(**_stamp(_RULE, "deadbeef0000"))
+
+        assert corr.rule_state(row, pc.rule_stamp(_CLASS)) == corr.RULE_EDITED
+
+    def test_a_matching_name_with_no_digest_is_current(self, corr, pc):
+        """The name is what the reviewer saw, so the row's claim is met.
+
+        The digest is the stricter, optional check; its absence means the
+        `edited` question cannot be put to this row, not that the answer is no.
+        """
+        row = _row(**_stamp(_RULE))
+
+        assert corr.rule_state(row, pc.rule_stamp(_CLASS)) == corr.RULE_CURRENT
+
+    def test_an_unstamped_row_is_UNKNOWN_and_never_current(self, corr, pc):
+        """The law. Reading these as current is #3814 itself, not a rounding of it."""
+        assert corr.rule_state(_row(), pc.rule_stamp(_CLASS)) == corr.RULE_UNKNOWN
+
+    def test_an_empty_rule_string_is_unknown_too(self, corr, pc):
+        assert corr.rule_state(_row(rule=""), pc.rule_stamp(_CLASS)) == corr.RULE_UNKNOWN
+
+    def test_the_872_committed_rows_are_all_unknown(self, corr):
+        """The live record, read as it stands: nothing in it can be back-filled.
+
+        A regression here would mean some reader had started treating the legacy
+        rows as answered, which is the one outcome this issue forbids.
+        """
+        import json
+
+        rows = json.loads((_PILE_DIR / "human_record" / "PILE__corrections.json").read_text())
+        states = {state for _, state in corr.rule_states(rows)}
+
+        assert states == {corr.RULE_UNKNOWN}, f"expected every legacy row to be unknown, got {states}"
+
+
+class TestTheQuery:
+    """What a build and a tool each get to ask."""
+
+    def test_superseded_rows_are_the_actionable_set(self, corr, pc):
+        rows = [
+            _row(**pc.rule_stamp(_CLASS)),
+            _row(**_stamp("vase incl pots and planters")) | {"image_id": 8},
+            _row() | {"image_id": 9},
+        ]
+
+        assert [r["image_id"] for r in corr.superseded_rows(rows)] == [8]
+
+    def test_unknown_rows_are_NOT_reported_as_superseded(self, corr):
+        """What makes the build's line self-suppressing instead of a constant.
+
+        872 unstamped rows is a number nobody can act on, and a build that prints
+        one every run teaches everyone to skip the line that matters.
+        """
+        assert corr.superseded_rows([_row(), _row() | {"image_id": 8}]) == []
+
+    def test_states_are_resolved_per_class(self, corr, pc):
+        rows = [_row(**pc.rule_stamp(_CLASS)), _row("bowl", **pc.rule_stamp("bowl"))]
+
+        assert [s for _, s in corr.rule_states(rows)] == [corr.RULE_CURRENT, corr.RULE_CURRENT]
+
+    def test_a_stamp_from_ANOTHER_class_reads_as_superseded(self, corr, pc):
+        """A row is checked against its own class's rule, not against any rule."""
+        rows = [_row("bowl", **pc.rule_stamp(_CLASS))]
+
+        assert [s for _, s in corr.rule_states(rows)] == [corr.RULE_SUPERSEDED]
+
+
+class TestWhatTheBuildSays:
+    """Every build reads `corrections.json`, so what it says there is a standing cost.
+
+    The ruling on #3814's second open question: the build names the one state
+    somebody can act on, and stays silent about the one nobody can.
+    """
+
+    def _load(self, corr, pc, tmp_path, monkeypatch, rows):
+        path = tmp_path / "corrections.json"
+        path.write_text(json.dumps(rows))
+        monkeypatch.setenv("VTS_CORRECTIONS", str(path))
+        return corr.load_corrections()
+
+    def test_it_names_a_row_whose_rule_was_ruled_away(self, corr, pc, tmp_path, monkeypatch, capsys):
+        self._load(corr, pc, tmp_path, monkeypatch, [_row(**_stamp("vase incl pots and planters"))])
+
+        out = capsys.readouterr().out
+        assert "ruled away" in out and _CLASS in out and "rule_drift.py" in out
+
+    def test_it_says_NOTHING_about_the_unstamped_rows(self, corr, pc, tmp_path, monkeypatch, capsys):
+        """872 of them, un-actionable and un-repairable: a line every run is a line ignored."""
+        self._load(corr, pc, tmp_path, monkeypatch, [_row(), _row() | {"image_id": 8}])
+
+        assert capsys.readouterr().out == ""
+
+    def test_it_says_nothing_when_every_row_is_current(self, corr, pc, tmp_path, monkeypatch, capsys):
+        self._load(corr, pc, tmp_path, monkeypatch, [_row(**pc.rule_stamp(_CLASS))])
+
+        assert capsys.readouterr().out == ""
+
+    def test_a_superseded_row_is_still_LOADED(self, corr, pc, tmp_path, monkeypatch):
+        """Named, not refused: the reviewer was right and the definition moved after them."""
+        got = self._load(corr, pc, tmp_path, monkeypatch, [_row(**_stamp("vase incl pots and planters"))])
+
+        assert (7, _CLASS) in got
+
+
+_COLS = ["image_id", "class", "stratum", "cell", "text_score", "reference", "exhaustive", "n_boxes", "detector"]
+
+
+def _run_corrections(tmp_path: Path, verdicts: list[dict]) -> dict[int, dict]:
+    """Drive `verdicts_to_corrections.py` over *verdicts* and return its rows by image id.
+
+    A subprocess, like its sibling tests: ``pile_config.setup_env()`` edits
+    ``os.environ`` and ``sys.meta_path`` at import, and ``VTS_PILE`` has to be
+    somewhere that exists.
+    """
+    slates = tmp_path / "slates"
+    (slates / _CLASS).mkdir(parents=True)
+    with (slates / _CLASS / "manifest.csv").open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=_COLS)
+        w.writeheader()
+        for v in verdicts:
+            w.writerow(
+                {
+                    "image_id": v["image_id"],
+                    "class": _CLASS,
+                    "stratum": v["stratum"],
+                    "cell": f"{_CLASS}@medium",
+                    "text_score": "0.0",
+                    "reference": "absent",
+                    "exhaustive": "no",
+                    "n_boxes": "0",
+                    "detector": _RULE,
+                }
+            )
+    vpath = tmp_path / "verdicts.json"
+    vpath.write_text(json.dumps(verdicts))
+    out = tmp_path / "corrections.json"
+    proc = subprocess.run(  # noqa: S603  # interpreter + test-controlled args
+        [
+            sys.executable,
+            "verdicts_to_corrections.py",
+            "--verdicts",
+            str(vpath),
+            "--adjudication",
+            str(tmp_path / "no_adjudication.json"),
+            "--slates",
+            str(slates),
+            "--triage",
+            str(tmp_path / "no_triage.json"),
+            "--sheets",
+            str(tmp_path / "no_sheets"),
+            "--merge",
+            "",
+            "--out",
+            str(out),
+        ],
+        cwd=_PILE_DIR,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "VTS_PILE": str(tmp_path / "pile")},
+    )
+    assert proc.returncode == 0, proc.stderr
+    return {int(r["image_id"]): r for r in json.loads(out.read_text())}
+
+
+def _verdict(iid: int, **extra) -> dict:
+    return {
+        "image_id": iid,
+        "class": _CLASS,
+        "stratum": "boundary",
+        "human": "present",
+        "reference": "absent",
+        "exhaustive": "no",
+        "box": None,
+        "text_score": 0.0,
+        "export": "test",
+        **extra,
+    }
+
+
+class TestCarryThrough:
+    """`verdicts_to_corrections.py` carries the verdict's stamp and never re-derives one.
+
+    This is the half that would be easiest to get subtly wrong. The script reads
+    August verdict files and runs today; taking the rule from
+    ``SCALE_CLASS_RULES`` at that moment would stamp every one of them with a
+    wording their reviewers never saw -- which looks like a fix and is the bug.
+    """
+
+    def test_a_stamped_verdict_produces_a_stamped_row(self, tmp_path):
+        got = _run_corrections(tmp_path, [_verdict(1, rule=_RULE, rule_digest="0123456789ab")])
+
+        assert got[1]["rule"] == _RULE
+        assert got[1]["rule_digest"] == "0123456789ab"
+
+    def test_a_verdict_cast_under_a_WITHDRAWN_rule_keeps_that_rule(self, tmp_path):
+        got = _run_corrections(tmp_path, [_verdict(1, rule="vase incl pots and planters")])
+
+        assert got[1]["rule"] == "vase incl pots and planters"
+
+    def test_an_unstamped_verdict_produces_an_unstamped_row(self, tmp_path):
+        """The anti-regression. Every verdict file banked before #3814 is this case."""
+        got = _run_corrections(tmp_path, [_verdict(1)])
+
+        assert "rule" not in got[1] and "rule_digest" not in got[1]
+
+    def test_a_rebox_carries_the_stamp_too(self, tmp_path):
+        got = _run_corrections(
+            tmp_path,
+            [_verdict(1, stratum="positive_boxed", box=[0.1, 0.1, 0.6, 0.6], reference="present", rule=_RULE)],
+        )
+
+        assert got[1]["source"] == "human_rebox" and got[1]["rule"] == _RULE
+
+    def test_a_confirmation_carries_the_stamp_too(self, tmp_path):
+        """The modal outcome of the exhaustive pass, and the one that buys the most."""
+        got = _run_corrections(tmp_path, [_verdict(1, stratum="positive_boxed", reference="present", rule=_RULE)])
+
+        assert got[1]["source"] == "human_confirmed" and got[1]["rule"] == _RULE


### PR DESCRIPTION
Closes #3814

## The problem

A row in `corrections.json` records *what* a reviewer answered and never *which question they were shown*. The class rule **is** the question — it is the detector name read while voting (#3612) — so when a ruling changes a rule, every row cast under the old wording silently starts meaning something else.

It cost the 80-image planter recheck. `vase` claimed "flower pots, planters" until #3784 withdrew the line, and nothing on the 31 `vase` rows or the 49 `bowl` rows said which wording they were cast under, so the only way to find out was to ask a human all 80 again (#3778) — of which **21** had moved and 59 had not. Re-asking was right; what this ends is the answer being *unknowable*.

## What lands

**Two fields, `rule` and `rule_digest`** (`pile_config.rule_stamp`). The issue asked whether the name or a content hash is the right key; the answer is both, and recording both is cheap. The name is the wording a reviewer saw and is readable in a diff; the digest covers the rule's whole `test`, which can be rewritten while the name stands still — #3756 did exactly that to `bench`'s Bad list. They answer different questions, so the reader keeps them apart: `superseded` (name moved) vs `edited` (only the wording behind it did).

**The stamp comes from what the reviewer was shown, never from the table.** This is the half that would have been easiest to get subtly wrong:

- `ingest_slate.py` reads it off the slate's `detector` column. A new `pile_config.rule_of_review_name` inverts `review_name`; a detector naming a withdrawn rule records that name and **no digest**, because nothing can reconstruct a body that has been rewritten.
- `verdicts_to_corrections.py` **carries** the verdict's stamp and never re-derives one. It reads August verdict files and runs today — taking the rule from `SCALE_CLASS_RULES` at that moment would stamp every one of them with a wording their reviewers never saw, which looks like a fix and is the bug. Triage rows get no stamp: no reviewer read a rule.
- `apply_recheck.py` takes it from the labelset whose rule it has just verified.

**Absence means unknown, and is never read as current.** The 872 rows on disk cannot be back-filled from anything. `pilebuild.corrections.rule_state` sorts a row into `current` / `edited` / `superseded` / `unknown`, and a test pins that every one of the 872 committed rows reads as `unknown`.

**A recheck now stamps both directions.** A Bad carries the rule that retired it; a **Good** changes no label and establishes the one thing nothing else can — that a human looked at this photo under the rule now in force. 59 of the 80 planter images came back that way and the file could not say so, which is why all 80 had to be asked rather than 31. `apply_recheck.py` also refuses a labelset whose *digest* has moved under an unchanged name, and `bank_verdicts.py` writes that digest so future labelsets can be held to it.

**`rule_drift.py` is the reader.** Per-class table, plus `--state superseded --ids` to emit the recheck slate a ruling implies.

## The second open question: build, or a tool that is asked?

Both — the two options only conflict if you count the same number. The issue's objection to a build report was that it "prints a number nobody can act on mid-run", and that is true of `unknown`: it starts at 872 and decays only as passes land, so a line every run is a line everyone learns to skip.

So `load_corrections` names the **superseded** rows on every build and says nothing about `unknown`. That count is zero today and becomes non-zero exactly when a ruling lands on stamped rows — the moment worth interrupting somebody for. It names, and does not refuse: a superseded row is not malformed, the reviewer was right and the definition moved after them.

## Verification

Against a synthetic file built from the 872 committed rows, with `vase` stamped under the withdrawn planter rule, `bowl` stamped current, and `bench` name-matched with a moved digest:

```
class            superseded       edited      unknown      current   rule in force
bench                                 11                             bench not chairs
bowl                                                            49   bowl incl plates not planters or wrappers
vase                     31                                          vase not planters
ALL                      31           11          781           49

=== 31 rows answer a rule that has been ruled away ===
   class          rows    voted under                        in force
   vase           31      vase incl pots and planters        vase not planters
```

and the build's one line, from the same file:

```
[corrections] 31 of 872 rows answer a rule that has since been ruled away (vase) --
`python rule_drift.py --state superseded --ids` names them (#3814)
```

Read unmodified, the live record is 872 `unknown` and nothing else — which is the finding, not a gap.

34 new tests in `tests_lib/meta/test_pile_rule_version.py` and 9 more in `test_pile_apply_recheck.py`.

## Note for whoever runs the next recheck

`apply_recheck.py --dry-run` against the live `corrections.json` will now want to stamp the 80 planter rows it already ruled on (21 retired + 59 re-confirmed). That is the permitted back-fill — the evidence is the labelset sitting beside the file — but it writes to shared pile state, so it is left for a session that means to touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b1xA9ArRkoQscwxTenJE5